### PR TITLE
feat(crash): native symbolication pipeline — server side (task #80)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
     unzip \
+    llvm \
+    binutils \
     && rm -rf /var/lib/apt/lists/*
 
 # Download Android command-line tools + accept licenses + install build-tools

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -21,7 +21,7 @@
 
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { writeFile, unlink, mkdir } from "node:fs/promises";
+import { writeFile, unlink, mkdir, rm, readdir } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { tmpdir } from "node:os";
@@ -80,6 +80,118 @@ app.post("/retrace", async (c) => {
     );
   } finally {
     await Promise.allSettled([unlink(mappingPath), unlink(tracePath)]);
+  }
+});
+
+/**
+ * POST /symbolicate-native — body = raw native-symbols zip (unstripped .so
+ * files), X-Quiver-Frames header = JSON array of
+ * { index, offset, soname, build_id? } (offset hex like "0x1a2b" or bare
+ * hex). Extracts the zip, matches each frame's soname (verifying the ELF
+ * BuildId when provided), and resolves offsets with llvm-symbolizer.
+ * Returns { frames: [{ index, resolved | error }] }.
+ */
+app.post("/symbolicate-native", async (c) => {
+  const framesHeader = c.req.header("X-Quiver-Frames") ?? "[]";
+  let frames: Array<{ index: number; offset: string; soname: string; build_id?: string }>;
+  try {
+    frames = JSON.parse(framesHeader);
+    if (!Array.isArray(frames)) throw new Error("not an array");
+  } catch {
+    return c.json({ error: "X-Quiver-Frames must be a JSON array" }, 400);
+  }
+  if (frames.length === 0 || frames.length > 256) {
+    return c.json({ error: "frames must contain 1-256 entries" }, 400);
+  }
+  const ab = await c.req.arrayBuffer();
+  if (ab.byteLength === 0) return c.json({ error: "empty symbols zip" }, 400);
+  if (ab.byteLength > 500 * 1024 * 1024) return c.json({ error: "symbols zip too large" }, 413);
+
+  const dir = join(tmpdir(), `natsym-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const zipPath = join(dir, "symbols.zip");
+  const outDir = join(dir, "symbols");
+  try {
+    await mkdir(outDir, { recursive: true });
+    await writeFile(zipPath, Buffer.from(ab));
+    await execFileAsync("unzip", ["-o", "-q", zipPath, "-d", outDir], {
+      maxBuffer: 8 * 1024 * 1024,
+    });
+
+    // Index extracted .so files by basename (archives often nest abi dirs).
+    const soByName = new Map<string, string>();
+    const walk = async (d: string): Promise<void> => {
+      for (const entry of await readdir(d, { withFileTypes: true })) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else if (entry.name.endsWith(".so") && !soByName.has(entry.name)) soByName.set(entry.name, full);
+      }
+    };
+    await walk(outDir);
+
+    const buildIdCache = new Map<string, string>();
+    const elfBuildId = async (soPath: string): Promise<string> => {
+      const cached = buildIdCache.get(soPath);
+      if (cached !== undefined) return cached;
+      let id = "";
+      try {
+        const { stdout } = await execFileAsync("readelf", ["-n", soPath], {
+          maxBuffer: 4 * 1024 * 1024,
+        });
+        id = /Build ID:\s*([0-9a-f]+)/i.exec(stdout)?.[1]?.toLowerCase() ?? "";
+      } catch {
+        // leave empty — treated as unverifiable
+      }
+      buildIdCache.set(soPath, id);
+      return id;
+    };
+
+    const results: Array<{ index: number; resolved?: string; error?: string }> = [];
+    for (const frame of frames) {
+      const soname = String(frame.soname ?? "").split("/").pop() ?? "";
+      const soPath = soname ? soByName.get(soname) : undefined;
+      if (!soPath) {
+        results.push({ index: frame.index, error: `no ${soname || "(missing soname)"} in symbols archive` });
+        continue;
+      }
+      if (frame.build_id) {
+        const actual = await elfBuildId(soPath);
+        if (actual && actual !== String(frame.build_id).toLowerCase()) {
+          results.push({
+            index: frame.index,
+            error: `BuildId mismatch: crash ${frame.build_id}, archive ${actual}`,
+          });
+          continue;
+        }
+      }
+      const offset = String(frame.offset ?? "").startsWith("0x")
+        ? String(frame.offset)
+        : `0x${frame.offset}`;
+      try {
+        const { stdout } = await execFileAsync(
+          "llvm-symbolizer",
+          ["--obj=" + soPath, "--output-style=GNU", "--demangle", "--functions=linkage", offset],
+          { maxBuffer: 4 * 1024 * 1024 },
+        );
+        const lines = stdout.trim().split("\n").filter(Boolean);
+        results.push({
+          index: frame.index,
+          resolved: lines.length > 0 ? `${lines[0]}${lines[1] ? ` (${lines[1]})` : ""}` : "??",
+        });
+      } catch (err) {
+        results.push({
+          index: frame.index,
+          error: `symbolizer failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+    return c.json({ frames: results });
+  } catch (err) {
+    return c.json(
+      { error: `symbolicate failed: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
   }
 });
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -105,7 +105,7 @@ find and rotate the key in the app's Settings tab or via
 | `message` | Yes | Feedback text (max 10,000 chars). |
 | `kind` | No | `feedback` (default), `bug`, or `crash`. |
 | `contact` | No | Reply-to handle (email, Raft name, …). |
-| `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. |
+| `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. Crash tickets add `crash_exception_class` / `crash_top_frame` (grouping signature) and, for native crashes, `crash_native_frames` — an array of `{ index, offset, soname, build_id }` that the server symbolicates against the build's `native-symbols` asset. |
 | `attachments` | No | Up to 3 files, 10 MB each (screenshots, logs). |
 
 Returns `201` with `{ "id": "<ticket id>", "status": "open" }`. Rate limit:

--- a/docs/symbolication-matrix.md
+++ b/docs/symbolication-matrix.md
@@ -12,7 +12,7 @@ lane exists.
 | Lane | Client uploads | Build asset | Server pipeline | Status |
 |---|---|---|---|---|
 | Android Java/R8 | stack text (kind=crash ticket, `crash_*` signature fields) | `proguard-mapping` (mapping.txt) | container `retrace` → internal ticket comment | ✅ |
-| Android native (NDK) | tombstone-style dump: abort message, signal, per-frame `#NN pc <offset> <soname> (BuildId: …)` | `native-symbols` (zip of unstripped `.so`) | container: `symbolic` (rust) resolves offset→symbol per frame, matched by BuildId (`llvm-symbolizer` as fallback) | 🔨 next |
+| Android native (NDK) | `metadata.crash_native_frames`: `[{ index, offset, soname, build_id }]` (plus the human-readable dump as attachment) | `native-symbols` (zip of unstripped `.so`) | ✅ container `/symbolicate-native`: unzip → BuildId verify (`readelf -n`) → `llvm-symbolizer` per frame → internal ticket comment (missing asset ⇒ actionable comment). `symbolic` upgrade slot reserved. | server ✅ · SDK capture 🔨 |
 | iOS | crash record with a **binary images section** (image UUID + load address + slide) and frame addresses — `backtrace_symbols` text alone is NOT symbolicatable | `dsym` (zip of dSYM bundles) | container: `symbolic` by image UUID + address-slide; no mac/atos dependency | 📐 (SDK prerequisite: images section) |
 | Electron / Crashpad | minidump | Breakpad `.sym` files | `minidump-stackwalk` (rust-minidump) | ⏸ no electron lane yet |
 

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -191,6 +191,18 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     }
   }
 
+  // Native crashes: symbolicate frames against the native-symbols asset.
+  const nativeFrames = parseNativeFrames(metadata["crash_native_frames"]);
+  if (kind === "crash" && nativeFrames.length > 0) {
+    const run = () =>
+      symbolicateNativeCrashTicket(c.env, app.id, ticketId, versionCode, nativeFrames);
+    try {
+      c.executionCtx.waitUntil(run());
+    } catch {
+      run().catch(() => {});
+    }
+  }
+
   // Crash alerting: fire webhooks when a signature is first seen or when it
   // spikes (10/50/100 tickets within an hour — fires once per tier as the
   // count crosses it, so no extra state table is needed).
@@ -343,6 +355,135 @@ export async function retraceCrashTicket(
   } catch (err) {
     console.error(
       `[retrace] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export interface NativeFrame {
+  index: number;
+  offset: string;
+  soname: string;
+  build_id?: string;
+}
+
+/**
+ * SDK contract (symbolication matrix): metadata.crash_native_frames is a
+ * JSON array (or already-parsed array) of
+ * { index, offset, soname, build_id? }. Bounded and shape-checked here so a
+ * hostile client can't feed junk to the container.
+ */
+export function parseNativeFrames(raw: unknown): NativeFrame[] {
+  let value = raw;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(value)) return [];
+  const frames: NativeFrame[] = [];
+  for (const entry of value.slice(0, 256)) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const offset = String(e["offset"] ?? "").trim();
+    const soname = String(e["soname"] ?? "").trim();
+    if (!/^(0x)?[0-9a-fA-F]{1,16}$/.test(offset) || !soname) continue;
+    const frame: NativeFrame = {
+      index: Number.isFinite(Number(e["index"])) ? Number(e["index"]) : frames.length,
+      offset,
+      soname: soname.slice(0, 200),
+    };
+    const buildId = String(e["build_id"] ?? "").trim().toLowerCase();
+    if (/^[0-9a-f]{8,64}$/.test(buildId)) frame.build_id = buildId;
+    frames.push(frame);
+  }
+  return frames;
+}
+
+/**
+ * Resolve native frames against the build's native-symbols archive via the
+ * container's llvm-symbolizer endpoint and append the result as an internal
+ * comment — same UX as the Java/R8 retrace flow. Missing artifact leaves an
+ * operator-actionable comment naming the asset kind (matrix decision #6).
+ */
+export async function symbolicateNativeCrashTicket(
+  env: Env,
+  appId: string,
+  ticketId: string,
+  versionCode: number | null,
+  frames: NativeFrame[],
+): Promise<void> {
+  try {
+    if (versionCode === null || frames.length === 0) return;
+    const appendComment = async (body: string) => {
+      await env.DB.batch([
+        env.DB.prepare(
+          `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
+           VALUES (?1, ?2, 'quiver-symbolicate', ?3, 1, ?4)`,
+        ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
+        env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
+          Date.now(),
+          ticketId,
+        ),
+      ]);
+    };
+
+    const symbols = await env.DB.prepare(
+      `SELECT ba.r2_key FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       WHERE b.app_id = ?1 AND b.version_code = ?2
+         AND ba.artifact_kind = 'native-symbols'
+       ORDER BY ba.created_at DESC LIMIT 1`,
+    )
+      .bind(appId, versionCode)
+      .first<{ r2_key: string }>();
+    if (!symbols) {
+      const ids = [...new Set(frames.map((f) => f.build_id).filter(Boolean))].join(", ");
+      await appendComment(
+        `Native crash could not be symbolicated: no 'native-symbols' build asset ` +
+          `for version_code ${versionCode}${ids ? ` (crash BuildId: ${ids})` : ""}. ` +
+          `Publish the build with its unstripped .so archive (quiver builds publish-android --symbols).`,
+      );
+      return;
+    }
+
+    const zipObj = await env.APK_BUCKET.get(symbols.r2_key);
+    if (!zipObj) return;
+    const zipBytes = await zipObj.arrayBuffer();
+
+    const { getRandom } = await import("@cloudflare/containers");
+    const container = await getRandom(env.APK_PARSER, 1);
+    const res = await container.fetch(
+      new Request("http://container/symbolicate-native", {
+        method: "POST",
+        body: zipBytes,
+        headers: {
+          "content-type": "application/zip",
+          "X-Quiver-Frames": JSON.stringify(frames),
+        },
+      }),
+    );
+    if (!res.ok) return;
+    const parsed = (await res.json()) as {
+      frames?: Array<{ index: number; resolved?: string; error?: string }>;
+    };
+    const resolved = parsed.frames ?? [];
+    if (resolved.length === 0) return;
+
+    const byIndex = new Map(resolved.map((f) => [f.index, f]));
+    const lines = frames.map((f) => {
+      const r = byIndex.get(f.index);
+      const outcome = r?.resolved ?? (r?.error ? `?? (${r.error})` : "??");
+      return `#${String(f.index).padStart(2, "0")} ${f.offset} ${f.soname} — ${outcome}`;
+    });
+    await appendComment(
+      "Symbolicated native stack (auto-resolved from native-symbols):\n\n" +
+        lines.join("\n").slice(0, 20_000),
+    );
+  } catch (err) {
+    console.error(
+      `[symbolicate] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3245,6 +3245,42 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(home.open_count).toBe(2);
   });
 
+  it("parseNativeFrames bounds and shape-checks SDK input", async () => {
+    const { parseNativeFrames } = await import("../src/routes/feedback");
+    const frames = parseNativeFrames(JSON.stringify([
+      { index: 0, offset: "0x1a2b", soname: "libraft.so", build_id: "E0276A1082493B6A57BD" },
+      { index: 1, offset: "nonsense", soname: "libraft.so" },
+      { index: 2, offset: "beef", soname: "" },
+      "garbage",
+      { index: 3, offset: "cafe", soname: "libc.so", build_id: "zz" },
+    ]));
+    expect(frames).toEqual([
+      { index: 0, offset: "0x1a2b", soname: "libraft.so", build_id: "e0276a1082493b6a57bd" },
+      { index: 3, offset: "cafe", soname: "libc.so" },
+    ]);
+    expect(parseNativeFrames("not json")).toEqual([]);
+    expect(parseNativeFrames(42)).toEqual([]);
+  });
+
+  it("symbolicateNativeCrashTicket leaves an actionable comment when symbols are missing", async () => {
+    const env = makeEnv();
+    const { symbolicateNativeCrashTicket } = await import("../src/routes/feedback");
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?1, ?2, 'crash', 'open', 'native crash', '{}', ?3, ?4)`,
+    ).bind("tick-nat", "app-scope", 1, 1).run();
+    await symbolicateNativeCrashTicket(env as any, "app-scope", "tick-nat", 1000200, [
+      { index: 0, offset: "0x1a2b", soname: "libraft.so", build_id: "abcd1234" },
+    ]);
+    const comment = (await env.DB.prepare(
+      "SELECT author_actor, body FROM feedback_comments WHERE ticket_id = ?1",
+    ).bind("tick-nat").all()).results[0] as { author_actor: string; body: string };
+    expect(comment.author_actor).toBe("quiver-symbolicate");
+    expect(comment.body).toContain("native-symbols");
+    expect(comment.body).toContain("1000200");
+    expect(comment.body).toContain("abcd1234");
+  });
+
   it("changelogToHtml renders bullets safely", async () => {
     const { changelogToHtml } = await import("../src/routes/public_v2");
     const html = changelogToHtml("- one **bold**\n- two <script>x</script>\n\nplain `c`");


### PR DESCRIPTION
Container gains POST /symbolicate-native (unzip native-symbols archive,
verify ELF BuildId with readelf, resolve each frame with llvm-symbolizer;
llvm + binutils added to the image). The worker parses bounded
metadata.crash_native_frames from crash submissions, looks up the
build's native-symbols asset, and appends the symbolicated stack as an
internal comment — or an actionable comment naming the missing asset
kind and BuildIds. Command pipeline verified end-to-end against a real
fixture .so in the bookworm base image.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
