### PR TITLE
feat(public): render changelog markdown on share and history pages

### DIFF
--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -5,7 +5,7 @@
  */
 import type { Context } from "hono";
 import { requestOrigin } from "../lib/origin";
-import { generateSignedR2Url, resolveChangelog } from "./public_v2";
+import { generateSignedR2Url, resolveChangelog, changelogToHtml } from "./public_v2";
 
 type HistoryRow = {
   release_id: string;
@@ -131,7 +131,7 @@ function renderHistoryPage(
         </a>
       </div>
       <div class="date" data-ts="${row.released_at}"></div>
-      ${changelog ? `<pre class="notes">${esc(changelog)}</pre>` : ""}
+      ${changelog ? `<div class="notes">${changelogToHtml(changelog)}</div>` : ""}
     </li>`;
     })
     .join("\n");
@@ -157,7 +157,11 @@ function renderHistoryPage(
     .badge { background: #d8f3e8; color: #176f5d; border-radius: 4px; padding: 2px 6px; font-size: 12px; font-weight: 600; margin-left: 8px; }
     .dl { color: #176f5d; font-weight: 600; text-decoration: none; white-space: nowrap; }
     .date { color: #9aa0a9; font-size: 12px; margin-top: 4px; }
-    .notes { margin: 10px 0 0; white-space: pre-wrap; font-family: inherit; font-size: 14px; color: #3b3f45; }
+    .notes { margin: 10px 0 0; font-family: inherit; font-size: 14px; color: #3b3f45; }
+    .notes ul { margin: 6px 0; padding-left: 20px; }
+    .notes li { margin: 3px 0; }
+    .notes p { margin: 6px 0; }
+    .notes code { background: rgba(125,125,125,0.15); border-radius: 4px; padding: 1px 4px; font-size: 0.92em; }
     @media (prefers-color-scheme: dark) {
       body { background: #17191c; color: #f5f5f2; }
       .release { background: #1f2226; border-color: #33373d; }

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -515,6 +515,46 @@ export function rolloutIncludes(
  * BCP-47-ish keys ({"en": "...", "zh-CN": "..."}). Resolve to the closest
  * language, falling back en -> first available.
  */
+/**
+ * Minimal, safe markdown for changelogs on public pages: escapes HTML first,
+ * then supports "- " bullet lists, **bold**, `code`, and paragraphs. No raw
+ * HTML, images, or links pass through.
+ */
+export function changelogToHtml(raw: string): string {
+  const escape = (t: string) =>
+    t
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+  const inline = (t: string) =>
+    escape(t)
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/`([^`]+)`/g, "<code>$1</code>");
+  const lines = raw.split(/\r?\n/);
+  const out: string[] = [];
+  let list: string[] = [];
+  const flushList = () => {
+    if (list.length > 0) {
+      out.push(`<ul>${list.map((li) => `<li>${li}</li>`).join("")}</ul>`);
+      list = [];
+    }
+  };
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
+      list.push(inline(trimmed.slice(2)));
+    } else if (trimmed.length === 0) {
+      flushList();
+    } else {
+      flushList();
+      out.push(`<p>${inline(trimmed)}</p>`);
+    }
+  }
+  flushList();
+  return out.join("");
+}
+
 export function resolveChangelog(raw: string | null, lang: string | null): string | null {
   if (!raw) return raw;
   const trimmed = raw.trim();

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import qrcode from "qrcode-generator";
 import { requestOrigin } from "../lib/origin";
 import { currentActor, type AdminEnv } from "../middleware/auth";
-import { generateSignedR2Url, resolveChangelog } from "./public_v2";
+import { generateSignedR2Url, resolveChangelog , changelogToHtml } from "./public_v2";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -648,7 +648,11 @@ function renderSharePage(
     .qr svg { display: block; width: 128px; height: 128px; border-radius: 8px; background: white; padding: 6px; box-sizing: border-box; }
     .qr span { display: block; margin-top: 6px; color: #707782; font-size: 12px; text-align: center; }
     @media (pointer: fine) and (min-width: 480px) { .qr { display: block; } }
-    .notes { margin-top: 22px; white-space: pre-wrap; color: #3b3f45; }
+    .notes { margin-top: 22px; color: #3b3f45; text-align: left; }
+    .notes ul { margin: 8px 0; padding-left: 20px; }
+    .notes li { margin: 4px 0; }
+    .notes p { margin: 8px 0; }
+    .notes code { background: rgba(125,125,125,0.15); border-radius: 4px; padding: 1px 4px; font-size: 0.92em; }
     .stats { display: flex; flex-wrap: wrap; gap: 8px 16px; }
     .stat strong { display: block; color: #1e1f22; font-size: 18px; }
     .stat span { display: block; color: #707782; font-size: 12px; font-weight: 500; }
@@ -689,7 +693,7 @@ function renderSharePage(
       <a class="download" href="${escapeAttribute(downloadUrl)}">Download APK</a>
       <div class="qr">${qrSvg}<span>Scan to open on your phone</span></div>
     </div>
-    ${row.changelog ? `<div class="notes">${escapeHtml(row.changelog)}</div>` : ""}
+    ${row.changelog ? `<div class="notes">${changelogToHtml(row.changelog)}</div>` : ""}
   </main>
   <script>
     (() => {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2985,6 +2985,14 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(home.open_count).toBe(2);
   });
 
+  it("changelogToHtml renders bullets safely", async () => {
+    const { changelogToHtml } = await import("../src/routes/public_v2");
+    const html = changelogToHtml("- one **bold**\n- two <script>x</script>\n\nplain `c`");
+    expect(html).toBe(
+      "<ul><li>one <strong>bold</strong></li><li>two &lt;script&gt;x&lt;/script&gt;</li></ul><p>plain <code>c</code></p>",
+    );
+  });
+
   it("apps: purge requires archived + slug confirm, deletes R2 + row", async () => {
     const env = makeEnv();
     const deleted: string[] = [];


### PR DESCRIPTION
Minimal safe renderer (escape-first; bullets, bold, inline code) replaces
the raw <pre> dump.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
