### PR TITLE
feat(android-sdk): send stable device id for staged rollouts

### DIFF
--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverDeviceId.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverDeviceId.kt
@@ -1,0 +1,38 @@
+package io.quiver.update
+
+import android.content.Context
+import java.util.UUID
+
+/**
+ * Stable per-install device identifier used for staged rollouts.
+ *
+ * The server buckets clients by hashing (release_id, device_id), so the id
+ * only needs to be stable per install — a random UUID persisted in
+ * SharedPreferences. It is not derived from hardware identifiers and resets
+ * on reinstall / clear-data, which is acceptable for rollout cohorting.
+ */
+object QuiverDeviceId {
+    private const val PREFS_NAME = "quiver_update"
+    private const val KEY_DEVICE_ID = "device_id"
+
+    @Volatile
+    private var cached: String? = null
+
+    fun get(context: Context): String {
+        cached?.let { return it }
+        synchronized(this) {
+            cached?.let { return it }
+            val prefs = context.applicationContext
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val existing = prefs.getString(KEY_DEVICE_ID, null)
+            if (!existing.isNullOrBlank()) {
+                cached = existing
+                return existing
+            }
+            val created = UUID.randomUUID().toString()
+            prefs.edit().putString(KEY_DEVICE_ID, created).apply()
+            cached = created
+            return created
+        }
+    }
+}

--- a/clients/android/src/main/kotlin/io/quiver/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/UpdateChecker.kt
@@ -55,6 +55,7 @@ class UpdateChecker(
     private val arch: String? = null,
     private val client: QuiverClient = QuiverClient(baseUrl),
     private val installer: ApkInstaller = ApkInstaller(context),
+    private val deviceId: String? = null,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -77,6 +78,7 @@ class UpdateChecker(
             productType = productType,
             platform = platform,
             arch = arch,
+            deviceId = deviceId ?: QuiverDeviceId.get(context),
         )
         if (response.requireUpdate() != null) {
             installUpdate(response)

--- a/clients/android/src/main/kotlin/io/quiver/update/internal/QuiverClient.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/internal/QuiverClient.kt
@@ -36,6 +36,7 @@ class QuiverClient(
         platform: String = "android",
         arch: String? = null,
         filetype: String = "apk",
+        deviceId: String? = null,
     ): UpdateCheckResponse = withContext(Dispatchers.IO) {
         val urlBuilder = baseUrl.trimEnd('/').toHttpUrl().newBuilder()
             .addPathSegments("public/v2/apps")
@@ -50,10 +51,14 @@ class QuiverClient(
             urlBuilder.addQueryParameter("arch", arch)
         }
         val url = urlBuilder.build()
-        val request = Request.Builder()
+        val requestBuilder = Request.Builder()
             .url(url)
             .header("accept", "application/json")
-            .build()
+        if (!deviceId.isNullOrBlank()) {
+            // Stable per-install id; the server uses it to bucket staged rollouts.
+            requestBuilder.header("X-Quiver-Device-Id", deviceId)
+        }
+        val request = requestBuilder.build()
 
         httpClient.newCall(request).execute().use { response ->
             val body = response.body?.string()


### PR DESCRIPTION
Companion to #3 (worker-side rollout gating). The SDK now sends `X-Quiver-Device-Id` on update checks:

- `QuiverDeviceId.get(context)` — random UUID persisted in SharedPreferences (`quiver_update/device_id`), cached in memory; not derived from hardware ids.
- `QuiverClient.checkForUpdate(deviceId = …)` — optional param, header only set when non-blank (no behavior change for existing callers).
- `UpdateChecker` — defaults to `QuiverDeviceId.get(context)`.

Follow-up after merge: publish a new SDK version via the "Publish Android SDK" workflow, then bump the dependency in botiverse/mobile and pass the device id in `SlockKuiklyActivity.checkQuiverUpdate` (which calls `QuiverClient` directly).

Not built locally (no Android toolchain on this machine) — the change is additive Kotlin with default parameters; relying on the SDK publish workflow build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)