### PR TITLE
feat(ios): rename pod QuiverReport -> Quiver (0.1.1)

### DIFF
--- a/Quiver.podspec
+++ b/Quiver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-  s.name             = 'QuiverReport'
-  s.version          = '0.1.0'
+  s.name             = 'Quiver'
+  s.version          = '0.1.1'
   s.summary          = 'Quiver feedback + crash reporting for iOS.'
   s.description      = <<-DESC
     Native iOS reporting layer for Quiver: in-app feedback tickets

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -1,4 +1,4 @@
-# QuiverReport (iOS)
+# Quiver (iOS)
 
 Native iOS reporting layer for Quiver: feedback tickets and store-then-send
 crash reporting. Objective-C, no dependencies, iOS 14.1+.
@@ -6,7 +6,7 @@ crash reporting. Objective-C, no dependencies, iOS 14.1+.
 ## Install (CocoaPods, via git)
 
 ```ruby
-pod 'QuiverReport', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.0'
+pod 'Quiver', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.1'
 ```
 
 ## Configure & start


### PR DESCRIPTION
Pod/module name is Quiver per owner decision (room for future update/
diagnostics capabilities); the ObjC facade class stays QuiverReport —
ObjC has no namespaces and a bare Quiver class invites host collisions,
and a type named after its module breaks qualified Swift lookups.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
