### PR TITLE
docs: refresh public docs and README for today's features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ The "quiver" metaphor: admins load APK arrows into channels; clients pick the ri
 ## Features
 
 - **Channels** — keep main, preview, nightly, or debug releases separated by app. Publish to `main` for stable users, `preview` for validation, `nightly` for fast internal iteration.
-- **Update checks** — serve public latest/update responses with signed APK downloads; an Android SDK (`clients/android`) handles in-app update checks and installation.
-- **Share pages** — create revocable, expiring public download pages with view and download counts.
+- **Update checks & staged rollouts** — public latest/update responses with signed APK downloads, percentage rollouts bucketed by stable device id, and per-language changelogs; the Android SDK (`clients/android`) handles in-app checks, installation, and feedback submission.
+- **Share pages & version history** — revocable, expiring, optionally password-protected download pages with QR codes and view/download stats, plus an opt-in public version history page per app.
+- **Feedback tickets** — in-app feedback (attachments, device context) lands in a built-in ticket system with assignees, statuses, comments, and webhooks.
+- **Draft-first releases** — CI creates draft releases with generated changelogs; an agent reviews, writes bilingual notes, and publishes explicitly (`docs/release-runbook.md`).
 - **Raft access** — Login with Raft, org roles, direct app members, per-server visibility grants, and app-level deploy tokens for CI and agents.
 - **CI-friendly publishing** — the public npm CLI publishes Android releases and creates share links from GitHub Actions, local packaging lanes, or Raft agents:
 

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -1,37 +1,43 @@
 # Admin User Guide
 
-Quiver is a release and update distribution console for apps that need controlled binary delivery. Use the admin console to create apps, upload builds, publish releases, manage release channels, and give teammates or automation the access they need.
+Quiver is a release and update distribution console for apps that need controlled binary delivery. Use the admin console to create apps, upload builds, publish releases with staged rollouts, manage share links and feedback tickets, and give teammates or automation the access they need.
 
 ## Sign in
 
-Open the Quiver site and use Login with Raft. After sign-in, Quiver shows the apps you can access in the current organization.
+Open the Quiver site and use Login with Raft. After sign-in, Quiver drops you into your first app (or the app creation wizard if none exist). The left rail navigates between Apps, Org, and your account menu (Settings, Logout).
 
 If you can sign in but do not see an expected app, ask an organization admin to grant you app access or make the app visible to your Raft server.
 
 ## Apps
 
-The Apps page lists the apps visible to your account. Select an app to open its detail pages:
+Each app has a left sidebar with its sections; the app switcher at the top of the sidebar jumps between apps, creates new ones, or returns to the full list.
 
-- Overview: current app metadata and the default entry point.
-- Releases: published and draft releases by channel.
+- Overview: current app metadata and recent operations.
+- Channels: release tracks (`main`, `preview`, `nightly`, `debug`).
+- Releases: published and draft releases, staged rollout controls.
 - Builds: uploaded build artifacts and their metadata.
+- Shares: every public share link with stats, renewal, revocation, and passwords.
+- Feedback: tickets submitted from the app, with assignees, statuses, and comments.
 - Access: direct app members, deploy tokens, and Raft server visibility.
 - Audit: recent app activity.
+- Settings: app icon, default channel, public version history toggle, archive.
 
 Create one Quiver app per product distribution target. For example, an Android app should have its own Quiver app and release channels.
 
 ## Releases
 
-Use Releases to prepare and publish updates.
+The standard flow follows the draft-first policy: CI creates a **draft** release with a generated changelog; a human or agent reviews it, writes the final (optionally bilingual) changelog, and publishes explicitly. See the release runbook in the repository docs.
 
-1. Choose the app.
-2. Open Releases.
-3. Create a release or select an existing draft.
-4. Upload the installable artifact.
-5. Add release notes and metadata.
-6. Publish to the intended channel.
+1. CI (or `quiver builds publish-android --draft`) creates the draft.
+2. Review it in Releases (or `quiver releases show`).
+3. Write the final changelog — per-language notes are supported (`quiver releases update … --changelog-file zh=zh.md --changelog-file en=en.md`); clients receive the language matching their system locale.
+4. Publish from the release row (or `quiver releases publish`).
 
 For Android, Quiver selects updates by `version_code`. A device receives an update only when the published release has a higher `version_code` than the client reports.
+
+### Staged rollouts
+
+Set a rollout percentage when creating or editing a release (number input with 5/25/50/100 presets), and raise it with **Bump rollout**. Devices are bucketed by their stable device id, keep their bucket while the percentage climbs, and gated-out devices receive the previous active release. Clients without a device id (older SDKs) only receive fully rolled-out releases.
 
 ## Builds
 
