### PR TITLE
fix(public): actually select releases.changelog in the candidates query

### DIFF
--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -108,12 +108,12 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   // Candidates: active releases on (channel, [product_type]). No time window:
   // an active release must stay resolvable no matter how old it is.
   const candidateSql = productType
-    ? `SELECT id, build_id, created_at, product_type, rollout_cohort_count
+    ? `SELECT id, build_id, created_at, product_type, rollout_cohort_count, changelog
        FROM releases
        WHERE app_id = ?1 AND channel_id = ?2 AND product_type = ?3
          AND status = 'active'
        ORDER BY created_at DESC`
-    : `SELECT id, build_id, created_at, product_type, rollout_cohort_count
+    : `SELECT id, build_id, created_at, product_type, rollout_cohort_count, changelog
        FROM releases
        WHERE app_id = ?1 AND channel_id = ?2
          AND status = 'active'


### PR DESCRIPTION
The precedence fix in d19f388 read a column the SQL never selected, so
the fallback to builds.changelog always won.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
