### PR TITLE
feat(cli,worker): draft-first release flow with bilingual changelog

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,47 @@
+# Release runbook (draft-first flow)
+
+Policy (artin, 2026-07-04): **CI never completes a real release.** CI builds,
+signs, generates a raw changelog, and creates a **draft** release on Quiver.
+A human or agent then reviews, writes the final bilingual changelog, and
+publishes explicitly.
+
+## 1. CI (automatic)
+
+`botiverse/mobile` → Actions → **Android Release** (defaults to draft mode):
+
+- builds + signs the APK
+- generates a raw commit-subject changelog (previous build's
+  `provenance.source_commit` → HEAD, fallback last 15 subjects)
+- `quiver builds publish-android … --draft` creates the build + assets +
+  **draft** release (invisible to update checks and share pages)
+- job summary shows the draft release id and the raw changelog
+
+## 2. Review + bilingual changelog (agent/human)
+
+```sh
+# inspect the draft
+quiver releases show raft-android <releaseId>
+
+# write the reviewed changelog in both languages
+quiver releases update raft-android <releaseId> \
+  --changelog-zh-file changelog.zh.md \
+  --changelog-en-file changelog.en.md
+```
+
+Storage format: plain text (legacy, served as-is) or a JSON object
+`{"en": "…", "zh-CN": "…"}`. Clients pick a language via `lang=` /
+`X-Quiver-Lang` / `Accept-Language` on update checks; share pages use the
+browser's `Accept-Language`. Fallback order: exact tag → language prefix →
+`en` → first available.
+
+## 3. Publish (explicit)
+
+```sh
+quiver releases publish raft-android <releaseId>
+# then, if desired:
+quiver releases share raft-android <releaseId> --password <pw>
+```
+
+Publishing supersedes the previous active release on the same
+app/channel/product/release-type; staged rollout percentage can be set before
+or after publish (`rollout_cohort_count`, bump via admin or API).

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -2,6 +2,7 @@
  * `quiver releases` — release operations that are not part of build publish.
  */
 
+import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import { apiRequest } from "../lib/api.js";
 
@@ -25,6 +26,101 @@ export function registerReleaseCommands(program: Command): void {
   const releases = program
     .command("releases")
     .description("Manage release shares.");
+
+  releases
+    .command("show <appIdOrSlug> <releaseId>")
+    .description("Show a release (status, changelog, rollout) for review.")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const detail = await apiRequest<{ release: Record<string, unknown> }>(
+        `/api/apps/${appId}/releases/${releaseId}`,
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(detail, null, 2));
+        return;
+      }
+      const r = detail.release as {
+        id: string;
+        status: string;
+        changelog: string | null;
+        rollout_cohort_count: number | null;
+      };
+      console.log(`Release ${r.id}`);
+      console.log(`  status:  ${r.status}`);
+      console.log(`  rollout: ${r.rollout_cohort_count ?? 100}%`);
+      console.log(`  changelog:`);
+      console.log((r.changelog ?? "(none)").split("\n").map((l) => "    " + l).join("\n"));
+    });
+
+  releases
+    .command("update <appIdOrSlug> <releaseId>")
+    .description("Update a draft/active release; use to write the reviewed changelog before publish.")
+    .option("--changelog <text>", "Plain changelog text (single language).")
+    .option("--changelog-file <path>", "Read plain changelog from file.")
+    .option("--changelog-en <text>", "English changelog (bilingual mode).")
+    .option("--changelog-en-file <path>", "English changelog from file.")
+    .option("--changelog-zh <text>", "Chinese changelog (bilingual mode).")
+    .option("--changelog-zh-file <path>", "Chinese changelog from file.")
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        releaseId: string,
+        opts: {
+          changelog?: string;
+          changelogFile?: string;
+          changelogEn?: string;
+          changelogEnFile?: string;
+          changelogZh?: string;
+          changelogZhFile?: string;
+          json?: boolean;
+        },
+      ) => {
+        const appId = await resolveAppId(appIdOrSlug);
+        const en = opts.changelogEnFile ? readFileSync(opts.changelogEnFile, "utf8") : opts.changelogEn;
+        const zh = opts.changelogZhFile ? readFileSync(opts.changelogZhFile, "utf8") : opts.changelogZh;
+        const plain = opts.changelogFile ? readFileSync(opts.changelogFile, "utf8") : opts.changelog;
+        let changelog: string | undefined;
+        if (en || zh) {
+          const payload: Record<string, string> = {};
+          if (en) payload["en"] = en.trim();
+          if (zh) payload["zh-CN"] = zh.trim();
+          changelog = JSON.stringify(payload);
+        } else if (plain !== undefined) {
+          changelog = plain.trim();
+        }
+        if (changelog === undefined) {
+          throw new Error("nothing to update: pass --changelog(-file) or --changelog-en/--changelog-zh");
+        }
+        const updated = await apiRequest<Record<string, unknown>>(
+          `/api/apps/${appId}/releases/${releaseId}`,
+          { method: "PATCH", body: { changelog } },
+        );
+        if (opts.json) {
+          console.log(JSON.stringify(updated, null, 2));
+          return;
+        }
+        console.log(`Updated release ${releaseId} changelog${en || zh ? " (bilingual)" : ""}.`);
+      },
+    );
+
+  releases
+    .command("publish <appIdOrSlug> <releaseId>")
+    .description("Publish a draft release (the explicit human/agent step after changelog review).")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<Record<string, unknown>>(
+        `/api/apps/${appId}/releases/${releaseId}/publish`,
+        { method: "POST", body: {} },
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`Published release ${releaseId}.`);
+    });
 
   releases
     .command("share <appIdOrSlug> <releaseId>")

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -305,7 +305,7 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
       version: build.version_name,
       version_code: build.version_code,
       release_type: "stable",