@@ -43,8 +49,9 @@ Builds hold uploaded artifacts and provenance. Quiver distinguishes installable 
 | `proguard-mapping` | Android R8/ProGuard mapping file for crash symbolication. |
 | `native-symbols` | Native debug symbols. |
 | `metadata-file` | CI or build metadata archived with the build. |
+| `app-icon` | Launcher icon extracted automatically from the uploaded APK. |
 
-Public update checks only return installable artifacts. Support artifacts remain available to authenticated admins and publishers.
+Registering an installable APK triggers automatic parsing: package id, SDK levels, and the launcher icon are extracted server-side (aapt) with no extra CI parameters. Public update checks only return installable artifacts; support artifacts remain available to authenticated admins and publishers.
 
 ## Channels
 
@@ -52,20 +59,31 @@ Channels let you separate release tracks such as `main`, `preview`, `nightly`, o
 
 Android clients should send the channel they are configured to use. Debug builds can point at `debug`; release builds typically point at `main`.
 
-## Public Share Pages
+## Shares
 
-Release share pages provide a temporary public download page for a release. New share pages expire after 7 days by default. A share page can show basic view and download stats. Renew or change the expiration when a manual review window needs more time; revoke a share when it should no longer be accessible.
+The Shares tab lists every public share link for the app: release, creator, expiry, status, password badge, and view/download stats. From there you can create links (with an optional password), extend them by 7 days, set or remove passwords on existing links, and revoke them. Share URLs are shown once at creation — tokens are stored hashed.
+
+Share pages show the release's real app icon, a QR code on desktop, localized release notes, and live stats. Password-protected pages ask for the password before showing the download.
+
+```bash
+quiver releases share raft-android <release-id> --password <pw>   # optional password
+quiver releases update-share raft-android <release-id> <share-id> --ttl-seconds 1209600
+quiver releases revoke-share raft-android <release-id> <share-id>
+```
 
 Use share pages for human review and manual testing. Use the public update API for in-app update checks.
 
-CLI examples (`update-share` is available in source version `0.1.2`; use the HTTP API directly until that CLI version is published to npm):
+## Feedback
 
