### PR TITLE
fix(admin): center app page content beside the sidebar

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -865,7 +865,7 @@ function AppShell() {
         <div className="md:hidden">
           <AppContextNav />
         </div>
-        <main className="max-w-5xl px-6 py-6 w-full">
+        <main className="max-w-5xl mx-auto px-6 py-6 w-full">
         <Routes>
           <Route index element={<AppDetailRoute />} />
           <Route path="publish" element={<LegacyPublishRedirect />} />


### PR DESCRIPTION
Content column was left-hugging the sidebar leaving dead space on wide screens; now centered in the remaining width, matching the centered global header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)