### PR TITLE
feat(feedback): routed ticket pages, assignees; breadcrumb app header

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -18,7 +18,7 @@ import { Settings } from "./pages/Settings";
 import { Builds } from "./pages/Builds";
 import { Releases } from "./pages/Releases";
 import { AppShares } from "./pages/Shares";
-import { AppFeedback } from "./pages/Feedback";
+import { AppFeedback, FeedbackTicketPage } from "./pages/Feedback";
 import { OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
@@ -78,6 +78,32 @@ function QuiverMark({ className = "" }: { className?: string }) {
   );
 }
 
+function HeaderAppBreadcrumb() {
+  const location = useLocation();
+  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
+  const match = location.pathname.match(/^\/apps\/([0-9a-f-]{36})(?:\/|$)/);
+  if (!match) return null;
+  const app = apps.data?.apps.find((a) => a.id === match[1]);
+  if (!app) return null;
+  return (
+    <span className="hidden md:flex items-center gap-2 min-w-0 text-sm">
+      <span className="text-slate-300">/</span>
+      <Link
+        to={`/apps/${app.id}`}
+        className="font-semibold text-slate-900 truncate max-w-[220px] hover:underline"
+      >
+        {app.name}
+      </Link>
+      <span className="badge-blue">{app.platform}</span>
+      {Boolean(app.archived) && (
+        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800">
+          archived
+        </span>
+      )}
+    </span>
+  );
+}
+
 function Header({ account }: { account: AuthAccount }) {
   const onLogout = async () => {
     await logout();
@@ -127,6 +153,7 @@ function Header({ account }: { account: AuthAccount }) {
             <QuiverMark className="h-8 w-8 flex-none" />
             <span>Quiver</span>
           </Link>
+          <HeaderAppBreadcrumb />
           <nav className="flex items-center gap-2">
             <NavLink
               to="/apps"
@@ -277,9 +304,7 @@ function Header({ account }: { account: AuthAccount }) {
 
 function AppContextNav() {
   const { appId } = useParams();
-  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
   if (!appId) return null;
-  const app = apps.data?.apps.find((a) => a.id === appId);
   const base = `/apps/${appId}`;
   const tabClass = ({ isActive }: { isActive: boolean }) =>
     `inline-flex h-9 items-center rounded-md px-3 text-sm ${
@@ -290,26 +315,7 @@ function AppContextNav() {
 
   return (
     <div className="bg-white border-b border-slate-200 -mt-px">
-      <div className="max-w-5xl mx-auto px-4 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
-        <div className="flex items-center gap-2 mr-3 min-w-0">
-          <h1 className="text-base font-semibold leading-none truncate">
-            {app?.name ?? "…"}
-          </h1>
-          {app?.platform && (
-            <span className="badge-blue">{app.platform}</span>
-          )}
-          {app?.slug && (
-            <span className="hidden sm:inline text-xs text-slate-500 font-mono">
-              {app.slug}
-            </span>
-          )}
-          {Boolean(app?.archived) && (
-            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800">
-              archived
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-1 overflow-x-auto">
+      <div className="max-w-5xl mx-auto px-4 py-2 flex items-center gap-1 overflow-x-auto">
         <NavLink
           to={base}
           end
@@ -365,7 +371,6 @@ function AppContextNav() {
         >
           Settings
         </NavLink>
-        </div>
       </div>
     </div>
   );
@@ -393,6 +398,12 @@ function AppFeedbackRoute() {
   const { appId } = useParams();
   if (!appId) return null;
   return <AppFeedback appId={appId} />;
+}
+
+function FeedbackTicketRoute() {
+  const { appId, ticketId } = useParams();
+  if (!appId || !ticketId) return null;
+  return <FeedbackTicketPage appId={appId} ticketId={ticketId} />;
 }
 
 function AppSharesRoute() {
@@ -707,6 +718,7 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
           <Route path="releases" element={<ReleasesRoute />} />
           <Route path="shares" element={<AppSharesRoute />} />
           <Route path="feedback" element={<AppFeedbackRoute />} />
+          <Route path="feedback/:ticketId" element={<FeedbackTicketRoute />} />
           <Route path="access" element={<AppAccessRoute />} />
           <Route path="audit" element={<AuditRoute />} />
           <Route path="settings" element={<AppSettingsRoute />} />
@@ -772,6 +784,7 @@ function AppShell() {
           <Route path="releases" element={<ReleasesRoute />} />
           <Route path="shares" element={<AppSharesRoute />} />
           <Route path="feedback" element={<AppFeedbackRoute />} />
+          <Route path="feedback/:ticketId" element={<FeedbackTicketRoute />} />
           <Route path="access" element={<AppAccessRoute />} />
           <Route path="audit" element={<AuditRoute />} />
           <Route path="settings" element={<AppSettingsRoute />} />

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1067,6 +1067,7 @@ export interface FeedbackTicket {
   id: string;
   kind: "feedback" | "bug" | "crash";
   status: "open" | "in_progress" | "resolved" | "closed";
+  assignee: string | null;
   message: string;
   contact: string | null;
   version_name: string | null;
@@ -1117,12 +1118,19 @@ export const listFeedback = (appId: string, filters?: { status?: string | undefi
 export const getFeedback = (appId: string, ticketId: string) =>
   request<FeedbackDetail>(`/api/apps/${appId}/feedback/${ticketId}`, { admin: true });
 
-export const updateFeedbackStatus = (appId: string, ticketId: string, status: string) =>
-  request<{ id: string; status: string }>(`/api/apps/${appId}/feedback/${ticketId}`, {
-    method: "PATCH",
-    body: JSON.stringify({ status }),
-    admin: true,
-  });
+export const updateFeedbackTicket = (
+  appId: string,
+  ticketId: string,
+  body: { status?: string; assignee?: string | null },
+) =>
+  request<{ id: string; status: string | null; assignee: string | null }>(
+    `/api/apps/${appId}/feedback/${ticketId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      admin: true,
+    },
+  );
 
 export const addFeedbackComment = (appId: string, ticketId: string, body: string) =>
   request<{ id: string }>(`/api/apps/${appId}/feedback/${ticketId}/comments`, {

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -1,17 +1,18 @@
 /**
- * Feedback ticket triage (task #66): list + filter tickets submitted from
- * the app SDK, inspect device context and attachments, move status, and
- * keep a comment trail.
+ * Feedback ticket triage (task #66): list + filter tickets, and a routed
+ * per-ticket page (/apps/:appId/feedback/:ticketId) so tickets are
+ * shareable links. Tickets carry an assignee, status flow, and comments.
  */
 import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  FeedbackTicket,
   addFeedbackComment,
   feedbackAttachmentUrl,
+  getAuthMe,
   getFeedback,
   listFeedback,
-  updateFeedbackStatus,
+  updateFeedbackTicket,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 
@@ -31,9 +32,9 @@ const KIND_STYLES: Record<string, string> = {
 };
 
 export function AppFeedback({ appId }: { appId: string }) {
+  const navigate = useNavigate();
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [kindFilter, setKindFilter] = useState<string>("");
-  const [selected, setSelected] = useState<string | null>(null);
 
   const tickets = useQuery({
     queryKey: ["feedback", appId, statusFilter, kindFilter],
@@ -95,6 +96,7 @@ export function AppFeedback({ appId }: { appId: string }) {
               <tr className="text-left text-xs text-slate-500 border-b border-slate-200">
                 <th className="py-2 pr-3">Ticket</th>
                 <th className="py-2 pr-3">Status</th>
+                <th className="py-2 pr-3">Assignee</th>
                 <th className="py-2 pr-3">App version</th>
                 <th className="py-2 pr-3">Device</th>
                 <th className="py-2 pr-3">Created</th>
@@ -107,7 +109,7 @@ export function AppFeedback({ appId }: { appId: string }) {
                 <tr
                   key={t.id}
                   className="border-b border-slate-100 last:border-0 cursor-pointer hover:bg-slate-50"
-                  onClick={() => setSelected(t.id)}
+                  onClick={() => navigate(`/apps/${appId}/feedback/${t.id}`)}
                 >
                   <td className="py-2 pr-3 max-w-md">
                     <span className={`rounded px-1.5 py-0.5 text-xs font-medium mr-2 ${KIND_STYLES[t.kind]}`}>
@@ -120,6 +122,7 @@ export function AppFeedback({ appId }: { appId: string }) {
                       {t.status}
                     </span>
                   </td>
+                  <td className="py-2 pr-3 text-xs text-slate-600">{t.assignee ?? "—"}</td>
                   <td className="py-2 pr-3 text-xs text-slate-600">
                     {t.version_name ?? "—"}{t.version_code ? ` (${t.version_code})` : ""}
                   </td>
@@ -137,49 +140,42 @@ export function AppFeedback({ appId }: { appId: string }) {
           </table>
         )}
       </div>
-
-      {selected && (
-        <TicketDetail
-          appId={appId}
-          ticketId={selected}
-          onClose={() => setSelected(null)}
-        />
-      )}
     </div>
   );
 }
 
-function TicketDetail({
+export function FeedbackTicketPage({
   appId,
   ticketId,
-  onClose,
 }: {
   appId: string;
   ticketId: string;
-  onClose: () => void;
 }) {
   const toast = useToast();
   const queryClient = useQueryClient();
   const [comment, setComment] = useState("");
+  const [assigneeDraft, setAssigneeDraft] = useState<string | null>(null);
 
   const detail = useQuery({
     queryKey: ["feedback-detail", appId, ticketId],
     queryFn: () => getFeedback(appId, ticketId),
   });
+  const me = useQuery({ queryKey: ["auth-me"], queryFn: getAuthMe });
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["feedback-detail", appId, ticketId] });
     queryClient.invalidateQueries({ queryKey: ["feedback", appId] });
   };
 
-  const setStatus = useMutation({
-    mutationFn: (status: string) => updateFeedbackStatus(appId, ticketId, status),
-    onSuccess: (data) => {
-      toast.show({ kind: "success", title: `Status → ${data.status}` });
+  const update = useMutation({
+    mutationFn: (body: { status?: string; assignee?: string | null }) =>
+      updateFeedbackTicket(appId, ticketId, body),
+    onSuccess: () => {
+      setAssigneeDraft(null);
       invalidate();
     },
     onError: (e) =>
-      toast.show({ kind: "error", title: "Status update failed", description: (e as Error).message }),
+      toast.show({ kind: "error", title: "Update failed", description: (e as Error).message }),
   });
 
   const addComment = useMutation({
@@ -193,38 +189,116 @@ function TicketDetail({
   });
 
   const t = detail.data?.ticket;
+  const myName = me.data?.account?.display_name ?? null;
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-end bg-black/30" onClick={onClose}>
-      <div
-        className="h-full w-full max-w-xl overflow-y-auto bg-white p-5 shadow-xl space-y-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {detail.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-        {detail.error && (
-          <p className="text-sm text-red-600">{(detail.error as Error).message}</p>
-        )}
-        {t && (
-          <>
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="flex items-center gap-2">
-                  <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${KIND_STYLES[t.kind]}`}>{t.kind}</span>
-                  <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_STYLES[t.status]}`}>{t.status}</span>
-                </div>
-                <h3 className="mt-2 text-base font-semibold">Ticket {t.id.slice(0, 8)}</h3>
-                <p className="text-xs text-slate-500">
-                  {new Date(t.created_at).toLocaleString()}
-                  {t.contact ? ` · ${t.contact}` : ""}
-                </p>
+    <div className="space-y-4 max-w-3xl">
+      <div className="flex items-center gap-2 text-sm">
+        <Link to={`/apps/${appId}/feedback`} className="text-blue-600 hover:underline">
+          ← Feedback
+        </Link>
+      </div>
+
+      {detail.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+      {detail.error && (
+        <p className="text-sm text-red-600">{(detail.error as Error).message}</p>
+      )}
+      {t && (
+        <>
+          <div className="flex items-start justify-between gap-3 flex-wrap">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${KIND_STYLES[t.kind]}`}>{t.kind}</span>
+                <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_STYLES[t.status]}`}>{t.status}</span>
+                {t.assignee && (
+                  <span className="rounded bg-violet-100 px-1.5 py-0.5 text-xs font-medium text-violet-800">
+                    {t.assignee}
+                  </span>
+                )}
               </div>
-              <button className="btn-secondary text-xs" onClick={onClose}>Close</button>
+              <h2 className="mt-2 text-lg font-semibold">Ticket {t.id.slice(0, 8)}</h2>
+              <p className="text-xs text-slate-500">
+                {new Date(t.created_at).toLocaleString()}
+                {t.contact ? ` · ${t.contact}` : ""}
+              </p>
             </div>
-
-            <div className="rounded border border-slate-200 bg-slate-50 p-3 text-sm whitespace-pre-wrap">
-              {t.message}
+            <div className="flex items-center gap-2">
+              {STATUSES.map((s) => (
+                <button
+                  key={s}
+                  className={
+                    s === t.status
+                      ? "rounded border border-slate-900 bg-slate-900 px-2 py-1 text-xs text-white"
+                      : "rounded border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100"
+                  }
+                  disabled={update.isPending || s === t.status}
+                  onClick={() => update.mutate({ status: s })}
+                >
+                  {s}
+                </button>
+              ))}
             </div>
+          </div>
 
+          <div className="card text-sm whitespace-pre-wrap">{t.message}</div>
+
+          <div className="card">
+            <h4 className="text-sm font-semibold mb-2">Assignee</h4>
+            <div className="flex items-center gap-2 text-sm flex-wrap">
+              {assigneeDraft === null ? (
+                <>
+                  <span>{t.assignee ?? "Unassigned"}</span>
+                  {myName && t.assignee !== myName && (
+                    <button
+                      className="rounded border border-slate-300 px-2 py-1 text-xs hover:bg-slate-100"
+                      disabled={update.isPending}
+                      onClick={() => update.mutate({ assignee: myName })}
+                    >
+                      Assign to me
+                    </button>
+                  )}
+                  <button
+                    className="rounded border border-slate-300 px-2 py-1 text-xs hover:bg-slate-100"
+                    onClick={() => setAssigneeDraft(t.assignee ?? "")}
+                  >
+                    Edit
+                  </button>
+                  {t.assignee && (
+                    <button
+                      className="rounded border border-slate-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                      disabled={update.isPending}
+                      onClick={() => update.mutate({ assignee: null })}
+                    >
+                      Unassign
+                    </button>
+                  )}
+                </>
+              ) : (
+                <>
+                  <input
+                    className="rounded border border-slate-300 px-2 py-1 text-sm"
+                    value={assigneeDraft}
+                    autoFocus
+                    onChange={(e) => setAssigneeDraft(e.target.value)}
+                    placeholder="Name of the person handling this"
+                  />
+                  <button
+                    className="btn-primary text-xs"
+                    disabled={update.isPending}
+                    onClick={() => update.mutate({ assignee: assigneeDraft.trim() || null })}
+                  >
+                    Save
+                  </button>
+                  <button className="btn-secondary text-xs" onClick={() => setAssigneeDraft(null)}>
+                    Cancel
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="card">
+            <h4 className="text-sm font-semibold mb-2">Device context</h4>
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
               <dt className="text-slate-500">App version</dt>
               <dd>{t.version_name ?? "—"} {t.version_code ? `(${t.version_code})` : ""}</dd>
@@ -239,86 +313,66 @@ function TicketDetail({
               <dt className="text-slate-500">Device id</dt>
               <dd className="font-mono">{t.device_id ?? "—"}</dd>
             </dl>
+          </div>
 
-            {detail.data!.attachments.length > 0 && (
-              <div>
-                <h4 className="text-sm font-semibold mb-1">Attachments</h4>
-                <ul className="space-y-1 text-sm">
-                  {detail.data!.attachments.map((a) => (
-                    <li key={a.id}>
-                      <a
-                        className="text-blue-600 hover:underline"
-                        href={feedbackAttachmentUrl(appId, ticketId, a.id)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {a.filename}
-                      </a>
-                      <span className="ml-2 text-xs text-slate-400">
-                        {(a.size_bytes / 1024).toFixed(1)} KB
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            <div>
-              <h4 className="text-sm font-semibold mb-1">Status</h4>
-              <div className="flex gap-2">
-                {STATUSES.map((s) => (
-                  <button
-                    key={s}
-                    className={
-                      s === t.status
-                        ? "rounded border border-slate-900 bg-slate-900 px-2 py-1 text-xs text-white"
-                        : "rounded border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100"
-                    }
-                    disabled={setStatus.isPending || s === t.status}
-                    onClick={() => setStatus.mutate(s)}
-                  >
-                    {s}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <h4 className="text-sm font-semibold mb-1">
-                Comments ({detail.data!.comments.length})
-              </h4>
-              <ul className="space-y-2 text-sm">
-                {detail.data!.comments.map((cm) => (
-                  <li key={cm.id} className="rounded border border-slate-200 p-2">
-                    <div className="text-xs text-slate-500">
-                      {cm.author_actor} · {new Date(cm.created_at).toLocaleString()}
-                    </div>
-                    <div className="whitespace-pre-wrap">{cm.body}</div>
+          {detail.data!.attachments.length > 0 && (
+            <div className="card">
+              <h4 className="text-sm font-semibold mb-1">Attachments</h4>
+              <ul className="space-y-1 text-sm">
+                {detail.data!.attachments.map((a) => (
+                  <li key={a.id}>
+                    <a
+                      className="text-blue-600 hover:underline"
+                      href={feedbackAttachmentUrl(appId, ticketId, a.id)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {a.filename}
+                    </a>
+                    <span className="ml-2 text-xs text-slate-400">
+                      {(a.size_bytes / 1024).toFixed(1)} KB
+                    </span>
                   </li>
                 ))}
               </ul>
-              <div className="mt-2 flex gap-2">
-                <input
-                  className="flex-1 rounded border border-slate-300 px-2 py-1.5 text-sm"
-                  placeholder="Add a comment…"
-                  value={comment}
-                  onChange={(e) => setComment(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && comment.trim()) addComment.mutate();
-                  }}
-                />
-                <button
-                  className="btn-primary text-sm"
-                  disabled={addComment.isPending || !comment.trim()}
-                  onClick={() => addComment.mutate()}
-                >
-                  Send
-                </button>
-              </div>
             </div>
-          </>
-        )}
-      </div>
+          )}
+
+          <div className="card">
+            <h4 className="text-sm font-semibold mb-1">
+              Comments ({detail.data!.comments.length})
+            </h4>
+            <ul className="space-y-2 text-sm">
+              {detail.data!.comments.map((cm) => (
+                <li key={cm.id} className="rounded border border-slate-200 p-2">
+                  <div className="text-xs text-slate-500">
+                    {cm.author_actor} · {new Date(cm.created_at).toLocaleString()}
+                  </div>
+                  <div className="whitespace-pre-wrap">{cm.body}</div>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-2 flex gap-2">
+              <input
+                className="flex-1 rounded border border-slate-300 px-2 py-1.5 text-sm"
+                placeholder="Add a comment…"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && comment.trim()) addComment.mutate();
+                }}
+              />
+              <button
+                className="btn-primary text-sm"
+                disabled={addComment.isPending || !comment.trim()}
+                onClick={() => addComment.mutate()}
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/migrations/sql/0027_feedback_assignee.sql
+++ b/migrations/sql/0027_feedback_assignee.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feedback_tickets ADD COLUMN assignee TEXT;

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -201,7 +201,7 @@ export async function handleListFeedback(c: AdminContext) {
     where += ` AND kind = ?${binds.length}`;
   }
   const { results } = await c.env.DB.prepare(
-    `SELECT t.id, t.kind, t.status, t.message, t.contact, t.version_name,
+    `SELECT t.id, t.kind, t.status, t.assignee, t.message, t.contact, t.version_name,
             t.version_code, t.channel, t.device_model, t.os_version,
             t.created_at, t.updated_at,
             (SELECT COUNT(*) FROM feedback_attachments fa WHERE fa.ticket_id = t.id) AS attachment_count,
@@ -243,38 +243,58 @@ export async function handleGetFeedback(c: AdminContext) {
 export async function handleUpdateFeedback(c: AdminContext) {
   const appId = c.req.param("appId");
   const ticketId = c.req.param("ticketId");
-  const body = (await c.req.json().catch(() => ({}))) as { status?: string };
-  if (!body.status || !(TICKET_STATUSES as readonly string[]).includes(body.status)) {
-    return c.json({ error: `status must be one of ${TICKET_STATUSES.join(", ")}` }, 400);
+  const body = (await c.req.json().catch(() => ({}))) as {
+    status?: string;
+    assignee?: string | null;
+  };
+  const sets: string[] = [];
+  const binds: unknown[] = [];
+  if (body.status !== undefined) {
+    if (!(TICKET_STATUSES as readonly string[]).includes(body.status)) {
+      return c.json({ error: `status must be one of ${TICKET_STATUSES.join(", ")}` }, 400);
+    }
+    binds.push(body.status);
+    sets.push(`status = ?${binds.length}`);
   }
-  const now = Date.now();
-  const result = await c.env.DB.prepare(
-    `UPDATE feedback_tickets SET status = ?1, updated_at = ?2
-     WHERE app_id = ?3 AND id = ?4`,
+  if (body.assignee !== undefined) {
+    const assignee =
+      typeof body.assignee === "string" ? body.assignee.trim().slice(0, 120) : "";
+    binds.push(assignee || null);
+    sets.push(`assignee = ?${binds.length}`);
+  }
+  if (sets.length === 0) {
+    return c.json({ error: "nothing to update (status or assignee required)" }, 400);
+  }
+  const exists = await c.env.DB.prepare(
+    "SELECT id FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
   )
-    .bind(body.status, now, appId, ticketId)
+    .bind(appId, ticketId)
+    .first();
+  if (!exists) return c.json({ error: "ticket not found" }, 404);
+
+  const now = Date.now();
+  binds.push(now);
+  sets.push(`updated_at = ?${binds.length}`);
+  binds.push(appId, ticketId);
+  await c.env.DB.prepare(
+    `UPDATE feedback_tickets SET ${sets.join(", ")}
+     WHERE app_id = ?${binds.length - 1} AND id = ?${binds.length}`,
+  )
+    .bind(...binds)
     .run();
-  if (!result.meta || result.meta.changes === 0) {
-    const exists = await c.env.DB.prepare(
-      "SELECT id FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
-    )
-      .bind(appId, ticketId)
-      .first();
-    if (!exists) return c.json({ error: "ticket not found" }, 404);
-  }
   await c.env.DB.prepare(
     `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
-     VALUES (?1, ?2, 'feedback.status', ?3, ?4, ?5)`,
+     VALUES (?1, ?2, 'feedback.update', ?3, ?4, ?5)`,
   )
     .bind(
       crypto.randomUUID(),
       appId,
       currentActor(c),
-      JSON.stringify({ ticket_id: ticketId, status: body.status }),
+      JSON.stringify({ ticket_id: ticketId, status: body.status ?? null, assignee: body.assignee === undefined ? null : (body.assignee || null) }),
       now,
     )
     .run();
-  return c.json({ id: ticketId, status: body.status, updated_at: now });
+  return c.json({ id: ticketId, status: body.status ?? null, assignee: body.assignee ?? null, updated_at: now });
 }
 
 export async function handleAddFeedbackComment(c: AdminContext) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -216,6 +216,7 @@ function makeMockDb() {
       locale TEXT,
       metadata_json TEXT NOT NULL DEFAULT '{}',
       client_ip_hash TEXT,
+      assignee TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -2961,7 +2962,7 @@ describe("quiver public API v2 — scope resolution", () => {
     const ticketId = listBody.tickets[0].id as string;
 
     const updated = await handleUpdateFeedback(
-      adminContext({ appId: "app-scope", ticketId }, { body: { status: "in_progress" } }),
+      adminContext({ appId: "app-scope", ticketId }, { body: { status: "in_progress", assignee: "cc-quiver-owner" } }),
     );
     expect(updated.status).toBe(200);
 
@@ -2973,6 +2974,7 @@ describe("quiver public API v2 — scope resolution", () => {
     const detail = await handleGetFeedback(adminContext({ appId: "app-scope", ticketId }));
     const detailBody = await responseJson<any>(detail);
     expect(detailBody.ticket.status).toBe("in_progress");
+    expect(detailBody.ticket.assignee).toBe("cc-quiver-owner");
     expect(detailBody.ticket.device_id).toBe("dev-123");
     expect(detailBody.attachments.length).toBe(1);
     expect(detailBody.comments.length).toBe(1);


### PR DESCRIPTION
Round 2 of task #66 per artin's feedback:

- **Shareable ticket routes**: `/apps/:appId/feedback/:ticketId` full page replaces the drawer (device context, attachments, status flow, comments).
- **Assignee (经办人)**: migration 0027 adds `assignee`; PATCH now updates status and/or assignee (audited `feedback.update`); UI shows assignee in list + badge on detail, with Assign-to-me (from auth-me display name), free-text edit, and unassign.
- **Header crowding**: app identity (name/platform/archived) moves into the global nav as a GitHub-style breadcrumb next to the logo (hidden on small screens); the tab row is tabs-only again with full width.

Verification: worker tests 67/67 (assignee covered in the triage test), worker+admin tsc clean, admin build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)