### PR TITLE
feat(feedback): crash signatures, grouping, and auto-retrace deobfuscation

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1165,3 +1165,16 @@ export const uploadAppIcon = async (appId: string, file: File) => {
 };
 
 export const publicAppIconUrl = (slug: string) => `${API_BASE}/public/apps/${slug}/icon`;
+
+export interface CrashGroup {
+  signature: string;
+  count: number;
+  device_count: number;
+  first_seen: number;
+  last_seen: number;
+  versions: string | null;
+  open_count: number;
+}
+
+export const listCrashGroups = (appId: string) =>
+  request<{ groups: CrashGroup[] }>(`/api/apps/${appId}/feedback/crash-groups`, { admin: true });

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -11,6 +11,7 @@ import {
   feedbackAttachmentUrl,
   getAuthMe,
   getFeedback,
+  listCrashGroups,
   listFeedback,
   updateFeedbackTicket,
 } from "../lib/api";
@@ -33,6 +34,7 @@ const KIND_STYLES: Record<string, string> = {
 
 export function AppFeedback({ appId }: { appId: string }) {
   const navigate = useNavigate();
+  const [view, setView] = useState<"tickets" | "crashes">("tickets");
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [kindFilter, setKindFilter] = useState<string>("");
 
@@ -79,6 +81,36 @@ export function AppFeedback({ appId }: { appId: string }) {
           </select>
         </div>
       </div>
+
+      <div className="flex gap-1 text-sm">
+        <button
+          className={view === "tickets"
+            ? "rounded-md bg-slate-100 px-3 py-1 font-medium"
+            : "rounded-md px-3 py-1 text-slate-600 hover:bg-slate-50"}
+          onClick={() => setView("tickets")}
+        >
+          All tickets
+        </button>
+        <button
+          className={view === "crashes"
+            ? "rounded-md bg-slate-100 px-3 py-1 font-medium"
+            : "rounded-md px-3 py-1 text-slate-600 hover:bg-slate-50"}
+          onClick={() => setView("crashes")}
+        >
+          Crash groups
+        </button>
+      </div>
+
+      {view === "crashes" && (
+        <CrashGroups
+          appId={appId}
+          onOpenGroup={() => {
+            setKindFilter("crash");
+            setView("tickets");
+          }}
+        />
+      )}
+      {view === "tickets" && (
 
       <div className="card overflow-x-auto">
         {tickets.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
@@ -140,6 +172,67 @@ export function AppFeedback({ appId }: { appId: string }) {
           </table>
         )}
       </div>
+      )}
+    </div>
+  );
+}
+
+function CrashGroups({ appId, onOpenGroup }: { appId: string; onOpenGroup: () => void }) {
+  const groups = useQuery({
+    queryKey: ["crash-groups", appId],
+    queryFn: () => listCrashGroups(appId),
+  });
+  const rows = groups.data?.groups ?? [];
+  return (
+    <div className="card overflow-x-auto">
+      {groups.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+      {groups.error && (
+        <p className="text-sm text-red-600">Failed to load: {(groups.error as Error).message}</p>
+      )}
+      {!groups.isLoading && rows.length === 0 && (
+        <p className="text-sm text-slate-500">No crashes reported yet.</p>
+      )}
+      {rows.length > 0 && (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs text-slate-500 border-b border-slate-200">
+              <th className="py-2 pr-3">Crash signature</th>
+              <th className="py-2 pr-3">Count</th>
+              <th className="py-2 pr-3">Devices</th>
+              <th className="py-2 pr-3">Open</th>
+              <th className="py-2 pr-3">Versions</th>
+              <th className="py-2 pr-3">Last seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((g) => (
+              <tr
+                key={g.signature}
+                className="border-b border-slate-100 last:border-0 cursor-pointer hover:bg-slate-50"
+                onClick={onOpenGroup}
+                title="Open crash tickets"
+              >
+                <td className="py-2 pr-3 max-w-lg font-mono text-xs">{g.signature}</td>
+                <td className="py-2 pr-3 font-semibold">{g.count}</td>
+                <td className="py-2 pr-3 text-slate-600">{g.device_count}</td>
+                <td className="py-2 pr-3">
+                  {g.open_count > 0 ? (
+                    <span className="rounded bg-red-100 px-1.5 py-0.5 text-xs font-medium text-red-800">
+                      {g.open_count} open
+                    </span>
+                  ) : (
+                    <span className="text-xs text-slate-400">—</span>
+                  )}
+                </td>
+                <td className="py-2 pr-3 text-xs text-slate-600">{g.versions ?? "—"}</td>
+                <td className="py-2 pr-3 text-xs text-slate-600">
+                  {new Date(g.last_seen).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -22,6 +22,8 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { writeFile, unlink, mkdir } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -32,7 +34,54 @@ import {
 
 const app = new Hono();
 
+const execFileAsync = promisify(execFile);
+
+const RETRACE_BIN = "/opt/android-sdk/cmdline-tools/latest/bin/retrace";
+
 app.get("/health", (c) => c.json({ ok: true, service: "multi-parser" }));
+
+/**
+ * POST /retrace — body = { mapping, trace }. Deobfuscates an R8/ProGuard
+ * stack trace against the given mapping using the Android SDK retrace tool.
+ * Returns { retraced }.
+ */
+app.post("/retrace", async (c) => {
+  let body: { mapping?: string; trace?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid JSON body" }, 400);
+  }
+  const mapping = typeof body.mapping === "string" ? body.mapping : "";
+  const trace = typeof body.trace === "string" ? body.trace : "";
+  if (!mapping.trim() || !trace.trim()) {
+    return c.json({ error: "mapping and trace are required" }, 400);
+  }
+  if (mapping.length > 200 * 1024 * 1024) {
+    return c.json({ error: "mapping too large" }, 413);
+  }
+  const dir = join(tmpdir(), `retrace-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const mappingPath = join(dir, "mapping.txt");
+  const tracePath = join(dir, "trace.txt");
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(mappingPath, mapping);
+    await writeFile(tracePath, trace);
+    const { stdout } = await execFileAsync(
+      RETRACE_BIN,
+      [mappingPath, tracePath],
+      { maxBuffer: 32 * 1024 * 1024 },
+    );
+    return c.json({ retraced: stdout });
+  } catch (err) {
+    return c.json(
+      { error: `retrace failed: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  } finally {
+    await Promise.allSettled([unlink(mappingPath), unlink(tracePath)]);
+  }
+});
 
 app.post("/parse", async (c) => {
   const ab = await c.req.arrayBuffer();

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -81,6 +81,13 @@ The Feedback tab is a lightweight ticket system for reports submitted from the a
 - Triage with statuses (`open → in_progress → resolved/closed`), an assignee (Assign to me / edit / unassign), and a comment trail.
 - A `feedback:new` webhook fires on submission for org webhook subscribers.
 
+Crash tickets (`kind=crash`, submitted automatically by the SDK's crash
+reporter) get a grouping **signature** (exception class + top app frame) and a
+**Crash groups** view that aggregates by signature with occurrence and device
+counts. When a build's ProGuard/R8 `mapping.txt` was uploaded as a
+`proguard-mapping` asset for that version, Quiver auto-deobfuscates the stack
+in the container and posts the retraced trace as a ticket comment.
+
 ## Version history
 
 Settings → **Public version history** exposes `/apps/<slug>/history`: a public page listing published versions with localized changelogs and per-version downloads. It is off by default; when disabled the page returns 404.

--- a/migrations/sql/0030_feedback_signature.sql
+++ b/migrations/sql/0030_feedback_signature.sql
@@ -1,0 +1,4 @@
+ALTER TABLE feedback_tickets ADD COLUMN signature TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_signature
+  ON feedback_tickets(app_id, signature, created_at DESC);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -59,6 +59,7 @@ import {
   handleUpdateFeedback,
   handleAddFeedbackComment,
   handleDownloadFeedbackAttachment,
+  handleListCrashGroups,
 } from "./routes/feedback";
 import {
   handlePublicAppHistory,
@@ -555,6 +556,7 @@ admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
 admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);
+admin.get("/api/apps/:appId/feedback/crash-groups", requireAppRole("viewer"), handleListCrashGroups);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -103,6 +103,11 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     files.push(file);
   }
 
+  // Crash tickets get a grouping signature from their exception class + top
+  // app frame (populated by the SDK). Non-crash tickets have no signature.
+  const signature =
+    kind === "crash" ? crashSignature(metadata) : null;
+
   const now = Date.now();
   const ticketId = crypto.randomUUID();
 
@@ -133,8 +138,8 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       `INSERT INTO feedback_tickets
        (id, app_id, kind, status, message, contact, version_name, version_code,
         channel, device_id, device_model, os_version, arch, locale,
-        metadata_json, client_ip_hash, created_at, updated_at)
-       VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)`,
+        metadata_json, client_ip_hash, signature, created_at, updated_at)
+       VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)`,
     ).bind(
       ticketId,
       app.id,
@@ -151,6 +156,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       meta("locale", 40),
       JSON.stringify(metadata),
       clientIpHash,
+      signature,
       now,
       now,
     ),
@@ -163,6 +169,18 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     ),
   ];
   await c.env.DB.batch(statements);
+
+  // Crash tickets: deobfuscate the stack in the background using the
+  // proguard-mapping asset stored for this version_code.
+  if (kind === "crash" && attachmentRows.length > 0) {
+    const logKey = attachmentRows[0]!.r2Key;
+    const run = () => retraceCrashTicket(c.env, app.id, ticketId, versionCode, logKey);
+    try {
+      c.executionCtx.waitUntil(run());
+    } catch {
+      run().catch(() => {});
+    }
+  }
 
   if (app.org_id) {
     await emitWebhookEvent(c.env.DB, {
@@ -184,6 +202,107 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   }
 
   return c.json({ id: ticketId, status: "open", attachments: attachmentRows.length }, 201);
+}
+
+/** Signature = "<ExceptionClass>@<top app frame>", trimmed and bounded. */
+function crashSignature(metadata: Record<string, unknown>): string | null {
+  const exc = String(metadata["crash_exception_class"] ?? metadata["exception_class"] ?? "").trim();
+  const frame = String(metadata["crash_top_frame"] ?? metadata["top_frame"] ?? "").trim();
+  if (!exc && !frame) return null;
+  // Strip source line numbers from the frame so the same crash groups across
+  // builds: "a.b.C.m(File.kt:42)" -> "a.b.C.m".
+  const normFrame = frame.replace(/\([^)]*\)/, "").trim();
+  return `${exc || "UnknownException"}@${normFrame}`.slice(0, 300);
+}
+
+/**
+ * Best-effort deobfuscation: find the proguard-mapping build asset for the
+ * crash's version_code, fetch the crash log, run the container retrace tool,
+ * and append the result as an internal comment.
+ */
+export async function retraceCrashTicket(
+  env: Env,
+  appId: string,
+  ticketId: string,
+  versionCode: number | null,
+  logR2Key: string,
+): Promise<void> {
+  try {
+    if (versionCode === null) return;
+    const mapping = await env.DB.prepare(
+      `SELECT ba.r2_key FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       WHERE b.app_id = ?1 AND b.version_code = ?2
+         AND ba.artifact_kind = 'proguard-mapping'
+       ORDER BY ba.created_at DESC LIMIT 1`,
+    )
+      .bind(appId, versionCode)
+      .first<{ r2_key: string }>();
+    if (!mapping) return;
+
+    const [mappingObj, logObj] = await Promise.all([
+      env.APK_BUCKET.get(mapping.r2_key),
+      env.APK_BUCKET.get(logR2Key),
+    ]);
+    if (!mappingObj || !logObj) return;
+    const [mappingText, logText] = await Promise.all([
+      mappingObj.text(),
+      logObj.text(),
+    ]);
+
+    const { getRandom } = await import("@cloudflare/containers");
+    const container = await getRandom(env.APK_PARSER, 1);
+    const res = await container.fetch(
+      new Request("http://container/retrace", {
+        method: "POST",
+        body: JSON.stringify({ mapping: mappingText, trace: logText }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    if (!res.ok) return;
+    const { retraced } = (await res.json()) as { retraced?: string };
+    if (!retraced || !retraced.trim()) return;
+
+    const body =
+      "Deobfuscated stack trace (auto-retraced from build mapping):\n\n" +
+      retraced.trim().slice(0, 20_000);
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
+         VALUES (?1, ?2, 'quiver-retrace', ?3, 1, ?4)`,
+      ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
+      env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
+        Date.now(),
+        ticketId,
+      ),
+    ]);
+  } catch (err) {
+    console.error(
+      `[retrace] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export async function handleListCrashGroups(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const { results } = await c.env.DB.prepare(
+    `SELECT
+       COALESCE(signature, '(unsignatured)') AS signature,
+       COUNT(*) AS count,
+       COUNT(DISTINCT device_id) AS device_count,
+       MIN(created_at) AS first_seen,
+       MAX(created_at) AS last_seen,
+       GROUP_CONCAT(DISTINCT version_name) AS versions,
+       SUM(CASE WHEN status IN ('open','in_progress') THEN 1 ELSE 0 END) AS open_count
+     FROM feedback_tickets
+     WHERE app_id = ?1 AND kind = 'crash'
+     GROUP BY COALESCE(signature, '(unsignatured)')
+     ORDER BY count DESC, last_seen DESC
+     LIMIT 200`,
+  )
+    .bind(appId)
+    .all();
+  return c.json({ groups: results });
 }
 
 export async function handleListFeedback(c: AdminContext) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -217,6 +217,7 @@ function makeMockDb() {
       metadata_json TEXT NOT NULL DEFAULT '{}',
       client_ip_hash TEXT,
       assignee TEXT,
+      signature TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -2891,6 +2892,60 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(clearResp.status).toBe(200);
     const open = await handlePublicReleaseShare(makeSharePublicContext(env, token));
     expect(await open.text()).toContain("Download APK");
+  });
+
+  it("feedback: crash tickets get a signature and group by it", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = { put: async () => {}, get: async () => null };
+    const { handlePublicFeedbackSubmit, handleListCrashGroups } = await import(
+      "../src/routes/feedback"
+    );
+
+    const submitCrash = async (topFrame: string, device: string, version: string) => {
+      const form = new FormData();
+      form.set("message", "crash");
+      form.set("kind", "crash");
+      form.set(
+        "metadata",
+        JSON.stringify({
+          version_name: version,
+          version_code: 1000101,
+          device_id: device,
+          crash_exception_class: "java.lang.NullPointerException",
+          crash_top_frame: topFrame,
+        }),
+      );
+      const ctx = {
+        env,
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: `10.0.0.${device.length}` } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any;
+      return handlePublicFeedbackSubmit(ctx);
+    };
+
+    // Two crashes share a frame (same signature), one differs.
+    expect((await submitCrash("build.raft.app.Home.onCreate(Home.kt:10)", "devA", "1.0.1")).status).toBe(201);
+    expect((await submitCrash("build.raft.app.Home.onCreate(Home.kt:22)", "devB", "1.0.2")).status).toBe(201);
+    expect((await submitCrash("build.raft.app.Feed.load(Feed.kt:5)", "devC", "1.0.1")).status).toBe(201);
+
+    const groupsCtx = {
+      env,
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : "") },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any;
+    const res = await handleListCrashGroups(groupsCtx);
+    const body = await responseJson<any>(res);
+    // Home.onCreate collapses line numbers → one group of 2; Feed.load → 1.
+    expect(body.groups.length).toBe(2);
+    const home = body.groups.find((g: any) => g.signature.includes("Home.onCreate"));
+    expect(home.count).toBe(2);
+    expect(home.device_count).toBe(2);
+    expect(home.open_count).toBe(2);
   });
 
   it("feedback: public submit stores ticket + attachment, admin can triage", async () => {


### PR DESCRIPTION
Tasks #73 (server crash parsing) + #74 (grouped UI):

## Signatures & grouping (#73)
- Migration 0030 adds indexed `feedback_tickets.signature`. Crash tickets compute a signature from `crash_exception_class` + line-stripped top app frame, so the same crash groups across builds.
- `GET /api/apps/:appId/feedback/crash-groups` aggregates crash tickets by signature: count, distinct devices, open count, affected versions, last seen.

## Auto-retrace deobfuscation (#73)
- New container endpoint `POST /retrace` runs the Android SDK `retrace` tool (already on the image's cmdline-tools) against a mapping + trace.
- Creating a crash ticket schedules a background job (`waitUntil`) that locates the `proguard-mapping` build asset for the crash's `version_code`, retraces the attached log, and posts the deobfuscated stack as an internal comment. Best-effort; no mapping → no-op.

## UI (#74)
- Feedback tab gets an **All tickets / Crash groups** toggle; the crash view lists signatures with counts, devices, open badge, versions, and last-seen.

⚠️ Container image changed — deploy with `containers_rollout=immediate`.

Verification: worker tests 69/69 (new signature-grouping test), worker+container+admin tsc clean, admin build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)