### PR TITLE
feat(ohos): official @oranix/quiver HarmonyOS SDK (HAR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ build/
 .next/
 out/
 .vite/
+clients/ohos/.hvigor/
+clients/ohos/**/BuildProfile.ets
 
 # OS
 .DS_Store

--- a/clients/ohos/AppScope/app.json5
+++ b/clients/ohos/AppScope/app.json5
@@ -1,0 +1,10 @@
+{
+  "app": {
+    "bundleName": "io.oranix.quiver.ohos.sdk",
+    "vendor": "Oranix",
+    "versionCode": 1000000,
+    "versionName": "0.1.0",
+    "icon": "$media:app_icon",
+    "label": "$string:app_name"
+  }
+}

--- a/clients/ohos/README.md
+++ b/clients/ohos/README.md
@@ -1,0 +1,88 @@
+# @oranix/quiver (HarmonyOS)
+
+Official Quiver SDK for HarmonyOS (ArkTS HAR): feedback tickets and
+store-then-send crash reporting against a Quiver server's public feedback
+endpoint. Mirrors the Android SDK (`io.quiver:quiver-android-updater`) and
+the iOS `Quiver` pod.
+
+## Install
+
+```bash
+ohpm install @oranix/quiver
+```
+
+(Until the first ohpm release, consume the HAR from a local build of
+`clients/ohos`.)
+
+## Configure & start
+
+All configuration is runtime parameters — the SDK ships nothing
+app-specific. Get the client key from your app's Settings tab in the Quiver
+console (Sentry-DSN model: it identifies the app; rotate it from the console
+if it leaks).
+
+```ts
+import { Quiver } from '@oranix/quiver';
+
+Quiver.start({
+  baseUrl: 'https://quiver.example.com',
+  appSlug: 'my-app',
+  channel: 'main',          // Quiver release-channel routing field
+  clientKey: 'qk_…',
+});
+```
+
+Call it as early as possible (UIAbility `onCreate`).
+
+## Feedback
+
+```ts
+import { QuiverFeedbackClient } from '@oranix/quiver';
+
+const ticketId = await QuiverFeedbackClient.submit(
+  context,                    // common.UIAbilityContext
+  'Feed does not refresh',    // message
+  'bug',                      // 'feedback' | 'bug' | 'crash'
+  [logFilePath],              // up to 3 files, 10 MB each
+  [],                         // extras: Array<{ key, value }>
+);
+```
+
+Device metadata (version, model, OS, ABI, locale, per-install device id) is
+attached automatically.
+
+## Crash reporting (store-then-send)
+
+At crash time (e.g. an `errorManager` observer), write the crash log and its
+signature sidecar — no network in the dying process:
+
+```ts
+import { QuiverCrashUploader } from '@oranix/quiver';
+
+QuiverCrashUploader.writeMeta(crashLogPath, {
+  exception_class: error.name,
+  exception_message: error.message,
+  top_frame: topFrame,
+  reason: 'uncaught_error',
+  crash_at: Date.now(),
+});
+```
+
+On the next launch (a few seconds after startup):
+
+```ts
+QuiverCrashUploader.enforceRetention(context);
+await QuiverCrashUploader.uploadPending(context);
+```
+
+Pending crashes upload as `kind=crash` tickets, grouped by signature
+server-side; local retention cap is 5.
+
+## Publishing (maintainers)
+
+```bash
+# from clients/ohos, with DevEco/hvigor toolchain
+ohpm install --all
+hvigorw --mode module -p module=quiver@default assembleHar
+ohpm publish quiver/build/default/outputs/default/quiver.har   # needs the org's ohpm publish token
+```

--- a/clients/ohos/build-profile.json5
+++ b/clients/ohos/build-profile.json5
@@ -1,0 +1,35 @@
+{
+  "app": {
+    "signingConfigs": [],
+    "products": [
+      {
+        "name": "default",
+        "signingConfig": "default",
+        "compatibleSdkVersion": "6.1.0(23)",
+        "runtimeOS": "HarmonyOS",
+        "buildOption": {
+          "strictMode": {
+            "useNormalizedOHMUrl": true
+          }
+        },
+        "targetSdkVersion": "6.1.0(23)"
+      }
+    ],
+    "buildModeSet": [
+      { "name": "debug" },
+      { "name": "release" }
+    ]
+  },
+  "modules": [
+    {
+      "name": "quiver",
+      "srcPath": "./quiver",
+      "targets": [
+        {
+          "name": "default",
+          "applyToProducts": ["default"]
+        }
+      ]
+    }
+  ]
+}

--- a/clients/ohos/hvigor/hvigor-config.json5
+++ b/clients/ohos/hvigor/hvigor-config.json5
@@ -1,0 +1,20 @@
+{
+  "modelVersion": "6.1.0",
+  "dependencies": {},
+  "execution": {
+    "analyze": "normal",
+    "daemon": true,
+    "incremental": true,
+    "parallel": true,
+    "typeCheck": false,
+    "optimizationStrategy": "performance"
+  },
+  "logging": {},
+  "debugging": {},
+  "nodeOptions": {
+    "maxOldSpaceSize": 4096
+  },
+  "properties": {
+    "hvigor.enableMemoryCache": true
+  }
+}

--- a/clients/ohos/hvigorfile.ts
+++ b/clients/ohos/hvigorfile.ts
@@ -1,0 +1,6 @@
+import { appTasks } from '@ohos/hvigor-ohos-plugin';
+
+export default {
+  system: appTasks,
+  plugins: []
+}

--- a/clients/ohos/oh-package.json5
+++ b/clients/ohos/oh-package.json5
@@ -1,0 +1,11 @@
+{
+  "modelVersion": "6.1.0",
+  "name": "quiver-ohos-sdk",
+  "version": "0.1.0",
+  "description": "Workspace for the @oranix/quiver HarmonyOS SDK (HAR).",
+  "main": "",
+  "author": "Oranix",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/clients/ohos/quiver/Index.ets
+++ b/clients/ohos/quiver/Index.ets
@@ -1,0 +1,4 @@
+export { Quiver, QuiverConfig } from './src/main/ets/Quiver';
+export { QuiverFeedbackClient, QuiverFeedbackExtras } from './src/main/ets/QuiverFeedbackClient';
+export { QuiverCrashUploader, CrashMeta } from './src/main/ets/QuiverCrashUploader';
+export { QuiverDeviceId } from './src/main/ets/QuiverDeviceId';

--- a/clients/ohos/quiver/build-profile.json5
+++ b/clients/ohos/quiver/build-profile.json5
@@ -1,0 +1,21 @@
+{
+  "apiType": "stageMode",
+  "buildOption": {},
+  "buildOptionSet": [
+    {
+      "name": "release",
+      "arkOptions": {
+        "obfuscation": {
+          "ruleOptions": {
+            "enable": false
+          }
+        }
+      }
+    }
+  ],
+  "targets": [
+    {
+      "name": "default"
+    }
+  ]
+}

--- a/clients/ohos/quiver/hvigorfile.ts
+++ b/clients/ohos/quiver/hvigorfile.ts
@@ -1,0 +1,6 @@
+import { harTasks } from '@ohos/hvigor-ohos-plugin';
+
+export default {
+  system: harTasks,
+  plugins: []
+}

--- a/clients/ohos/quiver/oh-package.json5
+++ b/clients/ohos/quiver/oh-package.json5
@@ -1,0 +1,12 @@
+{
+  "name": "@oranix/quiver",
+  "version": "0.1.0",
+  "description": "Quiver feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
+  "main": "Index.ets",
+  "author": "Oranix",
+  "license": "MIT",
+  "homepage": "https://github.com/oranix-io/quiver",
+  "repository": "https://github.com/oranix-io/quiver",
+  "keywords": ["quiver", "crash", "feedback", "harmonyos"],
+  "dependencies": {}
+}

--- a/clients/ohos/quiver/src/main/ets/Quiver.ets
+++ b/clients/ohos/quiver/src/main/ets/Quiver.ets
@@ -1,0 +1,45 @@
+/**
+ * Quiver SDK entry point for HarmonyOS. All configuration is runtime
+ * parameters — the SDK ships nothing app-specific; the client key follows
+ * the Sentry-DSN model (identifies the app, ships in the bundle, rotatable
+ * from the Quiver console).
+ */
+export interface QuiverConfig {
+  /** Quiver server origin, e.g. https://quiver.example.com (no trailing /). */
+  baseUrl: string;
+  /** App slug in the Quiver console. */
+  appSlug: string;
+  /** Release channel this build reports under (Quiver routing/archival field). */
+  channel: string;
+  /** Per-app client key (qk_…) required by the feedback endpoint. */
+  clientKey: string;
+}
+
+export class Quiver {
+  private static current: QuiverConfig | null = null;
+
+  /** Call once, as early as possible (ability onCreate). */
+  static start(config: QuiverConfig): void {
+    const trimmed: QuiverConfig = {
+      baseUrl: config.baseUrl.endsWith('/')
+        ? config.baseUrl.substring(0, config.baseUrl.length - 1)
+        : config.baseUrl,
+      appSlug: config.appSlug,
+      channel: config.channel,
+      clientKey: config.clientKey,
+    };
+    Quiver.current = trimmed;
+  }
+
+  static get config(): QuiverConfig {
+    const config = Quiver.current;
+    if (config === null) {
+      throw new Error('Quiver.start(config) must be called before using the SDK');
+    }
+    return config;
+  }
+
+  static get started(): boolean {
+    return Quiver.current !== null;
+  }
+}

--- a/clients/ohos/quiver/src/main/ets/QuiverCrashUploader.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverCrashUploader.ets
@@ -1,0 +1,123 @@
+import { common } from '@kit.AbilityKit';
+import fs from '@ohos.file.fs';
+import hilog from '@ohos.hilog';
+import { QuiverFeedbackClient, QuiverFeedbackExtras } from './QuiverFeedbackClient';
+
+const TAG: string = 'QuiverCrashUploader';
+const MAX_STORED_CRASHES: number = 5;
+
+export interface CrashMeta {
+  exception_class?: string;
+  exception_message?: string;
+  top_frame?: string;
+  reason?: string;
+  crash_at?: number;
+}
+
+/**
+ * Store-then-send crash reporting for OHOS (mirrors the Android SDK's
+ * QuiverCrash): SlockOhosCrashReporter writes crash-<ts>.txt plus a
+ * .meta.json sidecar at crash time; this uploader runs on the next launch,
+ * submits each pending crash as a kind=crash Quiver ticket (full log
+ * attached, signature fields in metadata), and deletes local files on
+ * success.
+ */
+export class QuiverCrashUploader {
+  static crashDir(context: common.UIAbilityContext): string {
+    return `${context.filesDir}/crashes`;
+  }
+
+  /** Write the signature sidecar next to a crash log. */
+  static writeMeta(crashPath: string, meta: CrashMeta): void {
+    const metaPath = `${crashPath.replace(/\.txt$/, '')}.meta.json`;
+    const file = fs.openSync(metaPath, fs.OpenMode.CREATE | fs.OpenMode.TRUNC | fs.OpenMode.WRITE_ONLY);
+    try {
+      fs.writeSync(file.fd, JSON.stringify(meta));
+    } finally {
+      fs.closeSync(file);
+    }
+  }
+
+  /** Delete oldest crashes beyond the retention cap. */
+  static enforceRetention(context: common.UIAbilityContext): void {
+    const dir = QuiverCrashUploader.crashDir(context);
+    if (!fs.accessSync(dir)) {
+      return;
+    }
+    const logs = fs
+      .listFileSync(dir)
+      .filter((name: string): boolean => name.startsWith('crash-') && name.endsWith('.txt'))
+      .sort()
+      .reverse();
+    for (const name of logs.slice(MAX_STORED_CRASHES - 1)) {
+      QuiverCrashUploader.deletePair(`${dir}/${name}`);
+    }
+  }
+
+  /** Upload all pending crashes; call on launch, off the critical path. */
+  static async uploadPending(context: common.UIAbilityContext): Promise<void> {
+    const dir = QuiverCrashUploader.crashDir(context);
+    if (!fs.accessSync(dir)) {
+      return;
+    }
+    const sidecars = fs
+      .listFileSync(dir)
+      .filter((name: string): boolean => name.endsWith('.meta.json'))
+      .sort();
+    for (const sidecarName of sidecars) {
+      const sidecarPath = `${dir}/${sidecarName}`;
+      const logPath = `${dir}/${sidecarName.replace(/\.meta\.json$/, '')}.txt`;
+      if (!fs.accessSync(logPath)) {
+        fs.unlinkSync(sidecarPath);
+        continue;
+      }
+      let meta: CrashMeta = {};
+      try {
+        meta = JSON.parse(fs.readTextSync(sidecarPath)) as CrashMeta;
+      } catch (error) {
+        hilog.warn(0x0000, TAG, 'meta parse failed for %{public}s', sidecarName);
+      }
+      const exceptionClass = meta.exception_class ?? 'OhosCrash';
+      const topFrame = meta.top_frame ?? '';
+      const detail = (meta.exception_message ?? '').slice(0, 200);
+      let message = `Crash: ${exceptionClass}`;
+      if (detail.length > 0) {
+        message = `${message}: ${detail}`;
+      }
+      if (topFrame.length > 0) {
+        message = `${message}\nat ${topFrame}`;
+      }
+      const extras: QuiverFeedbackExtras[] = [
+        { key: 'crash_exception_class', value: exceptionClass },
+        { key: 'crash_top_frame', value: topFrame },
+        { key: 'crash_reason', value: meta.reason ?? '' },
+        { key: 'crash_at', value: String(meta.crash_at ?? 0) },
+      ];
+      try {
+        const ticketId = await QuiverFeedbackClient.submit(context, message, 'crash', [logPath], extras);
+        QuiverCrashUploader.deletePair(logPath);
+        hilog.info(0x0000, TAG, 'uploaded crash %{public}s as %{public}s', sidecarName, ticketId.slice(0, 8));
+      } catch (error) {
+        hilog.warn(0x0000, TAG, 'crash upload failed for %{public}s: %{public}s', sidecarName, String(error));
+      }
+    }
+  }
+
+  private static deletePair(logPath: string): void {
+    try {
+      if (fs.accessSync(logPath)) {
+        fs.unlinkSync(logPath);
+      }
+    } catch (error) {
+      hilog.warn(0x0000, TAG, 'delete failed: %{public}s', String(error));
+    }
+    const metaPath = `${logPath.replace(/\.txt$/, '')}.meta.json`;
+    try {
+      if (fs.accessSync(metaPath)) {
+        fs.unlinkSync(metaPath);
+      }
+    } catch (error) {
+      hilog.warn(0x0000, TAG, 'delete failed: %{public}s', String(error));
+    }
+  }
+}

--- a/clients/ohos/quiver/src/main/ets/QuiverDeviceId.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverDeviceId.ets
@@ -1,0 +1,31 @@
+import { common } from '@kit.AbilityKit';
+import dataPreferences from '@ohos.data.preferences';
+import util from '@ohos.util';
+
+const PREFS_NAME: string = 'quiver_update';
+const KEY_DEVICE_ID: string = 'device_id';
+
+/**
+ * Stable per-install device id used for staged rollouts and ticket
+ * correlation — mirrors the Android SDK's QuiverDeviceId.
+ */
+export class QuiverDeviceId {
+  private static cached: string | null = null;
+
+  static get(context: common.UIAbilityContext): string {
+    if (QuiverDeviceId.cached !== null) {
+      return QuiverDeviceId.cached;
+    }
+    const prefs = dataPreferences.getPreferencesSync(context, { name: PREFS_NAME });
+    const existing = prefs.getSync(KEY_DEVICE_ID, '') as string;
+    if (existing.length > 0) {
+      QuiverDeviceId.cached = existing;
+      return existing;
+    }
+    const created = util.generateRandomUUID(true);
+    prefs.putSync(KEY_DEVICE_ID, created);
+    prefs.flush();
+    QuiverDeviceId.cached = created;
+    return created;
+  }
+}

--- a/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
@@ -1,0 +1,109 @@
+import { bundleManager, common } from '@kit.AbilityKit';
+import deviceInfo from '@ohos.deviceInfo';
+import http from '@ohos.net.http';
+import i18n from '@ohos.i18n';
+import hilog from '@ohos.hilog';
+import { Quiver } from './Quiver';
+import { QuiverDeviceId } from './QuiverDeviceId';
+
+const TAG: string = 'QuiverFeedbackClient';
+const REQUEST_TIMEOUT_MS: number = 30000;
+
+export interface QuiverFeedbackExtras {
+  key: string;
+  value: string;
+}
+
+/**
+ * Submits feedback / crash tickets to the Quiver feedback endpoint
+ * (multipart/form-data) — the OHOS counterpart of the Android SDK's
+ * QuiverFeedback. Device and app metadata are attached automatically.
+ */
+export class QuiverFeedbackClient {
+  /**
+   * @returns the created ticket id
+   */
+  static async submit(
+    context: common.UIAbilityContext,
+    message: string,
+    kind: string,
+    attachmentPaths: string[],
+    extras: QuiverFeedbackExtras[],
+  ): Promise<string> {
+    const bundleInfo = bundleManager.getBundleInfoForSelfSync(bundleManager.BundleFlag.GET_BUNDLE_INFO_DEFAULT);
+    const metadata: Record<string, string | number> = {
+      'version_name': bundleInfo.versionName,
+      'version_code': bundleInfo.versionCode,
+      'channel': Quiver.config.channel,
+      'device_id': QuiverDeviceId.get(context),
+      'device_model': `${deviceInfo.manufacture} ${deviceInfo.productModel}`.trim(),
+      'os_version': `${deviceInfo.osFullName} (API ${deviceInfo.sdkApiVersion})`,
+      'arch': deviceInfo.abiList ?? 'unknown',
+      'locale': i18n.System.getSystemLocale(),
+      'platform': 'ohos',
+    };
+    for (const extra of extras) {
+      metadata[extra.key] = extra.value;
+    }
+
+    const multiFormDataList: Array<http.MultiFormData> = [
+      {
+        name: 'message',
+        contentType: 'text/plain',
+        data: message,
+      },
+      {
+        name: 'kind',
+        contentType: 'text/plain',
+        data: kind,
+      },
+      {
+        name: 'metadata',
+        contentType: 'text/plain',
+        data: JSON.stringify(metadata),
+      },
+    ];
+    for (const path of attachmentPaths) {
+      const fileName = path.split('/').pop() ?? 'attachment.txt';
+      multiFormDataList.push({
+        name: 'attachments',
+        contentType: 'text/plain',
+        remoteFileName: fileName,
+        filePath: path,
+      });
+    }
+
+    const client = http.createHttp();
+    try {
+      const response = await client.request(
+        `${Quiver.config.baseUrl}/public/v2/apps/${Quiver.config.appSlug}/feedback`,
+        {
+          method: http.RequestMethod.POST,
+          header: {
+            'Content-Type': 'multipart/form-data',
+            'Accept': 'application/json',
+            'X-Quiver-Client-Key': Quiver.config.clientKey,
+          },
+          multiFormDataList: multiFormDataList,
+          connectTimeout: REQUEST_TIMEOUT_MS,
+          readTimeout: REQUEST_TIMEOUT_MS,
+        },
+      );
+      const code = Number(response.responseCode ?? 0);
+      const body = typeof response.result === 'string' ? response.result : '';
+      if (code < 200 || code >= 300) {
+        hilog.warn(0x0000, TAG, 'feedback submit failed code=%{public}d body=%{public}s', code, body.slice(0, 200));
+        throw new Error(`quiver feedback failed: HTTP ${code}`);
+      }
+      const parsed = JSON.parse(body) as Record<string, string>;
+      const ticketId = parsed['id'] ?? '';
+      if (ticketId.length === 0) {
+        throw new Error('quiver feedback: missing ticket id in response');
+      }
+      hilog.info(0x0000, TAG, 'feedback submitted ticket=%{public}s kind=%{public}s', ticketId.slice(0, 8), kind);
+      return ticketId;
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/clients/ohos/quiver/src/main/module.json5
+++ b/clients/ohos/quiver/src/main/module.json5
@@ -1,0 +1,7 @@
+{
+  "module": {
+    "name": "quiver",
+    "type": "har",
+    "deviceTypes": ["phone", "tablet", "2in1"]
+  }
+}


### PR DESCRIPTION
Extracted from the Raft OHOS app's ets/quiver layer as a standalone HAR
workspace under clients/ohos: Quiver.start(config) runtime configuration
(no app constants in the SDK), QuiverFeedbackClient multipart submission
with the client key, store-then-send QuiverCrashUploader, and
QuiverDeviceId. ohpm packaging as @oranix/quiver; publish needs the org
token (owner-held).

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
