### PR TITLE
feat(ios): QuiverReport CocoaPod — feedback + crash reporting SDK

### DIFF
--- a/QuiverReport.podspec
+++ b/QuiverReport.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name             = 'QuiverReport'
+  s.version          = '0.1.0'
+  s.summary          = 'Quiver feedback + crash reporting for iOS.'
+  s.description      = <<-DESC
+    Native iOS reporting layer for Quiver: in-app feedback tickets
+    (multipart with attachments and automatic device metadata) and
+    store-then-send crash reporting (uncaught NSExceptions and fatal
+    signals, uploaded as crash tickets on the next launch). Configured at
+    runtime — base URL, app slug, channel, and client key are init
+    parameters, never compiled into the SDK.
+  DESC
+  s.homepage         = 'https://github.com/oranix-io/quiver'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Oranix' => 'artin@cat.ms' }
+  s.source           = { :git => 'https://github.com/oranix-io/quiver.git', :tag => "ios-v#{s.version}" }
+
+  s.ios.deployment_target = '14.1'
+  s.source_files     = 'clients/ios/Sources/QuiverReport/**/*.{h,m}'
+  s.public_header_files = 'clients/ios/Sources/QuiverReport/QuiverReport.h'
+  s.frameworks       = 'Foundation', 'UIKit'
+  s.requires_arc     = true
+end

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -1,0 +1,55 @@
+# QuiverReport (iOS)
+
+Native iOS reporting layer for Quiver: feedback tickets and store-then-send
+crash reporting. Objective-C, no dependencies, iOS 14.1+.
+
+## Install (CocoaPods, via git)
+
+```ruby
+pod 'QuiverReport', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.0'
+```
+
+## Configure & start
+
+All configuration is runtime parameters — the SDK ships nothing app-specific.
+Get the client key from your app's Settings tab in the Quiver console
+(Sentry-DSN model: it identifies the app and ships in the bundle; rotate it
+from the console if it leaks).
+
+```swift
+QuiverReport.start(with: QuiverReportConfig(
+    baseUrl: "https://quiver.example.com",
+    appSlug: "my-app",
+    channel: "main",
+    clientKey: "qk_…"
+))
+```
+
+`start(with:)` installs the crash handlers and uploads any pending crash
+reports a few seconds after launch. Call it as early as possible (app init).
+
+## Feedback
+
+```swift
+QuiverReport.submitFeedback(
+    "Feed doesn't refresh after login.",
+    kind: "bug",                      // "feedback" | "bug" | "crash"
+    attachmentPaths: [logFilePath],   // up to 3 files, 10 MB each
+    extras: nil
+) { ticketId, error in … }
+```
+
+Device metadata (version, model, OS, arch, locale, per-install device id) is
+attached automatically.
+
+## Crash reporting
+
+- Uncaught `NSException`s: full `callStackSymbols` plus a signature sidecar.
+- Fatal signals (SIGABRT/SEGV/BUS/ILL/FPE/TRAP): the guaranteed record is
+  written with async-signal-safe calls only; stack capture runs last as
+  best-effort.
+- Reports upload as `kind=crash` tickets on the next launch and are grouped
+  by signature server-side; retention cap 5 pending reports on disk.
+
+Known v1 gaps: no all-threads dump, no Mach exception handling, no dSYM
+symbolication server-side.

