### PR TITLE
feat(alerts): crash webhooks — new signature groups and hourly spikes

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -935,6 +935,9 @@ export const forceUpdate = (
 // =============================================================================
 
 export type WebhookEventType =
+  | "feedback:new"
+  | "crash:new_group"
+  | "crash:spike"
   | "release:new"
   | "release:superseded"
   | "release:rolled_back"
@@ -943,6 +946,9 @@ export type WebhookEventType =
   | "build:failed";
 
 export const WEBHOOK_EVENT_TYPES: WebhookEventType[] = [
+  "feedback:new",
+  "crash:new_group",
+  "crash:spike",
   "release:new",
   "release:superseded",
   "release:rolled_back",

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -84,6 +84,10 @@ The Feedback tab is a lightweight ticket system for reports submitted from the a
 - Tickets are shareable pages (`/apps/<id>/feedback/<ticket>`).
 - Triage with statuses (`open → in_progress → resolved/closed`), an assignee (Assign to me / edit / unassign), and a comment trail.
 - A `feedback:new` webhook fires on submission for org webhook subscribers.
+- Crash alerting: `crash:new_group` fires the first time a crash signature is
+  seen for an app; `crash:spike` fires as a signature crosses 10, 50, and 100
+  occurrences within an hour. Subscribe a webhook to either event (Org
+  settings → Webhooks) to get paged instead of polling the console.
 
 Crash tickets (`kind=crash`, submitted automatically by the SDK's crash
 reporter) get a grouping **signature** (exception class + top app frame) and a

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -110,7 +110,8 @@ find and rotate the key in the app's Settings tab or via
 
 Returns `201` with `{ "id": "<ticket id>", "status": "open" }`. Rate limit:
 10 submissions per hour per app + client IP. Tickets appear in the admin
-Feedback tab; a `feedback:new` webhook fires for subscribed endpoints. The
+Feedback tab; a `feedback:new` webhook fires for subscribed endpoints (crash
+tickets can additionally trigger `crash:new_group` / `crash:spike`). The
 Android SDK's `QuiverFeedback.submit(...)` wraps this endpoint and attaches
 device metadata automatically.
 

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -191,6 +191,61 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     }
   }
 
+  // Crash alerting: fire webhooks when a signature is first seen or when it
+  // spikes (10/50/100 tickets within an hour — fires once per tier as the
+  // count crosses it, so no extra state table is needed).
+  if (kind === "crash" && signature && app.org_id) {
+    const orgId = app.org_id;
+    const alert = async () => {
+      const prior = await c.env.DB.prepare(
+        `SELECT COUNT(*) AS n FROM feedback_tickets
+         WHERE app_id = ?1 AND signature = ?2 AND id != ?3`,
+      )
+        .bind(app.id, signature, ticketId)
+        .first<{ n: number }>();
+      const base = {
+        app_slug: app.slug,
+        signature,
+        ticket_id: ticketId,
+        message: message.slice(0, 300),
+        version_name: meta("version_name"),
+        version_code: versionCode,
+      };
+      if ((prior?.n ?? 0) === 0) {
+        await emitWebhookEvent(c.env.DB, {
+          orgId,
+          appId: app.id,
+          event: "crash:new_group",
+          body: base,
+        });
+        return;
+      }
+      const recent = await c.env.DB.prepare(
+        `SELECT COUNT(*) AS n FROM feedback_tickets
+         WHERE app_id = ?1 AND signature = ?2 AND created_at >= ?3`,
+      )
+        .bind(app.id, signature, now - 60 * 60 * 1000)
+        .first<{ n: number }>();
+      const hourCount = recent?.n ?? 0;
+      if (hourCount === 10 || hourCount === 50 || hourCount === 100) {
+        await emitWebhookEvent(c.env.DB, {
+          orgId,
+          appId: app.id,
+          event: "crash:spike",
+          body: { ...base, count_last_hour: hourCount },
+        });
+      }
+    };
+    const guarded = alert().catch(() => {
+      // alerting must never fail the submission
+    });
+    try {
+      c.executionCtx.waitUntil(guarded);
+    } catch {
+      await guarded;
+    }
+  }
+
   if (app.org_id) {
     await emitWebhookEvent(c.env.DB, {
       orgId: app.org_id,

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -25,6 +25,8 @@ import type { AdminContext } from "../lib/permissions";
 
 type WebhookEventType =
   | "feedback:new"
+  | "crash:new_group"
+  | "crash:spike"
   | "release:new"
   | "release:superseded"
   | "release:rolled_back"
@@ -256,9 +258,9 @@ export async function emitWebhookEvent(
          (id, webhook_id, event_type, payload_json, status,
           attempts, max_attempts, last_attempt_at, next_attempt_at,
           created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, 'pending', 0, 3, NULL, ?5, ?5, ?5)`,
+         VALUES (?1, ?2, ?3, ?4, 'pending', 0, 3, NULL, ?5, ?6, ?7)`,
       )
-      .bind(crypto.randomUUID(), s.id, payload.event, body, now),
+      .bind(crypto.randomUUID(), s.id, payload.event, body, now, now, now),
   );
   await db.batch(stmts);
 }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2985,6 +2985,58 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(home.open_count).toBe(2);
   });
 
