### PR TITLE
feat(analytics): per-release update-check metrics

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -150,6 +150,10 @@ export interface Release {
   created_by: string;
   created_at: number;
   updated_at: number;
+  // release_metrics (nullable when never checked)
+  offered_count?: number | null;
+  current_count?: number | null;
+  last_checked_at?: number | null;
 }
 
 export interface ReleaseScope {

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -387,6 +387,21 @@ function ReleaseRow({
       <div className="text-xs text-slate-500 font-mono mt-1 truncate">
         {r.id} (build {r.build_id.slice(0, 8)}…)
       </div>
+      {(r.offered_count || r.current_count) ? (
+        <div className="mt-1 flex items-center gap-3 text-xs text-slate-500">
+          <span title="Devices already on this version at update check">
+            <strong className="text-slate-700">{r.current_count ?? 0}</strong> on this version
+          </span>
+          <span title="Update-check responses offering this version to older clients">
+            <strong className="text-slate-700">{r.offered_count ?? 0}</strong> offered
+          </span>
+          {r.last_checked_at ? (
+            <span className="text-slate-400">
+              last check {new Date(r.last_checked_at).toLocaleString()}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
       {r.changelog && (
         <pre className="mt-2 pl-2 border-l-2 border-slate-100 font-mono whitespace-pre-wrap text-xs text-slate-600 max-h-32 overflow-y-auto">
           {r.changelog}

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -39,6 +39,10 @@ For Android, Quiver selects updates by `version_code`. A device receives an upda
 
 Set a rollout percentage when creating or editing a release (number input with 5/25/50/100 presets), and raise it with **Bump rollout**. Devices are bucketed by their stable device id, keep their bucket while the percentage climbs, and gated-out devices receive the previous active release. Clients without a device id (older SDKs) only receive fully rolled-out releases.
 
+Each release row shows update-check analytics: how many devices are already
+**on this version** and how many were **offered** it (update checks from older
+clients), so you can see real rollout coverage as the percentage climbs.
+
 ## Builds
 
 Builds hold uploaded artifacts and provenance. Quiver distinguishes installable artifacts from support artifacts:

--- a/migrations/sql/0031_release_metrics.sql
+++ b/migrations/sql/0031_release_metrics.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS release_metrics (
+  release_id TEXT PRIMARY KEY REFERENCES releases(id) ON DELETE CASCADE,
+  offered_count INTEGER NOT NULL DEFAULT 0,
+  current_count INTEGER NOT NULL DEFAULT 0,
+  last_checked_at INTEGER
+);

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -323,6 +323,35 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   });
 }
 
+/**
+ * Best-effort per-release counter: `current` when the client is already on
+ * this release, `offered` when it is being offered an update to it. Runs in
+ * the background; never affects the response.
+ */
+function bumpReleaseMetric(
+  c: Context<{ Bindings: Env }>,
+  releaseId: string | undefined,
+  kind: "offered" | "current",
+): void {
+  if (!releaseId) return;
+  const column = kind === "offered" ? "offered_count" : "current_count";
+  const now = Date.now();
+  const run = c.env.DB.prepare(
+    `INSERT INTO release_metrics (release_id, ${column}, last_checked_at)
+     VALUES (?1, 1, ?2)
+     ON CONFLICT(release_id) DO UPDATE SET
+       ${column} = ${column} + 1,
+       last_checked_at = ?3`,
+  )
+    .bind(releaseId, now, now)
+    .run();
+  try {
+    c.executionCtx.waitUntil(run.catch(() => {}));
+  } catch {
+    void run.catch(() => {});
+  }
+}
+
 export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
   const currentVersionCodeRaw =
     c.req.query("current_version_code") ??
@@ -345,6 +374,9 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
   const latest = (await latestResponse.json()) as PublicLatestResponse;
 
   if (latest.build.version_code <= currentVersionCode) {
+    if (latest.build.version_code === currentVersionCode) {
+      bumpReleaseMetric(c, latest.scoped?.release_id, "current");
+    }
     return c.json({
       update_available: false,
       app: latest.app,
@@ -388,6 +420,7 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
     );
   }
 
+  bumpReleaseMetric(c, latest.scoped?.release_id, "offered");
   return c.json({
     update_available: true,
     app: latest.app,

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -320,10 +320,12 @@ export async function handleListReleases(c: Context<{ Bindings: Env }>) {
   }
 
   const { results } = await c.env.DB.prepare(
-    `SELECT r.*, c.slug AS channel, b.version_name, b.version_code
+    `SELECT r.*, c.slug AS channel, b.version_name, b.version_code,
+            rm.offered_count, rm.current_count, rm.last_checked_at
      FROM releases r
      JOIN builds b ON b.id = r.build_id
      LEFT JOIN channels c ON c.id = r.channel_id
+     LEFT JOIN release_metrics rm ON rm.release_id = r.id
      WHERE ${conditions.join(" AND ")}
      ORDER BY r.created_at DESC
      LIMIT 200`,
@@ -337,9 +339,11 @@ export async function handleGetRelease(c: Context<{ Bindings: Env }>) {
   const appId = c.req.param("appId") ?? "";
   const releaseId = c.req.param("releaseId") ?? "";
   const release = await c.env.DB.prepare(
-    `SELECT r.*, c.slug AS channel
+    `SELECT r.*, c.slug AS channel,
+            rm.offered_count, rm.current_count, rm.last_checked_at
      FROM releases r
      LEFT JOIN channels c ON c.id = r.channel_id
+     LEFT JOIN release_metrics rm ON rm.release_id = r.id
      WHERE r.app_id = ?1 AND r.id = ?2`,
   )
     .bind(appId, releaseId)

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -164,6 +164,12 @@ function makeMockDb() {
       created_at INTEGER NOT NULL,
       FOREIGN KEY (release_id) REFERENCES releases(id) ON DELETE CASCADE
     );
+    CREATE TABLE release_metrics (
+      release_id TEXT PRIMARY KEY,
+      offered_count INTEGER NOT NULL DEFAULT 0,
+      current_count INTEGER NOT NULL DEFAULT 0,
+      last_checked_at INTEGER
+    );
     CREATE TABLE release_shares (
       id TEXT PRIMARY KEY,
       release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
@@ -2314,6 +2320,36 @@ describe("quiver public API v2 — scope resolution", () => {
     const bucket = rolloutBucket("rel-x", "device-1");
     expect(rolloutIncludes("rel-x", bucket + 1, "device-1")).toBe(true);
     expect(rolloutIncludes("rel-x", bucket, "device-1")).toBe(false);
+  });
+
+  it("updates/check records offered/current release metrics", async () => {
+    const env = makeEnv();
+    const { handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    await seedRelease(env, "rel-metric", "build-metric", [["full", "all"]], {
+      versionCode: 20,
+      versionName: "2.0.0",
+    });
+    await seedAsset(env, "build-metric", "asset-metric", { arch: "arm64-v8a" });
+
+    const query = (code: string) => ({
+      channel: "production",
+      product_type: "android-apk",
+      current_version_code: code,
+      platform: "android",
+      arch: "arm64-v8a",
+    });
+    // Two older clients (offered) + one already-current client.
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("10")));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("15")));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("20")));
+
+    const row = (await env.DB.prepare(
+      "SELECT offered_count, current_count FROM release_metrics WHERE release_id = ?1",
+    )
+      .bind("rel-metric")
+      .first()) as { offered_count: number; current_count: number } | null;
+    expect(row?.offered_count).toBe(2);
+    expect(row?.current_count).toBe(1);
   });
 
   it("updates/check gates a partial rollout by device bucket and falls back to the previous release", async () => {


### PR DESCRIPTION
Continuation (release analytics): the platform had stats only on share pages; releases had none.

- Migration 0031 `release_metrics` (offered_count, current_count, last_checked_at).
- The public update-check increments counters in the background (`waitUntil`, never affects the response): `current` when the client is already on the release, `offered` when an older client is offered it.
- Release list + detail expose the counters; the admin release row shows "N on this version / N offered" with last-check time — real rollout coverage as the percentage climbs, no need to route downloads through the worker.

Verification: worker tests 70/70 (new metrics-counting test), worker+admin tsc clean, admin build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)