--- a/clients/ios/Sources/QuiverReport/QuiverCrashReporter.h
+++ b/clients/ios/Sources/QuiverReport/QuiverCrashReporter.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Store-then-send crash reporting for the iOS host (mirrors the Android
+/// SDK's QuiverCrash and the OHOS QuiverCrashUploader): at crash time the
+/// handler only writes crash-<ts>.txt plus a .meta.json signature sidecar to
+/// disk; the next launch uploads each pending crash as a kind=crash Quiver
+/// ticket and deletes local files on success. Captures uncaught NSExceptions
+/// and fatal signals (SIGABRT/SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP).
+@interface QuiverCrashReporter : NSObject
+
+/// Install the exception and signal handlers. Call once, as early as
+/// possible (app init). Previous NSException handlers are chained.
++ (void)install;
+
+/// Upload pending crash reports after a delay (off the launch critical
+/// path). Safe to call every launch; no-op when nothing is pending.
++ (void)uploadPendingAfterDelay:(NSTimeInterval)delay;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/clients/ios/Sources/QuiverReport/QuiverCrashReporter.m
+++ b/clients/ios/Sources/QuiverReport/QuiverCrashReporter.m
@@ -1,0 +1,295 @@
+#import "QuiverCrashReporter.h"
+
+#import <execinfo.h>
+#import <fcntl.h>
+#import <signal.h>
+#import <unistd.h>
+
+#import "QuiverFeedbackClient.h"
+
+static NSUInteger const QuiverMaxStoredCrashes = 5;
+
+// Signal handlers cannot allocate; the crash directory path is captured as a
+// C string at install time and file names are assembled with the safe
+// append helpers below.
+static char gQuiverCrashDir[512] = {0};
+static NSUncaughtExceptionHandler *gQuiverPreviousExceptionHandler = NULL;
+
+static int const kQuiverFatalSignals[] = {SIGABRT, SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGTRAP};
+static int const kQuiverFatalSignalCount = sizeof(kQuiverFatalSignals) / sizeof(int);
+
+static NSString *QuiverCrashDirPath(void) {
+    NSString *base = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES).firstObject;
+    return [base stringByAppendingPathComponent:@"quiver/crashes"];
+}
+
+static void QuiverWriteMetaFile(NSString *logPath,
+                                     NSString *exceptionClass,
+                                     NSString *exceptionMessage,
+                                     NSString *topFrame,
+                                     NSString *reason) {
+    NSDictionary *meta = @{
+        @"exception_class" : exceptionClass ?: @"IosCrash",
+        @"exception_message" : exceptionMessage ?: @"",
+        @"top_frame" : topFrame ?: @"",
+        @"reason" : reason ?: @"",
+        @"crash_at" : @((long long)(NSDate.date.timeIntervalSince1970 * 1000.0)),
+    };
+    NSData *data = [NSJSONSerialization dataWithJSONObject:meta options:0 error:nil];
+    NSString *metaPath = [[logPath stringByDeletingPathExtension] stringByAppendingString:@".meta.json"];
+    [data writeToFile:metaPath atomically:YES];
+}
+
+/// First stack frame that belongs to the app image rather than system
+/// libraries — the same "top frame" notion the server groups crashes by.
+static NSString *QuiverTopAppFrame(NSArray<NSString *> *frames) {
+    NSString *executable = NSProcessInfo.processInfo.processName;
+    for (NSString *frame in frames) {
+        if (executable.length > 0 && [frame containsString:executable]) {
+            return frame;
+        }
+    }
+    return frames.count > 1 ? frames[1] : (frames.firstObject ?: @"");
+}
+
+static void QuiverHandleException(NSException *exception) {
+    NSString *dir = QuiverCrashDirPath();
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    long long ts = (long long)(NSDate.date.timeIntervalSince1970 * 1000.0);
+    NSString *logPath = [dir stringByAppendingPathComponent:[NSString stringWithFormat:@"crash-%lld.txt", ts]];
+
+    NSArray<NSString *> *frames = exception.callStackSymbols ?: @[];
+    NSMutableString *log = [NSMutableString string];
+    [log appendFormat:@"Uncaught exception: %@\n", exception.name ?: @"NSException"];
+    [log appendFormat:@"Reason: %@\n\n", exception.reason ?: @""];
+    [log appendString:@"Stack:\n"];
+    [log appendString:[frames componentsJoinedByString:@"\n"]];
+    [log appendString:@"\n"];
+    [log writeToFile:logPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+
+    QuiverWriteMetaFile(logPath,
+                             exception.name ?: @"NSException",
+                             exception.reason ?: @"",
+                             QuiverTopAppFrame(frames),
+                             @"uncaught_exception");
+
+    if (gQuiverPreviousExceptionHandler) {
+        gQuiverPreviousExceptionHandler(exception);
+    }
+}
+
+// ---- async-signal-safe primitives (no snprintf/malloc/ObjC in handlers) ----
+
+static size_t QuiverSafeStrLen(const char *text) {
+    size_t n = 0;
+    while (text[n] != '\0') n++;
+    return n;
+}
+
+static void QuiverSafeAppend(char *buffer, size_t capacity, size_t *offset, const char *text) {
+    size_t n = QuiverSafeStrLen(text);
+    if (*offset + n >= capacity) return;
+    for (size_t i = 0; i < n; i++) buffer[*offset + i] = text[i];
+    *offset += n;
+    buffer[*offset] = '\0';
+}
+
+static void QuiverSafeAppendNumber(char *buffer, size_t capacity, size_t *offset, long long value) {
+    char digits[24];
+    int i = 0;
+    if (value <= 0) {
+        QuiverSafeAppend(buffer, capacity, offset, "0");
+        return;
+    }
+    while (value > 0 && i < 20) {
+        digits[i++] = (char)('0' + (value % 10));
+        value /= 10;
+    }
+    char out[24];
+    for (int j = 0; j < i; j++) out[j] = digits[i - 1 - j];
+    out[i] = '\0';
+    QuiverSafeAppend(buffer, capacity, offset, out);
+}
+
+/// Async-signal context (task #76): the guaranteed record uses only
+/// async-signal-safe calls — time/open/write/close plus local char math.
+/// The meta sidecar is written FIRST so a report exists even if the
+/// best-effort stack capture at the end deadlocks in a corrupted-runtime
+/// crash; backtrace()/backtrace_symbols_fd() are not strictly safe and are
+/// deliberately last.
+static void QuiverHandleSignal(int signalNumber) {
+    if (gQuiverCrashDir[0] == '\0') {
+        signal(signalNumber, SIG_DFL);
+        raise(signalNumber);
+        return;
+    }
+    const char *name = "SIGNAL";
+    switch (signalNumber) {
+        case SIGABRT: name = "SIGABRT"; break;
+        case SIGSEGV: name = "SIGSEGV"; break;
+        case SIGBUS: name = "SIGBUS"; break;
+        case SIGILL: name = "SIGILL"; break;
+        case SIGFPE: name = "SIGFPE"; break;
+        case SIGTRAP: name = "SIGTRAP"; break;
+        default: break;
+    }
+    long long ts = (long long)time(NULL) * 1000LL;
+
+    // Meta sidecar first — the minimal guaranteed record.
+    char metaPath[640];
+    size_t off = 0;
+    QuiverSafeAppend(metaPath, sizeof(metaPath), &off, gQuiverCrashDir);
+    QuiverSafeAppend(metaPath, sizeof(metaPath), &off, "/crash-");
+    QuiverSafeAppendNumber(metaPath, sizeof(metaPath), &off, ts);
+    QuiverSafeAppend(metaPath, sizeof(metaPath), &off, ".meta.json");
+    int metaFd = open(metaPath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (metaFd >= 0) {
+        char meta[256];
+        off = 0;
+        QuiverSafeAppend(meta, sizeof(meta), &off, "{\"exception_class\":\"");
+        QuiverSafeAppend(meta, sizeof(meta), &off, name);
+        QuiverSafeAppend(meta, sizeof(meta), &off, "\",\"exception_message\":\"fatal signal\",\"reason\":\"signal\",\"crash_at\":");
+        QuiverSafeAppendNumber(meta, sizeof(meta), &off, ts);
+        QuiverSafeAppend(meta, sizeof(meta), &off, "}");
+        write(metaFd, meta, off);
+        close(metaFd);
+    }
+
+    // Log file with a fixed header (still fully safe calls only).
+    char logPath[640];
+    off = 0;
+    QuiverSafeAppend(logPath, sizeof(logPath), &off, gQuiverCrashDir);
+    QuiverSafeAppend(logPath, sizeof(logPath), &off, "/crash-");
+    QuiverSafeAppendNumber(logPath, sizeof(logPath), &off, ts);
+    QuiverSafeAppend(logPath, sizeof(logPath), &off, ".txt");
+    int logFd = open(logPath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (logFd >= 0) {
+        char header[96];
+        off = 0;
+        QuiverSafeAppend(header, sizeof(header), &off, "Fatal signal: ");
+        QuiverSafeAppend(header, sizeof(header), &off, name);
+        QuiverSafeAppend(header, sizeof(header), &off, "\n\nStack (best-effort):\n");
+        write(logFd, header, off);
+        // Best-effort, LAST: backtrace can touch unwind/runtime state and is
+        // not async-signal-safe; if it hangs or crashes, the record above is
+        // already on disk.
+        void *frames[64];
+        int frameCount = backtrace(frames, 64);
+        backtrace_symbols_fd(frames, frameCount, logFd);
+        close(logFd);
+    }
+
+    signal(signalNumber, SIG_DFL);
+    raise(signalNumber);
+}
+
+@implementation QuiverCrashReporter
+
++ (void)install {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *dir = QuiverCrashDirPath();
+        [[NSFileManager defaultManager] createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+        [dir getCString:gQuiverCrashDir maxLength:sizeof(gQuiverCrashDir) encoding:NSUTF8StringEncoding];
+
+        gQuiverPreviousExceptionHandler = NSGetUncaughtExceptionHandler();
+        NSSetUncaughtExceptionHandler(&QuiverHandleException);
+        for (int i = 0; i < kQuiverFatalSignalCount; i++) {
+            signal(kQuiverFatalSignals[i], &QuiverHandleSignal);
+        }
+        [self enforceRetention];
+    });
+}
+
++ (void)enforceRetention {
+    NSString *dir = QuiverCrashDirPath();
+    NSArray<NSString *> *entries = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:nil];
+    NSArray<NSString *> *logs = [[entries filteredArrayUsingPredicate:
+        [NSPredicate predicateWithBlock:^BOOL(NSString *name, NSDictionary *bindings) {
+            return [name hasPrefix:@"crash-"] && [name hasSuffix:@".txt"];
+        }]] sortedArrayUsingSelector:@selector(compare:)];
+    if (logs.count < QuiverMaxStoredCrashes) {
+        return;
+    }
+    NSUInteger excess = logs.count - (QuiverMaxStoredCrashes - 1);
+    for (NSUInteger i = 0; i < excess; i++) {
+        [self deletePairForLogPath:[dir stringByAppendingPathComponent:logs[i]]];
+    }
+}
+
++ (void)deletePairForLogPath:(NSString *)logPath {
+    NSFileManager *fm = NSFileManager.defaultManager;
+    [fm removeItemAtPath:logPath error:nil];
+    NSString *metaPath = [[logPath stringByDeletingPathExtension] stringByAppendingString:@".meta.json"];
+    [fm removeItemAtPath:metaPath error:nil];
+}
+
++ (void)uploadPendingAfterDelay:(NSTimeInterval)delay {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        [self uploadPendingNow];
+    });
+}
+
++ (void)uploadPendingNow {
+    NSString *dir = QuiverCrashDirPath();
+    NSArray<NSString *> *entries = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:nil];
+    NSArray<NSString *> *sidecars = [[entries filteredArrayUsingPredicate:
+        [NSPredicate predicateWithBlock:^BOOL(NSString *name, NSDictionary *bindings) {
+            return [name hasSuffix:@".meta.json"];
+        }]] sortedArrayUsingSelector:@selector(compare:)];
+
+    for (NSString *sidecarName in sidecars) {
+        NSString *sidecarPath = [dir stringByAppendingPathComponent:sidecarName];
+        NSString *logName = [[sidecarName stringByReplacingOccurrencesOfString:@".meta.json"
+                                                                    withString:@""] stringByAppendingString:@".txt"];
+        NSString *logPath = [dir stringByAppendingPathComponent:logName];
+        if (![NSFileManager.defaultManager fileExistsAtPath:logPath]) {
+            [NSFileManager.defaultManager removeItemAtPath:sidecarPath error:nil];
+            continue;
+        }
+
+        NSData *metaData = [NSData dataWithContentsOfFile:sidecarPath];
+        NSDictionary *meta = metaData
+            ? ([NSJSONSerialization JSONObjectWithData:metaData options:0 error:nil] ?: @{})
+            : @{};
+        NSString *exceptionClass = [meta[@"exception_class"] isKindOfClass:NSString.class]
+            ? meta[@"exception_class"] : @"IosCrash";
+        NSString *exceptionMessage = [meta[@"exception_message"] isKindOfClass:NSString.class]
+            ? meta[@"exception_message"] : @"";
+        NSString *topFrame = [meta[@"top_frame"] isKindOfClass:NSString.class] ? meta[@"top_frame"] : @"";
+
+        NSMutableString *message = [NSMutableString stringWithFormat:@"Crash: %@", exceptionClass];
+        if (exceptionMessage.length > 0) {
+            [message appendFormat:@": %@", [exceptionMessage substringToIndex:MIN(exceptionMessage.length, (NSUInteger)200)]];
+        }
+        if (topFrame.length > 0) {
+            [message appendFormat:@"\nat %@", topFrame];
+        }
+
+        NSDictionary<NSString *, NSString *> *extras = @{
+            @"crash_exception_class" : exceptionClass,
+            @"crash_top_frame" : topFrame,
+            @"crash_reason" : [meta[@"reason"] isKindOfClass:NSString.class] ? meta[@"reason"] : @"",
+            @"crash_at" : [NSString stringWithFormat:@"%@", meta[@"crash_at"] ?: @0],
+        };
+
+        dispatch_semaphore_t done = dispatch_semaphore_create(0);
+        [QuiverFeedbackClient submitWithMessage:message
+                                                kind:@"crash"
+                                     attachmentPaths:@[ logPath ]
+                                              extras:extras
+                                          completion:^(NSString *ticketId, NSError *error) {
+            if (ticketId.length > 0 && !error) {
+                [self deletePairForLogPath:logPath];
+                NSLog(@"[Quiver] uploaded crash %@ as %@", logName, [ticketId substringToIndex:MIN(ticketId.length, (NSUInteger)8)]);
+            } else {
+                NSLog(@"[Quiver] crash upload failed for %@: %@", logName, error.localizedDescription ?: @"unknown");
+            }
+            dispatch_semaphore_signal(done);
+        }];
+        dispatch_semaphore_wait(done, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60 * NSEC_PER_SEC)));
+    }
+}
+
+@end

