### PR TITLE
docs: add Android SDK integration guide

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -21,6 +21,12 @@ const pages = [
     source: "cli-reference.md",
   },
   {
+    slug: "android-sdk",
+    title: "Android SDK",
+    description: "In-app update checks, staged rollouts, feedback, and crash reporting for Android.",
+    source: "android-sdk.md",
+  },
+  {
     slug: "public-api-reference",
     title: "Public API Reference",
     description: "Public update-check, latest-release, and client integration contracts.",

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -589,13 +589,20 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
         <section className="border-t border-slate-200 bg-white">
           <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-8 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 className="text-lg font-semibold">Build from CI or local scripts.</h2>
+              <h2 className="text-lg font-semibold">Integrate the SDK, build from CI.</h2>
               <p className="mt-1 text-sm text-slate-600">
-                The public npm CLI can publish Android releases and create share
-                links from GitHub Actions, local packaging lanes, or Raft agents.
+                The Android SDK adds in-app update checks, staged rollouts,
+                feedback, and crash reporting; the public npm CLI publishes
+                releases and share links from CI or Raft agents.
               </p>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row">
+              <a
+                className="inline-flex h-10 items-center justify-center rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
+                href="/docs/android-sdk/"
+              >
+                Android SDK
+              </a>
               <a
                 className="inline-flex h-10 items-center justify-center rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
                 href="/docs/cli-reference/"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.quiver:quiver-android-updater:0.1.0")
+    implementation("io.quiver:quiver-android-updater:0.4.0")
 }
 ```
 

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -1,0 +1,121 @@
+# Android SDK
+
+`io.quiver:quiver-android-updater` is the Android SDK for Quiver. It handles
+in-app update checks and installation, staged-rollout device bucketing,
+feedback submission, and crash reporting.
+
+## Install
+
+The SDK is published to GitHub Packages.
+
+```kotlin
+// settings.gradle.kts or the module repositories block
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/oranix-io/quiver")
+        credentials {
+            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation("io.quiver:quiver-android-updater:0.4.0")
+}
+```
+
+Configuration (`BuildConfig` fields are a convenient place to keep these):
+
+| Value | Example |
+|---|---|
+| Base URL | `https://quiver.oranix.io` |
+| App slug | `raft-android` |
+| Channel | `main` / `preview` / `nightly` / `debug` |
+
+## Update checks and installation
+
+`UpdateChecker` hits the public update-check endpoint, compares
+`versionCode`, and (optionally) downloads + installs the APK.
+
+```kotlin
+val checker = UpdateChecker(
+    context = applicationContext,
+    baseUrl = BuildConfig.QUIVER_BASE_URL,
+    appSlug = BuildConfig.QUIVER_APP_SLUG,
+    installedVersionCode = BuildConfig.VERSION_CODE.toLong(),
+    channel = BuildConfig.QUIVER_CHANNEL,
+    arch = Build.SUPPORTED_ABIS.firstOrNull(),
+)
+
+// suspending; returns the response even when no update is available
+val response = checker.checkAndInstall()
+```
+
+The SDK sends a stable per-install id (`X-Quiver-Device-Id`, from
+`QuiverDeviceId`) so the server can bucket the device for **staged rollouts**
+— a release published at 25% only installs on the matching fraction of
+devices, and each device keeps its bucket as you raise the percentage.
+
+To check without installing (e.g. to render your own "update available" UI),
+call `QuiverClient(baseUrl).checkForUpdate(...)` and act on the result.
+
+## Feedback
+
+`QuiverFeedback` submits user feedback (with attachments) to the Quiver
+ticket system; it auto-attaches app/device metadata and the device id.
+
+```kotlin
+val ticketId = QuiverFeedback(
+    context = applicationContext,
+    baseUrl = BuildConfig.QUIVER_BASE_URL,
+    appSlug = BuildConfig.QUIVER_APP_SLUG,
+    versionName = BuildConfig.VERSION_NAME,
+    versionCode = BuildConfig.VERSION_CODE.toLong(),
+    channel = BuildConfig.QUIVER_CHANNEL,
+).submit(
+    message = "Feed doesn't refresh after login.",
+    kind = "bug",                       // "feedback" | "bug" | "crash"
+    contact = "user@example.com",       // optional
+    attachments = listOf(screenshot),   // up to 3 files, 10 MB each
+)
+```
+
+Tickets appear in the app's **Feedback** tab and are triageable from the
+admin console or the CLI (`quiver feedback ...`).
+
+## Crash reporting
+
+`QuiverCrash` captures uncaught exceptions, stores them locally, and uploads
+them as `kind=crash` tickets on the next launch (store-then-send, so no
+network runs in the dying process). Crash tickets are grouped by signature
+and auto-deobfuscated when the build's `mapping.txt` was uploaded.
+
+```kotlin
+class App : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        QuiverCrash.install(
+            context = this,
+            baseUrl = BuildConfig.QUIVER_BASE_URL,
+            appSlug = BuildConfig.QUIVER_APP_SLUG,
+            versionName = BuildConfig.VERSION_NAME,
+            versionCode = BuildConfig.VERSION_CODE.toLong(),
+            channel = BuildConfig.QUIVER_CHANNEL,
+            // optional: attach app-specific context (recent logs, etc.)
+            extraContext = { myDiagnostics.recentText() },
+        )
+    }
+}
+```
+
+The crash log includes an all-threads dump and process uptime. To get
+readable (deobfuscated) stacks in the console, publish the release with its
+R8/ProGuard `mapping.txt` as a `proguard-mapping` build asset — Quiver
+retraces crash reports for that `versionCode` automatically.
+
+## Notes
+
+- All network calls are suspend functions; call them off the main thread.
+- The device id is a random UUID in SharedPreferences, not a hardware id; it
+  resets on reinstall/clear-data, which is fine for rollout cohorting.


### PR DESCRIPTION
Per artin (homepage docs had no Android SDK integration): new /docs/android-sdk page — install/coordinates, UpdateChecker + staged rollouts (device id), QuiverFeedback, QuiverCrash + auto-deobfuscation. Registered in build-docs, linked from the landing CTA (now 'Android SDK' + 'CLI reference' + 'Admin guide'). README dep bumped to 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)