### PR TITLE
feat(cli): quiver feedback command group for agent ticket triage

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -119,6 +119,21 @@ quiver releases revoke-share raft-android <release-id> <share-id>
 shell history. Share URLs are printed once at creation; tokens are stored
 hashed.
 
+## Feedback Tickets
+
+Agents can triage feedback and crash tickets entirely from the CLI (viewer
+role for read, publisher for changes):
+
+```bash
+quiver feedback list raft-android --status open --kind crash
+quiver feedback show raft-android <ticket-id>
+quiver feedback update raft-android <ticket-id> --status in_progress --assignee cc-quiver-owner
+quiver feedback comment raft-android <ticket-id> "已复现，修复中"
+quiver feedback update raft-android <ticket-id> --status resolved
+```
+
+`--assignee none` unassigns. All subcommands accept `--json` for scripting.
+
 ## CI Environment Variables
 
 | Variable | Required | Purpose |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oranix/quiver-cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Quiver CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -1,0 +1,159 @@
+/**
+ * `quiver feedback` — agent-friendly ticket triage from the terminal.
+ * Works with app-scoped deploy tokens (viewer for list/show, publisher for
+ * update/comment).
+ */
+import type { Command } from "commander";
+import { apiRequest } from "../lib/api";
+
+interface TicketRow {
+  id: string;
+  kind: string;
+  status: string;
+  assignee: string | null;
+  message: string;
+  version_name: string | null;
+  version_code: number | null;
+  device_model: string | null;
+  created_at: number;
+  attachment_count: number;
+  comment_count: number;
+}
+
+async function resolveAppId(slugOrId: string): Promise<string> {
+  if (slugOrId.length === 36 && slugOrId.split("-").length === 5) return slugOrId;
+  const res = await apiRequest<{ apps: Array<{ id: string; slug: string }> }>("/api/apps");
+  const match = res.apps.find((a) => a.slug === slugOrId);
+  if (!match) {
+    console.error(`No app with slug '${slugOrId}'.`);
+    process.exit(1);
+  }
+  return match.id;
+}
+
+export function registerFeedbackCommands(program: Command): void {
+  const feedback = program
+    .command("feedback")
+    .description("Triage feedback/crash tickets.");
+
+  feedback
+    .command("list <appIdOrSlug>")
+    .description("List tickets, newest first.")
+    .option("--status <status>", "Filter: open | in_progress | resolved | closed.")
+    .option("--kind <kind>", "Filter: feedback | bug | crash.")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: { status?: string; kind?: string; json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const params = new URLSearchParams();
+      if (opts.status) params.set("status", opts.status);
+      if (opts.kind) params.set("kind", opts.kind);
+      const qs = params.toString();
+      const res = await apiRequest<{ tickets: TicketRow[] }>(
+        `/api/apps/${appId}/feedback${qs ? `?${qs}` : ""}`,
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      if (res.tickets.length === 0) {
+        console.log("No tickets.");
+        return;
+      }
+      for (const t of res.tickets) {
+        const preview = t.message.replace(/\s+/g, " ").slice(0, 60);
+        console.log(
+          `${t.id.slice(0, 8)}  ${t.status.padEnd(11)} ${t.kind.padEnd(8)} ` +
+            `${(t.assignee ?? "-").padEnd(16)} v${t.version_name ?? "?"} ` +
+            `[${t.attachment_count}📎 ${t.comment_count}💬]  ${preview}`,
+        );
+      }
+    });
+
+  feedback
+    .command("show <appIdOrSlug> <ticketId>")
+    .description("Show a ticket with device context, attachments, and comments.")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, ticketId: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const res = await apiRequest<{
+        ticket: Record<string, unknown>;
+        attachments: Array<{ id: string; filename: string; size_bytes: number }>;
+        comments: Array<{ author_actor: string; body: string; created_at: number }>;
+      }>(`/api/apps/${appId}/feedback/${ticketId}`);
+      if (opts.json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      const t = res.ticket as Record<string, unknown>;
+      console.log(`Ticket ${String(t["id"]).slice(0, 8)} (${t["kind"]}, ${t["status"]})`);
+      console.log(`  assignee: ${t["assignee"] ?? "-"}`);
+      console.log(`  version:  ${t["version_name"] ?? "?"} (${t["version_code"] ?? "?"}) · ${t["channel"] ?? "?"}`);
+      console.log(`  device:   ${t["device_model"] ?? "?"} · Android ${t["os_version"] ?? "?"} · ${t["arch"] ?? "?"} · ${t["locale"] ?? "?"}`);
+      console.log(`  device_id: ${t["device_id"] ?? "-"}`);
+      console.log(`  contact:  ${t["contact"] ?? "-"}`);
+      console.log(`  message:`);
+      console.log(String(t["message"] ?? "").split("\n").map((l) => "    " + l).join("\n"));
+      if (res.attachments.length) {
+        console.log(`  attachments:`);
+        for (const a of res.attachments) {
+          console.log(`    ${a.id}  ${a.filename} (${(a.size_bytes / 1024).toFixed(1)} KB)`);
+        }
+      }
+      if (res.comments.length) {
+        console.log(`  comments:`);
+        for (const cm of res.comments) {
+          console.log(`    [${new Date(cm.created_at).toISOString()}] ${cm.author_actor}: ${cm.body}`);
+        }
+      }
+    });
+
+  feedback
+    .command("update <appIdOrSlug> <ticketId>")
+    .description("Change status and/or assignee.")
+    .option("--status <status>", "open | in_progress | resolved | closed.")
+    .option("--assignee <name>", "Assign to a person/agent; use 'none' to unassign.")
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        ticketId: string,
+        opts: { status?: string; assignee?: string; json?: boolean },
+      ) => {
+        const appId = await resolveAppId(appIdOrSlug);
+        const body: { status?: string; assignee?: string | null } = {};
+        if (opts.status) body.status = opts.status;
+        if (opts.assignee !== undefined) {
+          body.assignee = opts.assignee === "none" ? null : opts.assignee;
+        }
+        if (body.status === undefined && body.assignee === undefined) {
+          throw new Error("nothing to update: pass --status and/or --assignee");
+        }
+        const res = await apiRequest<Record<string, unknown>>(
+          `/api/apps/${appId}/feedback/${ticketId}`,
+          { method: "PATCH", body },
+        );
+        if (opts.json) {
+          console.log(JSON.stringify(res, null, 2));
+          return;
+        }
+        console.log(`Updated ticket ${ticketId.slice(0, 8)}.`);
+      },
+    );
+
+  feedback
+    .command("comment <appIdOrSlug> <ticketId> <text>")
+    .description("Add a comment to a ticket.")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, ticketId: string, text: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const res = await apiRequest<Record<string, unknown>>(
+        `/api/apps/${appId}/feedback/${ticketId}/comments`,
+        { method: "POST", body: { body: text } },
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(`Commented on ${ticketId.slice(0, 8)}.`);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { registerAppCommands } from "./commands/apps.js";
 import { registerBuildCommands } from "./commands/builds.js";
 import { registerLoginCommands } from "./commands/login.js";
 import { registerReleaseCommands } from "./commands/releases.js";
+import { registerFeedbackCommands } from "./commands/feedback.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { getConfig } from "./lib/config.js";
 import { setApiBase } from "./lib/api.js";
@@ -54,6 +55,7 @@ registerWhoamiCommand(program);
 registerAppCommands(program);
 registerBuildCommands(program);
 registerReleaseCommands(program);
+registerFeedbackCommands(program);
 
 program
   .command("version")


### PR DESCRIPTION
Task #71: agents handle tickets end-to-end from the CLI (deploy-token auth) — list (status/kind filters), show (device context + attachments + comments), update (status/assignee, 'none' unassigns), comment. All --json capable. CLI 0.3.0; docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)