--- a/clients/ios/Sources/QuiverReport/QuiverDeviceId.h
+++ b/clients/ios/Sources/QuiverReport/QuiverDeviceId.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Stable per-install device id for Quiver (rollout cohorting and report
+/// correlation). A random UUID persisted in NSUserDefaults — not a hardware
+/// id; it resets on reinstall, mirroring the Android and OHOS helpers.
+@interface QuiverDeviceId : NSObject
+
++ (NSString *)deviceId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/clients/ios/Sources/QuiverReport/QuiverDeviceId.m
+++ b/clients/ios/Sources/QuiverReport/QuiverDeviceId.m
@@ -1,0 +1,22 @@
+#import "QuiverDeviceId.h"
+
+static NSString *const QuiverDeviceIdDefaultsKey = @"quiver_device_id";
+
+@implementation QuiverDeviceId
+
++ (NSString *)deviceId {
+    static NSString *cached = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+        NSString *stored = [defaults stringForKey:QuiverDeviceIdDefaultsKey];
+        if (stored.length == 0) {
+            stored = NSUUID.UUID.UUIDString.lowercaseString;
+            [defaults setObject:stored forKey:QuiverDeviceIdDefaultsKey];
+        }
+        cached = stored;
+    });
+    return cached;
+}
+
+@end

