### PR TITLE
fix(admin): custom select chevron with padding, unify select styling

### DIFF
--- a/admin/src/index.css
+++ b/admin/src/index.css
@@ -24,6 +24,14 @@
   .input {
     @apply block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500;
   }
+  /* Native select arrows render flush against the border; draw our own
+     chevron with breathing room instead. */
+  select.input {
+    @apply appearance-none bg-no-repeat !pr-8;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none'%3E%3Cpath d='M6 8l4 4 4-4' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-position: right 0.625rem center;
+    background-size: 1rem 1rem;
+  }
   .label {
     @apply block text-sm font-medium text-slate-700 mb-1;
   }

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -58,7 +58,7 @@ export function AppFeedback({ appId }: { appId: string }) {
         </div>
         <div className="flex items-center gap-2 text-sm">
           <select
-            className="rounded border border-slate-300 px-2 py-1.5"
+            className="input !w-auto !py-1.5"
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
           >
@@ -68,7 +68,7 @@ export function AppFeedback({ appId }: { appId: string }) {
             ))}
           </select>
           <select
-            className="rounded border border-slate-300 px-2 py-1.5"
+            className="input !w-auto !py-1.5"
             value={kindFilter}
             onChange={(e) => setKindFilter(e.target.value)}
           >

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -317,7 +317,7 @@ function CreateShareModal({
         <label className="block text-xs text-slate-600">
           Release
           <select
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            className="input mt-1 !py-1.5"
             value={releaseId}
             onChange={(e) => setReleaseId(e.target.value)}
           >
@@ -337,7 +337,7 @@ function CreateShareModal({
             max={30}
             value={ttlDays}
             onChange={(e) => setTtlDays(Math.min(30, Math.max(1, Number(e.target.value) || 7)))}
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            className="input mt-1 !py-1.5"
           />
         </label>
         <label className="block text-xs text-slate-600">
@@ -347,7 +347,7 @@ function CreateShareModal({
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Leave empty for a public link"
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+            className="input mt-1 !py-1.5"
           />
         </label>
         <div className="flex justify-end gap-2 pt-2">


### PR DESCRIPTION
Native select arrows sat flush at the border (artin's screenshot). select.input now draws its own chevron (appearance-none + inline SVG + pr-8), fixing every .input select app-wide; Feedback filter and Shares form controls normalized onto .input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)