-```bash
-quiver releases share raft-android <release-id>
-quiver releases update-share raft-android <release-id> <share-id>
-quiver releases update-share raft-android <release-id> <share-id> --ttl-seconds 1209600
-quiver releases update-share raft-android <release-id> <share-id> --expires-at 1783742182499
-```
+The Feedback tab is a lightweight ticket system for reports submitted from the app (via the SDK's `QuiverFeedback` or the public feedback endpoint). Each ticket carries the message, contact, app version, device context (including the rollout device id), and up to three attachments.
+
+- Tickets are shareable pages (`/apps/<id>/feedback/<ticket>`).
+- Triage with statuses (`open → in_progress → resolved/closed`), an assignee (Assign to me / edit / unassign), and a comment trail.
+- A `feedback:new` webhook fires on submission for org webhook subscribers.
+
+## Version history
+
+Settings → **Public version history** exposes `/apps/<slug>/history`: a public page listing published versions with localized changelogs and per-version downloads. It is off by default; when disabled the page returns 404.
 
 ## Access
 
@@ -77,13 +95,13 @@ The Access page controls who can see or publish an app.
 | Raft server visibility | Make the app visible to accounts from another Raft server. |
 | Deploy token | Give CI or an agent scoped API access to this app. |
 
-Deploy tokens are app-scoped bearer tokens. Create them for automation instead of reusing a human browser session. Copy the token when it is created; Quiver only shows the raw token once.
+Deploy tokens are app-scoped bearer tokens. Create them for automation instead of reusing a human browser session. Copy the token when it is created; Quiver only shows the raw token once. Each token records who created it, and actions performed with it are attributed as `deploy-token:<name>@<app>` in audit logs and release provenance.
 
 ## Common Issues
 
 ### No update is found
 
-Check that the published release is on the same channel as the client, has a higher `version_code`, and contains a compatible installable artifact.
+Check that the published release is on the same channel as the client, has a higher `version_code`, contains a compatible installable artifact, and — for partially rolled-out releases — that the device's bucket falls inside the rollout percentage.
 
 ### Download link is expired
 

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -13,7 +13,7 @@ npm install -g @oranix/quiver-cli
 Or run it without a permanent install:
 
 ```bash
-npm exec --package @oranix/quiver-cli@0.1.1 -- quiver --help
+npm exec --package @oranix/quiver-cli@0.2.1 -- quiver --help
 ```
 
 In CI, pin a version so release scripts stay reproducible.
@@ -53,7 +53,9 @@ quiver builds list raft-android
 
 ## Publish Android
 
-Use `builds publish-android` to upload an APK and create or publish a release.
+Use `builds publish-android` to upload an APK and create a release. Per the
+release policy, CI should pass `--draft` so a human or agent reviews the
+changelog before the release goes live.
 
 ```bash
 quiver builds publish-android raft-android \
@@ -61,9 +63,12 @@ quiver builds publish-android raft-android \
   --channel preview \
   --version-name 1.0.0 \
   --version-code 1000000 \
-  --package-name build.raft.app \
-  --release-notes "Preview build"
+  --changelog-file ./changelog.txt \
+  --draft
 ```
+
+Package id, SDK levels, and the launcher icon are extracted from the APK
+automatically on the server — no extra flags needed.
 
 Add support artifacts when available:
 
@@ -79,6 +84,40 @@ quiver builds publish-android raft-android \
 ```
 
 Public update checks only use the installable artifact. Mapping files, native symbols, and metadata stay available through authenticated admin APIs.
+
+## Review and Publish (draft flow)
+
+CI creates drafts; publishing is an explicit step after changelog review:
+
+```bash
+# inspect the draft (status, rollout, changelog)
+quiver releases show raft-android <release-id>
+
+# write the reviewed changelog; repeatable [lang=]file entries
+quiver releases update raft-android <release-id> \
+  --changelog-file zh=changelog.zh.md \
+  --changelog-file en=changelog.en.md
+
+# make it live
+quiver releases publish raft-android <release-id>
+```
+
+Bilingual changelogs are stored per language; clients receive the language
+matching their locale (`zh` normalizes to `zh-CN`; plain single-value
+changelogs are served as-is).
+
+## Share Links
+
+```bash
+quiver releases share raft-android <release-id> --password <pw>   # password optional
+quiver releases shares raft-android <release-id>                   # list
+quiver releases update-share raft-android <release-id> <share-id> --ttl-seconds 1209600
+quiver releases revoke-share raft-android <release-id> <share-id>
+```
+
+`--password` can also come from `QUIVER_SHARE_PASSWORD` to keep it out of
+shell history. Share URLs are printed once at creation; tokens are stored
+hashed.
 
 ## CI Environment Variables
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -1,6 +1,6 @@
 # Public API Reference
 
-Quiver's public API lets apps check for updates and download release artifacts without a Quiver admin session.
+Quiver's public API lets apps check for updates, download release artifacts, submit feedback, and view share/history pages without a Quiver admin session.
 
 Use the admin API or CLI for publishing. Use the public API from clients.
 
@@ -15,55 +15,131 @@ Self-hosted deployments should use their own origin.
 ## Check for Updates
 
 ```http
-GET /public/v2/apps/:appSlug/update-check?channel=main&current_version_code=1000000&platform=android&arch=arm64-v8a&filetype=apk
+GET /public/v2/apps/:appSlug/updates/check?channel=main&product_type=android-apk&current_version_code=1000000&platform=android&arch=arm64-v8a&filetype=apk
 ```
 
 ### Query Parameters
 
 | Name | Required | Description |
 |---|---|---|
-| `channel` | Yes | Release channel to check, such as `main`, `preview`, `nightly`, or `debug`. |
+| `channel` | No | Release channel, such as `main` (default), `preview`, `nightly`, or `debug`. |
 | `current_version_code` | Yes | Installed client version code. |
+| `product_type` | No | Product type, such as `android-apk`. |
 | `platform` | No | Client platform, such as `android`. |
 | `arch` | No | Client architecture, such as `arm64-v8a`. |
-| `filetype` | No | Desired installable file type, such as `apk`. |
+| `filetype` | No | Desired installable file type. Defaults to `apk`. |
+| `lang` | No | Preferred changelog language, such as `zh-CN` or `en`. Also read from `X-Quiver-Lang` or `Accept-Language`. |
+| `device_id` | No | Stable per-install identifier. Also read from `X-Quiver-Device-Id`. Required to participate in staged rollouts. |
+
+### Staged rollouts
+
+Releases can be published to a percentage of devices. The server buckets
+clients by hashing `(release_id, device_id)`, so a device keeps its bucket
+while the percentage climbs. Clients that send no device id only ever see
+fully rolled-out releases; gated-out clients fall through to the previous
+active release. The Android SDK sends the header automatically.
 
 ### Update Available
 
 ```json
 {
   "update_available": true,
-  "release": {
-    "id": "release-id",
-    "channel": "main",
-    "version_name": "1.0.1",
+  "app": { "slug": "raft-android", "platform": "android" },
+  "channel": "main",
+  "current_version_code": 1000000,
+  "latest": {
+    "build_id": "…",
+    "version": "1.0.1",
     "version_code": 1000100,
-    "release_notes": "Bug fixes and improvements"
+    "changelog": "Bug fixes and improvements",
+    "force_update": false,
+    "released_at": 1783162273735
   },
   "asset": {
+    "platform": "android",
+    "arch": "arm64-v8a",
     "filetype": "apk",
     "size_bytes": 29192396,
-    "file_hash": "sha256-hex",
-    "download_url": "https://quiver.oranix.io/public/r2/..."
-  }
+    "download_url": "https://quiver.oranix.io/public/r2/…"
+  },
+  "scoped": { "scope_type": "full", "scope_value": "all", "release_id": "…", "rollout_cohort_count": null }
 }
 ```
+
+`changelog` is localized: releases may carry per-language notes and the
+server returns the best match for the requested language (exact tag →
+language prefix → `en` → first available).
 
 ### No Update
 
 ```json
-{
-  "update_available": false
-}
+{ "update_available": false, "current_version_code": 1000100, "latest_version_code": 1000100 }
 ```
 
 ## Latest Release
 
 ```http
-GET /public/v2/apps/:appSlug/latest?channel=main&platform=android&arch=arm64-v8a&filetype=apk
+GET /public/v2/apps/:appSlug/latest?channel=main&product_type=android-apk
 ```
 
-This returns the latest compatible installable release for the channel, independent of the client's installed version.
+Returns the latest compatible installable release for the channel,
+independent of the client's installed version. Accepts the same `lang` and
+`device_id` inputs as the update check.
+
+## Submit Feedback
+
+```http
+POST /public/v2/apps/:appSlug/feedback
+Content-Type: multipart/form-data
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `message` | Yes | Feedback text (max 10,000 chars). |
+| `kind` | No | `feedback` (default), `bug`, or `crash`. |
+| `contact` | No | Reply-to handle (email, Raft name, …). |
+| `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. |
+| `attachments` | No | Up to 3 files, 10 MB each (screenshots, logs). |
+
+Returns `201` with `{ "id": "<ticket id>", "status": "open" }`. Rate limit:
+10 submissions per hour per app + client IP. Tickets appear in the admin
+Feedback tab; a `feedback:new` webhook fires for subscribed endpoints. The
+Android SDK's `QuiverFeedback.submit(...)` wraps this endpoint and attaches
+device metadata automatically.
+
+## Share Pages
+
+- `GET /share/:token` — public download page for one release (view/download
+  stats, QR code on desktop, localized changelog). Optionally
+  password-protected: the page shows an unlock form; `POST /share/:token/unlock`
+  sets a short-lived cookie scoped to that share.
+- `GET /share/:token/download` — the artifact download (302 to a signed URL).
+- `GET /share/:token/icon` — the app icon for that release's build (falls
+  back to the app-level icon).
+
+Share links are created from the admin Shares tab, the CLI, or the API, and
+can be renewed, revoked, and password-protected after creation.
+
+## Version History
+
+When enabled per app (Settings → Public version history):
+
+- `GET /apps/:appSlug/history` — public page listing published versions with
+  localized changelogs, sizes, and downloads.
+- `GET /apps/:appSlug/history/:releaseId/download` — per-version download
+  (302 to a signed URL).
+
+Disabled apps return `404`.
+
+## App Icon
+
+```http
+GET /public/apps/:appSlug/icon
+```
+
+Serves the app icon. Per-build icons are extracted automatically from
+uploaded APKs (aapt); an app-level icon can also be uploaded from the admin
+Settings page as a fallback.
 
 ## Download URLs
 
@@ -75,7 +151,7 @@ The response includes a readable download filename through `Content-Disposition`
 
 Recommended client flow:
 
-1. Send the installed `versionCode` and configured channel.
+1. Send the installed `versionCode`, configured channel, system language, and the SDK's persistent device id.
 2. If `update_available` is false, do nothing.
 3. If true, show release information or begin the update flow.
 4. Download the artifact from `asset.download_url`.
@@ -89,6 +165,7 @@ Recommended client flow:
 | `400` | Missing or invalid request parameters. |
 | `404` | App, channel, release, or compatible artifact was not found. |
 | `410` | Signed download URL expired. |
+| `429` | Rate limited (feedback submissions). |
 | `500` | Server error. Retry later or contact the Quiver operator. |
 
 ## Compatibility


### PR DESCRIPTION
Per artin: docs updated to cover everything shipped today — corrected update-check path/response, staged rollouts + device_id + lang, feedback endpoint, share passwords/QR/icons, version history, draft-first flow, CLI 0.2.1 commands and lang= changelog syntax, admin guide rewritten around the new navigation and tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)