### PR TITLE
fix(ios): explicit designated initializer on QuiverReportConfig (0.1.2)

### DIFF
--- a/Quiver.podspec
+++ b/Quiver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Quiver'
-  s.version          = '0.1.1'
+  s.version          = '0.1.2'
   s.summary          = 'Quiver feedback + crash reporting for iOS.'
   s.description      = <<-DESC
     Native iOS reporting layer for Quiver: in-app feedback tickets

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -6,7 +6,7 @@ crash reporting. Objective-C, no dependencies, iOS 14.1+.
 ## Install (CocoaPods, via git)
 
 ```ruby
-pod 'Quiver', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.1'
+pod 'Quiver', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.2'
 ```
 
 ## Configure & start

--- a/clients/ios/Sources/QuiverReport/QuiverReport.h
+++ b/clients/ios/Sources/QuiverReport/QuiverReport.h
@@ -13,10 +13,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *channel;
 @property (nonatomic, copy, readonly) NSString *clientKey;
 
+- (instancetype)initWithBaseUrl:(NSString *)baseUrl
+                        appSlug:(NSString *)appSlug
+                        channel:(NSString *)channel
+                      clientKey:(NSString *)clientKey NS_DESIGNATED_INITIALIZER;
+
 + (instancetype)configWithBaseUrl:(NSString *)baseUrl
                           appSlug:(NSString *)appSlug
                           channel:(NSString *)channel
                         clientKey:(NSString *)clientKey;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/clients/ios/Sources/QuiverReport/QuiverReport.m
+++ b/clients/ios/Sources/QuiverReport/QuiverReport.m
@@ -15,19 +15,31 @@ static NSTimeInterval const QuiverPendingUploadDelay = 3.0;
 
 @implementation QuiverReportConfig
 
+- (instancetype)initWithBaseUrl:(NSString *)baseUrl
+                        appSlug:(NSString *)appSlug
+                        channel:(NSString *)channel
+                      clientKey:(NSString *)clientKey {
+    self = [super init];
+    if (self) {
+        // Normalize the base URL once so callers can pass either form.
+        _baseUrl = [baseUrl hasSuffix:@"/"]
+            ? [[baseUrl substringToIndex:baseUrl.length - 1] copy]
+            : [baseUrl copy];
+        _appSlug = [appSlug copy];
+        _channel = [channel copy];
+        _clientKey = [clientKey copy];
+    }
+    return self;
+}
+
 + (instancetype)configWithBaseUrl:(NSString *)baseUrl
                           appSlug:(NSString *)appSlug
                           channel:(NSString *)channel
                         clientKey:(NSString *)clientKey {
-    QuiverReportConfig *config = [[QuiverReportConfig alloc] init];
-    // Normalize the base URL once so callers can pass either form.
-    config.baseUrl = [baseUrl hasSuffix:@"/"]
-        ? [baseUrl substringToIndex:baseUrl.length - 1]
-        : [baseUrl copy];
-    config.appSlug = [appSlug copy];
-    config.channel = [channel copy];
-    config.clientKey = [clientKey copy];
-    return config;
+    return [[QuiverReportConfig alloc] initWithBaseUrl:baseUrl
+                                               appSlug:appSlug
+                                               channel:channel
+                                             clientKey:clientKey];
 }
 
 @end


### PR DESCRIPTION
Guarantees the Swift-importable init(baseUrl:appSlug:channel:clientKey:)
instead of relying on factory-method import heuristics; bare init/new
are unavailable so a config can't exist half-built.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
