### PR TITLE
feat(landing): reposition as full-loop mobile release operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # Quiver
 
-**Ship Android builds, releases, and share links from one place.**
+**Ship it, roll it out, hear it break, fix it — one platform for mobile release operations.**
 
-Quiver manages APK uploads, release channels, public update checks, share pages, and Raft-based access control for humans and agents — fully Cloudflare-native (Workers + Container + D1 + R2).
+Quiver runs the whole release loop: CI lands builds as drafts, agents review and publish with bilingual changelogs, staged rollouts meter exposure by device cohort, share pages handle ad-hoc distribution, and in-app feedback and crash reports come back as tickets — grouped by signature, auto-deobfuscated, and triageable by humans and AI agents through the same API. Reporting SDKs cover Android and HarmonyOS today (iOS next) — fully Cloudflare-native (Workers + Container + D1 + R2).
 
 - **Live instance:** <https://quiver.oranix.io>
 - **Docs:** <https://quiver.oranix.io/docs> · [Admin guide](https://quiver.oranix.io/docs/admin-user-guide/) · [CLI reference](https://quiver.oranix.io/docs/cli-reference/)
 - **API explorer:** <https://quiver.oranix.io/api-docs>
 - **CLI on npm:** [`@oranix/quiver-cli`](https://www.npmjs.com/package/@oranix/quiver-cli)
 
-The "quiver" metaphor: admins load APK arrows into channels; clients pick the right one for their channel.
+The "quiver" metaphor: admins load APK arrows into channels; clients pick the right one for their channel — and tell you where it landed.
 
 ## Features
 
 - **Channels** — keep main, preview, nightly, or debug releases separated by app. Publish to `main` for stable users, `preview` for validation, `nightly` for fast internal iteration.
-- **Update checks & staged rollouts** — public latest/update responses with signed APK downloads, percentage rollouts bucketed by stable device id, and per-language changelogs; the Android SDK (`clients/android`) handles in-app checks, installation, and feedback submission.
+- **Update checks & staged rollouts** — public latest/update responses with signed APK downloads, percentage rollouts bucketed by stable device id, and per-language changelogs; the Android SDK (`clients/android`) handles in-app checks, installation, and feedback and crash submission; a HarmonyOS (ArkTS) reporting layer mirrors it.
 - **Share pages & version history** — revocable, expiring, optionally password-protected download pages with QR codes and view/download stats, plus an opt-in public version history page per app.
-- **Feedback tickets** — in-app feedback (attachments, device context) lands in a built-in ticket system with assignees, statuses, comments, and webhooks.
+- **Feedback tickets** — in-app feedback (attachments, device context) lands in a built-in ticket system with assignees, statuses, comments, and webhooks; submissions are authenticated with a per-app client key.
+- **Crash reporting** — store-then-send crash capture on Android and HarmonyOS uploads on next launch, groups by signature, and auto-retraces stacks against uploaded R8/ProGuard mappings.
 - **Draft-first releases** — CI creates draft releases with generated changelogs; an agent reviews, writes bilingual notes, and publishes explicitly (`docs/release-runbook.md`).
 - **Raft access** — Login with Raft, org roles, direct app members, per-server visibility grants, and app-level deploy tokens for CI and agents.
 - **CI-friendly publishing** — the public npm CLI publishes Android releases and creates share links from GitHub Actions, local packaging lanes, or Raft agents:

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -474,7 +474,7 @@ function AuthGate() {
 
 function PublicLanding({ account }: { account?: AuthAccount }) {
   useEffect(() => {
-    document.title = "Quiver - Android release distribution";
+    document.title = "Quiver - Mobile release operations";
   }, []);
 
   return (
@@ -514,15 +514,17 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
           <div className="mx-auto grid max-w-6xl gap-10 px-4 py-14 md:grid-cols-[1.1fr_0.9fr] md:items-center md:py-20">
             <div className="max-w-2xl">
               <div className="mb-4 inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
-                Release distribution for Raft-built apps
+                Release operations for Raft-built apps
               </div>
               <h1 className="text-4xl font-bold leading-tight sm:text-5xl">
-                Ship Android builds, releases, and share links from one place.
+                Ship it, roll it out, hear it break, fix it — one platform.
               </h1>
               <p className="mt-5 text-lg leading-8 text-slate-600">
-                Quiver manages APK uploads, release channels, public update
-                checks, share pages, and Raft-based access control for humans
-                and agents.
+                Quiver runs the whole release loop: builds land as drafts,
+                agents review and publish with bilingual changelogs, staged
+                rollouts meter exposure, and in-app feedback and crash
+                reports come back as tickets — grouped, deobfuscated, and
+                triageable by humans and agents alike.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <a
@@ -569,20 +571,20 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
 
         <section className="mx-auto grid max-w-6xl gap-4 px-4 py-8 sm:grid-cols-2 lg:grid-cols-4">
           <LandingFeature
-            title="Channels"
-            body="Keep main, preview, nightly, or debug releases separated by app."
+            title="Channels & staged rollouts"
+            body="Separate main, preview, and nightly; publish at 5% and raise it as confidence grows — devices keep their cohort."
           />
           <LandingFeature
-            title="Update checks"
-            body="Serve public latest/update responses with signed APK downloads."
+            title="Share pages & history"
+            body="Expiring, password-protectable download pages with QR codes, real app icons, and opt-in public version history."
           />
           <LandingFeature
-            title="Share pages"
-            body="Create expiring download pages with view and download counts."
+            title="Feedback tickets"
+            body="In-app feedback with attachments and device context lands in a built-in ticket system with assignees and comments."
           />
           <LandingFeature
-            title="Raft access"
-            body="Use Raft login, org roles, direct app members, and server visibility."
+            title="Crash reporting"
+            body="Store-then-send crash capture on Android and HarmonyOS, grouped by signature and auto-deobfuscated via mapping files."
           />
         </section>
 


### PR DESCRIPTION
Landing hero, feature cards, and README now describe the whole loop —
draft-first releases, staged rollouts, share pages, feedback tickets,
crash reporting on Android/HarmonyOS — instead of Android-only
distribution.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