-      changelog: build.changelog,
+      changelog: resolveChangelog(build.changelog, requestedLang(c)),
       force_update: Boolean(build.should_force_update),
       released_at: build.completed_at ?? build.created_at,
     },
@@ -467,6 +467,45 @@ export function rolloutIncludes(
   if (cohortCount <= 0) return false;
   if (!deviceId) return false;
   return rolloutBucket(releaseId, deviceId) < cohortCount;
+}
+
+/**
+ * Changelog may be plain text (legacy, treated as en) or a JSON object of
+ * BCP-47-ish keys ({"en": "...", "zh-CN": "..."}). Resolve to the closest
+ * language, falling back en -> first available.
+ */
+export function resolveChangelog(raw: string | null, lang: string | null): string | null {
+  if (!raw) return raw;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) return raw;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return raw;
+  }
+  const entries = Object.entries(parsed).filter(
+    (e): e is [string, string] => typeof e[1] === "string" && e[1].length > 0,
+  );
+  if (entries.length === 0) return null;
+  const lower = (lang ?? "").toLowerCase();
+  const exact = entries.find(([k]) => k.toLowerCase() === lower);
+  if (exact) return exact[1];
+  const prefix = lower.split("-")[0];
+  if (prefix) {
+    const partial = entries.find(([k]) => k.toLowerCase().split("-")[0] === prefix);
+    if (partial) return partial[1];
+  }
+  const en = entries.find(([k]) => k.toLowerCase().split("-")[0] === "en");
+  return (en ?? entries[0]!)[1];
+}
+
+function requestedLang(c: Context<{ Bindings: Env }>): string | null {
+  const explicit = c.req.query("lang") ?? c.req.header("X-Quiver-Lang");
+  if (explicit) return explicit;
+  const accept = c.req.header("accept-language");
+  if (!accept) return null;
+  return accept.split(",")[0]?.trim().split(";")[0] ?? null;
 }
 
 function splitPlatformArch(value: string | null): {

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import qrcode from "qrcode-generator";
 import { requestOrigin } from "../lib/origin";
 import { currentActor, type AdminEnv } from "../middleware/auth";
-import { generateSignedR2Url } from "./public_v2";
+import { generateSignedR2Url, resolveChangelog } from "./public_v2";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -328,7 +328,9 @@ export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
   const origin = publicRequestOrigin(c);
   const downloadUrl = new URL(`/share/${token}/download`, origin).toString();
   const shareUrl = new URL(`/share/${token}`, origin).toString();
-  return htmlResponse(renderSharePage(row, stats, downloadUrl, shareUrl));
+  const lang = (c.req.header("accept-language") ?? "").split(",")[0]?.trim().split(";")[0] ?? null;
+  const localized = { ...row, changelog: resolveChangelog(row.changelog, lang) };
+  return htmlResponse(renderSharePage(localized, stats, downloadUrl, shareUrl));
 }
 
 export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: Env }>) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2284,6 +2284,20 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(body.asset).toBeUndefined();
   });
 
+  it("resolveChangelog picks languages with sane fallbacks", async () => {
+    const { resolveChangelog } = await import("../src/routes/public_v2");
+    expect(resolveChangelog(null, "zh-CN")).toBe(null);
+    expect(resolveChangelog("plain text notes", "zh-CN")).toBe("plain text notes");
+    const bilingual = JSON.stringify({ en: "english notes", "zh-CN": "中文说明" });
+    expect(resolveChangelog(bilingual, "zh-CN")).toBe("中文说明");
+    expect(resolveChangelog(bilingual, "zh")).toBe("中文说明");
+    expect(resolveChangelog(bilingual, "en-US")).toBe("english notes");
+    expect(resolveChangelog(bilingual, "fr")).toBe("english notes");
+    expect(resolveChangelog(bilingual, null)).toBe("english notes");
+    expect(resolveChangelog(JSON.stringify({ "zh-CN": "只有中文" }), "fr")).toBe("只有中文");
+    expect(resolveChangelog("{not json", "en")).toBe("{not json");
+  });
+
   it("rollout helpers are deterministic and clamp edge counts", async () => {
     const { fnv1a32, rolloutBucket, rolloutIncludes } = await import(
       "../src/routes/public_v2"


### PR DESCRIPTION
Task #69 quiver side (release policy: CI only creates drafts; an agent reviews + publishes).

## CLI
- `quiver releases show <app> <releaseId>` — review a draft (status, rollout, changelog).
- `quiver releases update <app> <releaseId> --changelog-zh-file zh.md --changelog-en-file en.md` — write the reviewed changelog; bilingual mode stores `{"en":…,"zh-CN":…}`; plain `--changelog(-file)` still supported.
- `quiver releases publish <app> <releaseId>` — the explicit post-review publish step.
- (`builds publish-android --draft` already existed and is the CI entry point.)

## Worker changelog i18n
- Changelog may be legacy plain text (treated as en) or a `{lang: text}` JSON object.
- Update checks resolve via `lang=` / `X-Quiver-Lang` / `Accept-Language`; share pages via browser `Accept-Language`. Fallback: exact tag → language prefix → en → first available.

## Docs
- `docs/release-runbook.md`: CI-draft → review/bilingual changelog → explicit publish.

Verification: worker tests 68/68 (new resolveChangelog suite), tsc clean, CLI build clean.

Mobile-side PR next: workflow defaults to draft + prints the raw changelog in the job summary; publish helper also extracts the real APK icon (aapt) and pushes it via the icon API (task #67 follow-through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)