### PR TITLE
feat(shares): password protection and app-level share management

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -69,6 +69,16 @@ jobs:
             echo "value=${{ inputs.containers_rollout }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Apply D1 migrations
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec wrangler d1 migrations apply quiver-db --remote
+
       - name: Deploy Worker and admin assets
         working-directory: worker
         env:

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -17,6 +17,7 @@ import { AuditLog } from "./pages/AuditLog";
 import { Settings } from "./pages/Settings";
 import { Builds } from "./pages/Builds";
 import { Releases } from "./pages/Releases";
+import { AppShares } from "./pages/Shares";
 import { OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
@@ -309,6 +310,12 @@ function AppContextNav() {
           Releases
         </NavLink>
         <NavLink
+          to={`${base}/shares`}
+          className={tabClass}
+        >
+          Shares
+        </NavLink>
+        <NavLink
           to={`${base}/builds`}
           className={tabClass}
         >
@@ -353,6 +360,12 @@ function AppSettingsRoute() {
   const { appId } = useParams();
   if (!appId) return null;
   return <AppSettings appId={appId} />;
+}
+
+function AppSharesRoute() {
+  const { appId } = useParams();
+  if (!appId) return null;
+  return <AppShares appId={appId} />;
 }
 
 function AppAccessRoute() {
@@ -659,6 +672,7 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
           <Route path="channels" element={<AppChannelsRoute />} />
           <Route path="builds" element={<BuildsRoute />} />
           <Route path="releases" element={<ReleasesRoute />} />
+          <Route path="shares" element={<AppSharesRoute />} />
           <Route path="access" element={<AppAccessRoute />} />
           <Route path="audit" element={<AuditRoute />} />
           <Route path="settings" element={<AppSettingsRoute />} />
@@ -722,6 +736,7 @@ function AppShell() {
           <Route path="channels" element={<AppChannelsRoute />} />
           <Route path="builds" element={<BuildsRoute />} />
           <Route path="releases" element={<ReleasesRoute />} />
+          <Route path="shares" element={<AppSharesRoute />} />
           <Route path="access" element={<AppAccessRoute />} />
           <Route path="audit" element={<AuditRoute />} />
           <Route path="settings" element={<AppSettingsRoute />} />

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1010,3 +1010,53 @@ export const listWebhookDeliveries = (orgId: string, webhookId: string) =>
     `/api/orgs/${orgId}/webhooks/${webhookId}/deliveries`,
     { admin: true },
   );
+
+// ---- Release shares (P1: share management tab) ----
+
+export interface AppShare {
+  id: string;
+  release_id: string;
+  created_by: string;
+  created_at: number;
+  expires_at: number;
+  revoked_at: number | null;
+  has_password: number; // 0 | 1 from SQLite
+  release_status: string;
+  channel_slug: string;
+  version_name: string;
+  version_code: number;
+  view_count: number;
+  unique_view_count: number;
+  download_count: number;
+  unique_download_count: number;
+}
+
+export const listAppShares = (appId: string) =>
+  request<{ shares: AppShare[] }>(`/api/apps/${appId}/shares`, { admin: true });
+
+export const createReleaseShare = (
+  appId: string,
+  releaseId: string,
+  body: { ttl_seconds?: number; expires_at?: number; password?: string },
+) =>
+  request<{ id: string; share_url: string; expires_at: number; has_password: boolean }>(
+    `/api/apps/${appId}/releases/${releaseId}/shares`,
+    { method: "POST", body: JSON.stringify(body), admin: true },
+  );
+
+export const renewReleaseShare = (
+  appId: string,
+  releaseId: string,
+  shareId: string,
+  body: { ttl_seconds?: number; expires_at?: number },
+) =>
+  request<{ id: string; expires_at: number }>(
+    `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,
+    { method: "PATCH", body: JSON.stringify(body), admin: true },
+  );
+
+export const revokeReleaseShare = (appId: string, releaseId: string, shareId: string) =>
+  request<{ id: string }>(
+    `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,
+    { method: "DELETE", admin: true },
+  );

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -1,0 +1,329 @@
+/**
+ * App-level share management (task #65 P1).
+ *
+ * Lists every share link for the app across releases with stats, lets
+ * admins create (with optional password), renew, and revoke them. The
+ * share URL is only visible at creation time — tokens are stored hashed.
+ */
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AppShare,
+  createReleaseShare,
+  listAppShares,
+  listReleases,
+  renewReleaseShare,
+  revokeReleaseShare,
+} from "../lib/api";
+import { useToast } from "../components/Toast";
+
+const WEEK_SECONDS = 7 * 24 * 60 * 60;
+
+export function AppShares({ appId }: { appId: string }) {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+  const [createdUrl, setCreatedUrl] = useState<string | null>(null);
+
+  const shares = useQuery({
+    queryKey: ["app-shares", appId],
+    queryFn: () => listAppShares(appId),
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["app-shares", appId] });
+
+  const renew = useMutation({
+    mutationFn: (share: AppShare) =>
+      renewReleaseShare(appId, share.release_id, share.id, {
+        ttl_seconds: WEEK_SECONDS,
+      }),
+    onSuccess: () => {
+      toast.show({ kind: "success", title: "Share extended by 7 days" });
+      invalidate();
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Renew failed",
+        description: (e as Error).message,
+      }),
+  });
+
+  const revoke = useMutation({
+    mutationFn: (share: AppShare) =>
+      revokeReleaseShare(appId, share.release_id, share.id),
+    onSuccess: () => {
+      toast.show({ kind: "success", title: "Share revoked" });
+      invalidate();
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Revoke failed",
+        description: (e as Error).message,
+      }),
+  });
+
+  const rows = shares.data?.shares ?? [];
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-bold">Shares</h2>
+          <p className="text-sm text-slate-500">
+            Public download pages for this app's releases. URLs are shown only
+            once at creation — tokens are stored hashed.
+          </p>
+        </div>
+        <button className="btn-primary text-sm" onClick={() => setShowCreate(true)}>
+          New share
+        </button>
+      </div>
+
+      {createdUrl && (
+        <div className="card flex items-center gap-3 text-sm">
+          <span className="font-mono break-all flex-1">{createdUrl}</span>
+          <button
+            className="btn-secondary text-xs"
+            onClick={() => {
+              navigator.clipboard?.writeText(createdUrl);
+              toast.show({ kind: "success", title: "Copied share URL" });
+            }}
+          >
+            Copy
+          </button>
+          <button className="btn-secondary text-xs" onClick={() => setCreatedUrl(null)}>
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <div className="card overflow-x-auto">
+        {shares.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+        {shares.error && (
+          <p className="text-sm text-red-600">
+            Failed to load shares: {(shares.error as Error).message}
+          </p>
+        )}
+        {!shares.isLoading && rows.length === 0 && (
+          <p className="text-sm text-slate-500">
+            No shares yet. Create one here, from the CLI
+            (<code>quiver releases share</code>), or from the release workflow.
+          </p>
+        )}
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-slate-500 border-b border-slate-200">
+                <th className="py-2 pr-3">Release</th>
+                <th className="py-2 pr-3">Status</th>
+                <th className="py-2 pr-3">Created</th>
+                <th className="py-2 pr-3">Expires</th>
+                <th className="py-2 pr-3">Views</th>
+                <th className="py-2 pr-3">Downloads</th>
+                <th className="py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((share) => (
+                <ShareRow
+                  key={share.id}
+                  share={share}
+                  onRenew={() => renew.mutate(share)}
+                  onRevoke={() => revoke.mutate(share)}
+                  busy={renew.isPending || revoke.isPending}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {showCreate && (
+        <CreateShareModal
+          appId={appId}
+          onClose={() => setShowCreate(false)}
+          onCreated={(url) => {
+            setShowCreate(false);
+            setCreatedUrl(url);
+            invalidate();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function shareState(share: AppShare): { label: string; className: string } {
+  if (share.revoked_at) return { label: "revoked", className: "bg-slate-200 text-slate-600" };
+  if (share.expires_at <= Date.now()) return { label: "expired", className: "bg-amber-100 text-amber-800" };
+  return { label: "active", className: "bg-emerald-100 text-emerald-800" };
+}
+
+function ShareRow({
+  share,
+  onRenew,
+  onRevoke,
+  busy,
+}: {
+  share: AppShare;
+  onRenew: () => void;
+  onRevoke: () => void;
+  busy: boolean;
+}) {
+  const state = shareState(share);
+  const actionable = !share.revoked_at;
+  return (
+    <tr className="border-b border-slate-100 last:border-0">
+      <td className="py-2 pr-3">
+        <span className="font-medium">
+          {share.version_name} ({share.version_code})
+        </span>
+        <span className="ml-2 text-xs text-slate-500">{share.channel_slug}</span>
+        <div className="text-xs text-slate-400">by {share.created_by}</div>
+      </td>
+      <td className="py-2 pr-3">
+        <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${state.className}`}>
+          {state.label}
+        </span>
+        {Boolean(share.has_password) && (
+          <span className="ml-1 rounded bg-sky-100 px-1.5 py-0.5 text-xs font-medium text-sky-800">
+            password
+          </span>
+        )}
+      </td>
+      <td className="py-2 pr-3 text-xs text-slate-600">
+        {new Date(share.created_at).toLocaleString()}
+      </td>
+      <td className="py-2 pr-3 text-xs text-slate-600">
+        {new Date(share.expires_at).toLocaleString()}
+      </td>
+      <td className="py-2 pr-3">
+        {share.view_count}
+        <span className="text-xs text-slate-400"> ({share.unique_view_count} uniq)</span>
+      </td>
+      <td className="py-2 pr-3">
+        {share.download_count}
+        <span className="text-xs text-slate-400"> ({share.unique_download_count} uniq)</span>
+      </td>
+      <td className="py-2 text-right text-xs whitespace-nowrap">
+        {actionable && (
+          <>
+            <button className="text-blue-600 hover:underline mr-2" onClick={onRenew} disabled={busy}>
+              +7 days
+            </button>
+            <button className="text-red-600 hover:underline" onClick={onRevoke} disabled={busy}>
+              Revoke
+            </button>
+          </>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function CreateShareModal({
+  appId,
+  onClose,
+  onCreated,
+}: {
+  appId: string;
+  onClose: () => void;
+  onCreated: (url: string) => void;
+}) {
+  const toast = useToast();
+  const [releaseId, setReleaseId] = useState("");
+  const [password, setPassword] = useState("");
+  const [ttlDays, setTtlDays] = useState(7);
+
+  const releases = useQuery({
+    queryKey: ["releases", appId],
+    queryFn: () => listReleases(appId),
+  });
+  const options = useMemo(
+    () =>
+      (releases.data?.releases ?? [])
+        .filter((r: any) => r.status === "active" || r.status === "superseded")
+        .slice(0, 30),
+    [releases.data],
+  );
+
+  const create = useMutation({
+    mutationFn: () =>
+      createReleaseShare(appId, releaseId, {
+        ttl_seconds: ttlDays * 24 * 60 * 60,
+        ...(password.trim() ? { password: password.trim() } : {}),
+      }),
+    onSuccess: (data) => {
+      toast.show({
+        kind: "success",
+        title: data.has_password ? "Password-protected share created" : "Share created",
+      });
+      onCreated(data.share_url);
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Create share failed",
+        description: (e as Error).message,
+      }),
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40 p-4">
+      <div className="card w-full max-w-md space-y-3 bg-white">
+        <h3 className="text-base font-semibold">New share link</h3>
+        <label className="block text-xs text-slate-600">
+          Release
+          <select
+            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            value={releaseId}
+            onChange={(e) => setReleaseId(e.target.value)}
+          >
+            <option value="">Select a release…</option>
+            {options.map((r: any) => (
+              <option key={r.id} value={r.id}>
+                {r.version_name ?? r.id.slice(0, 8)} · {r.status}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-xs text-slate-600">
+          Lifetime (days)
+          <input
+            type="number"
+            min={1}
+            max={30}
+            value={ttlDays}
+            onChange={(e) => setTtlDays(Math.min(30, Math.max(1, Number(e.target.value) || 7)))}
+            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block text-xs text-slate-600">
+          Password (optional)
+          <input
+            type="text"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Leave empty for a public link"
+            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="btn-secondary text-sm" onClick={onClose} disabled={create.isPending}>
+            Cancel
+          </button>
+          <button
+            className="btn-primary text-sm"
+            onClick={() => create.mutate()}
+            disabled={create.isPending || !releaseId}
+          >
+            {create.isPending ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/migrations/sql/0025_release_share_password.sql
+++ b/migrations/sql/0025_release_share_password.sql
@@ -1,0 +1,1 @@
+ALTER TABLE release_shares ADD COLUMN password_hash TEXT;

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -31,20 +31,26 @@ export function registerReleaseCommands(program: Command): void {
     .description("Create a revocable public share page for a release.")
     .option("--ttl-seconds <seconds>", "Share lifetime in seconds.", DEFAULT_SHARE_TTL_SECONDS)
     .option("--expires-at <millis>", "Absolute expiration as Unix milliseconds.")
+    .option(
+      "--password <password>",
+      "Password-protect the share page (or set QUIVER_SHARE_PASSWORD to keep it out of shell history).",
+    )
     .option("--json", "Output JSON.", false)
     .action(
       async (
         appIdOrSlug: string,
         releaseId: string,
-        opts: { ttlSeconds?: string; expiresAt?: string; json?: boolean },
+        opts: { ttlSeconds?: string; expiresAt?: string; password?: string; json?: boolean },
       ) => {
         const appId = await resolveAppId(appIdOrSlug);
-        const body: { ttl_seconds?: number; expires_at?: number } = {};
+        const body: { ttl_seconds?: number; expires_at?: number; password?: string } = {};
         if (opts.expiresAt) {
           body.expires_at = parsePositiveNumber(opts.expiresAt, "--expires-at");
         } else {
           body.ttl_seconds = parsePositiveNumber(opts.ttlSeconds ?? DEFAULT_SHARE_TTL_SECONDS, "--ttl-seconds");
         }
+        const password = opts.password ?? process.env.QUIVER_SHARE_PASSWORD;
+        if (password) body.password = password;
         const share = await apiRequest<ReleaseShare>(
           `/api/apps/${appId}/releases/${releaseId}/shares`,
           { method: "POST", body },
@@ -56,6 +62,7 @@ export function registerReleaseCommands(program: Command): void {
         console.log(`Created release share ${share.id}`);
         console.log(`  url:        ${share.share_url ?? ""}`);
         console.log(`  expires_at: ${new Date(share.expires_at).toISOString()}`);
+        if (body.password) console.log("  password:   protected");
       },
     );
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -40,6 +40,8 @@ import {
   handlePublicReleaseShare,
   handleRevokeReleaseShare,
   handleUpdateReleaseShare,
+  handleListAppShares,
+  handlePublicReleaseShareUnlock,
 } from "./routes/shares";
 import {
   handleCreateAppDeployToken,
@@ -416,6 +418,7 @@ app.get("/public/v2/apps/:slug/updates/check", handlePublicV2UpdateCheck);
 app.get("/public/r2/:key", handlePublicR2Download);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);
+app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
 app.get("/api/invites/:token", handleGetInvite);
 
 function isWorkerRoute(pathname: string): boolean {
@@ -524,6 +527,7 @@ admin.delete("/api/apps/:appId/releases/:releaseId", requireAppRole("publisher")
 admin.post("/api/apps/:appId/releases/:releaseId/rollback", requireAppRole("publisher"), handleRollbackRelease);
 admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("publisher"), handleBumpRollout);
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
+admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
 admin.get("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("viewer"), handleListReleaseShares);
 admin.post("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("publisher"), handleCreateReleaseShare);
 admin.patch("/api/apps/:appId/releases/:releaseId/shares/:shareId", requireAppRole("publisher"), handleUpdateReleaseShare);

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -19,6 +19,7 @@ type ShareRow = {
 };
 
 type SharePageRow = {
+  password_hash: string | null;
   share_id: string;
   expires_at: number;
   app_slug: string;
@@ -55,7 +56,12 @@ export async function handleCreateReleaseShare(c: AdminContext) {
   const body = await c.req.json().catch(() => ({})) as {
     ttl_seconds?: number;
     expires_at?: number;
+    password?: string;
   };
+  const password = typeof body.password === "string" ? body.password.trim() : "";
+  if (password.length > 128) {
+    return c.json({ error: "password too long (max 128 chars)" }, 400);
+  }
 
   const release = await c.env.DB.prepare(
     "SELECT id, status FROM releases WHERE app_id = ?1 AND id = ?2",
@@ -78,13 +84,14 @@ export async function handleCreateReleaseShare(c: AdminContext) {
   const token = randomToken();
   const tokenHash = await sha256Hex(token);
   const id = crypto.randomUUID();
+  const passwordHash = password ? await sharePasswordHash(id, password) : null;
 
   await c.env.DB.batch([
     c.env.DB.prepare(
       `INSERT INTO release_shares
-       (id, release_id, token_hash, created_by, created_at, expires_at, revoked_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)`,
-    ).bind(id, releaseId, tokenHash, currentActor(c), now, expiresAt),
+       (id, release_id, token_hash, created_by, created_at, expires_at, revoked_at, password_hash)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7)`,
+    ).bind(id, releaseId, tokenHash, currentActor(c), now, expiresAt, passwordHash),
     c.env.DB.prepare(
       `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
        VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
@@ -93,7 +100,7 @@ export async function handleCreateReleaseShare(c: AdminContext) {
       appId,
       "release_share.create",
       currentActor(c),
-      JSON.stringify({ id, release_id: releaseId, expires_at: expiresAt }),
+      JSON.stringify({ id, release_id: releaseId, expires_at: expiresAt, has_password: Boolean(passwordHash) }),
       now,
     ),
   ]);
@@ -105,6 +112,7 @@ export async function handleCreateReleaseShare(c: AdminContext) {
     share_url: shareUrl,
     expires_at: expiresAt,
     revoked_at: null,
+    has_password: Boolean(passwordHash),
   }, 201);
 }
 
@@ -125,6 +133,7 @@ export async function handleListReleaseShares(c: AdminContext) {
        rs.created_at,
        rs.expires_at,
        rs.revoked_at,
+       (rs.password_hash IS NOT NULL) AS has_password,
        COALESCE(SUM(CASE WHEN rse.event_type = 'view' THEN 1 ELSE 0 END), 0) AS view_count,
        COALESCE(COUNT(DISTINCT CASE WHEN rse.event_type = 'view' THEN rse.visitor_hash END), 0) AS unique_view_count,
        COALESCE(SUM(CASE WHEN rse.event_type = 'download' THEN 1 ELSE 0 END), 0) AS download_count,
@@ -137,6 +146,40 @@ export async function handleListReleaseShares(c: AdminContext) {
   )
     .bind(releaseId)
     .all<ShareRow>();
+  return c.json({ shares: results });
+}
+
+export async function handleListAppShares(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const { results } = await c.env.DB.prepare(
+    `SELECT
+       rs.id,
+       rs.release_id,
+       rs.created_by,
+       rs.created_at,
+       rs.expires_at,
+       rs.revoked_at,
+       (rs.password_hash IS NOT NULL) AS has_password,
+       r.status AS release_status,
+       ch.slug AS channel_slug,
+       b.version_name,
+       b.version_code,
+       COALESCE(SUM(CASE WHEN rse.event_type = 'view' THEN 1 ELSE 0 END), 0) AS view_count,
+       COALESCE(COUNT(DISTINCT CASE WHEN rse.event_type = 'view' THEN rse.visitor_hash END), 0) AS unique_view_count,
+       COALESCE(SUM(CASE WHEN rse.event_type = 'download' THEN 1 ELSE 0 END), 0) AS download_count,
+       COALESCE(COUNT(DISTINCT CASE WHEN rse.event_type = 'download' THEN rse.visitor_hash END), 0) AS unique_download_count
+     FROM release_shares rs
+     JOIN releases r ON r.id = rs.release_id
+     JOIN channels ch ON ch.id = r.channel_id
+     JOIN builds b ON b.id = r.build_id
+     LEFT JOIN release_share_events rse ON rse.share_id = rs.id
+     WHERE r.app_id = ?1
+     GROUP BY rs.id
+     ORDER BY rs.created_at DESC
+     LIMIT 500`,
+  )
+    .bind(appId)
+    .all();
   return c.json({ shares: results });
 }
 
@@ -248,6 +291,11 @@ export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
     return htmlResponse(renderErrorPage("This share link is expired, revoked, or unavailable."), 404);
   }
 
+  if (row.password_hash && !(await hasValidUnlockCookie(c, row))) {
+    await recordShareEvent(c, row.share_id, "view");
+    return htmlResponse(renderPasswordPage(token, false));
+  }
+
   await recordShareEvent(c, row.share_id, "view");
   const stats = await loadShareStats(c.env.DB, row.share_id);
   const origin = publicRequestOrigin(c);
@@ -265,6 +313,10 @@ export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: En
     return htmlResponse(renderErrorPage("This share link is expired, revoked, or unavailable."), 404);
   }
 
+  if (row.password_hash && !(await hasValidUnlockCookie(c, row))) {
+    return c.redirect(`/share/${token}`, 302);
+  }
+
   await recordShareEvent(c, row.share_id, "download");
   const ttl = Number(c.env.SIGNED_URL_TTL_SECONDS ?? "3600");
   const signedUrl = await generateSignedR2Url(
@@ -276,12 +328,96 @@ export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: En
   return c.redirect(signedUrl, 302);
 }
 
+export async function handlePublicReleaseShareUnlock(c: Context<{ Bindings: Env }>) {
+  const token = c.req.param("token");
+  if (!token) return htmlResponse(renderErrorPage("Missing share token"), 400);
+  const row = await findActiveShare(c.env.DB, token);
+  if (!row) {
+    return htmlResponse(renderErrorPage("This share link is expired, revoked, or unavailable."), 404);
+  }
+  if (!row.password_hash) return c.redirect(`/share/${token}`, 302);
+
+  const form = await c.req.parseBody().catch(() => ({} as Record<string, unknown>));
+  const password = typeof form["password"] === "string" ? (form["password"] as string).trim() : "";
+  const candidate = password ? await sharePasswordHash(row.share_id, password) : "";
+  if (!password || candidate !== row.password_hash) {
+    // share_events only allows view/download; failed unlocks belong in the
+    // audit trail anyway.
+    await c.env.DB.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       SELECT ?1, r.app_id, 'release_share.unlock_failed', 'public', ?2, ?3
+       FROM releases r WHERE r.id = ?4`,
+    )
+      .bind(
+        crypto.randomUUID(),
+        JSON.stringify({ share_id: row.share_id }),
+        Date.now(),
+        row.release_id,
+      )
+      .run();
+    return htmlResponse(renderPasswordPage(token, true), 401);
+  }
+
+  const proof = await shareUnlockProof(row, currentDayBucket());
+  const headers = new Headers({
+    location: `/share/${token}`,
+    "set-cookie":
+      `${unlockCookieName(row.share_id)}=${proof}; Path=/share/${encodeURIComponent(token)}; ` +
+      "Max-Age=86400; HttpOnly; Secure; SameSite=Lax",
+  });
+  return new Response(null, { status: 303, headers });
+}
+
+/** Salted password hash; salt is the share id so equal passwords differ per share. */
+async function sharePasswordHash(shareId: string, password: string): Promise<string> {
+  return sha256Hex(`quiver-share-password:${shareId}:${password}`);
+}
+
+/**
+ * Stateless unlock proof: derivable only when the stored password hash is
+ * known server-side, bucketed by day so cookies age out within 48h.
+ */
+async function shareUnlockProof(
+  row: Pick<SharePageRow, "share_id" | "password_hash">,
+  dayBucket: number,
+): Promise<string> {
+  return sha256Hex(`quiver-share-unlock:${row.share_id}:${row.password_hash}:${dayBucket}`);
+}
+
+function currentDayBucket(): number {
+  return Math.floor(Date.now() / 86_400_000);
+}
+
+function unlockCookieName(shareId: string): string {
+  return `qshare_${shareId.slice(0, 8)}`;
+}
+
+async function hasValidUnlockCookie(
+  c: Context<{ Bindings: Env }>,
+  row: Pick<SharePageRow, "share_id" | "password_hash">,
+): Promise<boolean> {
+  const cookieHeader = c.req.header("cookie") ?? "";
+  const name = unlockCookieName(row.share_id);
+  const value = cookieHeader
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+  if (!value) return false;
+  const today = currentDayBucket();
+  for (const bucket of [today, today - 1]) {
+    if (value === (await shareUnlockProof(row, bucket))) return true;
+  }
+  return false;
+}
+
 async function findActiveShare(db: D1Database, token: string): Promise<SharePageRow | null> {
   const tokenHash = await sha256Hex(token);
   return db.prepare(
     `SELECT
        rs.id AS share_id,
        rs.expires_at AS expires_at,
+       rs.password_hash AS password_hash,
        a.slug AS app_slug,
        a.name AS app_name,
        ch.slug AS channel_slug,
@@ -519,6 +655,42 @@ function renderShareQrSvg(url: string): string {
   qr.addData(url);
   qr.make();
   return qr.createSvgTag({ cellSize: 4, margin: 0, scalable: true });
+}
+
+function renderPasswordPage(token: string, failed: boolean): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Password required</title>
+  <style>
+    :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f5f5f2; color: #1e1f22; }
+    main { width: min(360px, calc(100vw - 32px)); }
+    h1 { margin: 0 0 8px; font-size: 22px; }
+    p { margin: 0 0 20px; color: #5b616e; }
+    .error { color: #b3261e; font-weight: 600; }
+    input { width: 100%; box-sizing: border-box; min-height: 44px; padding: 0 12px; border: 1px solid #c8ccd2; border-radius: 6px; font-size: 16px; background: white; color: inherit; }
+    button { margin-top: 12px; width: 100%; min-height: 44px; border: 0; border-radius: 6px; background: #176f5d; color: white; font-weight: 700; font-size: 15px; cursor: pointer; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #17191c; color: #f5f5f2; }
+      p { color: #aeb5bf; }
+      input { background: #1f2226; border-color: #3a3f45; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Password required</h1>
+    <p>${failed ? '<span class="error">Wrong password. Try again.</span>' : "This download is password protected."}</p>
+    <form method="post" action="/share/${escapeAttribute(encodeURIComponent(token))}/unlock">
+      <input type="password" name="password" placeholder="Password" autofocus autocomplete="off" required>
+      <button type="submit">Unlock</button>
+    </form>
+  </main>
+</body>
+</html>`;
 }
 
 function renderErrorPage(message: string): string {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -171,7 +171,8 @@ function makeMockDb() {
       created_by TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       expires_at INTEGER NOT NULL,
-      revoked_at INTEGER
+      revoked_at INTEGER,
+      password_hash TEXT
     );
     CREATE TABLE release_share_events (
       id TEXT PRIMARY KEY,
@@ -2699,6 +2700,101 @@ describe("quiver public API v2 — scope resolution", () => {
       .bind()
       .all();
     expect(events.results).toEqual([{ event_type: "view", count: 1 }]);
+  });
+
+  it("password-protected share gates page and download until unlocked", async () => {
+    const env = makeEnv();
+    const {
+      handleCreateReleaseShare,
+      handlePublicReleaseShare,
+      handlePublicReleaseShareDownload,
+      handlePublicReleaseShareUnlock,
+    } = await import("../src/routes/shares");
+    await seedRelease(env, "rel-pw", "build-pw", [["full", "all"]], {
+      versionCode: 12,
+      versionName: "1.0.12",
+    });
+    await seedAsset(env, "build-pw", "asset-pw", { arch: "arm64-v8a" });
+    const created = await handleCreateReleaseShare(
+      makeShareAdminContext(
+        env,
+        { appId: "app-scope", releaseId: "rel-pw" },
+        { ttl_seconds: 600, password: "hunter2" },
+      ),
+    );
+    const createdBody = await responseJson<any>(created);
+    expect(createdBody.has_password).toBe(true);
+    const token = new URL(createdBody.share_url).pathname.replace("/share/", "");
+
+    // Page shows the password form, not the download.
+    const gated = await handlePublicReleaseShare(makeSharePublicContext(env, token));
+    expect(gated.status).toBe(200);
+    const gatedHtml = await gated.text();
+    expect(gatedHtml).toContain("Password required");
+    expect(gatedHtml).not.toContain("Download APK");
+
+    // Download without unlock bounces back to the page.
+    const blocked = await handlePublicReleaseShareDownload(makeSharePublicContext(env, token));
+    expect(blocked.status).toBe(302);
+    expect(blocked.headers.get("location")).toBe(`/share/${token}`);
+
+    const makeUnlockContext = (password: string, cookie?: string) =>
+      ({
+        env,
+        req: {
+          url: `https://quiver-worker.test/share/${token}/unlock`,
+          param: (name: string) => (name === "token" ? token : ""),
+          query: () => undefined,
+          header: (name: string) =>
+            name.toLowerCase() === "cookie" ? cookie : undefined,
+          parseBody: async () => ({ password }),
+          raw: { cf: { clientIp: "203.0.113.10" } },
+        },
+        redirect: (url: string, status = 302) =>
+          new Response(null, { status, headers: { location: url } }),
+        json: (data: unknown, status = 200) =>
+          new Response(JSON.stringify(data), { status }),
+      }) as any;
+
+    // Wrong password: 401 + failure recorded.
+    const denied = await handlePublicReleaseShareUnlock(makeUnlockContext("nope"));
+    expect(denied.status).toBe(401);
+
+    // Right password: 303 + unlock cookie.
+    const unlocked = await handlePublicReleaseShareUnlock(makeUnlockContext("hunter2"));
+    expect(unlocked.status).toBe(303);
+    const setCookie = unlocked.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("qshare_");
+    const cookiePair = setCookie.split(";")[0]!;
+
+    // With the cookie both page and download work.
+    const open = await handlePublicReleaseShare(
+      makeSharePublicContext(env, token, {
+        "cf-connecting-ip": "203.0.113.10",
+        "user-agent": "vitest",
+        "accept-language": "en-US",
+        cookie: cookiePair,
+      }),
+    );
+    expect(open.status).toBe(200);
+    expect(await open.text()).toContain("Download APK");
+
+    const download = await handlePublicReleaseShareDownload(
+      makeSharePublicContext(env, token, {
+        "cf-connecting-ip": "203.0.113.10",
+        "user-agent": "vitest",
+        cookie: cookiePair,
+      }),
+    );
+    expect(download.status).toBe(302);
+    expect(download.headers.get("location") ?? "").not.toBe(`/share/${token}`);
+
+    const failures = (await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release_share.unlock_failed'",
+    )
+      .bind()
+      .first()) as { count: number } | null;
+    expect(failures?.count).toBe(1);
   });
 
   it("share download redirects to signed R2 and records download stats", async () => {


### PR DESCRIPTION
Task #65 P1 follow-on, per artin's asks in #Quiver: share passwords + centralized management, with API/CLI as first-class citizens (agent-native).

## Password protection
- `release_shares.password_hash` (migration 0025); create API accepts optional `password` (salted SHA-256 per share; never logged, audit records only `has_password`).
- Public share page shows an unlock form; `POST /share/:token/unlock` verifies and sets a stateless, day-bucketed proof cookie scoped to `/share/<token>`; the download endpoint enforces the same proof (no session storage needed).
- Failed unlock attempts are recorded in `audit_logs` (`release_share.unlock_failed`).

## Management
- New `GET /api/apps/:appId/shares` — every share for the app with release/channel/version info, view/download stats, and `has_password`.
- New admin **Shares** tab: status (active/expired/revoked) + password badges, stats, "+7 days" renew, revoke, and a create modal (release picker, TTL, optional password). Share URL is displayed once at creation — tokens stay hashed at rest.

## API/CLI
- `quiver releases share --password <pw>` (or `QUIVER_SHARE_PASSWORD` env to keep it out of shell history); plain `password` field in the create API for CI/agents.

## Ops
- Deploy workflow now runs `wrangler d1 migrations apply quiver-db --remote` before deploying, so schema changes ship atomically with code.

## Verification
- Worker tests 65/65 (new end-to-end test: gated page, blocked download, wrong-password 401 + audit row, unlock cookie, unlocked page/download).
- `tsc --noEmit`, admin build, CLI build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)