### PR TITLE
feat(admin): Sentry-style left rail; app icon + package on share pages

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -115,161 +115,112 @@ function Header({ account }: { account: AuthAccount }) {
     };
   }, [showAccountMenu]);
 
+  const railItem = ({ isActive }: { isActive: boolean }) =>
+    `flex w-full flex-col items-center gap-0.5 rounded-md px-1 py-2 text-[11px] leading-none ${
+      isActive
+        ? "bg-slate-100 font-medium text-slate-950"
+        : "text-slate-500 hover:bg-slate-100 hover:text-slate-950"
+    }`;
+
   return (
-    <header className="bg-white border-b border-slate-200">
-      <div className="px-5 py-3 flex items-center justify-between gap-6">
-        <div className="flex items-center gap-6">
-          <Link
-            to="/"
-            className="inline-flex h-10 items-center gap-2 text-xl font-medium tracking-tight leading-none"
-            aria-label="Quiver"
-          >
-            <QuiverMark className="h-8 w-8 flex-none" />
-            <span>Quiver</span>
-          </Link>
-          <nav className="flex items-center gap-2">
-            <NavLink
-              to="/apps"
-              end
-              className={({ isActive }) =>
-                `inline-flex h-10 items-center rounded-md px-3 text-sm leading-none ${
-                  isActive ? "bg-slate-100 font-medium" : "hover:bg-slate-100"
-                }`
+    <header className="flex w-16 flex-none flex-col items-center border-r border-slate-200 bg-white py-3">
+      <Link to="/" aria-label="Quiver" className="mb-4">
+        <QuiverMark className="h-9 w-9" />
+      </Link>
+      <nav className="flex w-full flex-col items-stretch gap-1 px-2">
+        <NavLink to="/apps" end={false} className={railItem}>
+          <span aria-hidden="true" className="text-base leading-none">▦</span>
+          Apps
+        </NavLink>
+        <div className="relative w-full">
+          <NavLink
+            to={orgHref}
+            onClick={(e) => {
+              if (orgs.data && orgs.data.orgs.length > 1) {
+                e.preventDefault();
+                setShowOrgSwitcher((s) => !s);
               }
-            >
-              Apps
-            </NavLink>
-            <div className="relative">
-              <NavLink
-                to={orgHref}
-                onClick={(e) => {
-                  if (orgs.data && orgs.data.orgs.length > 1) {
-                    e.preventDefault();
-                    setShowOrgSwitcher((s) => !s);
-                  }
-                }}
-                className={({ isActive }) =>
-                  `inline-flex h-10 items-center rounded-md px-3 text-sm leading-none ${
-                    isActive ? "bg-slate-100 font-medium" : "hover:bg-slate-100"
-                  }`
-                }
-                aria-label={
-                  account.org_id
-                    ? `Org ${account.server_slug ?? account.server_id}, role ${account.org_role ?? "none"}`
-                    : "Org settings"
-                }
-              >
-                <span className="inline-flex items-center gap-1 leading-none">
-                  Org
-                  {account.org_role && (
-                    <span
-                      className="inline-flex items-center rounded px-1 text-xs leading-none"
-                      style={{
-                        color:
-                          account.org_role === "owner"
-                            ? "#a855f7"
-                            : account.org_role === "admin"
-                              ? "#3b82f6"
-                              : "#6b7280",
-                      }}
-                    >
-                      {account.org_role}
-                    </span>
-                  )}
-                  {orgs.data && orgs.data.orgs.length > 1 && (
-                    <span
-                      className="text-xs text-slate-400"
-                      title={`Member of ${orgs.data.orgs.length} organizations`}
-                    >
-                      ▾
-                    </span>
-                  )}
-                </span>
-              </NavLink>
-              {showOrgSwitcher &&
-                orgs.data &&
-                orgs.data.orgs.length > 1 && (
-                  <OrgSwitcher
-                    currentOrgId={account.org_id ?? null}
-                    buttonLabel={`Switch organization (${
-                      orgs.data.orgs.length
-                    } members of)`}
-                    onClose={() => setShowOrgSwitcher(false)}
-                    onSwitch={switchOrg}
-                  />
-                )}
-            </div>
-          </nav>
-        </div>
-        <div ref={accountMenuRef} className="relative text-sm">
-          <button
-            type="button"
-            className="inline-flex h-10 items-center gap-3 rounded-md px-2 hover:bg-slate-100"
-            onClick={() => setShowAccountMenu((open) => !open)}
-            aria-haspopup="menu"
-            aria-expanded={showAccountMenu}
+            }}
+            className={railItem}
+            aria-label={
+              account.org_id
+                ? `Org ${account.server_slug ?? account.server_id}, role ${account.org_role ?? "none"}`
+                : "Org settings"
+            }
           >
-            <span className="text-right leading-tight">
-              <span className="font-medium flex items-center gap-1 justify-end">
-                {account.display_name}
-                {account.principal_type === "agent" && (
-                  <span
-                    className="badge-purple text-xs"
-                    title="Raft agent principal"
-                  >
-                    agent
-                  </span>
-                )}
-              </span>
-              <span className="block text-xs text-slate-500">
-                {account.server_slug || account.server_id}
-              </span>
-            </span>
-            {account.avatar_url ? (
-              <img
-                src={account.avatar_url}
-                alt=""
-                className="h-8 w-8 rounded-full border border-slate-200"
+            <span aria-hidden="true" className="text-base leading-none">◫</span>
+            Org
+          </NavLink>
+          {showOrgSwitcher && orgs.data && orgs.data.orgs.length > 1 && (
+            <div className="absolute left-full top-0 z-40 ml-2">
+              <OrgSwitcher
+                currentOrgId={account.org_id ?? null}
+                buttonLabel={`Switch organization (${orgs.data.orgs.length} members of)`}
+                onClose={() => setShowOrgSwitcher(false)}
+                onSwitch={switchOrg}
               />
-            ) : (
-              <span className="h-8 w-8 rounded-full border border-slate-200 bg-slate-100 flex items-center justify-center text-xs font-semibold text-slate-600">
-                {account.display_name.slice(0, 1).toUpperCase()}
-              </span>
-            )}
-          </button>
-          {showAccountMenu && (
-            <div className="absolute right-0 top-full z-30 mt-2 w-64 rounded-md border border-slate-200 bg-white p-2 shadow-lg">
-              <div className="px-2 py-2 border-b border-slate-100">
-                <div className="font-medium text-slate-900">
-                  {account.display_name}
-                </div>
-                <div className="text-xs text-slate-500">
-                  {account.server_slug || account.server_id}
-                </div>
-                <div className="mt-1 text-xs text-slate-500">
-                  {account.principal_type === "agent" ? "Raft agent" : "Raft user"}
-                </div>
-              </div>
-              <Link
-                to="/settings"
-                role="menuitem"
-                className="mt-2 flex w-full items-center rounded-md px-2 py-2 text-left text-sm text-slate-700 no-underline hover:bg-slate-100"
-                onClick={() => setShowAccountMenu(false)}
-              >
-                Settings
-              </Link>
-              <button
-                type="button"
-                role="menuitem"
-                className="mt-1 flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm text-red-600 hover:bg-red-50"
-                onClick={onLogout}
-              >
-                <span>Logout</span>
-                <span aria-hidden="true">↗</span>
-              </button>
             </div>
           )}
         </div>
+      </nav>
+      <div ref={accountMenuRef} className="relative mt-auto flex w-full flex-col items-center px-2">
+        <button
+          type="button"
+          className="rounded-full outline-none hover:ring-2 hover:ring-slate-200"
+          onClick={() => setShowAccountMenu((open) => !open)}
+          aria-haspopup="menu"
+          aria-expanded={showAccountMenu}
+          title={`${account.display_name} · ${account.server_slug || account.server_id}`}
+        >
+          {account.avatar_url ? (
+            <img
+              src={account.avatar_url}
+              alt=""
+              className="h-9 w-9 rounded-full border border-slate-200"
+            />
+          ) : (
+            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-slate-100 text-xs font-semibold text-slate-600">
+              {account.display_name.slice(0, 1).toUpperCase()}
+            </span>
+          )}
+        </button>
+        {showAccountMenu && (
+          <div className="absolute bottom-0 left-full z-40 ml-2 w-64 rounded-md border border-slate-200 bg-white p-2 shadow-lg">
+            <div className="px-2 py-2 border-b border-slate-100">
+              <div className="font-medium text-slate-900 flex items-center gap-1">
+                {account.display_name}
+                {account.principal_type === "agent" && (
+                  <span className="badge-purple text-xs" title="Raft agent principal">
+                    agent
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-slate-500">
+                {account.server_slug || account.server_id}
+              </div>
+              <div className="mt-1 text-xs text-slate-500">
+                {account.principal_type === "agent" ? "Raft agent" : "Raft user"}
+              </div>
+            </div>
+            <Link
+              to="/settings"
+              role="menuitem"
+              className="mt-2 flex w-full items-center rounded-md px-2 py-2 text-left text-sm text-slate-700 no-underline hover:bg-slate-100"
+              onClick={() => setShowAccountMenu(false)}
+            >
+              Settings
+            </Link>
+            <button
+              type="button"
+              role="menuitem"
+              className="mt-1 flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm text-red-600 hover:bg-red-50"
+              onClick={onLogout}
+            >
+              <span>Logout</span>
+              <span aria-hidden="true">↗</span>
+            </button>
+          </div>
+        )}
       </div>
     </header>
   );
@@ -675,8 +626,9 @@ function LandingFeature({ title, body }: { title: string; body: string }) {
 
 function AuthenticatedApp({ account }: { account: AuthAccount }) {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex">
       <Header account={account} />
+      <div className="min-w-0 flex-1 flex flex-col">
       <Routes>
         <Route path="/" element={<Navigate to="/apps" replace />} />
         <Route path="/apps" element={<AppsListWithNav />} />
@@ -731,6 +683,7 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
           </a>
         </div>
       </footer>
+      </div>
     </div>
   );
 }
@@ -865,7 +818,7 @@ function AppShell() {
         <div className="md:hidden">
           <AppContextNav />
         </div>
-        <main className="max-w-5xl px-8 py-6 w-full">
+        <main className="w-full px-8 py-6">
         <Routes>
           <Route index element={<AppDetailRoute />} />
           <Route path="publish" element={<LegacyPublishRedirect />} />

--- a/migrations/sql/0028_app_icon.sql
+++ b/migrations/sql/0028_app_icon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE apps ADD COLUMN icon_r2_key TEXT;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -24,7 +24,15 @@ import {
   handleAuthMe,
   handleRaftCallback,
 } from "./routes/auth";
-import { handleListApps, handleCreateApp, handleGetApp, handleArchiveApp, handleUpdateApp } from "./routes/apps";
+import {
+  handleListApps,
+  handleCreateApp,
+  handleGetApp,
+  handleArchiveApp,
+  handleUpdateApp,
+  handleUploadAppIcon,
+  handlePublicAppIcon,
+} from "./routes/apps";
 import {
   handlePublicListChannels,
 } from "./routes/public";
@@ -428,6 +436,7 @@ app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
 app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
+app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/api/invites/:token", handleGetInvite);
 
 function isWorkerRoute(pathname: string): boolean {
@@ -537,6 +546,7 @@ admin.post("/api/apps/:appId/releases/:releaseId/rollback", requireAppRole("publ
 admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("publisher"), handleBumpRollout);
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
+admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -264,3 +264,48 @@ export async function handleUpdateApp(c: AdminContext) {
 
   return c.json({ ok: true });
 }
+
+const APP_ICON_MAX_BYTES = 1024 * 1024;
+
+/** PUT /api/apps/:appId/icon — upload a PNG/WebP app icon (<=1MB). */
+export async function handleUploadAppIcon(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const app = await c.env.DB.prepare("SELECT id FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+
+  const contentType = c.req.header("content-type") ?? "";
+  if (!/^image\/(png|webp|jpeg)$/.test(contentType)) {
+    return c.json({ error: "content-type must be image/png, image/webp, or image/jpeg" }, 400);
+  }
+  const bytes = await c.req.arrayBuffer();
+  if (bytes.byteLength === 0) return c.json({ error: "empty body" }, 400);
+  if (bytes.byteLength > APP_ICON_MAX_BYTES) {
+    return c.json({ error: "icon too large (max 1MB)" }, 400);
+  }
+  const key = `apps/${appId}/icon`;
+  await c.env.APK_BUCKET.put(key, bytes, {
+    httpMetadata: { contentType },
+  });
+  await c.env.DB.prepare("UPDATE apps SET icon_r2_key = ?1 WHERE id = ?2")
+    .bind(key, appId)
+    .run();
+  return c.json({ ok: true, icon_r2_key: key });
+}
+
+/** GET /public/apps/:slug/icon — public, cacheable app icon. */
+export async function handlePublicAppIcon(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  const app = await c.env.DB.prepare(
+    "SELECT icon_r2_key FROM apps WHERE slug = ?1",
+  )
+    .bind(slug)
+    .first<{ icon_r2_key: string | null }>();
+  if (!app?.icon_r2_key) return c.json({ error: "no icon" }, 404);
+  const object = await c.env.APK_BUCKET.get(app.icon_r2_key);
+  if (!object) return c.json({ error: "no icon" }, 404);
+  const headers = new Headers({ "cache-control": "public, max-age=300" });
+  object.writeHttpMetadata?.(headers);
+  return new Response(object.body, { headers });
+}

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -20,6 +20,8 @@ type ShareRow = {
 
 type SharePageRow = {
   password_hash: string | null;
+  icon_r2_key: string | null;
+  package_id: string | null;
   share_id: string;
   expires_at: number;
   app_slug: string;
@@ -445,6 +447,14 @@ async function findActiveShare(db: D1Database, token: string): Promise<SharePage
        rs.password_hash AS password_hash,
        a.slug AS app_slug,
        a.name AS app_name,
+       a.icon_r2_key AS icon_r2_key,
+       COALESCE(
+         json_extract(b.parsed_metadata_json, '$.package_id'),
+         json_extract(b.parsed_metadata_json, '$.package_name'),
+         json_extract(b.build_metadata_json, '$.package_id'),
+         json_extract(b.build_metadata_json, '$.package_name'),
+         json_extract(b.build_metadata_json, '$.android.package_id')
+       ) AS package_id,
        ch.slug AS channel_slug,
        r.id AS release_id,
        r.status AS release_status,
@@ -606,6 +616,8 @@ function renderSharePage(
     body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f5f5f2; color: #1e1f22; }
     main { width: min(560px, calc(100vw - 32px)); padding: 32px 0; }
     h1 { margin: 0 0 8px; font-size: 28px; line-height: 1.15; letter-spacing: 0; }
+    .apphead { display: flex; align-items: center; gap: 16px; }
+    .apphead .appicon { border-radius: 12px; flex: none; }
     p { margin: 0; color: #5b616e; line-height: 1.5; }
     dl { display: grid; grid-template-columns: 140px 1fr; gap: 10px 16px; margin: 28px 0; }
     dt { color: #707782; }
@@ -631,10 +643,15 @@ function renderSharePage(
 </head>
 <body>
   <main>
-    <h1>${escapeHtml(row.app_name || row.app_slug)}</h1>
-    <p>${escapeHtml(row.version_name)} · build ${row.version_code} · ${escapeHtml(row.channel_slug)}</p>
+    <div class="apphead">
+      ${row.icon_r2_key ? `<img class="appicon" src="/public/apps/${escapeAttribute(row.app_slug)}/icon" alt="" width="56" height="56">` : ""}
+      <div>
+        <h1>${escapeHtml(row.app_name || row.app_slug)}</h1>
+        <p>${escapeHtml(row.version_name)} · build ${row.version_code} · ${escapeHtml(row.channel_slug)}</p>
+      </div>
+    </div>
     <dl>
-      <dt>Package</dt><dd>${escapeHtml(row.app_slug)}</dd>
+      <dt>Package</dt><dd>${escapeHtml(row.package_id || row.app_slug)}</dd>
       <dt>Version</dt><dd>${escapeHtml(row.version_name)} (${row.version_code})</dd>
       <dt>Artifact</dt><dd>${escapeHtml(row.filetype.toUpperCase())} · ${formatBytes(row.size_bytes)}</dd>
       <dt>Platform</dt><dd>${escapeHtml([row.platform, row.arch, row.variant].filter(Boolean).join(" / "))}</dd>

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -52,7 +52,7 @@ function makeMockDb() {
     CREATE TABLE apps (
       id TEXT PRIMARY KEY, org_id TEXT, slug TEXT NOT NULL UNIQUE, name TEXT NOT NULL,
       platform TEXT NOT NULL, description TEXT, archived INTEGER NOT NULL DEFAULT 0,
-      archived_at INTEGER, created_at INTEGER NOT NULL
+      archived_at INTEGER, created_at INTEGER NOT NULL, icon_r2_key TEXT
     );
     CREATE TABLE channels (
       id TEXT PRIMARY KEY, app_id TEXT NOT NULL, slug TEXT NOT NULL,


### PR DESCRIPTION
Two pieces (second was in flight when the rail feedback landed):

## Sentry-style chrome (artin's reference screenshot)
- Top bar removed. Global nav is a narrow left rail: Quiver logo, Apps, Org (with the org switcher popover), and the account avatar pinned to the bottom (menu with Settings/Logout opening rightward).
- App pages: rail → app sidebar (switcher + sections) → content that fills the remaining width (no more centered box / dead right side).

## Task #67: app icon + package name (share pages)
- Migration 0028: `apps.icon_r2_key`.
- `PUT /api/apps/:appId/icon` (publisher; png/webp/jpeg ≤1MB → R2) and public cacheable `GET /public/apps/:slug/icon`.
- Share page header now shows the app icon (when set) beside the title, and the Package row shows the real package id extracted from build metadata (`json_extract` over parsed/build metadata, falls back to slug).

Verification: worker tests 67/67, worker+admin tsc clean, admin build clean.

Note: icon auto-extraction from the APK (container aapt) is a follow-up; for now the icon is uploaded once per app via API/admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)