### PR TITLE
feat(android): NDK crash capture — async-signal-safe record + next-launch upload (task #80)

### DIFF
--- a/.github/workflows/android-sdk-check.yml
+++ b/.github/workflows/android-sdk-check.yml
@@ -1,0 +1,22 @@
+name: Android SDK check
+
+on:
+  pull_request:
+    paths:
+      - "clients/android/**"
+      - ".github/workflows/android-sdk-check.yml"
+
+jobs:
+  assemble:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.10.2"
+      - name: Assemble release AAR (includes NDK build)
+        run: gradle -p clients/android assembleRelease

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -15,7 +15,18 @@ android {
     defaultConfig {
         minSdk = 24
         consumerProguardFiles("consumer-rules.pro")
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+        }
     }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+    ndkVersion = "26.3.11579264"
 
     publishing {
         singleVariant("release") {

--- a/clients/android/src/main/cpp/CMakeLists.txt
+++ b/clients/android/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(quivercrash C)
+
+add_library(quivercrash SHARED quiver_native_crash.c)
+target_compile_options(quivercrash PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
+# JNIEXPORT carries default visibility, so the entry point stays exported.

--- a/clients/android/src/main/cpp/quiver_native_crash.c
+++ b/clients/android/src/main/cpp/quiver_native_crash.c
@@ -1,0 +1,169 @@
+/*
+ * Async-signal-safe native crash capture (symbolication matrix, task #80).
+ *
+ * Discipline (same as the iOS handler): the signal handler uses ONLY
+ * async-signal-safe calls — open/write/close, time(), and local char
+ * formatting. No malloc, no JSON, no dladdr, no locks. The record is raw
+ * frame PCs from _Unwind_Backtrace plus a copy of /proc/self/maps; the
+ * Kotlin side turns PCs into (soname, offset, BuildId) on the NEXT launch,
+ * where address-space math is done from the maps snapshot.
+ */
+#include <fcntl.h>
+#include <jni.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <unwind.h>
+
+#define QUIVER_MAX_FRAMES 64
+#define QUIVER_DIR_MAX 512
+
+static char g_crash_dir[QUIVER_DIR_MAX];
+static int g_fatal_signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE, SIGTRAP};
+static struct sigaction g_previous[sizeof(g_fatal_signals) / sizeof(int)];
+static char g_altstack[SIGSTKSZ * 2];
+
+struct quiver_unwind_state {
+  uintptr_t frames[QUIVER_MAX_FRAMES];
+  int count;
+};
+
+static _Unwind_Reason_Code quiver_unwind_cb(struct _Unwind_Context *ctx, void *arg) {
+  struct quiver_unwind_state *state = (struct quiver_unwind_state *)arg;
+  if (state->count >= QUIVER_MAX_FRAMES) return _URC_END_OF_STACK;
+  uintptr_t pc = _Unwind_GetIP(ctx);
+  if (pc != 0) state->frames[state->count++] = pc;
+  return _URC_NO_REASON;
+}
+
+static size_t quiver_append(char *buf, size_t cap, size_t off, const char *text) {
+  size_t n = strlen(text);
+  if (off + n >= cap) return off;
+  memcpy(buf + off, text, n);
+  buf[off + n] = '\0';
+  return off + n;
+}
+
+static size_t quiver_append_hex(char *buf, size_t cap, size_t off, uint64_t value) {
+  char tmp[19];
+  int i = 18;
+  tmp[i--] = '\0';
+  if (value == 0) tmp[i--] = '0';
+  while (value != 0 && i >= 0) {
+    static const char digits[] = "0123456789abcdef";
+    tmp[i--] = digits[value & 0xf];
+    value >>= 4;
+  }
+  return quiver_append(buf, cap, off, &tmp[i + 1]);
+}
+
+static size_t quiver_append_dec(char *buf, size_t cap, size_t off, uint64_t value) {
+  char tmp[21];
+  int i = 20;
+  tmp[i--] = '\0';
+  if (value == 0) tmp[i--] = '0';
+  while (value != 0 && i >= 0) {
+    tmp[i--] = (char)('0' + (value % 10));
+    value /= 10;
+  }
+  return quiver_append(buf, cap, off, &tmp[i + 1]);
+}
+
+static void quiver_copy_maps(int out_fd) {
+  int maps_fd = open("/proc/self/maps", O_RDONLY);
+  if (maps_fd < 0) return;
+  char chunk[4096];
+  ssize_t n;
+  while ((n = read(maps_fd, chunk, sizeof(chunk))) > 0) {
+    ssize_t written = 0;
+    while (written < n) {
+      ssize_t w = write(out_fd, chunk + written, (size_t)(n - written));
+      if (w <= 0) break;
+      written += w;
+    }
+  }
+  close(maps_fd);
+}
+
+static void quiver_signal_handler(int signo, siginfo_t *info, void *ucontext) {
+  (void)ucontext;
+  if (g_crash_dir[0] != '\0') {
+    long long ts = (long long)time(NULL) * 1000LL;
+
+    char path[QUIVER_DIR_MAX + 64];
+    size_t off = 0;
+    off = quiver_append(path, sizeof(path), off, g_crash_dir);
+    off = quiver_append(path, sizeof(path), off, "/native-");
+    off = quiver_append_dec(path, sizeof(path), off, (uint64_t)ts);
+    off = quiver_append(path, sizeof(path), off, ".qnc");
+
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd >= 0) {
+      char header[256];
+      off = 0;
+      off = quiver_append(header, sizeof(header), off, "QNC1\nsignal ");
+      off = quiver_append_dec(header, sizeof(header), off, (uint64_t)signo);
+      off = quiver_append(header, sizeof(header), off, "\nfault_addr 0x");
+      off = quiver_append_hex(header, sizeof(header), off,
+                              (uint64_t)(uintptr_t)(info != NULL ? info->si_addr : 0));
+      off = quiver_append(header, sizeof(header), off, "\ncrash_at ");
+      off = quiver_append_dec(header, sizeof(header), off, (uint64_t)ts);
+      off = quiver_append(header, sizeof(header), off, "\nframes\n");
+      write(fd, header, off);
+
+      struct quiver_unwind_state state;
+      state.count = 0;
+      _Unwind_Backtrace(quiver_unwind_cb, &state);
+      char line[32];
+      for (int i = 0; i < state.count; i++) {
+        off = 0;
+        off = quiver_append(line, sizeof(line), off, "0x");
+        off = quiver_append_hex(line, sizeof(line), off, (uint64_t)state.frames[i]);
+        off = quiver_append(line, sizeof(line), off, "\n");
+        write(fd, line, off);
+      }
+
+      write(fd, "maps\n", 5);
+      quiver_copy_maps(fd);
+      close(fd);
+    }
+  }
+
+  /* Restore and re-raise so the system (and any chained handler) proceeds. */
+  for (size_t i = 0; i < sizeof(g_fatal_signals) / sizeof(int); i++) {
+    if (g_fatal_signals[i] == signo) {
+      sigaction(signo, &g_previous[i], NULL);
+      raise(signo);
+      return;
+    }
+  }
+  signal(signo, SIG_DFL);
+  raise(signo);
+}
+
+JNIEXPORT void JNICALL
+Java_io_quiver_update_QuiverNativeCrash_nativeInstall(JNIEnv *env, jclass clazz, jstring crash_dir) {
+  (void)clazz;
+  const char *dir = (*env)->GetStringUTFChars(env, crash_dir, NULL);
+  if (dir == NULL) return;
+  strncpy(g_crash_dir, dir, sizeof(g_crash_dir) - 1);
+  g_crash_dir[sizeof(g_crash_dir) - 1] = '\0';
+  (*env)->ReleaseStringUTFChars(env, crash_dir, dir);
+
+  stack_t ss;
+  ss.ss_sp = g_altstack;
+  ss.ss_size = sizeof(g_altstack);
+  ss.ss_flags = 0;
+  sigaltstack(&ss, NULL);
+
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_sigaction = quiver_signal_handler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+  for (size_t i = 0; i < sizeof(g_fatal_signals) / sizeof(int); i++) {
+    sigaction(g_fatal_signals[i], &sa, &g_previous[i]);
+  }
+}

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
@@ -48,8 +48,12 @@ object QuiverCrash {
         clientKey: String? = null,
         copyToClipboard: Boolean = true,
         uploadOnLaunch: Boolean = true,
+        captureNativeCrashes: Boolean = true,
         extraContext: (() -> String)? = null,
     ) {
+        if (captureNativeCrashes) {
+            QuiverNativeCrash.install(context.applicationContext)
+        }
         if (!installed.compareAndSet(false, true)) return
         val appContext = context.applicationContext
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
@@ -82,6 +86,13 @@ object QuiverCrash {
             thread(name = "quiver-crash-upload", isDaemon = true) {
                 runCatching {
                     uploadPending(appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey)
+                    if (captureNativeCrashes) {
+                        runCatching {
+                            QuiverNativeCrash.uploadPending(
+                                appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey,
+                            )
+                        }
+                    }
                 }
                     .onFailure { Log.w(TAG, "Crash upload pass failed", it) }
             }

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
@@ -87,10 +87,13 @@ object QuiverCrash {
                 runCatching {
                     uploadPending(appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey)
                     if (captureNativeCrashes) {
+                        // Dedicated background thread — blocking here is fine.
                         runCatching {
-                            QuiverNativeCrash.uploadPending(
-                                appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey,
-                            )
+                            kotlinx.coroutines.runBlocking {
+                                QuiverNativeCrash.uploadPending(
+                                    appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey,
+                                )
+                            }
                         }
                     }
                 }

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverNativeCrash.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverNativeCrash.kt
@@ -1,0 +1,170 @@
+package io.quiver.update
+
+import android.content.Context
+import java.io.File
+
+/**
+ * NDK crash capture (symbolication matrix, task #80). The native handler
+ * writes a minimal async-signal-safe record (.qnc: signal, fault address,
+ * raw frame PCs, /proc/self/maps snapshot) at crash time; this class turns
+ * records into `crash_native_frames` metadata on the NEXT launch and
+ * submits them as kind=crash tickets. The server symbolicates against the
+ * build's native-symbols asset.
+ */
+object QuiverNativeCrash {
+
+    private const val MAX_STORED = 5
+    private const val MAX_FRAMES = 64
+
+    @JvmStatic
+    private external fun nativeInstall(crashDir: String)
+
+    internal fun crashDir(context: Context): File =
+        File(context.filesDir, "quiver/native-crashes")
+
+    /** Install the native signal handlers. Safe to call once per process. */
+    fun install(context: Context): Boolean {
+        return runCatching {
+            val dir = crashDir(context)
+            dir.mkdirs()
+            System.loadLibrary("quivercrash")
+            nativeInstall(dir.absolutePath)
+            true
+        }.getOrDefault(false)
+    }
+
+    /** Parse + upload pending records; call off the launch critical path. */
+    suspend fun uploadPending(
+        context: Context,
+        baseUrl: String,
+        appSlug: String,
+        versionName: String? = null,
+        versionCode: Long? = null,
+        channel: String? = null,
+        clientKey: String? = null,
+    ) {
+        val dir = crashDir(context)
+        val records = (dir.listFiles { f -> f.name.endsWith(".qnc") } ?: emptyArray())
+            .sortedBy { it.name }
+        if (records.isEmpty()) return
+        // Retention: newest survive, same policy as QuiverCrash.
+        records.dropLast(MAX_STORED).forEach { it.delete() }
+
+        val feedback = QuiverFeedback(
+            context = context,
+            baseUrl = baseUrl,
+            appSlug = appSlug,
+            versionName = versionName,
+            versionCode = versionCode,
+            channel = channel,
+            clientKey = clientKey,
+        )
+        for (record in records.takeLast(MAX_STORED)) {
+            val parsed = runCatching { parseRecord(record.readText()) }.getOrNull()
+            if (parsed == null) {
+                record.delete()
+                continue
+            }
+            val framesJson = parsed.frames.joinToString(",", "[", "]") { f ->
+                """{"index":${f.index},"offset":"0x${f.offset.toString(16)}","soname":"${f.soname}"}"""
+            }
+            val top = parsed.frames.firstOrNull()
+            val result = runCatching {
+                feedback.submit(
+                    message = "Native crash: ${parsed.signalName}" +
+                        (top?.let { "\nat ${it.soname}+0x${it.offset.toString(16)}" } ?: ""),
+                    kind = "crash",
+                    attachments = listOf(record),
+                    extras = mapOf(
+                        "crash_exception_class" to parsed.signalName,
+                        "crash_top_frame" to (top?.let { "${it.soname}+0x${it.offset.toString(16)}" } ?: ""),
+                        "crash_reason" to "native_signal",
+                        "crash_at" to parsed.crashAt.toString(),
+                        "crash_native_frames" to framesJson,
+                    ),
+                )
+            }
+            if (result.isSuccess) record.delete()
+        }
+    }
+
+    internal data class NativeFrame(val index: Int, val offset: Long, val soname: String)
+    internal data class ParsedRecord(
+        val signalName: String,
+        val crashAt: Long,
+        val frames: List<NativeFrame>,
+    )
+
+    private val SIGNAL_NAMES = mapOf(
+        4 to "SIGILL", 5 to "SIGTRAP", 6 to "SIGABRT",
+        7 to "SIGBUS", 8 to "SIGFPE", 11 to "SIGSEGV",
+    )
+
+    private data class MapEntry(
+        val start: Long,
+        val end: Long,
+        val fileOffset: Long,
+        val path: String,
+    )
+
+    /**
+     * .qnc format (written by the signal handler):
+     *   QNC1 / "signal N" / "fault_addr 0x…" / "crash_at MS" / "frames" /
+     *   one 0x<pc> per line / "maps" / raw /proc/self/maps lines.
+     * PC → (soname, offset) uses the maps snapshot from the same process, so
+     * ASLR is already accounted for: offset = pc - start + file_offset.
+     */
+    internal fun parseRecord(text: String): ParsedRecord? {
+        val lines = text.lines()
+        if (lines.firstOrNull()?.trim() != "QNC1") return null
+        var signal = 0
+        var crashAt = 0L
+        val pcs = mutableListOf<Long>()
+        val maps = mutableListOf<MapEntry>()
+        var section = "header"
+        for (line in lines.drop(1)) {
+            val trimmed = line.trim()
+            when {
+                trimmed == "frames" -> section = "frames"
+                trimmed == "maps" -> section = "maps"
+                section == "header" && trimmed.startsWith("signal ") ->
+                    signal = trimmed.removePrefix("signal ").trim().toIntOrNull() ?: 0
+                section == "header" && trimmed.startsWith("crash_at ") ->
+                    crashAt = trimmed.removePrefix("crash_at ").trim().toLongOrNull() ?: 0L
+                section == "frames" && trimmed.startsWith("0x") ->
+                    trimmed.removePrefix("0x").toLongOrNull(16)?.let { pcs.add(it) }
+                section == "maps" && trimmed.isNotEmpty() -> parseMapLine(trimmed)?.let { maps.add(it) }
+            }
+        }
+        if (signal == 0 || pcs.isEmpty()) return null
+        val frames = pcs.take(MAX_FRAMES).mapIndexedNotNull { index, pc ->
+            val map = maps.firstOrNull { pc >= it.start && pc < it.end && it.path.endsWith(".so") }
+                ?: return@mapIndexedNotNull null
+            NativeFrame(
+                index = index,
+                offset = pc - map.start + map.fileOffset,
+                soname = map.path.substringAfterLast('/'),
+            )
+        }
+        if (frames.isEmpty()) return null
+        return ParsedRecord(
+            signalName = SIGNAL_NAMES[signal] ?: "SIG$signal",
+            crashAt = crashAt,
+            frames = frames,
+        )
+    }
+
+    /** "7f0000-7f1000 r-xp 00042000 fd:00 123  /path/libfoo.so" */
+    private fun parseMapLine(line: String): MapEntry? {
+        val parts = line.split(Regex("\\s+"))
+        if (parts.size < 6) return null
+        val range = parts[0].split('-')
+        if (range.size != 2 || !parts[1].contains('x')) return null
+        return MapEntry(
+            start = range[0].toLongOrNull(16) ?: return null,
+            end = range[1].toLongOrNull(16) ?: return null,
+            fileOffset = parts[2].toLongOrNull(16) ?: return null,
+            path = parts.subList(5, parts.size).joinToString(" "),
+        )
+    }
+}


### PR DESCRIPTION
Native handler (libquivercrash) writes a minimal .qnc record at crash
time: signal, fault address, raw _Unwind_Backtrace PCs, and a
/proc/self/maps snapshot — open/write/close and local char math only.
QuiverNativeCrash parses records on the next launch (offset = pc - map
start + file offset from the same-process maps), submits kind=crash
tickets with crash_native_frames for server-side symbolication, and is
wired into QuiverCrash.install (captureNativeCrashes, default on). New
PR workflow compiles the AAR incl. the NDK build.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
