### PR TITLE
feat(apps): purge — permanent delete of archived apps incl. R2 objects

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1197,6 +1197,12 @@ export const getFeedbackStats = (appId: string) =>
 export const listCrashGroups = (appId: string) =>
   request<{ groups: CrashGroup[] }>(`/api/apps/${appId}/feedback/crash-groups`, { admin: true });
 
+export const purgeApp = (appId: string, confirmSlug: string) =>
+  request<{ ok: true; purged_app_id: string; r2_objects_deleted: number }>(
+    `/api/apps/${appId}/purge`,
+    { method: "POST", admin: true, body: JSON.stringify({ confirm_slug: confirmSlug }) },
+  );
+
 export const getAppClientKey = (appId: string) =>
   request<{ app_id: string; client_key: string | null }>(
     `/api/apps/${appId}/client-key`,

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -17,6 +17,7 @@ import {
   updateAppPublicHistory,
   getAppClientKey,
   rotateAppClientKey,
+  purgeApp,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
@@ -443,6 +444,22 @@ export function AppSettings({ appId }: { appId: string }) {
 
   const [confirmArchive, setConfirmArchive] = useState(false);
 
+  const [confirmPurge, setConfirmPurge] = useState(false);
+  const purge = useMutation({
+    mutationFn: () => purgeApp(appId, app?.slug ?? ""),
+    onSuccess: (res) => {
+      toast.show({
+        kind: "success",
+        title: `App purged (${res.r2_objects_deleted} stored files removed)`,
+      });
+      setConfirmPurge(false);
+      qc.invalidateQueries({ queryKey: ["apps"] });
+      window.location.assign("/apps");
+    },
+    onError: (e) =>
+      toast.show({ kind: "error", title: "Purge failed", description: (e as Error).message }),
+  });
+
   const archive = useMutation({
     mutationFn: (archived: boolean) =>
       archiveApp(appId, { archived }),
@@ -519,15 +536,46 @@ export function AppSettings({ appId }: { appId: string }) {
               )}
             </div>
             {isOrgAdmin && (
-              <button
-                className="btn-secondary text-xs"
-                onClick={() => setConfirmArchive(true)}
-                disabled={archive.isPending}
-              >
-                {app.archived ? "Restore app" : "Archive app"}
-              </button>
+              <div className="flex flex-col items-end gap-2">
+                <button
+                  className="btn-secondary text-xs"
+                  onClick={() => setConfirmArchive(true)}
+                  disabled={archive.isPending}
+                >
+                  {app.archived ? "Restore app" : "Archive app"}
+                </button>
+                {Boolean(app.archived) && (
+                  <button
+                    className="btn-secondary !border-red-300 !text-red-700 text-xs"
+                    disabled={purge.isPending}
+                    onClick={() => setConfirmPurge(true)}
+                  >
+                    Purge permanently
+                  </button>
+                )}
+              </div>
             )}
           </div>
+
+          <ConfirmActionDialog
+            open={confirmPurge}
+            title="Purge this app permanently?"
+            objectLabel={app.name ?? app.slug ?? app.id}
+            objectHint={`slug: ${app.slug}`}
+            body={
+              <>
+                Deletes the app and <strong>everything it owns</strong> — builds,
+                releases, share links, feedback tickets, and all stored files in
+                R2. <strong>This cannot be undone.</strong>
+              </>
+            }
+            confirmLabel="Purge permanently"
+            confirmKind="danger"
+            typeToConfirm={app.slug}
+            pending={purge.isPending}
+            onConfirm={() => purge.mutate()}
+            onCancel={() => setConfirmPurge(false)}
+          />
 
           <ConfirmActionDialog
             open={confirmArchive}

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -20,7 +20,10 @@ Each app has a left sidebar with its sections; the app switcher at the top of th
 - Feedback: tickets submitted from the app, with assignees, statuses, and comments.
 - Access: direct app members, deploy tokens, and Raft server visibility.
 - Audit: recent app activity.
-- Settings: app icon, default channel, public version history toggle, archive.
+- Settings: app name/description, app icon, client key, default channel,
+  public version history toggle, archive. Archived apps can be **purged**
+  (permanent delete of the app, its builds/releases/tickets, and all stored
+  files — requires typing the slug to confirm; `POST /api/apps/:id/purge`).
 
 Create one Quiver app per product distribution target. For example, an Android app should have its own Quiver app and release channels.
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -29,6 +29,7 @@ import {
   handleCreateApp,
   handleGetApp,
   handleArchiveApp,
+  handlePurgeApp,
   handleUpdateApp,
   handleUploadAppIcon,
   handlePublicAppIcon,
@@ -531,6 +532,7 @@ admin.post("/api/apps", requireCurrentOrgRole("admin"), handleCreateApp);
 admin.get("/api/apps/:appId", requireAppRole("viewer"), handleGetApp);
 admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);
+admin.post("/api/apps/:appId/purge", requireAppRole("admin"), handlePurgeApp);
 
 admin.get("/api/apps/:appId/builds", requireAppRole("viewer"), handleListBuilds);
 admin.post("/api/apps/:appId/builds", requireAppRole("publisher"), handleCreateBuild);

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -170,6 +170,72 @@ export async function handleArchiveApp(c: Context<{ Bindings: Env }>) {
   return c.json({ ok: true, archived: targetArchived });
 }
 
+/**
+ * Hard delete: removes the app row (children cascade) and every R2 object it
+ * owns (build assets, feedback attachments, icon, apps/<id>/ prefix). Only
+ * allowed on archived apps — archive first, purge second. Irreversible; the
+ * DB keeps no tombstone (children cascade), so the response is the record.
+ */
+export async function handlePurgeApp(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const app = await c.env.DB.prepare(
+    "SELECT id, slug, archived, icon_r2_key FROM apps WHERE id = ?1",
+  )
+    .bind(appId)
+    .first<{ id: string; slug: string; archived: number; icon_r2_key: string | null }>();
+  if (!app) return c.json({ error: "not found" }, 404);
+  if (!app.archived) {
+    return c.json({ error: "archive the app before purging it" }, 409);
+  }
+  const body = (await c.req.json().catch(() => ({}))) as { confirm_slug?: string };
+  if (body.confirm_slug !== app.slug) {
+    return c.json({ error: "confirm_slug must match the app slug" }, 400);
+  }
+
+  // Collect every known R2 key, then sweep the app's prefixes for strays.
+  const keys = new Set<string>();
+  if (app.icon_r2_key) keys.add(app.icon_r2_key);
+  const [assets, attachments] = await Promise.all([
+    c.env.DB.prepare(
+      `SELECT a.r2_key AS r2_key FROM build_assets a
+       JOIN builds b ON b.id = a.build_id WHERE b.app_id = ?1`,
+    )
+      .bind(appId)
+      .all<{ r2_key: string }>(),
+    c.env.DB.prepare(
+      `SELECT fa.r2_key AS r2_key FROM feedback_attachments fa
+       JOIN feedback_tickets t ON t.id = fa.ticket_id WHERE t.app_id = ?1`,
+    )
+      .bind(appId)
+      .all<{ r2_key: string }>(),
+  ]);
+  for (const row of assets.results) keys.add(row.r2_key);
+  for (const row of attachments.results) keys.add(row.r2_key);
+  for (const prefix of [`apps/${appId}/`, `feedback/${appId}/`]) {
+    let cursor: string | undefined;
+    do {
+      const page = await c.env.APK_BUCKET.list(
+        cursor ? { prefix, cursor, limit: 1000 } : { prefix, limit: 1000 },
+      );
+      for (const obj of page.objects) keys.add(obj.key);
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor);
+  }
+
+  const keyList = [...keys];
+  for (let i = 0; i < keyList.length; i += 500) {
+    await c.env.APK_BUCKET.delete(keyList.slice(i, i + 500));
+  }
+
+  // Children (builds, releases, tickets, tokens, audit rows, …) cascade.
+  await c.env.DB.prepare("DELETE FROM apps WHERE id = ?1").bind(appId).run();
+
+  console.log(
+    `app purged: id=${appId} slug=${app.slug} actor=${currentActor(c)} r2_objects=${keyList.length}`,
+  );
+  return c.json({ ok: true, purged_app_id: appId, slug: app.slug, r2_objects_deleted: keyList.length });
+}
+
 export async function handleGetApp(c: Context<{ Bindings: Env }>) {
   const appId = c.req.param("appId") ?? "";
   const row = await c.env.DB.prepare(

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2985,6 +2985,44 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(home.open_count).toBe(2);
   });
 
+  it("apps: purge requires archived + slug confirm, deletes R2 + row", async () => {
+    const env = makeEnv();
+    const deleted: string[] = [];
+    env.APK_BUCKET = {
+      list: async ({ prefix }: { prefix: string }) => ({
+        objects: prefix === "apps/app-scope/" ? [{ key: "apps/app-scope/stray.apk" }] : [],
+        truncated: false,
+      }),
+      delete: async (keys: string | string[]) => {
+        deleted.push(...(Array.isArray(keys) ? keys : [keys]));
+      },
+    };
+    const { handlePurgeApp } = await import("../src/routes/apps");
+    const ctx = (body: Record<string, unknown>) =>
+      ({
+        env,
+        req: { param: () => "app-scope", json: async () => body },
+        get: () => "tester",
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      }) as any;
+
+    // active app -> 409
+    expect((await handlePurgeApp(ctx({ confirm_slug: "scope-app" }))).status).toBe(409);
+    await env.DB.prepare("UPDATE apps SET archived = 1 WHERE id = ?1").bind("app-scope").run();
+    // wrong confirm -> 400
+    expect((await handlePurgeApp(ctx({ confirm_slug: "nope" }))).status).toBe(400);
+    // correct -> 200, R2 sweep ran, row gone
+    const res = await handlePurgeApp(ctx({ confirm_slug: "scope-app" }));
+    expect(res.status).toBe(200);
+    expect(deleted).toContain("apps/app-scope/stray.apk");
+    const row = await env.DB.prepare("SELECT id FROM apps WHERE id = ?1").bind("app-scope").first();
+    expect(row).toBeNull();
+    // restore for later tests in this suite
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, client_key, created_at) VALUES (?1,?2,?3,?4,?5,?6,?7)",
+    ).bind("app-scope", "default", "scope-app", "Scope App", "android", "qk_test", 1).run();
+  });
+
   it("feedback: crash alert webhooks fire on new group only once", async () => {
     const env = makeEnv();
     env.APK_BUCKET = { put: async () => {}, get: async () => null };


### PR DESCRIPTION
POST /api/apps/:id/purge (app admin): requires the app to be archived
and the slug in confirm_slug; collects build-asset/attachment/icon keys
plus an apps/<id>/ + feedback/<id>/ prefix sweep, deletes them from R2,
then deletes the app row (children cascade). Danger-zone dialog with
type-slug confirm.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