+  it("feedback: crash alert webhooks fire on new group only once", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = { put: async () => {}, get: async () => null };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+
+    await env.DB.prepare(
+      `INSERT INTO webhooks (id, org_id, app_id, url, secret, events_json, enabled, created_at, updated_at)
+       VALUES (?1, ?2, NULL, ?3, ?4, ?5, 1, ?6, ?7)`,
+    )
+      .bind("wh-crash", "default", "https://example.test/hook", "s3cret", JSON.stringify(["crash:new_group", "crash:spike"]), Date.now(), Date.now())
+      .run();
+
+    const submitCrash = async (topFrame: string, ip: string) => {
+      const form = new FormData();
+      form.set("message", "crash");
+      form.set("kind", "crash");
+      form.set(
+        "metadata",
+        JSON.stringify({
+          crash_exception_class: "java.lang.IllegalStateException",
+          crash_top_frame: topFrame,
+        }),
+      );
+      const waited: Promise<unknown>[] = [];
+      const ctx = {
+        env,
+        executionCtx: { waitUntil: (p: Promise<unknown>) => waited.push(p) },
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: (n: string) => (n === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: ip } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any;
+      const res = await handlePublicFeedbackSubmit(ctx);
+      await Promise.all(waited);
+      return res;
+    };
+
+    expect((await submitCrash("app.Main.boot(Main.kt:1)", "10.1.0.1")).status).toBe(201);
+    expect((await submitCrash("app.Main.boot(Main.kt:9)", "10.1.0.2")).status).toBe(201); // same signature
+    expect((await submitCrash("app.Feed.load(Feed.kt:3)", "10.1.0.3")).status).toBe(201); // new signature
+
+    const deliveries = (await env.DB.prepare(
+      "SELECT event_type FROM webhook_deliveries WHERE webhook_id = ?1 ORDER BY created_at",
+    ).bind("wh-crash").all()).results as Array<{ event_type: string }>;
+    expect(deliveries.filter((d) => d.event_type === "crash:new_group").length).toBe(2);
+    expect(deliveries.filter((d) => d.event_type === "crash:spike").length).toBe(0);
+  });
+
   it("feedback: client key is always required", async () => {
     const env = makeEnv();
     const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");


### PR DESCRIPTION
crash:new_group fires on the first ticket with a given signature;
crash:spike fires as a signature crosses 10/50/100 tickets within an
hour (stateless tier-crossing, no alert table). Runs via waitUntil so
submissions never block. Also fixes emitWebhookEvent's numbered-param
reuse and adds the missing feedback/crash events to the admin webhook
event picker.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
