### PR TITLE
feat(feedback): require per-app client key on public submissions

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1182,3 +1182,15 @@ export interface CrashGroup {
 
 export const listCrashGroups = (appId: string) =>
   request<{ groups: CrashGroup[] }>(`/api/apps/${appId}/feedback/crash-groups`, { admin: true });
+
+export const getAppClientKey = (appId: string) =>
+  request<{ app_id: string; client_key: string | null }>(
+    `/api/apps/${appId}/client-key`,
+    { admin: true },
+  );
+
+export const rotateAppClientKey = (appId: string) =>
+  request<{ app_id: string; client_key: string; rotated_at: number }>(
+    `/api/apps/${appId}/rotate-client-key`,
+    { method: "POST", body: "{}", admin: true },
+  );

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -15,6 +15,8 @@ import {
   uploadAppIcon,
   publicAppIconUrl,
   updateAppPublicHistory,
+  getAppClientKey,
+  rotateAppClientKey,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
@@ -166,6 +168,75 @@ export function AppChannels({ appId }: { appId: string }) {
           />
         )}
       </section>
+    </div>
+  );
+}
+
+function ClientKeyPanel({ appId }: { appId: string }) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const [revealed, setRevealed] = useState(false);
+  const keyQuery = useQuery({
+    queryKey: ["client-key", appId],
+    queryFn: () => getAppClientKey(appId),
+  });
+  const rotate = useMutation({
+    mutationFn: () => rotateAppClientKey(appId),
+    onSuccess: () => {
+      toast.show({ kind: "success", title: "Client key rotated — update client configs" });
+      qc.invalidateQueries({ queryKey: ["client-key", appId] });
+    },
+    onError: (e) =>
+      toast.show({ kind: "error", title: "Rotate failed", description: (e as Error).message }),
+  });
+  const key = keyQuery.data?.client_key ?? null;
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium">Client key</div>
+        <div className="text-xs text-slate-500">
+          Required on feedback/crash submissions (X-Quiver-Client-Key). Embedded in
+          client builds; rotate if leaked.
+        </div>
+        {key && revealed && (
+          <div className="mt-1 font-mono text-xs break-all">{key}</div>
+        )}
+        {!key && !keyQuery.isLoading && (
+          <div className="mt-1 text-xs text-amber-700">
+            No key set — submissions are currently unauthenticated. Rotate to generate one.
+          </div>
+        )}
+      </div>
+      {key && (
+        <>
+          <button
+            className="btn-secondary !py-1 !px-2 !text-xs"
+            onClick={() => setRevealed((v) => !v)}
+          >
+            {revealed ? "Hide" : "Reveal"}
+          </button>
+          <button
+            className="btn-secondary !py-1 !px-2 !text-xs"
+            onClick={() => {
+              navigator.clipboard?.writeText(key);
+              toast.show({ kind: "success", title: "Client key copied" });
+            }}
+          >
+            Copy
+          </button>
+        </>
+      )}
+      <button
+        className="btn-secondary !py-1 !px-2 !text-xs"
+        disabled={rotate.isPending}
+        onClick={() => {
+          if (window.confirm("Rotate the client key? Older client builds stop reporting until they carry the new key.")) {
+            rotate.mutate();
+          }
+        }}
+      >
+        {rotate.isPending ? "…" : key ? "Rotate" : "Generate"}
+      </button>
     </div>
   );
 }