--- a/clients/ios/Sources/QuiverReport/QuiverFeedbackClient.h
+++ b/clients/ios/Sources/QuiverReport/QuiverFeedbackClient.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Submits feedback / crash tickets to the Quiver feedback endpoint
+/// (multipart/form-data) — the iOS counterpart of the Android SDK's
+/// QuiverFeedback and the OHOS QuiverFeedbackClient. App and device
+/// metadata are attached automatically; the per-app client key is sent as
+/// X-Quiver-Client-Key.
+@interface QuiverFeedbackClient : NSObject
+
+/// kind is "feedback", "bug", or "crash". Completion runs on an arbitrary
+/// queue with the created ticket id, or an error.
++ (void)submitWithMessage:(NSString *)message
+                     kind:(NSString *)kind
+          attachmentPaths:(nullable NSArray<NSString *> *)attachmentPaths
+                   extras:(nullable NSDictionary<NSString *, NSString *> *)extras
+               completion:(void (^)(NSString *_Nullable ticketId, NSError *_Nullable error))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/clients/ios/Sources/QuiverReport/QuiverFeedbackClient.m
+++ b/clients/ios/Sources/QuiverReport/QuiverFeedbackClient.m
@@ -1,0 +1,142 @@
+#import "QuiverFeedbackClient.h"
+
+#import "QuiverReport.h"
+
+#import <UIKit/UIKit.h>
+#import <sys/utsname.h>
+
+#import "QuiverDeviceId.h"
+
+static NSString *const QuiverErrorDomain = @"QuiverReport";
+static NSTimeInterval const QuiverRequestTimeout = 30.0;
+
+static NSString *QuiverHardwareModel(void) {
+    struct utsname systemInfo;
+    if (uname(&systemInfo) != 0) {
+        return UIDevice.currentDevice.model ?: @"iOS";
+    }
+    NSString *machine = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    return machine.length > 0 ? machine : (UIDevice.currentDevice.model ?: @"iOS");
+}
+
+static NSString *QuiverArch(void) {
+#if defined(__arm64__)
+    return @"arm64";
+#elif defined(__x86_64__)
+    return @"x86_64";
+#else
+    return @"unknown";
+#endif
+}
+
+static void QuiverAppendFormField(NSMutableData *body, NSString *boundary, NSString *name, NSString *value) {
+    NSMutableString *part = [NSMutableString string];
+    [part appendFormat:@"--%@\r\n", boundary];
+    [part appendFormat:@"Content-Disposition: form-data; name=\"%@\"\r\n", name];
+    [part appendString:@"Content-Type: text/plain; charset=utf-8\r\n\r\n"];
+    [body appendData:[part dataUsingEncoding:NSUTF8StringEncoding]];
+    [body appendData:[value dataUsingEncoding:NSUTF8StringEncoding]];
+    [body appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+}
+
+@implementation QuiverFeedbackClient
+
++ (NSDictionary<NSString *, id> *)metadataWithExtras:(NSDictionary<NSString *, NSString *> *)extras {
+    NSDictionary *info = NSBundle.mainBundle.infoDictionary ?: @{};
+    UIDevice *device = UIDevice.currentDevice;
+    NSMutableDictionary<NSString *, id> *metadata = [NSMutableDictionary dictionary];
+    metadata[@"version_name"] = info[@"CFBundleShortVersionString"] ?: @"";
+    metadata[@"version_code"] = @([(info[@"CFBundleVersion"] ?: @"0") longLongValue]);
+    metadata[@"channel"] = (QuiverReport.config.channel ?: @"");
+    metadata[@"device_id"] = [QuiverDeviceId deviceId];
+    metadata[@"device_model"] = QuiverHardwareModel();
+    metadata[@"os_version"] = [NSString stringWithFormat:@"%@ %@", device.systemName ?: @"iOS", device.systemVersion ?: @""];
+    metadata[@"arch"] = QuiverArch();
+    metadata[@"locale"] = NSLocale.currentLocale.localeIdentifier ?: @"";
+    metadata[@"platform"] = @"ios";
+    [extras enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+        metadata[key] = value;
+    }];
+    return metadata;
+}
+
++ (void)submitWithMessage:(NSString *)message
+                     kind:(NSString *)kind
+          attachmentPaths:(NSArray<NSString *> *)attachmentPaths
+                   extras:(NSDictionary<NSString *, NSString *> *)extras
+               completion:(void (^)(NSString *_Nullable, NSError *_Nullable))completion {
+    NSString *boundary = [NSString stringWithFormat:@"Quiver%@", NSUUID.UUID.UUIDString];
+    NSMutableData *body = [NSMutableData data];
+    QuiverAppendFormField(body, boundary, @"message", message ?: @"");
+    QuiverAppendFormField(body, boundary, @"kind", kind.length > 0 ? kind : @"feedback");
+
+    NSDictionary *metadata = [self metadataWithExtras:extras];
+    NSData *metadataData = [NSJSONSerialization dataWithJSONObject:metadata options:0 error:nil];
+    NSString *metadataText = metadataData
+        ? [[NSString alloc] initWithData:metadataData encoding:NSUTF8StringEncoding]
+        : @"{}";
+    QuiverAppendFormField(body, boundary, @"metadata", metadataText ?: @"{}");
+
+    for (NSString *path in attachmentPaths) {
+        NSData *fileData = [NSData dataWithContentsOfFile:path];
+        if (!fileData) {
+            continue;
+        }
+        NSString *fileName = path.lastPathComponent ?: @"attachment.txt";
+        NSMutableString *part = [NSMutableString string];
+        [part appendFormat:@"--%@\r\n", boundary];
+        [part appendFormat:@"Content-Disposition: form-data; name=\"attachments\"; filename=\"%@\"\r\n", fileName];
+        [part appendString:@"Content-Type: text/plain\r\n\r\n"];
+        [body appendData:[part dataUsingEncoding:NSUTF8StringEncoding]];
+        [body appendData:fileData];
+        [body appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    }
+    [body appendData:[[NSString stringWithFormat:@"--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+
+    QuiverReportConfig *config = QuiverReport.config;
+    if (!config) {
+        completion(nil, [NSError errorWithDomain:QuiverErrorDomain
+                                            code:0
+                                        userInfo:@{NSLocalizedDescriptionKey : @"QuiverReport not started"}]);
+        return;
+    }
+    NSString *urlText = [NSString stringWithFormat:@"%@/public/v2/apps/%@/feedback",
+                                                   config.baseUrl, config.appSlug];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlText]];
+    request.HTTPMethod = @"POST";
+    request.timeoutInterval = QuiverRequestTimeout;
+    [request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary]
+        forHTTPHeaderField:@"Content-Type"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [request setValue:(QuiverReport.config.clientKey ?: @"") forHTTPHeaderField:@"X-Quiver-Client-Key"];
+    [request setValue:[QuiverDeviceId deviceId] forHTTPHeaderField:@"X-Quiver-Device-Id"];
+
+    NSURLSessionUploadTask *task = [NSURLSession.sharedSession
+        uploadTaskWithRequest:request
+                     fromData:body
+            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error) {
+                    completion(nil, error);
+                    return;
+                }
+                NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+                NSDictionary *parsed = nil;
+                if (data.length > 0) {
+                    parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+                }
+                NSString *ticketId = [parsed isKindOfClass:NSDictionary.class] ? parsed[@"id"] : nil;
+                if (statusCode < 200 || statusCode >= 300 || ![ticketId isKindOfClass:NSString.class] || ticketId.length == 0) {
+                    NSString *detail = [parsed isKindOfClass:NSDictionary.class] && parsed[@"error"]
+                        ? [NSString stringWithFormat:@"%@", parsed[@"error"]]
+                        : [NSString stringWithFormat:@"HTTP %ld", (long)statusCode];
+                    completion(nil, [NSError errorWithDomain:QuiverErrorDomain
+                                                        code:statusCode
+                                                    userInfo:@{NSLocalizedDescriptionKey : detail}]);
+                    return;
+                }
+                completion(ticketId, nil);
+            }];
+    [task resume];
+}
+
+@end

