### PR TITLE
fix(worker): enforce rollout percentage in public update resolution

### DIFF
--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -32,6 +32,50 @@ import { ReleaseAssetUploader } from "../components/ReleaseAssetUploader";
 import { createBuildAsset, uploadApk } from "../lib/api";
 import type { PendingFile } from "../lib/releaseFileDetect";
 
+
+const ROLLOUT_PRESETS = [5, 25, 50, 100];
+
+function RolloutPercentInput({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+}) {
+  return (
+    <span className="flex items-center gap-1">
+      <input
+        type="number"
+        min={0}
+        max={100}
+        step={1}
+        value={value}
+        onChange={(e) => {
+          const next = Number(e.target.value);
+          if (Number.isFinite(next)) onChange(Math.min(100, Math.max(0, Math.trunc(next))));
+        }}
+        className="w-16 rounded border border-slate-300 px-2 py-1 text-right font-mono text-xs"
+      />
+      <span className="text-slate-500">%</span>
+      {ROLLOUT_PRESETS.map((preset) => (
+        <button
+          key={preset}
+          type="button"
+          onClick={() => onChange(preset)}
+          className={
+            "rounded border px-1.5 py-0.5 text-[11px] " +
+            (value === preset
+              ? "border-slate-900 bg-slate-900 text-white"
+              : "border-slate-300 text-slate-600 hover:bg-slate-100")
+          }
+        >
+          {preset}
+        </button>
+      ))}
+    </span>
+  );
+}
+
 function parseJsonStringArray(value: string): string[] {
   try {
     const parsed = JSON.parse(value) as unknown;
@@ -413,16 +457,7 @@ function ReleaseRow({
       {showRollout && (
         <div className="mt-2 pt-2 border-t border-slate-100 flex items-center gap-2 text-xs">
           <label>Rollout %:</label>
-          <input
-            type="range"
-            min={0}
-            max={100}
-            step={5}
-            value={newPercent}
-            onChange={(e) => setNewPercent(Number(e.target.value))}
-            className="flex-1"
-          />
-          <span className="font-mono w-10 text-right">{newPercent}%</span>
+          <RolloutPercentInput value={newPercent} onChange={setNewPercent} />
           <button
             className="btn-primary text-xs"
             onClick={() => bump.mutate(newPercent)}
@@ -647,15 +682,7 @@ function EditReleaseDialog({
           </label>
           <div className="flex items-center gap-2 text-xs">
             <label className="flex-1">Rollout cohort %</label>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              step={5}
-              value={rolloutPercent}
-              onChange={(e) => setRolloutPercent(Number(e.target.value))}
-            />
-            <span className="font-mono w-10 text-right">{rolloutPercent}%</span>
+            <RolloutPercentInput value={rolloutPercent} onChange={setRolloutPercent} />
           </div>
         </div>
         <div className="flex gap-2 justify-end pt-4 mt-3 border-t border-slate-100">
@@ -1075,17 +1102,10 @@ function NewReleaseDialog({
                       <label className="flex-1">
                         Rollout cohort % (default 100)
                       </label>
-                      <input
-                        type="range"
-                        min={0}
-                        max={100}
-                        step={5}
+                      <RolloutPercentInput
                         value={rolloutPercent}
-                        onChange={(e) => setRolloutPercent(Number(e.target.value))}
+                        onChange={setRolloutPercent}
                       />
-                      <span className="font-mono w-10 text-right">
-                        {rolloutPercent}%
-                      </span>
                     </div>
                   </div>
                 )}

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -56,6 +56,7 @@ type PublicLatestResponse = {
     scope_type: "full" | "platform" | "user_cohort" | "ip_range";
     scope_value: string;
     release_id: string;
+    rollout_cohort_count?: number | null;
   };
   fallback_release: unknown | null;
   expires_in: number;
@@ -75,6 +76,8 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   const channel = c.req.query("channel") ?? "main";
   const productType = c.req.query("product_type"); // optional; if null, picks most recent across all
   const cohort = c.req.header("X-Quiver-Cohort") ?? null;
+  const deviceId =
+    c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
   const clientPlatform = effectiveClientPlatform(c);
   // cf.clientIp is server-only (we never trust X-Forwarded-For here).
   const clientIp =
@@ -102,29 +105,40 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
     );
   }
 
-  // Candidates: active releases on (channel, [product_type]) within last 30 days.
-  const since = Date.now() - 30 * 24 * 3600 * 1000;
+  // Candidates: active releases on (channel, [product_type]). No time window:
+  // an active release must stay resolvable no matter how old it is.
   const candidateSql = productType
-    ? `SELECT id, build_id, created_at, product_type
+    ? `SELECT id, build_id, created_at, product_type, rollout_cohort_count
        FROM releases
        WHERE app_id = ?1 AND channel_id = ?2 AND product_type = ?3
-         AND status = 'active' AND created_at > ?4
+         AND status = 'active'
        ORDER BY created_at DESC`
-    : `SELECT id, build_id, created_at, product_type
+    : `SELECT id, build_id, created_at, product_type, rollout_cohort_count
        FROM releases
        WHERE app_id = ?1 AND channel_id = ?2
-         AND status = 'active' AND created_at > ?3
+         AND status = 'active'
        ORDER BY created_at DESC`;
   const candidateStmt = c.env.DB.prepare(candidateSql);
-  const candidates = await (productType
-    ? candidateStmt.bind(app.id, channelRow.id, productType, since)
-    : candidateStmt.bind(app.id, channelRow.id, since)
+  const allCandidates = await (productType
+    ? candidateStmt.bind(app.id, channelRow.id, productType)
+    : candidateStmt.bind(app.id, channelRow.id)
   ).all<{
     id: string;
     build_id: string;
     created_at: number;
     product_type: string;
+    rollout_cohort_count: number | null;
   }>();
+
+  // Rollout gate: a release with rollout_cohort_count < 100 is only served to
+  // clients whose stable per-release bucket falls below the percentage.
+  // Clients that do not send a device id only ever see fully rolled-out
+  // releases. Gated-out clients fall through to the previous active release.
+  const candidates = {
+    results: allCandidates.results.filter((release) =>
+      rolloutIncludes(release.id, release.rollout_cohort_count, deviceId),
+    ),
+  };
   if (candidates.results.length === 0) {
     return c.json(
       {
@@ -300,6 +314,9 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
       scope_type: winner.scope_type,
       scope_value: winner.scope_value,
       release_id: winner.release_id,
+      rollout_cohort_count:
+        candidates.results.find((r) => r.id === winner.release_id)
+          ?.rollout_cohort_count ?? null,
     },
     fallback_release: fallbackRelease,
     expires_in: ttl,
@@ -413,6 +430,43 @@ export function selectBestAsset(
     if (archMatch) return archMatch;
   }
   return candidates.find((a) => a.arch === null) ?? candidates[0] ?? null;
+}
+
+/**
+ * Stable 32-bit FNV-1a hash. Deterministic across runtimes so a device keeps
+ * the same bucket for a given release while the rollout percentage climbs.
+ */
+export function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/** Bucket in [0, 100). Salted by release id so cohorts reshuffle per release. */
+export function rolloutBucket(releaseId: string, deviceId: string): number {
+  return fnv1a32(`${releaseId}:${deviceId}`) % 100;
+}
+
+/**
+ * true when the release should be served to this client.
+ * - null / >=100 cohort count: fully rolled out, everyone matches.
+ * - gated release + no device id: excluded (legacy clients only get full
+ *   releases; they fall through to the previous active release).
+ * - gated release + device id: stable bucket must fall under the percentage.
+ */
+export function rolloutIncludes(
+  releaseId: string,
+  cohortCount: number | null,
+  deviceId: string | null,
+): boolean {
+  if (cohortCount === null || cohortCount === undefined) return true;
+  if (cohortCount >= 100) return true;
+  if (cohortCount <= 0) return false;
+  if (!deviceId) return false;
+  return rolloutBucket(releaseId, deviceId) < cohortCount;
 }
 
 function splitPlatformArch(value: string | null): {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -1773,6 +1773,7 @@ describe("quiver public API v2 — scope resolution", () => {
       versionCode?: number;
       versionName?: string;
       shouldForceUpdate?: number;
+      rolloutCohortCount?: number | null;
     } = {},
   ) {
     const now = opts.createdAt ?? Date.now();
@@ -1814,7 +1815,7 @@ describe("quiver public API v2 — scope resolution", () => {
         "stable",
         "active",
         scopes.length === 1 && scopes[0]?.[0] === "full" && scopes[0]?.[1] === "all" ? 1 : 0,
-        100,
+        opts.rolloutCohortCount === undefined ? 100 : opts.rolloutCohortCount,
         null,
         "tester",
         now,
@@ -2242,6 +2243,113 @@ describe("quiver public API v2 — scope resolution", () => {
       latest_version_code: 10,
     });
     expect(body.asset).toBeUndefined();
+  });
+
+  it("rollout helpers are deterministic and clamp edge counts", async () => {
+    const { fnv1a32, rolloutBucket, rolloutIncludes } = await import(
+      "../src/routes/public_v2"
+    );
+    expect(fnv1a32("abc")).toBe(fnv1a32("abc"));
+    expect(rolloutBucket("rel-x", "device-1")).toBe(
+      rolloutBucket("rel-x", "device-1"),
+    );
+    expect(rolloutIncludes("rel-x", null, null)).toBe(true);
+    expect(rolloutIncludes("rel-x", 100, null)).toBe(true);
+    expect(rolloutIncludes("rel-x", 0, "device-1")).toBe(false);
+    expect(rolloutIncludes("rel-x", 50, null)).toBe(false);
+    const bucket = rolloutBucket("rel-x", "device-1");
+    expect(rolloutIncludes("rel-x", bucket + 1, "device-1")).toBe(true);
+    expect(rolloutIncludes("rel-x", bucket, "device-1")).toBe(false);
+  });
+
+  it("updates/check gates a partial rollout by device bucket and falls back to the previous release", async () => {
+    const env = makeEnv();
+    const { handlePublicV2UpdateCheck, rolloutBucket } = await import(
+      "../src/routes/public_v2"
+    );
+    await seedRelease(env, "rel-stable", "build-stable", [["full", "all"]], {
+      versionCode: 10,
+      versionName: "1.0.10",
+      createdAt: Date.now() - 1000,
+    });
+    await seedAsset(env, "build-stable", "asset-stable", { arch: "arm64-v8a" });
+    await seedRelease(env, "rel-gated", "build-gated", [["full", "all"]], {
+      versionCode: 11,
+      versionName: "1.0.11",
+      rolloutCohortCount: 30,
+    });
+    await seedAsset(env, "build-gated", "asset-gated", { arch: "arm64-v8a" });
+
+    let inDevice = "";
+    let outDevice = "";
+    for (let i = 0; i < 1000 && (!inDevice || !outDevice); i++) {
+      const candidate = `device-${i}`;
+      if (rolloutBucket("rel-gated", candidate) < 30) {
+        inDevice = inDevice || candidate;
+      } else {
+        outDevice = outDevice || candidate;
+      }
+    }
+    expect(inDevice).not.toBe("");
+    expect(outDevice).not.toBe("");
+
+    const query = {
+      channel: "production",
+      product_type: "android-apk",
+      current_version_code: "9",
+      platform: "android",
+      arch: "arm64-v8a",
+    };
+
+    const inResponse = await handlePublicV2UpdateCheck(
+      makePublicContext(env, query, { "X-Quiver-Device-Id": inDevice }),
+    );
+    expect(inResponse.status).toBe(200);
+    const inBody = await responseJson<any>(inResponse);
+    expect(inBody.update_available).toBe(true);
+    expect(inBody.latest.version_code).toBe(11);
+    expect(inBody.scoped.rollout_cohort_count).toBe(30);
+
+    const outResponse = await handlePublicV2UpdateCheck(
+      makePublicContext(env, query, { "X-Quiver-Device-Id": outDevice }),
+    );
+    expect(outResponse.status).toBe(200);
+    const outBody = await responseJson<any>(outResponse);
+    expect(outBody.update_available).toBe(true);
+    expect(outBody.latest.version_code).toBe(10);
+
+    const legacyResponse = await handlePublicV2UpdateCheck(
+      makePublicContext(env, query),
+    );
+    expect(legacyResponse.status).toBe(200);
+    const legacyBody = await responseJson<any>(legacyResponse);
+    expect(legacyBody.update_available).toBe(true);
+    expect(legacyBody.latest.version_code).toBe(10);
+  });
+
+  it("updates/check still resolves an active release older than 30 days", async () => {
+    const env = makeEnv();
+    const { handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    await seedRelease(env, "rel-old", "build-old", [["full", "all"]], {
+      versionCode: 10,
+      versionName: "1.0.10",
+      createdAt: Date.now() - 60 * 24 * 3600 * 1000,
+    });
+    await seedAsset(env, "build-old", "asset-old", { arch: "arm64-v8a" });
+
+    const response = await handlePublicV2UpdateCheck(
+      makePublicContext(env, {
+        channel: "production",
+        product_type: "android-apk",
+        current_version_code: "1",
+        platform: "android",
+        arch: "arm64-v8a",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = await responseJson<any>(response);
+    expect(body.update_available).toBe(true);
+    expect(body.latest.version_code).toBe(10);
   });
 
   it("updates/check compares server-side and returns one compatible apk asset", async () => {


### PR DESCRIPTION
Task #65 P0: the gradual-rollout feature was cosmetic — `rollout_cohort_count` was stored by the admin API but never read by the public v2 resolver, so a "50% rollout" shipped to 100% of clients.

## Changes
- **Real gating in `handlePublicV2Latest`**: candidates with `rollout_cohort_count < 100` are served only when `fnv1a32("<release_id>:<device_id>") % 100 < count`, using the new `X-Quiver-Device-Id` header (or `device_id` query param).
  - Stable per-release bucket: a device that got the release at 10% keeps it as the percentage climbs.
  - Clients without a device id only ever see fully rolled-out releases (safe for legacy clients).
  - Gated-out clients fall through to the previous active release instead of 404.
  - `scoped.rollout_cohort_count` added to the response for QA/debugging.
- **Removed the 30-day candidate window**: an active release older than 30 days silently vanished from update checks (404 "no active release"). Active releases now stay resolvable regardless of age.
- **Admin UI**: rollout sliders (create modal, edit modal, bump-rollout row) replaced with a number input (0–100) plus 5/25/50/100 preset buttons, per artin's feedback.

## Verification
- `pnpm --filter @oranix/quiver-worker test` — 64/64 pass, including 3 new tests: helper determinism/clamping, in-bucket vs out-of-bucket vs legacy-client resolution with fallback, and >30-day-old release resolution.
- `wrangler types && tsc --noEmit` — clean.
- `pnpm --filter @oranix/quiver-admin build` — clean.
- Note: `eslint` fails repo-wide on clean main (ESLint v9 needs eslint.config.js migration) — pre-existing, untouched here.

## Follow-up (separate PR)
Android SDK (`clients/android`): generate + persist a device id and send `X-Quiver-Device-Id` on update checks; then bump the SDK dependency in the mobile app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)