### PR TITLE
feat(android-sdk): QuiverCrash — capture, store, and report crashes

### DIFF
--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
@@ -1,0 +1,272 @@
+package io.quiver.update
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+
+/**
+ * Crash capture + deferred reporting (Bugly-style store-then-send).
+ *
+ * On crash: chain into any existing default handler, write a structured
+ * crash log to `<externalFilesDir>/crashes/` (with an internal-files
+ * fallback), write a metadata sidecar for later upload, and optionally copy
+ * the log to the clipboard. No network happens in the dying process.
+ *
+ * On the next launch, [install] schedules [uploadPending] on a background
+ * thread: each stored crash is submitted through the Quiver feedback channel
+ * (`kind=crash`, full log attached, signature fields in metadata) and the
+ * local files are removed on success. At most [MAX_STORED_CRASHES] recent
+ * crashes are kept.
+ *
+ * This replaces the app-side SlockCrashReporter; app-specific context (e.g.
+ * recent diagnostics) is injected via [extraContext].
+ */
+object QuiverCrash {
+    private const val TAG = "QuiverCrash"
+    private const val CRASH_LOG_MAX_CHARS = 180_000
+    private const val MAX_STORED_CRASHES = 5
+    private val installed = AtomicBoolean(false)
+    private val processStartMs = System.currentTimeMillis()
+
+    fun install(
+        context: Context,
+        baseUrl: String,
+        appSlug: String,
+        versionName: String? = null,
+        versionCode: Long? = null,
+        channel: String? = null,
+        copyToClipboard: Boolean = true,
+        uploadOnLaunch: Boolean = true,
+        extraContext: (() -> String)? = null,
+    ) {
+        if (!installed.compareAndSet(false, true)) return
+        val appContext = context.applicationContext
+        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            val crashLog =
+                runCatching { buildCrashLog(appContext, thread, throwable, extraContext) }
+                    .getOrElse { buildFallbackCrashLog(thread, throwable, it) }
+                    .take(CRASH_LOG_MAX_CHARS)
+
+            runCatching { writeCrash(appContext, thread, throwable, crashLog) }
+                .onFailure { Log.e(TAG, "Failed to write crash log", it) }
+            if (copyToClipboard) {
+                runCatching {
+                    val clipboard =
+                        appContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText("Crash log", crashLog))
+                }
+                    .onSuccess { Log.e(TAG, "Crash log copied to clipboard") }
+                    .onFailure { Log.e(TAG, "Failed to copy crash log to clipboard", it) }
+            }
+
+            defaultHandler?.uncaughtException(thread, throwable)
+                ?: run {
+                    Log.e(TAG, "Unhandled crash", throwable)
+                    kotlin.system.exitProcess(2)
+                }
+        }
+
+        if (uploadOnLaunch) {
+            thread(name = "quiver-crash-upload", isDaemon = true) {
+                runCatching {
+                    uploadPending(appContext, baseUrl, appSlug, versionName, versionCode, channel)
+                }
+                    .onFailure { Log.w(TAG, "Crash upload pass failed", it) }
+            }
+        }
+    }
+
+    /**
+     * Upload stored crashes through the feedback channel and delete them on
+     * success. Safe to call repeatedly; runs synchronously on the calling
+     * thread.
+     */
+    fun uploadPending(
+        context: Context,
+        baseUrl: String,
+        appSlug: String,
+        versionName: String? = null,
+        versionCode: Long? = null,
+        channel: String? = null,
+    ) {
+        val dir = crashDir(context) ?: return
+        val sidecars =
+            dir.listFiles { f -> f.name.endsWith(".meta.json") }?.sortedBy { it.name } ?: return
+        if (sidecars.isEmpty()) return
+        val feedback =
+            QuiverFeedback(
+                context = context,
+                baseUrl = baseUrl,
+                appSlug = appSlug,
+                versionName = versionName,
+                versionCode = versionCode,
+                channel = channel,
+            )
+        for (sidecar in sidecars) {
+            val logFile = File(sidecar.absolutePath.removeSuffix(".meta.json") + ".txt")
+            if (!logFile.isFile) {
+                sidecar.delete()
+                continue
+            }
+            val meta = runCatching { JSONObject(sidecar.readText()) }.getOrNull() ?: JSONObject()
+            val exceptionClass = meta.optString("exception_class", "UnknownException")
+            val topFrame = meta.optString("top_frame", "")
+            val message =
+                buildString {
+                    append("Crash: ").append(exceptionClass)
+                    val detail = meta.optString("exception_message", "")
+                    if (detail.isNotBlank()) append(": ").append(detail.take(200))
+                    if (topFrame.isNotBlank()) append("\nat ").append(topFrame)
+                }
+            val result =
+                runCatching {
+                    runBlocking {
+                        feedback.submit(
+                            message = message,
+                            kind = "crash",
+                            attachments = listOf(logFile),
+                            extras =
+                                mapOf(
+                                    "crash_exception_class" to exceptionClass,
+                                    "crash_top_frame" to topFrame,
+                                    "crash_thread" to meta.optString("thread", ""),
+                                    "crash_at" to meta.optLong("crash_at", 0L),
+                                    "crash_process_uptime_ms" to meta.optLong("process_uptime_ms", -1L),
+                                ),
+                        )
+                    }
+                }
+            if (result.isSuccess) {
+                logFile.delete()
+                sidecar.delete()
+                Log.i(TAG, "Uploaded crash ${logFile.name} as ticket ${result.getOrNull()}")
+            } else {
+                Log.w(TAG, "Crash upload failed for ${logFile.name}", result.exceptionOrNull())
+            }
+        }
+    }
+
+    private fun crashDir(context: Context): File? {
+        val dir =
+            context.getExternalFilesDir(null)?.resolve("crashes")
+                ?: context.filesDir?.resolve("crashes")
+                ?: return null
+        dir.mkdirs()
+        return dir
+    }
+
+    private fun writeCrash(
+        context: Context,
+        thread: Thread,
+        throwable: Throwable,
+        crashLog: String,
+    ) {
+        val dir = crashDir(context) ?: return
+        // Cap retention: keep the newest MAX_STORED_CRASHES - 1 before adding.
+        val existing =
+            dir.listFiles { f -> f.name.startsWith("crash-") && f.name.endsWith(".txt") }
+                ?.sortedByDescending { it.name } ?: emptyList()
+        for (old in existing.drop(MAX_STORED_CRASHES - 1)) {
+            old.delete()
+            File(old.absolutePath.removeSuffix(".txt") + ".meta.json").delete()
+        }
+        val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+        val base = dir.resolve("crash-$timestamp")
+        File("${base.absolutePath}.txt").writeText(crashLog)
+        val topFrame =
+            throwable.stackTrace.firstOrNull()?.let { "${it.className}.${it.methodName}(${it.fileName}:${it.lineNumber})" }
+                ?: ""
+        val meta =
+            JSONObject()
+                .put("exception_class", throwable.javaClass.name)
+                .put("exception_message", throwable.message ?: "")
+                .put("top_frame", topFrame)
+                .put("thread", thread.name)
+                .put("crash_at", System.currentTimeMillis())
+                .put("process_uptime_ms", System.currentTimeMillis() - processStartMs)
+        File("${base.absolutePath}.meta.json").writeText(meta.toString())
+        Log.e(TAG, "Crash log written to: ${base.absolutePath}.txt")
+    }
+
+    private fun buildCrashLog(
+        context: Context,
+        thread: Thread,
+        throwable: Throwable,
+        extraContext: (() -> String)?,
+    ): String =
+        buildString {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            appendLine("Crash log")
+            appendLine("Crash at: ${Date()}")
+            appendLine("Package: ${context.packageName}")
+            appendLine("Version name: ${packageInfo.versionName.orEmpty()}")
+            appendLine(
+                "Version code: " +
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        packageInfo.longVersionCode.toString()
+                    } else {
+                        @Suppress("DEPRECATION") packageInfo.versionCode.toString()
+                    },
+            )
+            appendLine("Device: ${Build.MANUFACTURER} ${Build.MODEL}".trim())
+            appendLine("Android: ${Build.VERSION.RELEASE} / SDK ${Build.VERSION.SDK_INT}")
+            appendLine("Device id: ${QuiverDeviceId.get(context)}")
+            appendLine("Thread: ${thread.name}")
+            appendLine("Exception: ${throwable.javaClass.name}")
+            appendLine("Message: ${throwable.message.orEmpty()}")
+            appendLine()
+            appendLine("Stack trace:")
+            appendLine(Log.getStackTraceString(throwable))
+            appendLine()
+            appendLine("Process uptime: ${System.currentTimeMillis() - processStartMs} ms")
+            appendLine()
+            appendLine("All threads:")
+            runCatching {
+                for ((t, frames) in Thread.getAllStackTraces()) {
+                    if (t === thread) continue
+                    appendLine("  Thread ${t.name} (${t.state}):")
+                    frames.take(24).forEach { frame -> appendLine("    at $frame") }
+                }
+            }
+            extraContext?.let { provider ->
+                runCatching {
+                    val extra = provider()
+                    if (extra.isNotBlank()) {
+                        appendLine()
+                        appendLine("App context:")
+                        appendLine(extra)
+                    }
+                }
+            }
+        }
+
+    private fun buildFallbackCrashLog(
+        thread: Thread,
+        throwable: Throwable,
+        buildError: Throwable,
+    ): String =
+        buildString {
+            appendLine("Crash log")
+            appendLine("Crash at: ${Date()}")
+            appendLine("Thread: ${thread.name}")
+            appendLine("Exception: ${throwable.javaClass.name}")
+            appendLine("Message: ${throwable.message.orEmpty()}")
+            appendLine()
+            appendLine("Stack trace:")
+            appendLine(Log.getStackTraceString(throwable))
+            appendLine()
+            appendLine("Crash log build error:")
+            appendLine(Log.getStackTraceString(buildError))
+        }
+}


### PR DESCRIPTION
Task #72: SlockCrashReporter fully migrated into the SDK + Bugly-style store-then-send reporting and Sentry-style all-threads dump / process-uptime metadata. Crashes land as kind=crash feedback tickets with signature fields for server-side grouping (#73). App-specific context injects via extraContext callback. SDK 0.4.0 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)