### PR TITLE
feat(feedback): SDK-facing ticket submission and admin triage

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -18,6 +18,7 @@ import { Settings } from "./pages/Settings";
 import { Builds } from "./pages/Builds";
 import { Releases } from "./pages/Releases";
 import { AppShares } from "./pages/Shares";
+import { AppFeedback } from "./pages/Feedback";
 import { OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
@@ -335,6 +336,12 @@ function AppContextNav() {
           Shares
         </NavLink>
         <NavLink
+          to={`${base}/feedback`}
+          className={tabClass}
+        >
+          Feedback
+        </NavLink>
+        <NavLink
           to={`${base}/builds`}
           className={tabClass}
         >
@@ -380,6 +387,12 @@ function AppSettingsRoute() {
   const { appId } = useParams();
   if (!appId) return null;
   return <AppSettings appId={appId} />;
+}
+
+function AppFeedbackRoute() {
+  const { appId } = useParams();
+  if (!appId) return null;
+  return <AppFeedback appId={appId} />;
 }
 
 function AppSharesRoute() {
@@ -693,6 +706,7 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
           <Route path="builds" element={<BuildsRoute />} />
           <Route path="releases" element={<ReleasesRoute />} />
           <Route path="shares" element={<AppSharesRoute />} />
+          <Route path="feedback" element={<AppFeedbackRoute />} />
           <Route path="access" element={<AppAccessRoute />} />
           <Route path="audit" element={<AuditRoute />} />
           <Route path="settings" element={<AppSettingsRoute />} />
@@ -757,6 +771,7 @@ function AppShell() {
           <Route path="builds" element={<BuildsRoute />} />
           <Route path="releases" element={<ReleasesRoute />} />
           <Route path="shares" element={<AppSharesRoute />} />
+          <Route path="feedback" element={<AppFeedbackRoute />} />
           <Route path="access" element={<AppAccessRoute />} />
           <Route path="audit" element={<AuditRoute />} />
           <Route path="settings" element={<AppSettingsRoute />} />

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1060,3 +1060,76 @@ export const revokeReleaseShare = (appId: string, releaseId: string, shareId: st
     `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,
     { method: "DELETE", admin: true },
   );
+
+// ---- Feedback tickets (task #66) ----
+
+export interface FeedbackTicket {
+  id: string;
+  kind: "feedback" | "bug" | "crash";
+  status: "open" | "in_progress" | "resolved" | "closed";
+  message: string;
+  contact: string | null;
+  version_name: string | null;
+  version_code: number | null;
+  channel: string | null;
+  device_model: string | null;
+  os_version: string | null;
+  created_at: number;
+  updated_at: number;
+  attachment_count: number;
+  comment_count: number;
+}
+
+export interface FeedbackDetail {
+  ticket: FeedbackTicket & {
+    device_id: string | null;
+    arch: string | null;
+    locale: string | null;
+    metadata_json: string;
+  };
+  attachments: Array<{
+    id: string;
+    filename: string;
+    content_type: string | null;
+    size_bytes: number;
+    created_at: number;
+  }>;
+  comments: Array<{
+    id: string;
+    author_actor: string;
+    body: string;
+    internal: number;
+    created_at: number;
+  }>;
+}
+
+export const listFeedback = (appId: string, filters?: { status?: string | undefined; kind?: string | undefined }) => {
+  const params = new URLSearchParams();
+  if (filters?.status) params.set("status", filters.status);
+  if (filters?.kind) params.set("kind", filters.kind);
+  const qs = params.toString();
+  return request<{ tickets: FeedbackTicket[] }>(
+    `/api/apps/${appId}/feedback${qs ? `?${qs}` : ""}`,
+    { admin: true },
+  );
+};
+
+export const getFeedback = (appId: string, ticketId: string) =>
+  request<FeedbackDetail>(`/api/apps/${appId}/feedback/${ticketId}`, { admin: true });
+
+export const updateFeedbackStatus = (appId: string, ticketId: string, status: string) =>
+  request<{ id: string; status: string }>(`/api/apps/${appId}/feedback/${ticketId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ status }),
+    admin: true,
+  });
+
+export const addFeedbackComment = (appId: string, ticketId: string, body: string) =>
+  request<{ id: string }>(`/api/apps/${appId}/feedback/${ticketId}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+    admin: true,
+  });
+
+export const feedbackAttachmentUrl = (appId: string, ticketId: string, attachmentId: string) =>
+  `/api/apps/${appId}/feedback/${ticketId}/attachments/${attachmentId}`;

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -1,0 +1,324 @@
+/**
+ * Feedback ticket triage (task #66): list + filter tickets submitted from
+ * the app SDK, inspect device context and attachments, move status, and
+ * keep a comment trail.
+ */
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  FeedbackTicket,
+  addFeedbackComment,
+  feedbackAttachmentUrl,
+  getFeedback,
+  listFeedback,
+  updateFeedbackStatus,
+} from "../lib/api";
+import { useToast } from "../components/Toast";
+
+const STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
+
+const STATUS_STYLES: Record<string, string> = {
+  open: "bg-red-100 text-red-800",
+  in_progress: "bg-sky-100 text-sky-800",
+  resolved: "bg-emerald-100 text-emerald-800",
+  closed: "bg-slate-200 text-slate-600",
+};
+
+const KIND_STYLES: Record<string, string> = {
+  feedback: "bg-slate-100 text-slate-700",
+  bug: "bg-amber-100 text-amber-800",
+  crash: "bg-red-100 text-red-800",
+};
+
+export function AppFeedback({ appId }: { appId: string }) {
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [kindFilter, setKindFilter] = useState<string>("");
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const tickets = useQuery({
+    queryKey: ["feedback", appId, statusFilter, kindFilter],
+    queryFn: () =>
+      listFeedback(appId, {
+        status: statusFilter || undefined,
+        kind: kindFilter || undefined,
+      }),
+  });
+
+  const rows = tickets.data?.tickets ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">Feedback</h2>
+          <p className="text-sm text-slate-500">
+            Tickets submitted from the app (SDK <code>POST /public/v2/apps/&lt;slug&gt;/feedback</code>).
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <select
+            className="rounded border border-slate-300 px-2 py-1.5"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="">All statuses</option>
+            {STATUSES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
+            className="rounded border border-slate-300 px-2 py-1.5"
+            value={kindFilter}
+            onChange={(e) => setKindFilter(e.target.value)}
+          >
+            <option value="">All kinds</option>
+            <option value="feedback">feedback</option>
+            <option value="bug">bug</option>
+            <option value="crash">crash</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="card overflow-x-auto">
+        {tickets.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+        {tickets.error && (
+          <p className="text-sm text-red-600">
+            Failed to load feedback: {(tickets.error as Error).message}
+          </p>
+        )}
+        {!tickets.isLoading && rows.length === 0 && (
+          <p className="text-sm text-slate-500">No feedback tickets yet.</p>
+        )}
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-slate-500 border-b border-slate-200">
+                <th className="py-2 pr-3">Ticket</th>
+                <th className="py-2 pr-3">Status</th>
+                <th className="py-2 pr-3">App version</th>
+                <th className="py-2 pr-3">Device</th>
+                <th className="py-2 pr-3">Created</th>
+                <th className="py-2 pr-3">📎</th>
+                <th className="py-2 pr-3">💬</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((t) => (
+                <tr
+                  key={t.id}
+                  className="border-b border-slate-100 last:border-0 cursor-pointer hover:bg-slate-50"
+                  onClick={() => setSelected(t.id)}
+                >
+                  <td className="py-2 pr-3 max-w-md">
+                    <span className={`rounded px-1.5 py-0.5 text-xs font-medium mr-2 ${KIND_STYLES[t.kind]}`}>
+                      {t.kind}
+                    </span>
+                    <span className="align-middle">{t.message.slice(0, 80)}{t.message.length > 80 ? "…" : ""}</span>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_STYLES[t.status]}`}>
+                      {t.status}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-3 text-xs text-slate-600">
+                    {t.version_name ?? "—"}{t.version_code ? ` (${t.version_code})` : ""}
+                  </td>
+                  <td className="py-2 pr-3 text-xs text-slate-600">
+                    {[t.device_model, t.os_version && `Android ${t.os_version}`].filter(Boolean).join(" · ") || "—"}
+                  </td>
+                  <td className="py-2 pr-3 text-xs text-slate-600">
+                    {new Date(t.created_at).toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-xs">{t.attachment_count || ""}</td>
+                  <td className="py-2 pr-3 text-xs">{t.comment_count || ""}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {selected && (
+        <TicketDetail
+          appId={appId}
+          ticketId={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function TicketDetail({
+  appId,
+  ticketId,
+  onClose,
+}: {
+  appId: string;
+  ticketId: string;
+  onClose: () => void;
+}) {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const [comment, setComment] = useState("");
+
+  const detail = useQuery({
+    queryKey: ["feedback-detail", appId, ticketId],
+    queryFn: () => getFeedback(appId, ticketId),
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["feedback-detail", appId, ticketId] });
+    queryClient.invalidateQueries({ queryKey: ["feedback", appId] });
+  };
+
+  const setStatus = useMutation({
+    mutationFn: (status: string) => updateFeedbackStatus(appId, ticketId, status),
+    onSuccess: (data) => {
+      toast.show({ kind: "success", title: `Status → ${data.status}` });
+      invalidate();
+    },
+    onError: (e) =>
+      toast.show({ kind: "error", title: "Status update failed", description: (e as Error).message }),
+  });
+
+  const addComment = useMutation({
+    mutationFn: () => addFeedbackComment(appId, ticketId, comment.trim()),
+    onSuccess: () => {
+      setComment("");
+      invalidate();
+    },
+    onError: (e) =>
+      toast.show({ kind: "error", title: "Comment failed", description: (e as Error).message }),
+  });
+
+  const t = detail.data?.ticket;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-black/30" onClick={onClose}>
+      <div
+        className="h-full w-full max-w-xl overflow-y-auto bg-white p-5 shadow-xl space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {detail.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+        {detail.error && (
+          <p className="text-sm text-red-600">{(detail.error as Error).message}</p>
+        )}
+        {t && (
+          <>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${KIND_STYLES[t.kind]}`}>{t.kind}</span>
+                  <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_STYLES[t.status]}`}>{t.status}</span>
+                </div>
+                <h3 className="mt-2 text-base font-semibold">Ticket {t.id.slice(0, 8)}</h3>
+                <p className="text-xs text-slate-500">
+                  {new Date(t.created_at).toLocaleString()}
+                  {t.contact ? ` · ${t.contact}` : ""}
+                </p>
+              </div>
+              <button className="btn-secondary text-xs" onClick={onClose}>Close</button>
+            </div>
+
+            <div className="rounded border border-slate-200 bg-slate-50 p-3 text-sm whitespace-pre-wrap">
+              {t.message}
+            </div>
+
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+              <dt className="text-slate-500">App version</dt>
+              <dd>{t.version_name ?? "—"} {t.version_code ? `(${t.version_code})` : ""}</dd>
+              <dt className="text-slate-500">Channel</dt>
+              <dd>{t.channel ?? "—"}</dd>
+              <dt className="text-slate-500">Device</dt>
+              <dd>{t.device_model ?? "—"}</dd>
+              <dt className="text-slate-500">OS / arch</dt>
+              <dd>{[t.os_version, t.arch].filter(Boolean).join(" / ") || "—"}</dd>
+              <dt className="text-slate-500">Locale</dt>
+              <dd>{t.locale ?? "—"}</dd>
+              <dt className="text-slate-500">Device id</dt>
+              <dd className="font-mono">{t.device_id ?? "—"}</dd>
+            </dl>
+
+            {detail.data!.attachments.length > 0 && (
+              <div>
+                <h4 className="text-sm font-semibold mb-1">Attachments</h4>
+                <ul className="space-y-1 text-sm">
+                  {detail.data!.attachments.map((a) => (
+                    <li key={a.id}>
+                      <a
+                        className="text-blue-600 hover:underline"
+                        href={feedbackAttachmentUrl(appId, ticketId, a.id)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {a.filename}
+                      </a>
+                      <span className="ml-2 text-xs text-slate-400">
+                        {(a.size_bytes / 1024).toFixed(1)} KB
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div>
+              <h4 className="text-sm font-semibold mb-1">Status</h4>
+              <div className="flex gap-2">
+                {STATUSES.map((s) => (
+                  <button
+                    key={s}
+                    className={
+                      s === t.status
+                        ? "rounded border border-slate-900 bg-slate-900 px-2 py-1 text-xs text-white"
+                        : "rounded border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100"
+                    }
+                    disabled={setStatus.isPending || s === t.status}
+                    onClick={() => setStatus.mutate(s)}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h4 className="text-sm font-semibold mb-1">
+                Comments ({detail.data!.comments.length})
+              </h4>
+              <ul className="space-y-2 text-sm">
+                {detail.data!.comments.map((cm) => (
+                  <li key={cm.id} className="rounded border border-slate-200 p-2">
+                    <div className="text-xs text-slate-500">
+                      {cm.author_actor} · {new Date(cm.created_at).toLocaleString()}
+                    </div>
+                    <div className="whitespace-pre-wrap">{cm.body}</div>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-2 flex gap-2">
+                <input
+                  className="flex-1 rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  placeholder="Add a comment…"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && comment.trim()) addComment.mutate();
+                  }}
+                />
+                <button
+                  className="btn-primary text-sm"
+                  disabled={addComment.isPending || !comment.trim()}
+                  onClick={() => addComment.mutate()}
+                >
+                  Send
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverFeedback.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverFeedback.kt
@@ -1,0 +1,125 @@
+package io.quiver.update
+
+import android.content.Context
+import android.os.Build
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+/**
+ * Feedback submission to the Quiver server (companion to UpdateChecker).
+ *
+ * Posts `multipart/form-data` to `POST /public/v2/apps/{slug}/feedback` with
+ * the message, optional contact, optional attachments (screenshots, logs;
+ * server caps: 3 files, 10 MB each), and device/app metadata including the
+ * same persistent device id used for staged rollouts so tickets can be
+ * correlated with rollout cohorts.
+ */
+class QuiverFeedback(
+    private val context: Context,
+    private val baseUrl: String,
+    private val appSlug: String,
+    private val versionName: String? = null,
+    private val versionCode: Long? = null,
+    private val channel: String? = null,
+    private val httpClient: OkHttpClient = defaultClient(),
+) {
+    /**
+     * @param message  user-visible feedback text (required)
+     * @param kind     "feedback" | "bug" | "crash"
+     * @param contact  optional reply-to handle (email, Raft name, …)
+     * @param attachments up to 3 files, 10 MB each (server enforced)
+     * @param extras   extra metadata merged into the ticket's metadata_json
+     * @return ticket id
+     */
+    suspend fun submit(
+        message: String,
+        kind: String = "feedback",
+        contact: String? = null,
+        attachments: List<File> = emptyList(),
+        extras: Map<String, Any?> = emptyMap(),
+    ): String = withContext(Dispatchers.IO) {
+        require(message.isNotBlank()) { "message must not be blank" }
+
+        val metadata = JSONObject().apply {
+            versionName?.let { put("version_name", it) }
+            versionCode?.let { put("version_code", it) }
+            channel?.let { put("channel", it) }
+            put("device_id", QuiverDeviceId.get(context))
+            put("device_model", "${Build.MANUFACTURER} ${Build.MODEL}".trim())
+            put("os_version", Build.VERSION.RELEASE ?: Build.VERSION.SDK_INT.toString())
+            put("arch", Build.SUPPORTED_ABIS.firstOrNull() ?: "unknown")
+            put("locale", Locale.getDefault().toLanguageTag())
+            for ((key, value) in extras) put(key, value ?: JSONObject.NULL)
+        }
+
+        val bodyBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
+            .addFormDataPart("message", message)
+            .addFormDataPart("kind", kind)
+            .addFormDataPart("metadata", metadata.toString())
+        if (!contact.isNullOrBlank()) {
+            bodyBuilder.addFormDataPart("contact", contact)
+        }
+        for (file in attachments.take(3)) {
+            if (!file.isFile) continue
+            bodyBuilder.addFormDataPart(
+                "attachments",
+                file.name,
+                file.asRequestBody(guessMediaType(file.name).toMediaTypeOrNull()),
+            )
+        }
+
+        val url = baseUrl.trimEnd('/').toHttpUrl().newBuilder()
+            .addPathSegments("public/v2/apps")
+            .addPathSegment(appSlug)
+            .addPathSegment("feedback")
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("accept", "application/json")
+            .post(bodyBuilder.build())
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (response.code !in 200..299) {
+                throw QuiverFeedbackException(response.code, body.take(300))
+            }
+            // {"id":"…","status":"open","attachments":N}
+            JSONObject(body).optString("id").ifBlank {
+                throw QuiverFeedbackException(response.code, "missing ticket id in response")
+            }
+        }
+    }
+
+    private fun guessMediaType(name: String): String = when {
+        name.endsWith(".png", true) -> "image/png"
+        name.endsWith(".jpg", true) || name.endsWith(".jpeg", true) -> "image/jpeg"
+        name.endsWith(".webp", true) -> "image/webp"
+        name.endsWith(".txt", true) || name.endsWith(".log", true) -> "text/plain"
+        name.endsWith(".json", true) || name.endsWith(".jsonl", true) -> "application/json"
+        name.endsWith(".zip", true) -> "application/zip"
+        else -> "application/octet-stream"
+    }
+
+    companion object {
+        fun defaultClient(): OkHttpClient = OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+}
+
+class QuiverFeedbackException(val code: Int, detail: String) :
+    RuntimeException("feedback submission failed (HTTP $code): $detail")

--- a/migrations/sql/0026_feedback_tickets.sql
+++ b/migrations/sql/0026_feedback_tickets.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS feedback_tickets (
+  id TEXT PRIMARY KEY,
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL DEFAULT 'feedback' CHECK (kind IN ('feedback', 'bug', 'crash')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'resolved', 'closed')),
+  message TEXT NOT NULL,
+  contact TEXT,
+  version_name TEXT,
+  version_code INTEGER,
+  channel TEXT,
+  device_id TEXT,
+  device_model TEXT,
+  os_version TEXT,
+  arch TEXT,
+  locale TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  client_ip_hash TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_app
+  ON feedback_tickets(app_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_rate
+  ON feedback_tickets(app_id, client_ip_hash, created_at);
+
+CREATE TABLE IF NOT EXISTS feedback_attachments (
+  id TEXT PRIMARY KEY,
+  ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  r2_key TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  content_type TEXT,
+  size_bytes INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_attachments_ticket
+  ON feedback_attachments(ticket_id);
+
+CREATE TABLE IF NOT EXISTS feedback_comments (
+  id TEXT PRIMARY KEY,
+  ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  author_actor TEXT NOT NULL,
+  body TEXT NOT NULL,
+  internal INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_comments_ticket
+  ON feedback_comments(ticket_id, created_at);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -44,6 +44,14 @@ import {
   handlePublicReleaseShareUnlock,
 } from "./routes/shares";
 import {
+  handlePublicFeedbackSubmit,
+  handleListFeedback,
+  handleGetFeedback,
+  handleUpdateFeedback,
+  handleAddFeedbackComment,
+  handleDownloadFeedbackAttachment,
+} from "./routes/feedback";
+import {
   handleCreateAppDeployToken,
   handleListAppDeployTokens,
   handleRevokeAppDeployToken,
@@ -419,6 +427,7 @@ app.get("/public/r2/:key", handlePublicR2Download);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
+app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
 app.get("/api/invites/:token", handleGetInvite);
 
 function isWorkerRoute(pathname: string): boolean {
@@ -528,6 +537,11 @@ admin.post("/api/apps/:appId/releases/:releaseId/rollback", requireAppRole("publ
 admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("publisher"), handleBumpRollout);
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
+admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
+admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
+admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);
+admin.post("/api/apps/:appId/feedback/:ticketId/comments", requireAppRole("publisher"), handleAddFeedbackComment);
+admin.get("/api/apps/:appId/feedback/:ticketId/attachments/:attachmentId", requireAppRole("viewer"), handleDownloadFeedbackAttachment);
 admin.get("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("viewer"), handleListReleaseShares);
 admin.post("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("publisher"), handleCreateReleaseShare);
 admin.patch("/api/apps/:appId/releases/:releaseId/shares/:shareId", requireAppRole("publisher"), handleUpdateReleaseShare);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -1,0 +1,337 @@
+/**
+ * Feedback tickets (task #66): public SDK-facing submission endpoint plus
+ * admin ticket management.
+ *
+ * Public submit is unauthenticated (like update checks) but rate-limited per
+ * app + hashed client IP. Attachments live in R2 under feedback/…; admins
+ * download them through an authenticated streaming endpoint (no presign
+ * needed).
+ */
+import type { Context } from "hono";
+import { currentActor, type AdminEnv } from "../middleware/auth";
+import { emitWebhookEvent } from "./webhooks";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+const MAX_ATTACHMENTS = 3;
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const MAX_MESSAGE_CHARS = 10_000;
+const RATE_LIMIT_PER_HOUR = 10;
+
+const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
+const TICKET_KINDS = ["feedback", "bug", "crash"] as const;
+
+export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await c.env.DB.prepare(
+    "SELECT id, org_id, slug FROM apps WHERE slug = ?1 AND archived = 0",
+  )
+    .bind(slug)
+    .first<{ id: string; org_id: string | null; slug: string }>();
+  if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
+
+  let form: FormData;
+  try {
+    form = await c.req.formData();
+  } catch {
+    return c.json({ error: "multipart/form-data body required" }, 400);
+  }
+
+  const message = String(form.get("message") ?? "").trim();
+  if (!message) return c.json({ error: "message is required" }, 400);
+  if (message.length > MAX_MESSAGE_CHARS) {
+    return c.json({ error: `message too long (max ${MAX_MESSAGE_CHARS} chars)` }, 400);
+  }
+  const kindRaw = String(form.get("kind") ?? "feedback");
+  const kind = (TICKET_KINDS as readonly string[]).includes(kindRaw) ? kindRaw : "feedback";
+  const contact = String(form.get("contact") ?? "").trim() || null;
+
+  let metadata: Record<string, unknown> = {};
+  const metadataRaw = form.get("metadata");
+  if (typeof metadataRaw === "string" && metadataRaw.trim()) {
+    try {
+      const parsed = JSON.parse(metadataRaw);
+      if (parsed && typeof parsed === "object") metadata = parsed as Record<string, unknown>;
+    } catch {
+      return c.json({ error: "metadata must be valid JSON" }, 400);
+    }
+  }
+  const meta = (key: string, max = 200): string | null => {
+    const value = metadata[key];
+    if (value === undefined || value === null) return null;
+    return String(value).slice(0, max) || null;
+  };
+  const versionCodeRaw = metadata["version_code"];
+  const versionCode =
+    typeof versionCodeRaw === "number" && Number.isFinite(versionCodeRaw)
+      ? Math.trunc(versionCodeRaw)
+      : null;
+
+  // Rate limit per app + hashed client ip.
+  const clientIp =
+    (c.req.raw?.cf as { clientIp?: string } | undefined)?.clientIp ??
+    c.req.header("cf-connecting-ip") ??
+    "unknown";
+  const clientIpHash = await sha256Hex(`feedback:${app.id}:${clientIp}`);
+  const oneHourAgo = Date.now() - 3600_000;
+  const recent = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS count FROM feedback_tickets
+     WHERE app_id = ?1 AND client_ip_hash = ?2 AND created_at > ?3`,
+  )
+    .bind(app.id, clientIpHash, oneHourAgo)
+    .first<{ count: number }>();
+  if ((recent?.count ?? 0) >= RATE_LIMIT_PER_HOUR) {
+    return c.json({ error: "too many feedback submissions; try again later" }, 429);
+  }
+
+  // Collect attachments before writing anything.
+  const files: File[] = [];
+  for (const entry of form.getAll("attachments")) {
+    if (typeof entry === "string") continue;
+    const file = entry as File;
+    if (file.size === 0) continue;
+    if (files.length >= MAX_ATTACHMENTS) {
+      return c.json({ error: `too many attachments (max ${MAX_ATTACHMENTS})` }, 400);
+    }
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      return c.json(
+        { error: `attachment '${file.name}' too large (max ${MAX_ATTACHMENT_BYTES} bytes)` },
+        400,
+      );
+    }
+    files.push(file);
+  }
+
+  const now = Date.now();
+  const ticketId = crypto.randomUUID();
+
+  const attachmentRows: Array<{
+    id: string;
+    r2Key: string;
+    filename: string;
+    contentType: string | null;
+    sizeBytes: number;
+  }> = [];
+  for (const [index, file] of files.entries()) {
+    const safeName = file.name.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) || `attachment-${index}`;
+    const r2Key = `feedback/${app.id}/${ticketId}/${index}-${safeName}`;
+    await c.env.APK_BUCKET.put(r2Key, await file.arrayBuffer(), {
+      httpMetadata: { contentType: file.type || "application/octet-stream" },
+    });
+    attachmentRows.push({
+      id: crypto.randomUUID(),
+      r2Key,
+      filename: safeName,
+      contentType: file.type || null,
+      sizeBytes: file.size,
+    });
+  }
+
+  const statements = [
+    c.env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, contact, version_name, version_code,
+        channel, device_id, device_model, os_version, arch, locale,
+        metadata_json, client_ip_hash, created_at, updated_at)
+       VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)`,
+    ).bind(
+      ticketId,
+      app.id,
+      kind,
+      message,
+      contact,
+      meta("version_name"),
+      versionCode,
+      meta("channel"),
+      meta("device_id"),
+      meta("device_model"),
+      meta("os_version"),
+      meta("arch"),
+      meta("locale", 40),
+      JSON.stringify(metadata),
+      clientIpHash,
+      now,
+      now,
+    ),
+    ...attachmentRows.map((a) =>
+      c.env.DB.prepare(
+        `INSERT INTO feedback_attachments
+         (id, ticket_id, r2_key, filename, content_type, size_bytes, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
+      ).bind(a.id, ticketId, a.r2Key, a.filename, a.contentType, a.sizeBytes, now),
+    ),
+  ];
+  await c.env.DB.batch(statements);
+
+  if (app.org_id) {
+    await emitWebhookEvent(c.env.DB, {
+      orgId: app.org_id,
+      appId: app.id,
+      event: "feedback:new",
+      body: {
+        ticket_id: ticketId,
+        app_slug: app.slug,
+        kind,
+        message: message.slice(0, 500),
+        version_name: meta("version_name"),
+        version_code: versionCode,
+        attachments: attachmentRows.length,
+      },
+    }).catch(() => {
+      // webhook fan-out must never fail the submission
+    });
+  }
+
+  return c.json({ id: ticketId, status: "open", attachments: attachmentRows.length }, 201);
+}
+
+export async function handleListFeedback(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const status = c.req.query("status");
+  const kind = c.req.query("kind");
+  const binds: unknown[] = [appId];
+  let where = "app_id = ?1";
+  if (status && (TICKET_STATUSES as readonly string[]).includes(status)) {
+    binds.push(status);
+    where += ` AND status = ?${binds.length}`;
+  }
+  if (kind && (TICKET_KINDS as readonly string[]).includes(kind)) {
+    binds.push(kind);
+    where += ` AND kind = ?${binds.length}`;
+  }
+  const { results } = await c.env.DB.prepare(
+    `SELECT t.id, t.kind, t.status, t.message, t.contact, t.version_name,
+            t.version_code, t.channel, t.device_model, t.os_version,
+            t.created_at, t.updated_at,
+            (SELECT COUNT(*) FROM feedback_attachments fa WHERE fa.ticket_id = t.id) AS attachment_count,
+            (SELECT COUNT(*) FROM feedback_comments fc WHERE fc.ticket_id = t.id) AS comment_count
+     FROM feedback_tickets t
+     WHERE ${where}
+     ORDER BY t.created_at DESC
+     LIMIT 200`,
+  )
+    .bind(...binds)
+    .all();
+  return c.json({ tickets: results });
+}
+
+export async function handleGetFeedback(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const ticketId = c.req.param("ticketId");
+  const ticket = await c.env.DB.prepare(
+    "SELECT * FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
+  )
+    .bind(appId, ticketId)
+    .first();
+  if (!ticket) return c.json({ error: "ticket not found" }, 404);
+  const { results: attachments } = await c.env.DB.prepare(
+    `SELECT id, filename, content_type, size_bytes, created_at
+     FROM feedback_attachments WHERE ticket_id = ?1 ORDER BY created_at`,
+  )
+    .bind(ticketId)
+    .all();
+  const { results: comments } = await c.env.DB.prepare(
+    `SELECT id, author_actor, body, internal, created_at
+     FROM feedback_comments WHERE ticket_id = ?1 ORDER BY created_at`,
+  )
+    .bind(ticketId)
+    .all();
+  return c.json({ ticket, attachments, comments });
+}
+
+export async function handleUpdateFeedback(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const ticketId = c.req.param("ticketId");
+  const body = (await c.req.json().catch(() => ({}))) as { status?: string };
+  if (!body.status || !(TICKET_STATUSES as readonly string[]).includes(body.status)) {
+    return c.json({ error: `status must be one of ${TICKET_STATUSES.join(", ")}` }, 400);
+  }
+  const now = Date.now();
+  const result = await c.env.DB.prepare(
+    `UPDATE feedback_tickets SET status = ?1, updated_at = ?2
+     WHERE app_id = ?3 AND id = ?4`,
+  )
+    .bind(body.status, now, appId, ticketId)
+    .run();
+  if (!result.meta || result.meta.changes === 0) {
+    const exists = await c.env.DB.prepare(
+      "SELECT id FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
+    )
+      .bind(appId, ticketId)
+      .first();
+    if (!exists) return c.json({ error: "ticket not found" }, 404);
+  }
+  await c.env.DB.prepare(
+    `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+     VALUES (?1, ?2, 'feedback.status', ?3, ?4, ?5)`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      appId,
+      currentActor(c),
+      JSON.stringify({ ticket_id: ticketId, status: body.status }),
+      now,
+    )
+    .run();
+  return c.json({ id: ticketId, status: body.status, updated_at: now });
+}
+
+export async function handleAddFeedbackComment(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const ticketId = c.req.param("ticketId");
+  const body = (await c.req.json().catch(() => ({}))) as {
+    body?: string;
+    internal?: boolean;
+  };
+  const text = (body.body ?? "").trim();
+  if (!text) return c.json({ error: "body is required" }, 400);
+  const ticket = await c.env.DB.prepare(
+    "SELECT id FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
+  )
+    .bind(appId, ticketId)
+    .first();
+  if (!ticket) return c.json({ error: "ticket not found" }, 404);
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    ).bind(id, ticketId, currentActor(c), text, body.internal ? 1 : 0, now),
+    c.env.DB.prepare(
+      "UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2",
+    ).bind(now, ticketId),
+  ]);
+  return c.json({ id, ticket_id: ticketId, created_at: now }, 201);
+}
+
+export async function handleDownloadFeedbackAttachment(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const ticketId = c.req.param("ticketId");
+  const attachmentId = c.req.param("attachmentId");
+  const row = await c.env.DB.prepare(
+    `SELECT fa.r2_key, fa.filename, fa.content_type
+     FROM feedback_attachments fa
+     JOIN feedback_tickets t ON t.id = fa.ticket_id
+     WHERE t.app_id = ?1 AND t.id = ?2 AND fa.id = ?3`,
+  )
+    .bind(appId, ticketId, attachmentId)
+    .first<{ r2_key: string; filename: string; content_type: string | null }>();
+  if (!row) return c.json({ error: "attachment not found" }, 404);
+  const object = await c.env.APK_BUCKET.get(row.r2_key);
+  if (!object) return c.json({ error: "attachment blob missing" }, 404);
+  return new Response(object.body, {
+    headers: {
+      "content-type": row.content_type ?? "application/octet-stream",
+      "content-disposition": `attachment; filename="${row.filename}"`,
+    },
+  });
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -24,6 +24,7 @@ import { currentActorInfo } from "../middleware/auth";
 import type { AdminContext } from "../lib/permissions";
 
 type WebhookEventType =
+  | "feedback:new"
   | "release:new"
   | "release:superseded"
   | "release:rolled_back"

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -199,6 +199,43 @@ function makeMockDb() {
       completed_at INTEGER,
       FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
     );
+    CREATE TABLE feedback_tickets (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL,
+      kind TEXT NOT NULL DEFAULT 'feedback',
+      status TEXT NOT NULL DEFAULT 'open',
+      message TEXT NOT NULL,
+      contact TEXT,
+      version_name TEXT,
+      version_code INTEGER,
+      channel TEXT,
+      device_id TEXT,
+      device_model TEXT,
+      os_version TEXT,
+      arch TEXT,
+      locale TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      client_ip_hash TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE feedback_attachments (
+      id TEXT PRIMARY KEY,
+      ticket_id TEXT NOT NULL,
+      r2_key TEXT NOT NULL,
+      filename TEXT NOT NULL,
+      content_type TEXT,
+      size_bytes INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE feedback_comments (
+      id TEXT PRIMARY KEY,
+      ticket_id TEXT NOT NULL,
+      author_actor TEXT NOT NULL,
+      body TEXT NOT NULL,
+      internal INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    );
     CREATE TABLE audit_logs (
       id TEXT PRIMARY KEY, app_id TEXT NOT NULL, action TEXT NOT NULL,
       actor TEXT NOT NULL, payload TEXT NOT NULL, created_at INTEGER NOT NULL,
@@ -2839,6 +2876,112 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(clearResp.status).toBe(200);
     const open = await handlePublicReleaseShare(makeSharePublicContext(env, token));
     expect(await open.text()).toContain("Download APK");
+  });
+
+  it("feedback: public submit stores ticket + attachment, admin can triage", async () => {
+    const env = makeEnv();
+    const putCalls: Array<{ key: string; bytes: number }> = [];
+    env.APK_BUCKET = {
+      put: async (key: string, body: ArrayBuffer) => {
+        putCalls.push({ key, bytes: body.byteLength ?? 0 });
+      },
+      get: async (key: string) => {
+        const hit = putCalls.find((p) => p.key === key);
+        if (!hit) return null;
+        return { body: new Blob(["log"]).stream() };
+      },
+    };
+    const {
+      handlePublicFeedbackSubmit,
+      handleListFeedback,
+      handleUpdateFeedback,
+      handleAddFeedbackComment,
+      handleGetFeedback,
+      handleDownloadFeedbackAttachment,
+    } = await import("../src/routes/feedback");
+
+    const form = new FormData();
+    form.set("message", "首页打开就闪退");
+    form.set("kind", "bug");
+    form.set("contact", "artin@cat.ms");
+    form.set(
+      "metadata",
+      JSON.stringify({
+        version_name: "1.0.1",
+        version_code: 1000101,
+        channel: "main",
+        device_id: "dev-123",
+        device_model: "HUAWEI SGT-AL10",
+        os_version: "12",
+        arch: "arm64-v8a",
+        locale: "zh-CN",
+      }),
+    );
+    form.append(
+      "attachments",
+      new File([new Uint8Array([1, 2, 3])], "logcat.txt", { type: "text/plain" }),
+    );
+
+    const submitContext = {
+      env,
+      req: {
+        param: (name: string) => (name === "slug" ? "scope-app" : ""),
+        header: () => undefined,
+        formData: async () => form,
+        raw: { cf: { clientIp: "203.0.113.9" } },
+      },
+      json: (data: unknown, status = 200) =>
+        new Response(JSON.stringify(data), { status }),
+    } as any;
+
+    const submitted = await handlePublicFeedbackSubmit(submitContext);
+    expect(submitted.status).toBe(201);
+    const submittedBody = await responseJson<any>(submitted);
+    expect(submittedBody.attachments).toBe(1);
+    expect(putCalls.length).toBe(1);
+    expect(putCalls[0]!.key).toContain("feedback/app-scope/");
+
+    const adminContext = (params: Record<string, string>, opts: { query?: Record<string, string>; body?: unknown } = {}) =>
+      ({
+        env,
+        req: {
+          param: (name: string) => params[name] ?? "",
+          query: (name: string) => opts.query?.[name],
+          json: async () => opts.body ?? {},
+        },
+        get: (name: string) => (name === "admin_actor" ? "tester" : undefined),
+        json: (data: unknown, status = 200) =>
+          new Response(JSON.stringify(data), { status }),
+      }) as any;
+
+    const listed = await handleListFeedback(adminContext({ appId: "app-scope" }, { query: { kind: "bug" } }));
+    const listBody = await responseJson<any>(listed);
+    expect(listBody.tickets.length).toBe(1);
+    expect(listBody.tickets[0].attachment_count).toBe(1);
+    const ticketId = listBody.tickets[0].id as string;
+
+    const updated = await handleUpdateFeedback(
+      adminContext({ appId: "app-scope", ticketId }, { body: { status: "in_progress" } }),
+    );
+    expect(updated.status).toBe(200);
+
+    const commented = await handleAddFeedbackComment(
+      adminContext({ appId: "app-scope", ticketId }, { body: { body: "已复现，排查中" } }),
+    );
+    expect(commented.status).toBe(201);
+
+    const detail = await handleGetFeedback(adminContext({ appId: "app-scope", ticketId }));
+    const detailBody = await responseJson<any>(detail);
+    expect(detailBody.ticket.status).toBe("in_progress");
+    expect(detailBody.ticket.device_id).toBe("dev-123");
+    expect(detailBody.attachments.length).toBe(1);
+    expect(detailBody.comments.length).toBe(1);
+
+    const download = await handleDownloadFeedbackAttachment(
+      adminContext({ appId: "app-scope", ticketId, attachmentId: detailBody.attachments[0].id }),
+    );
+    expect(download.status).toBe(200);
+    expect(download.headers.get("content-disposition")).toContain("logcat.txt");
   });
 
   it("share download redirects to signed R2 and records download stats", async () => {


### PR DESCRIPTION
Task #66 (反馈闭环) — first slice: submission channel + ticket system.

## Worker
- Migration 0026: `feedback_tickets` (kind feedback/bug/crash, status open/in_progress/resolved/closed, device context incl. rollout device_id), `feedback_attachments` (R2), `feedback_comments`.
- `POST /public/v2/apps/:slug/feedback` — unauthenticated multipart (message, kind, contact, metadata JSON, ≤3 attachments ≤10 MB each), rate limit 10/hour per app+hashed-IP, `feedback:new` webhook emitted (fan-out failure never breaks submission).
- Admin API: list (status/kind filters), detail (attachments+comments), status PATCH (audited), comments, authed attachment streaming download.

## Admin UI
- New Feedback tab: filterable ticket table, slide-over detail with device context, attachment links, one-click status transitions, comment trail.

## SDK
- `QuiverFeedback.submit(...)` — OkHttp multipart, auto device/app metadata + persistent device id (correlates tickets with rollout cohorts). Needs SDK 0.3.0 publish after merge.

## Verification
- Worker tests 68/68 incl. end-to-end: submit with attachment → list → status → comment → detail → attachment download.
- worker/admin tsc clean, admin build clean.

Phase 2 (later): crash capture in SDK (uncaughtExceptionHandler → kind=crash), signature-based grouping in admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)