### PR TITLE
feat(admin): shared app header, unified layout, share password editing

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -278,7 +278,9 @@ function Header({ account }: { account: AuthAccount }) {
 
 function AppContextNav() {
   const { appId } = useParams();
+  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
   if (!appId) return null;
+  const app = apps.data?.apps.find((a) => a.id === appId);
   const base = `/apps/${appId}`;
   const tabClass = ({ isActive }: { isActive: boolean }) =>
     `inline-flex h-9 items-center rounded-md px-3 text-sm ${
@@ -289,6 +291,22 @@ function AppContextNav() {
 
   return (
     <div className="bg-white border-b border-slate-200 -mt-px">
+      <div className="max-w-5xl mx-auto px-4 pt-4 flex items-baseline gap-3">
+        <h1 className="text-xl font-bold leading-tight">
+          {app?.name ?? "…"}
+        </h1>
+        {app?.platform && (
+          <span className="badge-blue align-middle">{app.platform}</span>
+        )}
+        {app?.slug && (
+          <span className="text-sm text-slate-500 font-mono">{app.slug}</span>
+        )}
+        {Boolean(app?.archived) && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800">
+            archived
+          </span>
+        )}
+      </div>
       <div className="max-w-5xl mx-auto px-4 py-2 flex items-center gap-1">
         <NavLink
           to={base}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1048,7 +1048,7 @@ export const renewReleaseShare = (
   appId: string,
   releaseId: string,
   shareId: string,
-  body: { ttl_seconds?: number; expires_at?: number },
+  body: { ttl_seconds?: number; expires_at?: number; password?: string | null },
 ) =>
   request<{ id: string; expires_at: number }>(
     `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -27,7 +27,6 @@ export function AppDetail({ appId }: { appId: string }) {
 
   return (
     <div>
-      <AppHeading app={app} />
       {apps.error && (
         <AppErrorBanner
           title="Cannot load apps"
@@ -103,19 +102,6 @@ function AppErrorBanner({
   );
 }
 
-function AppHeading({ app }: { app?: App }) {
-  return (
-    <div className="mb-6">
-      <div className="text-sm text-slate-500">App</div>
-      <h1 className="text-2xl font-bold">
-        {app?.name ?? "..."}{" "}
-        <span className="badge-blue align-middle">{app?.platform}</span>
-      </h1>
-      <div className="text-sm text-slate-500 font-mono">{app?.slug}</div>
-    </div>
-  );
-}
-
 export function AppChannels({ appId }: { appId: string }) {
   const qc = useQueryClient();
   const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
@@ -129,7 +115,6 @@ export function AppChannels({ appId }: { appId: string }) {
 
   return (
     <div>
-      <AppHeading app={app} />
 
       <section>
         <div className="flex items-center justify-between mb-3">
@@ -218,7 +203,6 @@ export function AppSettings({ appId }: { appId: string }) {
 
   return (
     <div>
-      <AppHeading app={app} />
 
       <div className="card !p-4 text-sm space-y-3">
         <h2 className="text-base font-semibold">Settings</h2>

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -50,6 +50,28 @@ export function AppShares({ appId }: { appId: string }) {
       }),
   });
 
+  const setPassword = useMutation({
+    mutationFn: ({ share, password }: { share: AppShare; password: string | null }) =>
+      renewReleaseShare(appId, share.release_id, share.id, {
+        // PATCH requires an expiry; keep the current one.
+        expires_at: share.expires_at,
+        password,
+      }),
+    onSuccess: (_data, vars) => {
+      toast.show({
+        kind: "success",
+        title: vars.password ? "Password set" : "Password removed",
+      });
+      invalidate();
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Password update failed",
+        description: (e as Error).message,
+      }),
+  });
+
   const revoke = useMutation({
     mutationFn: (share: AppShare) =>
       revokeReleaseShare(appId, share.release_id, share.id),
@@ -68,7 +90,7 @@ export function AppShares({ appId }: { appId: string }) {
   const rows = shares.data?.shares ?? [];
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-bold">Shares</h2>
@@ -133,7 +155,19 @@ export function AppShares({ appId }: { appId: string }) {
                   share={share}
                   onRenew={() => renew.mutate(share)}
                   onRevoke={() => revoke.mutate(share)}
-                  busy={renew.isPending || revoke.isPending}
+                  onSetPassword={() => {
+                    const next = window.prompt(
+                      share.has_password
+                        ? "New password (leave empty to remove the password):"
+                        : "Password for this share:",
+                    );
+                    if (next === null) return;
+                    setPassword.mutate({
+                      share,
+                      password: next.trim() ? next.trim() : null,
+                    });
+                  }}
+                  busy={renew.isPending || revoke.isPending || setPassword.isPending}
                 />
               ))}
             </tbody>
@@ -166,11 +200,13 @@ function ShareRow({
   share,
   onRenew,
   onRevoke,
+  onSetPassword,
   busy,
 }: {
   share: AppShare;
   onRenew: () => void;
   onRevoke: () => void;
+  onSetPassword: () => void;
   busy: boolean;
 }) {
   const state = shareState(share);
@@ -213,6 +249,9 @@ function ShareRow({
           <>
             <button className="text-blue-600 hover:underline mr-2" onClick={onRenew} disabled={busy}>
               +7 days
+            </button>
+            <button className="text-blue-600 hover:underline mr-2" onClick={onSetPassword} disabled={busy}>
+              {share.has_password ? "Password…" : "Set password"}
             </button>
             <button className="text-red-600 hover:underline" onClick={onRevoke} disabled={busy}>
               Revoke

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -228,6 +228,7 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
   const body = await c.req.json().catch(() => ({})) as {
     ttl_seconds?: number;
     expires_at?: number;
+    password?: string | null;
   };
   const now = Date.now();
 
@@ -252,9 +253,32 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
     return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
   }
 
+  // password: undefined = leave unchanged, null/"" = clear, string = set.
+  let passwordChange: "unchanged" | "cleared" | "set" = "unchanged";
+  let passwordHash: string | null = null;
+  if (body.password !== undefined) {
+    const trimmed = typeof body.password === "string" ? body.password.trim() : "";
+    if (trimmed.length > 128) {
+      return c.json({ error: "password too long (max 128 chars)" }, 400);
+    }
+    if (trimmed) {
+      passwordHash = await sharePasswordHash(existing.id, trimmed);
+      passwordChange = "set";
+    } else {
+      passwordChange = "cleared";
+    }
+  }
+
+  const updateStmt =
+    passwordChange === "unchanged"
+      ? c.env.DB.prepare("UPDATE release_shares SET expires_at = ?1 WHERE id = ?2")
+          .bind(expiresAt, shareId)
+      : c.env.DB.prepare(
+          "UPDATE release_shares SET expires_at = ?1, password_hash = ?2 WHERE id = ?3",
+        ).bind(expiresAt, passwordHash, shareId);
+
   await c.env.DB.batch([
-    c.env.DB.prepare("UPDATE release_shares SET expires_at = ?1 WHERE id = ?2")
-      .bind(expiresAt, shareId),
+    updateStmt,
     c.env.DB.prepare(
       `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
        VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
@@ -268,6 +292,7 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
         release_id: releaseId,
         previous_expires_at: existing.expires_at,
         expires_at: expiresAt,
+        password_change: passwordChange,
       }),
       now,
     ),

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2797,6 +2797,50 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(failures?.count).toBe(1);
   });
 
+  it("share PATCH can set and clear a password on an existing share", async () => {
+    const env = makeEnv();
+    const {
+      handleCreateReleaseShare,
+      handleUpdateReleaseShare,
+      handlePublicReleaseShare,
+    } = await import("../src/routes/shares");
+    await seedRelease(env, "rel-pw2", "build-pw2", [["full", "all"]], {
+      versionCode: 13,
+      versionName: "1.0.13",
+    });
+    await seedAsset(env, "build-pw2", "asset-pw2", { arch: "arm64-v8a" });
+    const created = await handleCreateReleaseShare(
+      makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-pw2" }, { ttl_seconds: 600 }),
+    );
+    const createdBody = await responseJson<any>(created);
+    expect(createdBody.has_password).toBe(false);
+    const token = new URL(createdBody.share_url).pathname.replace("/share/", "");
+
+    // Set a password on the existing share.
+    const setResp = await handleUpdateReleaseShare(
+      makeShareAdminContext(
+        env,
+        { appId: "app-scope", releaseId: "rel-pw2", shareId: createdBody.id },
+        { expires_at: createdBody.expires_at, password: "s3cret" },
+      ),
+    );
+    expect(setResp.status).toBe(200);
+    const gated = await handlePublicReleaseShare(makeSharePublicContext(env, token));
+    expect(await gated.text()).toContain("Password required");
+
+    // Clear it again.
+    const clearResp = await handleUpdateReleaseShare(
+      makeShareAdminContext(
+        env,
+        { appId: "app-scope", releaseId: "rel-pw2", shareId: createdBody.id },
+        { expires_at: createdBody.expires_at, password: null },
+      ),
+    );
+    expect(clearResp.status).toBe(200);
+    const open = await handlePublicReleaseShare(makeSharePublicContext(env, token));
+    expect(await open.text()).toContain("Download APK");
+  });
+
   it("share download redirects to signed R2 and records download stats", async () => {
     const env = makeEnv();
     const {


### PR DESCRIPTION
Follow-ups from #Quiver task #65 thread (artin's screenshot feedback + "existing shares can't set a password"):

## Layout
- App identity (name, platform badge, slug, archived flag) promoted into the shared header above the tab bar — visible on all eight app sub-pages, not just the three that embedded `AppHeading`. Duplicate card removed from Overview/Channels/Settings.
- Shares page no longer double-wraps the AppShell container (was the only page doing so).

## Share password editing
- `PATCH /api/apps/:appId/releases/:releaseId/shares/:shareId` accepts `password`: string sets/replaces, `null`/empty clears; `password_change` recorded in the audit payload.
- Shares tab: "Set password" / "Password…" row action (prompt-based; empty input removes).
- CLI note: `renewReleaseShare` API client carries the same field; CLI subcommand for editing can follow if needed (creation already supports `--password`).

Verification: worker tests 66/66 (new test: PATCH sets password → page gated; PATCH null → page open), worker+admin `tsc --noEmit` clean, admin build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)