### PR TITLE
feat(admin): icon upload UI, default-enter first app, richer switcher

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
+    "lucide-react": "^1.23.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0"

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -10,6 +10,7 @@ import {
   Link,
 } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { Building2, ChevronsUpDown, LayoutGrid, Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { AppsList } from "./pages/AppsList";
 import { AppChannels, AppDetail, AppSettings } from "./pages/AppDetail";
@@ -129,7 +130,7 @@ function Header({ account }: { account: AuthAccount }) {
       </Link>
       <nav className="flex w-full flex-col items-stretch gap-1 px-2">
         <NavLink to="/apps" end={false} className={railItem}>
-          <span aria-hidden="true" className="text-base leading-none">▦</span>
+          <LayoutGrid className="h-4 w-4" aria-hidden="true" />
           Apps
         </NavLink>
         <div className="relative w-full">
@@ -148,7 +149,7 @@ function Header({ account }: { account: AuthAccount }) {
                 : "Org settings"
             }
           >
-            <span aria-hidden="true" className="text-base leading-none">◫</span>
+            <Building2 className="h-4 w-4" aria-hidden="true" />
             Org
           </NavLink>
           {showOrgSwitcher && orgs.data && orgs.data.orgs.length > 1 && (
@@ -690,9 +691,28 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
 
 function AppsListWithNav() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const showAll = params.get("all") === "1";
+  const openNew = params.get("new") === "1";
+  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
+
+  // Default behavior per artin: /apps drops you into the first app; the
+  // full list is reachable via ?all=1 (sidebar "All apps"), and with zero
+  // apps we go straight to the creation wizard.
+  if (!showAll && !openNew && apps.data) {
+    const active = apps.data.apps.filter((a) => !a.archived);
+    if (active.length > 0) {
+      return <Navigate to={`/apps/${active[0]!.id}`} replace />;
+    }
+  }
+  const zeroApps = apps.data ? apps.data.apps.filter((a) => !a.archived).length === 0 : false;
   return (
     <StandardPageShell>
-      <AppsList onSelectApp={(appId) => navigate(`/apps/${appId}`)} />
+      <AppsList
+        onSelectApp={(appId) => navigate(`/apps/${appId}`)}
+        initialShowCreate={openNew || zeroApps}
+      />
     </StandardPageShell>
   );
 }
@@ -722,6 +742,7 @@ const APP_NAV_SECTIONS: Array<{ label: string; items: Array<{ to: string; label:
 function AppSidebar() {
   const { appId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
   if (!appId) return null;
@@ -748,7 +769,7 @@ function AppSidebar() {
               <span className="truncate text-xs text-slate-400 font-mono">{app?.slug}</span>
             </span>
           </span>
-          <span className="text-slate-400" aria-hidden="true">⌄</span>
+          <ChevronsUpDown className="h-4 w-4 text-slate-400" aria-hidden="true" />
         </button>
         {switcherOpen && (
           <div className="absolute left-3 right-3 top-full z-30 -mt-1 rounded-md border border-slate-200 bg-white py-1 shadow-lg">
@@ -759,7 +780,8 @@ function AppSidebar() {
                 className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
                 onClick={() => {
                   setSwitcherOpen(false);
-                  navigate(`/apps/${a.id}`);
+                  const section = location.pathname.split("/")[3] ?? "";
+                  navigate(section ? `/apps/${a.id}/${section}` : `/apps/${a.id}`);
                 }}
               >
                 <span className="truncate">{a.name}</span>
@@ -770,11 +792,18 @@ function AppSidebar() {
               <div className="px-3 py-2 text-xs text-slate-400">No other apps</div>
             )}
             <Link
-              to="/apps"
-              className="mt-1 flex items-center gap-1 border-t border-slate-100 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50"
+              to="/apps?new=1"
+              className="mt-1 flex items-center gap-1.5 border-t border-slate-100 px-3 py-2 text-xs text-slate-600 hover:bg-slate-50"
               onClick={() => setSwitcherOpen(false)}
             >
-              ← All apps
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" /> New app
+            </Link>
+            <Link
+              to="/apps?all=1"
+              className="flex items-center gap-1.5 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50"
+              onClick={() => setSwitcherOpen(false)}
+            >
+              <LayoutGrid className="h-3.5 w-3.5" aria-hidden="true" /> All apps
             </Link>
           </div>
         )}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1141,3 +1141,19 @@ export const addFeedbackComment = (appId: string, ticketId: string, body: string
 
 export const feedbackAttachmentUrl = (appId: string, ticketId: string, attachmentId: string) =>
   `/api/apps/${appId}/feedback/${ticketId}/attachments/${attachmentId}`;
+
+export const uploadAppIcon = async (appId: string, file: File) => {
+  const res = await fetch(`${API_BASE}/api/apps/${appId}/icon`, {
+    method: "PUT",
+    headers: { "content-type": file.type || "image/png" },
+    body: file,
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new ApiError(res.status, text, text || `${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<{ ok: boolean; icon_r2_key: string }>;
+};
+
+export const publicAppIconUrl = (slug: string) => `${API_BASE}/public/apps/${slug}/icon`;

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -12,6 +12,8 @@ import {
   updateApp,
   type App,
   type Channel,
+  uploadAppIcon,
+  publicAppIconUrl,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
@@ -167,6 +169,60 @@ export function AppChannels({ appId }: { appId: string }) {
   );
 }
 
+function AppIconUploader({ appId, slug }: { appId: string; slug: string }) {
+  const toast = useToast();
+  const [bust, setBust] = useState(0);
+  const upload = useMutation({
+    mutationFn: (file: File) => uploadAppIcon(appId, file),
+    onSuccess: () => {
+      toast.show({ kind: "success", title: "App icon updated" });
+      setBust(Date.now());
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Icon upload failed",
+        description: (e as Error).message,
+      }),
+  });
+  return (
+    <div className="flex items-center gap-3">
+      <img
+        src={`${publicAppIconUrl(slug)}${bust ? `?v=${bust}` : ""}`}
+        alt=""
+        width={44}
+        height={44}
+        className="h-11 w-11 rounded-lg border border-slate-200 bg-slate-50 object-cover"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.visibility = "hidden";
+        }}
+        onLoad={(e) => {
+          (e.target as HTMLImageElement).style.visibility = "visible";
+        }}
+      />
+      <div>
+        <div className="text-sm font-medium">App icon</div>
+        <div className="text-xs text-slate-500">
+          Shown on share/download pages. PNG/WebP/JPEG, max 1MB.
+        </div>
+      </div>
+      <label className="btn-secondary !py-1 !px-2 !text-xs ml-auto cursor-pointer">
+        {upload.isPending ? "Uploading…" : "Upload"}
+        <input
+          type="file"
+          accept="image/png,image/webp,image/jpeg"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) upload.mutate(file);
+            e.currentTarget.value = "";
+          }}
+        />
+      </label>
+    </div>
+  );
+}
+
 export function AppSettings({ appId }: { appId: string }) {
   const qc = useQueryClient();
   const toast = useToast();
@@ -206,6 +262,9 @@ export function AppSettings({ appId }: { appId: string }) {
 
       <div className="card !p-4 text-sm space-y-3">
         <h2 className="text-base font-semibold">Settings</h2>
+
+        {/* App icon */}
+        <AppIconUploader appId={appId} slug={app.slug} />
 
         {/* Default release channel picker */}
         <DefaultChannelPicker appId={appId} app={app} isOrgAdmin={isOrgAdmin} />

--- a/admin/src/pages/AppsList.tsx
+++ b/admin/src/pages/AppsList.tsx
@@ -9,14 +9,14 @@ import {
 } from "../lib/api";
 import { AppCreationWizard } from "../components/AppCreationWizard";
 
-export function AppsList({ onSelectApp }: { onSelectApp: (id: string) => void }) {
+export function AppsList({ onSelectApp, initialShowCreate }: { onSelectApp: (id: string) => void; initialShowCreate?: boolean }) {
   const qc = useQueryClient();
   const { data, error, isLoading } = useQuery({
     queryKey: ["apps"],
     queryFn: () => listApps(),
   });
 
-  const [showCreate, setShowCreate] = useState(false);
+  const [showCreate, setShowCreate] = useState(initialShowCreate ?? false);
   const [showArchived, setShowArchived] = useState(false);
 
   // Phase 1: filter archived client-side (server doesn't yet support query param).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.101.1(react@18.3.1)
+      lucide-react:
+        specifier: ^1.23.0
+        version: 1.23.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1544,6 +1547,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.23.0:
+    resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3287,6 +3295,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.23.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
Completes task #67 admin side + artin's latest nav feedback:

- **App icon uploader** in App Settings (preview, PNG/WebP/JPEG ≤1MB, PUT /api/apps/:id/icon) — share pages pick it up immediately.
- **/apps default behavior**: goes straight into the first active app; `?all=1` shows the full list (sidebar "All apps"); zero apps → creation wizard opens automatically (`?new=1` also supported).
- **App switcher**: adds "+ New app", keeps the current section when jumping between apps.
- **lucide-react** icons for the rail (LayoutGrid/Building2), switcher caret (ChevronsUpDown), and menu items.

Verification: admin build + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)