### PR TITLE
fix(worker): allowlist /docs/android-sdk/

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -409,6 +409,7 @@ app.get("/api-docs", (c) => c.html(`<!doctype html>
 const publicDocs = new Set([
   "/docs/",
   "/docs/admin-user-guide/",
+  "/docs/android-sdk/",
   "/docs/cli-reference/",
   "/docs/public-api-reference/",
 ]);


### PR DESCRIPTION
The /docs/* handler gates on a hardcoded page set; #32's new page 404ed. Added. (Follow-up thought: derive the allowlist from the built docs manifest so new pages can't silently 404 again.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)