--- a/clients/ios/Sources/QuiverReport/QuiverReport.h
+++ b/clients/ios/Sources/QuiverReport/QuiverReport.h
@@ -1,0 +1,56 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runtime configuration for Quiver reporting. All values are init
+/// parameters — nothing is compiled into the SDK; the host app owns its
+/// slug, channel, and client key (Sentry-DSN model: the key identifies the
+/// app and ships in the app bundle, it is not a user secret).
+@interface QuiverReportConfig : NSObject
+
+@property (nonatomic, copy, readonly) NSString *baseUrl;
+@property (nonatomic, copy, readonly) NSString *appSlug;
+@property (nonatomic, copy, readonly) NSString *channel;
+@property (nonatomic, copy, readonly) NSString *clientKey;
+
++ (instancetype)configWithBaseUrl:(NSString *)baseUrl
+                          appSlug:(NSString *)appSlug
+                          channel:(NSString *)channel
+                        clientKey:(NSString *)clientKey;
+
+@end
+
+/// Entry point: feedback tickets and store-then-send crash reporting for
+/// iOS, posting to a Quiver server's public feedback endpoint.
+///
+///   [QuiverReport startWithConfig:
+///       [QuiverReportConfig configWithBaseUrl:@"https://quiver.example.com"
+///                                     appSlug:@"my-app"
+///                                     channel:@"main"
+///                                   clientKey:@"qk_…"]];
+///
+/// startWithConfig: installs the crash handlers (uncaught NSExceptions and
+/// fatal signals, written to disk at crash time) and schedules the upload of
+/// pending crash reports a few seconds after launch.
+@interface QuiverReport : NSObject
+
++ (void)startWithConfig:(QuiverReportConfig *)config;
+
+/// The active config, or nil before startWithConfig:.
++ (nullable QuiverReportConfig *)config;
+
+/// Submit a feedback / bug / crash ticket. kind is "feedback", "bug", or
+/// "crash". Completion runs on an arbitrary queue with the created ticket
+/// id, or an error.
++ (void)submitFeedback:(NSString *)message
+                  kind:(NSString *)kind
+       attachmentPaths:(nullable NSArray<NSString *> *)attachmentPaths
+                extras:(nullable NSDictionary<NSString *, NSString *> *)extras
+            completion:(void (^)(NSString *_Nullable ticketId, NSError *_Nullable error))completion;
+
+/// Stable per-install device id (random UUID persisted in NSUserDefaults).
++ (NSString *)deviceId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/clients/ios/Sources/QuiverReport/QuiverReport.m
+++ b/clients/ios/Sources/QuiverReport/QuiverReport.m
@@ -1,0 +1,65 @@
+#import "QuiverReport.h"
+
+#import "QuiverCrashReporter.h"
+#import "QuiverDeviceId.h"
+#import "QuiverFeedbackClient.h"
+
+static NSTimeInterval const QuiverPendingUploadDelay = 3.0;
+
+@interface QuiverReportConfig ()
+@property (nonatomic, copy, readwrite) NSString *baseUrl;
+@property (nonatomic, copy, readwrite) NSString *appSlug;
+@property (nonatomic, copy, readwrite) NSString *channel;
+@property (nonatomic, copy, readwrite) NSString *clientKey;
+@end
+
+@implementation QuiverReportConfig
+
++ (instancetype)configWithBaseUrl:(NSString *)baseUrl
+                          appSlug:(NSString *)appSlug
+                          channel:(NSString *)channel
+                        clientKey:(NSString *)clientKey {
+    QuiverReportConfig *config = [[QuiverReportConfig alloc] init];
+    // Normalize the base URL once so callers can pass either form.
+    config.baseUrl = [baseUrl hasSuffix:@"/"]
+        ? [baseUrl substringToIndex:baseUrl.length - 1]
+        : [baseUrl copy];
+    config.appSlug = [appSlug copy];
+    config.channel = [channel copy];
+    config.clientKey = [clientKey copy];
+    return config;
+}
+
+@end
+
+static QuiverReportConfig *gQuiverReportConfig = nil;
+
+@implementation QuiverReport
+
++ (void)startWithConfig:(QuiverReportConfig *)config {
+    gQuiverReportConfig = config;
+    [QuiverCrashReporter install];
+    [QuiverCrashReporter uploadPendingAfterDelay:QuiverPendingUploadDelay];
+}
+
++ (QuiverReportConfig *)config {
+    return gQuiverReportConfig;
+}
+
++ (void)submitFeedback:(NSString *)message
+                  kind:(NSString *)kind
+       attachmentPaths:(NSArray<NSString *> *)attachmentPaths
+                extras:(NSDictionary<NSString *, NSString *> *)extras
+            completion:(void (^)(NSString *_Nullable, NSError *_Nullable))completion {
+    [QuiverFeedbackClient submitWithMessage:message
+                                       kind:kind
+                            attachmentPaths:attachmentPaths
+                                     extras:extras
+                                 completion:completion];
+}
+
++ (NSString *)deviceId {
+    return [QuiverDeviceId deviceId];
+}
+
+@end


### PR DESCRIPTION
Extracted from the Raft iOS host layer (botiverse/mobile #71 + #84
hardening): QuiverReport facade with runtime config (base URL, slug,
channel, client key as init parameters — nothing compiled in),
QuiverFeedbackClient multipart submission, QuiverDeviceId, and the
async-signal-safe store-then-send QuiverCrashReporter. Podspec at repo
root for :git consumption; compile validation happens in the consumer's
iOS CI (this repo has no macOS job).

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
