### PR TITLE
feat(worker,container): auto-extract per-build app icon and metadata

### DIFF
--- a/container/src/parsers/apk.ts
+++ b/container/src/parsers/apk.ts
@@ -56,6 +56,39 @@ export async function parseApk(
     const appLabel =
       badging.match(/^application-label(?:-[a-z]+)?:'([^']+)'/m)?.[1] ?? null;
 
+    // Launcher icon: prefer the highest-density PNG/WebP entry from
+    // application-icon-<density> lines; adaptive-icon XML entries are
+    // skipped (no rasterizer in this container).
+    let iconBase64: string | null = null;
+    let iconContentType: string | null = null;
+    const iconCandidates = [
+      ...badging.matchAll(/^application-icon-(\d+):'([^']+)'/gm),
+    ]
+      .map((m) => ({ density: Number(m[1]), path: m[2]! }))
+      .sort((a, b) => b.density - a.density);
+    const singleIcon = badging.match(/^application:.*icon='([^']+)'/m)?.[1];
+    if (singleIcon) iconCandidates.push({ density: 0, path: singleIcon });
+    for (const candidate of iconCandidates) {
+      const lower = candidate.path.toLowerCase();
+      const isPng = lower.endsWith(".png");
+      const isWebp = lower.endsWith(".webp");
+      if (!isPng && !isWebp) continue;
+      try {
+        const { stdout: iconBytes } = await execFileAsync(
+          "unzip",
+          ["-p", apkPath, candidate.path],
+          { maxBuffer: 5 * 1024 * 1024, encoding: "buffer" },
+        );
+        const buf = iconBytes as unknown as Buffer;
+        if (buf.length === 0) continue;
+        iconBase64 = buf.toString("base64");
+        iconContentType = isPng ? "image/png" : "image/webp";
+        break;
+      } catch {
+        // entry missing or unzip failure — try the next density
+      }
+    }
+
     const { stdout: certsOut } = await execFileAsync(
       APKSIGNER_BIN,
       ["verify", "--print-certs", apkPath],
@@ -73,6 +106,8 @@ export async function parseApk(
       version_code: Number.isFinite(versionCode) ? versionCode : null,
       package_id: packageName || null,
       app_label: appLabel,
+      icon_base64: iconBase64,
+      icon_content_type: iconContentType,
       size_bytes: bytes.byteLength,
       file_hash_sha256: sha256Hex(bytes),
       raw: {

--- a/container/src/parsers/index.ts
+++ b/container/src/parsers/index.ts
@@ -32,6 +32,9 @@ export interface ParsedMetadata {
   size_bytes: number;
   file_hash_sha256: string;
   raw: Record<string, unknown>; // parser-specific extras
+  /** Launcher icon extracted from the package, when available. */
+  icon_base64?: string | null;
+  icon_content_type?: string | null;
 }
 
 const EXT_TO_KIND: Record<string, ParserKind> = {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -50,6 +50,7 @@ import {
   handleUpdateReleaseShare,
   handleListAppShares,
   handlePublicReleaseShareUnlock,
+  handlePublicReleaseShareIcon,
 } from "./routes/shares";
 import {
   handlePublicFeedbackSubmit,
@@ -435,6 +436,7 @@ app.get("/public/r2/:key", handlePublicR2Download);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
+app.get("/share/:token/icon", handlePublicReleaseShareIcon);
 app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/api/invites/:token", handleGetInvite);

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -397,9 +397,100 @@ export async function handleCreateBuildAsset(c: Context<{ Bindings: Env }>) {
   const body = (await c.req.json()) as BuildAssetInput;
   try {
     const id = await createBuildAsset(c.env.DB, appId, buildId, body, currentActor(c));
+    // Installable Android APKs get parsed automatically in the background:
+    // aapt metadata merges into builds.parsed_metadata_json and the real
+    // launcher icon becomes an app-icon build asset (per-version icons on
+    // share pages, no extra CI/CLI parameters).
+    if (
+      (body.artifact_kind ?? "installable") === "installable" &&
+      body.platform === "android" &&
+      body.filetype === "apk" &&
+      body.r2_key
+    ) {
+      try {
+        c.executionCtx.waitUntil(
+          autoParseApkAsset(c.env, appId, buildId, body.r2_key),
+        );
+      } catch {
+        // executionCtx unavailable (tests) — parse inline, best effort.
+        autoParseApkAsset(c.env, appId, buildId, body.r2_key).catch(() => {});
+      }
+    }
     return c.json({ id, build_id: buildId, ...body }, 201);
   } catch (e) {
     return c.json({ error: (e as Error).message }, 400);
+  }
+}
+
+/**
+ * Fetch the APK from R2, parse it in the apk-parser container, merge the
+ * metadata into the build row, and register the extracted launcher icon as
+ * an app-icon asset. Best-effort: failures only log.
+ */
+export async function autoParseApkAsset(
+  env: Env,
+  appId: string,
+  buildId: string,
+  r2Key: string,
+): Promise<void> {
+  try {
+    const object = await env.APK_BUCKET.get(r2Key);
+    if (!object) return;
+    const bytes = await object.arrayBuffer();
+    // Lazy import: @cloudflare/containers pulls in the cloudflare:workers
+    // builtin, which only exists in the Workers runtime (not vitest/node).
+    const { getRandom } = await import("@cloudflare/containers");
+    const container = await getRandom(env.APK_PARSER, 1);
+    const res = await container.fetch(
+      new Request("http://container/parse?parser_kind=apk-aapt", {
+        method: "POST",
+        body: bytes,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    if (!res.ok) {
+      console.error(`[auto-parse] container ${res.status} for build ${buildId}`);
+      return;
+    }
+    const metadata = (await res.json()) as Record<string, unknown> & {
+      icon_base64?: string | null;
+      icon_content_type?: string | null;
+    };
+    const { icon_base64, icon_content_type, ...parsed } = metadata;
+    await env.DB.prepare(
+      "UPDATE builds SET parsed_metadata_json = ?1, updated_at = ?2 WHERE id = ?3",
+    )
+      .bind(JSON.stringify(parsed), Date.now(), buildId)
+      .run();
+
+    if (icon_base64) {
+      const iconBytes = Uint8Array.from(atob(icon_base64), (ch) => ch.charCodeAt(0));
+      const ext = icon_content_type === "image/webp" ? "webp" : "png";
+      const iconKey = `apps/${appId}/builds/${buildId}/icon.${ext}`;
+      await env.APK_BUCKET.put(iconKey, iconBytes, {
+        httpMetadata: { contentType: icon_content_type ?? "image/png" },
+      });
+      const digest = await crypto.subtle.digest("SHA-256", iconBytes);
+      const hash = Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      const now = Date.now();
+      await env.DB.batch([
+        env.DB.prepare(
+          "DELETE FROM build_assets WHERE build_id = ?1 AND artifact_kind = 'app-icon'",
+        ).bind(buildId),
+        env.DB.prepare(
+          `INSERT INTO build_assets
+           (id, build_id, artifact_kind, platform, arch, variant, filetype, r2_key,
+            file_hash, size_bytes, signature, metadata_json, created_at)
+           VALUES (?1, ?2, 'app-icon', 'android', NULL, NULL, ?3, ?4, ?5, ?6, NULL, '{}', ?7)`,
+        ).bind(crypto.randomUUID(), buildId, ext, iconKey, hash, iconBytes.length, now),
+      ]);
+    }
+  } catch (err) {
+    console.error(
+      `[auto-parse] failed for build ${buildId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -330,7 +330,7 @@ export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
   const shareUrl = new URL(`/share/${token}`, origin).toString();
   const lang = (c.req.header("accept-language") ?? "").split(",")[0]?.trim().split(";")[0] ?? null;
   const localized = { ...row, changelog: resolveChangelog(row.changelog, lang) };
-  return htmlResponse(renderSharePage(localized, stats, downloadUrl, shareUrl));
+  return htmlResponse(renderSharePage(localized, stats, downloadUrl, shareUrl, token));
 }
 
 export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: Env }>) {
@@ -355,6 +355,18 @@ export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: En
     publicRequestOrigin(c),
   );
   return c.redirect(signedUrl, 302);
+}
+
+export async function handlePublicReleaseShareIcon(c: Context<{ Bindings: Env }>) {
+  const token = c.req.param("token");
+  if (!token) return c.json({ error: "missing token" }, 400);
+  const row = await findActiveShare(c.env.DB, token);
+  if (!row?.icon_r2_key) return c.json({ error: "no icon" }, 404);
+  const object = await c.env.APK_BUCKET.get(row.icon_r2_key);
+  if (!object) return c.json({ error: "no icon" }, 404);
+  const headers = new Headers({ "cache-control": "public, max-age=300" });
+  object.writeHttpMetadata?.(headers);
+  return new Response(object.body, { headers });
 }
 
 export async function handlePublicReleaseShareUnlock(c: Context<{ Bindings: Env }>) {
@@ -449,7 +461,12 @@ async function findActiveShare(db: D1Database, token: string): Promise<SharePage
        rs.password_hash AS password_hash,
        a.slug AS app_slug,
        a.name AS app_name,
-       a.icon_r2_key AS icon_r2_key,
+       COALESCE(
+         (SELECT ia.r2_key FROM build_assets ia
+          WHERE ia.build_id = b.id AND ia.artifact_kind = 'app-icon'
+          ORDER BY ia.created_at DESC LIMIT 1),
+         a.icon_r2_key
+       ) AS icon_r2_key,
        COALESCE(
          json_extract(b.parsed_metadata_json, '$.package_id'),
          json_extract(b.parsed_metadata_json, '$.package_name'),
@@ -603,6 +620,7 @@ function renderSharePage(
   stats: ShareStats,
   downloadUrl: string,
   shareUrl: string,
+  shareToken: string,
 ): string {
   const title = `${row.app_slug} ${row.version_name} (${row.version_code})`;
   const expiresIso = new Date(row.expires_at).toISOString();
@@ -646,7 +664,7 @@ function renderSharePage(
 <body>
   <main>
     <div class="apphead">
-      ${row.icon_r2_key ? `<img class="appicon" src="/public/apps/${escapeAttribute(row.app_slug)}/icon" alt="" width="56" height="56">` : ""}
+      ${row.icon_r2_key ? `<img class="appicon" src="/share/${escapeAttribute(encodeURIComponent(shareToken))}/icon" alt="" width="56" height="56">` : ""}
       <div>
         <h1>${escapeHtml(row.app_name || row.app_slug)}</h1>
         <p>${escapeHtml(row.version_name)} · build ${row.version_code} · ${escapeHtml(row.channel_slug)}</p>


### PR DESCRIPTION
Task #67 follow-through per artin: share pages must show the **real icon parsed from the APK, per version**, with zero extra CLI parameters.

- **Container**: apk parser extracts the highest-density PNG/WebP launcher icon (`aapt dump badging` + `unzip -p`), returned as `icon_base64`/`icon_content_type`. Adaptive-icon-XML-only APKs skip gracefully.
- **Worker**: registering an installable `android/apk` asset kicks off a background parse (`waitUntil`): merged aapt metadata lands in `builds.parsed_metadata_json` (so `package_id` etc. populate automatically for every future build) and the icon becomes an `app-icon` build asset (idempotent).
- **Share pages**: icon resolves per build (`app-icon` asset → app-level icon fallback) and is served via `GET /share/:token/icon`; the admin-uploaded app icon is now just a fallback.
- CLI: unchanged (the earlier `--icon` idea was dropped per artin).

⚠️ Container image changed — deploying with `containers_rollout=immediate`.

Verification: worker tests 68/68 (containers lib lazily imported so vitest stays happy), worker+container tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)