@@ -323,6 +394,9 @@ export function AppSettings({ appId }: { appId: string }) {
 
         {/* Public version history */}
         <PublicHistoryToggle appId={appId} app={app} />
+
+        {/* Client key (feedback/crash reporting auth) */}
+        <ClientKeyPanel appId={appId} />
 
         {/* Default release channel picker */}
         <DefaultChannelPicker appId={appId} app={app} isOrgAdmin={isOrgAdmin} />

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
@@ -45,6 +45,7 @@ object QuiverCrash {
         versionName: String? = null,
         versionCode: Long? = null,
         channel: String? = null,
+        clientKey: String? = null,
         copyToClipboard: Boolean = true,
         uploadOnLaunch: Boolean = true,
         extraContext: (() -> String)? = null,
@@ -80,7 +81,7 @@ object QuiverCrash {
         if (uploadOnLaunch) {
             thread(name = "quiver-crash-upload", isDaemon = true) {
                 runCatching {
-                    uploadPending(appContext, baseUrl, appSlug, versionName, versionCode, channel)
+                    uploadPending(appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey)
                 }
                     .onFailure { Log.w(TAG, "Crash upload pass failed", it) }
             }
@@ -99,6 +100,7 @@ object QuiverCrash {
         versionName: String? = null,
         versionCode: Long? = null,
         channel: String? = null,
+        clientKey: String? = null,
     ) {
         val dir = crashDir(context) ?: return
         val sidecars =
@@ -112,6 +114,7 @@ object QuiverCrash {
                 versionName = versionName,
                 versionCode = versionCode,
                 channel = channel,
+                clientKey = clientKey,
             )
         for (sidecar in sidecars) {
             val logFile = File(sidecar.absolutePath.removeSuffix(".meta.json") + ".txt")

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverFeedback.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverFeedback.kt
@@ -32,6 +32,7 @@ class QuiverFeedback(
     private val versionName: String? = null,
     private val versionCode: Long? = null,
     private val channel: String? = null,
+    private val clientKey: String? = null,
     private val httpClient: OkHttpClient = defaultClient(),
 ) {
     /**
@@ -84,11 +85,14 @@ class QuiverFeedback(
             .addPathSegment(appSlug)
             .addPathSegment("feedback")
             .build()
-        val request = Request.Builder()
+        val requestBuilder = Request.Builder()
             .url(url)
             .header("accept", "application/json")
             .post(bodyBuilder.build())
-            .build()
+        if (!clientKey.isNullOrBlank()) {
+            requestBuilder.header("X-Quiver-Client-Key", clientKey)
+        }
+        val request = requestBuilder.build()
 
         httpClient.newCall(request).execute().use { response ->
             val body = response.body?.string().orEmpty()

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -99,7 +99,18 @@ curl -X POST https://quiver.oranix.io/api/apps \
 ```
 
 New apps are seeded with default channels (`main`, `preview`, `nightly`) and
-product types.
+product types, and get a **client key** (`qk_…`) that clients must send as
+`X-Quiver-Client-Key` on feedback/crash submissions:
+
+```bash
+curl -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+  https://quiver.oranix.io/api/apps/<appId>/client-key          # read
+curl -X POST -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+  https://quiver.oranix.io/api/apps/<appId>/rotate-client-key   # (re)generate
+```
+
+Rotation invalidates the old key immediately — client builds must be updated
+with the new one.
 
 ## Rules for agents
 

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -73,6 +73,7 @@ val ticketId = QuiverFeedback(
     versionName = BuildConfig.VERSION_NAME,
     versionCode = BuildConfig.VERSION_CODE.toLong(),
     channel = BuildConfig.QUIVER_CHANNEL,
+    clientKey = BuildConfig.QUIVER_CLIENT_KEY,   // app Settings → Client key
 ).submit(
     message = "Feed doesn't refresh after login.",
     kind = "bug",                       // "feedback" | "bug" | "crash"
@@ -102,6 +103,7 @@ class App : Application() {
             versionName = BuildConfig.VERSION_NAME,
             versionCode = BuildConfig.VERSION_CODE.toLong(),
             channel = BuildConfig.QUIVER_CHANNEL,
+            clientKey = BuildConfig.QUIVER_CLIENT_KEY,
             // optional: attach app-specific context (recent logs, etc.)
             extraContext = { myDiagnostics.recentText() },
         )
@@ -119,3 +121,6 @@ retraces crash reports for that `versionCode` automatically.
 - All network calls are suspend functions; call them off the main thread.
 - The device id is a random UUID in SharedPreferences, not a hardware id; it
   resets on reinstall/clear-data, which is fine for rollout cohorting.
+- The client key (`qk_…`) authenticates feedback/crash submissions. It ships
+  inside the APK (Sentry-DSN model — app identifier, not a user secret); get
+  it from the app's Settings tab and put it in `BuildConfig`.

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -91,7 +91,14 @@ independent of the client's installed version. Accepts the same `lang` and
 ```http
 POST /public/v2/apps/:appSlug/feedback
 Content-Type: multipart/form-data
+X-Quiver-Client-Key: qk_...
 ```
+
+Requires the app's **client key** (Sentry-DSN model: it identifies the app,
+it is not a user secret). Pass it in the `X-Quiver-Client-Key` header (or a
+`client_key` query parameter); missing or mismatched keys get `401`. Admins
+find and rotate the key in the app's Settings tab or via
+`GET /api/apps/:id/client-key` / `POST /api/apps/:id/rotate-client-key`.
 
 | Field | Required | Description |
 |---|---|---|
@@ -165,6 +172,7 @@ Recommended client flow:
 | `400` | Missing or invalid request parameters. |
 | `404` | App, channel, release, or compatible artifact was not found. |
 | `410` | Signed download URL expired. |
+| `401` | Missing/invalid client key (feedback submissions). |
 | `429` | Rate limited (feedback submissions). |
 | `500` | Server error. Retry later or contact the Quiver operator. |
 

--- a/migrations/sql/0032_app_client_key.sql
+++ b/migrations/sql/0032_app_client_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE apps ADD COLUMN client_key TEXT;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -32,6 +32,8 @@ import {
   handleUpdateApp,
   handleUploadAppIcon,
   handlePublicAppIcon,
+  handleGetClientKey,
+  handleRotateClientKey,
 } from "./routes/apps";
 import {
   handlePublicListChannels,
@@ -558,6 +560,8 @@ admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
 admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);
+admin.get("/api/apps/:appId/client-key", requireAppRole("admin"), handleGetClientKey);
+admin.post("/api/apps/:appId/rotate-client-key", requireAppRole("admin"), handleRotateClientKey);
 admin.get("/api/apps/:appId/feedback/crash-groups", requireAppRole("viewer"), handleListCrashGroups);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -116,8 +116,8 @@ export async function handleCreateApp(c: AdminContext) {
   // (Phase 2.3 app-creation wizard path; small enough to inline here.)
   await c.env.DB.batch([
     c.env.DB.prepare(
-      "INSERT INTO apps (id, org_id, slug, name, platform, description, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-    ).bind(id, orgId, body.slug, body.name, body.platform, body.description ?? null, now),
+      "INSERT INTO apps (id, org_id, slug, name, platform, description, created_at, client_key) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+    ).bind(id, orgId, body.slug, body.name, body.platform, body.description ?? null, now, generateClientKey()),
     // product_types
     c.env.DB.prepare(
       `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'android-apk', 'Android APK', 'Android application package', '[]', '[{"platform":"android","filetype":"apk"}]', 'apk-aapt', '{"requires_native_codes":true}', ?, ?)`,
@@ -314,4 +314,43 @@ export async function handlePublicAppIcon(c: Context<{ Bindings: Env }>) {
   const headers = new Headers({ "cache-control": "public, max-age=300" });
   object.writeHttpMetadata?.(headers);
   return new Response(object.body, { headers });
+}
+
+/** qk_-prefixed random client key (Sentry-DSN-style shared credential). */
+export function generateClientKey(): string {
+  const bytes = new Uint8Array(20);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `qk_${hex}`;
+}
+
+/** POST /api/apps/:appId/rotate-client-key (admin). */
+export async function handleRotateClientKey(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const app = await c.env.DB.prepare("SELECT id FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+  const key = generateClientKey();
+  const now = Date.now();
+  await c.env.DB.batch([
+    c.env.DB.prepare("UPDATE apps SET client_key = ?1 WHERE id = ?2").bind(key, appId),
+    c.env.DB.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       VALUES (?1, ?2, 'app.client_key_rotated', ?3, '{}', ?4)`,
+    ).bind(crypto.randomUUID(), appId, currentActor(c), now),
+  ]);
+  return c.json({ app_id: appId, client_key: key, rotated_at: now });
+}
+
+/** GET /api/apps/:appId/client-key (admin) — view the current key. */
+export async function handleGetClientKey(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const app = await c.env.DB.prepare("SELECT client_key FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ client_key: string | null }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+  return c.json({ app_id: appId, client_key: app.client_key });
 }

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -25,11 +25,20 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   const slug = c.req.param("slug");
   if (!slug) return c.json({ error: "slug required" }, 400);
   const app = await c.env.DB.prepare(
-    "SELECT id, org_id, slug FROM apps WHERE slug = ?1 AND archived = 0",
+    "SELECT id, org_id, slug, client_key FROM apps WHERE slug = ?1 AND archived = 0",
   )
     .bind(slug)
-    .first<{ id: string; org_id: string | null; slug: string }>();
+    .first<{ id: string; org_id: string | null; slug: string; client_key: string | null }>();
   if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
+
+  // Client-key gate (Sentry-DSN model): always required. Apps predating the
+  // key column have none until an admin generates one — their submissions
+  // are rejected rather than silently open.
+  const presented =
+    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+  if (!app.client_key || presented !== app.client_key) {
+    return c.json({ error: "invalid or missing client key" }, 401);
+  }
 
   let form: FormData;
   try {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -52,7 +52,7 @@ function makeMockDb() {
     CREATE TABLE apps (
       id TEXT PRIMARY KEY, org_id TEXT, slug TEXT NOT NULL UNIQUE, name TEXT NOT NULL,
       platform TEXT NOT NULL, description TEXT, archived INTEGER NOT NULL DEFAULT 0,
-      archived_at INTEGER, created_at INTEGER NOT NULL, icon_r2_key TEXT, public_history INTEGER NOT NULL DEFAULT 0
+      archived_at INTEGER, created_at INTEGER NOT NULL, icon_r2_key TEXT, public_history INTEGER NOT NULL DEFAULT 0, client_key TEXT
     );
     CREATE TABLE channels (
       id TEXT PRIMARY KEY, app_id TEXT NOT NULL, slug TEXT NOT NULL,
@@ -1791,8 +1791,8 @@ describe("quiver public API v2 — scope resolution", () => {
   function makeEnv() {
     const env = makeMockEnv();
     env.DB.prepare(
-      "INSERT OR IGNORE INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-    ).bind("app-scope", "default", "scope-app", "Scope App", "android", 1).run();
+      "INSERT OR IGNORE INTO apps (id, org_id, slug, name, platform, client_key, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).bind("app-scope", "default", "scope-app", "Scope App", "android", "qk_test", 1).run();
     env.DB.prepare(
       `INSERT INTO channels (id, app_id, slug, name, enabled_product_types_json, metadata_json, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -2955,7 +2955,8 @@ describe("quiver public API v2 — scope resolution", () => {
         env,
         req: {
           param: (n: string) => (n === "slug" ? "scope-app" : ""),
-          header: () => undefined,
+          header: (n: string) => (n === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
           formData: async () => form,
           raw: { cf: { clientIp: `10.0.0.${device.length}` } },
         },
@@ -2982,6 +2983,42 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(home.count).toBe(2);
     expect(home.device_count).toBe(2);
     expect(home.open_count).toBe(2);
+  });
+
+  it("feedback: client key is always required", async () => {
+    const env = makeEnv();
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    env.APK_BUCKET = { put: async () => {}, get: async () => null };
+
+    const submit = (headers: Record<string, string | undefined>) => {
+      const form = new FormData();
+      form.set("message", "key gate test");
+      return handlePublicFeedbackSubmit({
+        env,
+        req: {
+          param: (name: string) => (name === "slug" ? "scope-app" : ""),
+          header: (name: string) => headers[name],
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.7" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+    };
+
+    // missing/wrong -> 401, correct -> 201
+    expect((await submit({})).status).toBe(401);
+    expect((await submit({ "X-Quiver-Client-Key": "qk_wrong" })).status).toBe(401);
+    expect((await submit({ "X-Quiver-Client-Key": "qk_test" })).status).toBe(201);
+
+    // app without a key rejects everything (legacy rows until admin generates one)
+    await env.DB.prepare("UPDATE apps SET client_key = NULL WHERE id = ?1")
+      .bind("app-scope")
+      .run();
+    expect((await submit({ "X-Quiver-Client-Key": "qk_test" })).status).toBe(401);
+    await env.DB.prepare("UPDATE apps SET client_key = ?1 WHERE id = ?2")
+      .bind("qk_test", "app-scope")
+      .run();
   });
 
   it("feedback: public submit stores ticket + attachment, admin can triage", async () => {
@@ -3032,7 +3069,8 @@ describe("quiver public API v2 — scope resolution", () => {
       env,
       req: {
         param: (name: string) => (name === "slug" ? "scope-app" : ""),
-        header: () => undefined,
+        header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+        query: () => undefined,
         formData: async () => form,
         raw: { cf: { clientIp: "203.0.113.9" } },
       },


### PR DESCRIPTION
Slug-only feedback submission let anyone spam any app's ticket queue. Every app now carries a client key (Sentry-DSN model — identifies the app, embedded in client builds, not a user secret):

- `0032_app_client_key.sql`: `apps.client_key`; generated automatically on app creation (`qk_` + 40 hex chars).
- `POST /public/v2/apps/:slug/feedback` requires `X-Quiver-Client-Key` (or `client_key` query param); missing/mismatch → 401. Enforcement is unconditional — no shipped build reports yet, so there is no legacy fleet to protect. Apps predating the column reject submissions until an admin generates a key.
- Admin API: `GET /api/apps/:id/client-key`, `POST /api/apps/:id/rotate-client-key` (audit-logged, app admin role).
- Settings tab: Client key panel (reveal/copy/rotate-with-confirm).
- Android SDK: `QuiverFeedback` / `QuiverCrash.install` / `QuiverCrash.uploadPending` accept `clientKey` and send the header (SDK 0.5.0 to follow).
- Docs: public-api-reference (401 + header), android-sdk, agent-guide (key management via API).

Tests: 71/71 (gate: missing/wrong/correct, keyless app rejects); build green; lint = pre-existing eslint v9 breakage (fails on main too).

Post-deploy: generate keys for raft-android and raft-ohos, wire into mobile BuildConfig/OHOS config before the next release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)