### PR TITLE
fix(admin): dedupe app identity from page bodies, air out app header

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -291,8 +291,8 @@ function AppContextNav() {
 
   return (
     <div className="bg-white border-b border-slate-200 -mt-px">
-      <div className="max-w-5xl mx-auto px-4 pt-4 flex items-baseline gap-3">
-        <h1 className="text-xl font-bold leading-tight">
+      <div className="max-w-5xl mx-auto px-4 pt-6 pb-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+        <h1 className="text-2xl font-bold leading-tight">
           {app?.name ?? "…"}
         </h1>
         {app?.platform && (
@@ -307,7 +307,7 @@ function AppContextNav() {
           </span>
         )}
       </div>
-      <div className="max-w-5xl mx-auto px-4 py-2 flex items-center gap-1">
+      <div className="max-w-5xl mx-auto px-4 pt-2 pb-3 flex items-center gap-1 overflow-x-auto">
         <NavLink
           to={base}
           end

--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -43,17 +43,10 @@ export function Builds({ appId }: { appId: string }) {
   const [prepareBuild, setPrepareBuild] = useState<Build | null>(null);
 
   return (
-    <div className="p-4">
-      <div className="mb-6">
+    <div>
+      <div className="mb-4">
         <div className="flex items-center justify-between">
-          <div>
-            <div className="text-sm text-slate-500">Builds</div>
-            <h1 className="text-2xl font-bold">
-              {thisApp?.name ?? "..."}
-              <span className="badge-blue align-middle ml-2">{thisApp?.platform}</span>
-            </h1>
-            <div className="text-sm text-slate-500 font-mono">{thisApp?.slug}</div>
-          </div>
+          <h2 className="text-lg font-semibold">Builds</h2>
           <a
             href={`/apps/${appId}/releases`}
             className="btn-primary text-sm no-underline"

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -146,15 +146,8 @@ export function Releases({ appId }: { appId: string }) {
 
   return (
     <div>
-      <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <div className="text-sm text-slate-500">Releases</div>
-          <h1 className="text-2xl font-bold">
-            {thisApp?.name ?? "..."}
-            <span className="badge-blue align-middle ml-2">{thisApp?.platform}</span>
-          </h1>
-          <div className="text-sm text-slate-500 font-mono">{thisApp?.slug}</div>
-        </div>
+      <div className="mb-4 flex items-center justify-between gap-4 flex-wrap">
+        <h2 className="text-lg font-semibold">Releases</h2>
         <button
           className="btn-primary text-sm"
           onClick={() => setShowNewRelease(true)}


### PR DESCRIPTION
Follow-up to #7 per artin's screenshot: Releases/Builds body identity blocks removed (slim page titles remain), shared header gets larger title + breathing room, tab row scrolls on overflow, Builds rogue p-4 wrapper dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)