### PR TITLE
docs: iOS and HarmonyOS SDK pages

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -48,6 +48,20 @@ const pages = [
     source: "android-sdk.md",
   },
   {
+    slug: "ios-sdk",
+    title: "iOS SDK",
+    category: "SDKs & API",
+    description: "Feedback tickets and store-then-send crash reporting for iOS (the Quiver CocoaPod).",
+    source: "ios-sdk.md",
+  },
+  {
+    slug: "ohos-sdk",
+    title: "HarmonyOS SDK",
+    category: "SDKs & API",
+    description: "Feedback tickets and crash reporting for HarmonyOS (the @oranix/quiver ohpm package).",
+    source: "ohos-sdk.md",
+  },
+  {
     slug: "public-api-reference",
     title: "Public API Reference",
     category: "SDKs & API",

--- a/docs/public/ios-sdk.md
+++ b/docs/public/ios-sdk.md
@@ -1,0 +1,66 @@
+# iOS SDK
+
+`Quiver` is the iOS SDK for Quiver: in-app **feedback tickets** and
+store-then-send **crash reporting** posted to a Quiver server's public
+feedback endpoint. Objective-C, no dependencies, iOS 14.1+.
+
+## Install (CocoaPods, via git)
+
+```ruby
+pod 'Quiver', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.2'
+```
+
+## Configure & start
+
+All configuration is runtime parameters — the SDK ships nothing
+app-specific. Get the client key from your app's **Settings** tab in the
+Quiver console (Sentry-DSN model: it identifies the app and ships in the
+bundle; rotate it from the console if it leaks).
+
+```swift
+import Quiver
+
+QuiverReport.start(with: QuiverReportConfig(
+    baseUrl: "https://quiver.example.com",
+    appSlug: "my-app",
+    channel: "main",          // Quiver release-channel routing field
+    clientKey: "qk_…"
+))
+```
+
+`start(with:)` installs the crash handlers and uploads any pending crash
+reports a few seconds after launch. Call it as early as possible (app init).
+
+## Feedback
+
+```swift
+QuiverReport.submitFeedback(
+    "Feed doesn't refresh after login.",
+    kind: "bug",                      // "feedback" | "bug" | "crash"
+    attachmentPaths: [logFilePath],   // up to 3 files, 10 MB each
+    extras: nil
+) { ticketId, error in … }
+```
+
+Device metadata (version, model, OS, arch, locale, per-install device id) is
+attached automatically.
+
+## Crash reporting
+
+- Uncaught `NSException`s: full `callStackSymbols` plus a signature sidecar.
+- Fatal signals (SIGABRT/SEGV/BUS/ILL/FPE/TRAP): the guaranteed record is
+  written with async-signal-safe calls only; stack capture runs last as
+  best-effort.
+- Reports upload as `kind=crash` tickets on the next launch and are grouped
+  by signature server-side; retention cap 5 pending reports on disk.
+
+Known v1 gaps: no all-threads dump, no Mach exception handling, no dSYM
+symbolication server-side yet.
+
+## Notes
+
+- The client key (`qk_…`) authenticates feedback/crash submissions. It ships
+  inside the app bundle (Sentry-DSN model — app identifier, not a user
+  secret); it is never logged or included in diagnostics exports.
+- The device id is a random UUID in `NSUserDefaults`, not a hardware id; it
+  resets on reinstall.

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -1,0 +1,80 @@
+# HarmonyOS SDK
+
+`@oranix/quiver` is the HarmonyOS SDK for Quiver (ArkTS HAR): **feedback
+tickets** and store-then-send **crash reporting** against a Quiver server's
+public feedback endpoint. Mirrors the Android and iOS SDKs.
+
+> **Status:** the package is being published to ohpm. Until it's live,
+> consume the HAR from a local build of `clients/ohos` in the
+> [Quiver repo](https://github.com/oranix-io/quiver).
+
+## Install
+
+```bash
+ohpm install @oranix/quiver
+```
+
+## Configure & start
+
+All configuration is runtime parameters — the SDK ships nothing
+app-specific. Get the client key from your app's **Settings** tab in the
+Quiver console (Sentry-DSN model: it identifies the app; rotate it from the
+console if it leaks).
+
+```ts
+import { Quiver } from '@oranix/quiver';
+
+Quiver.start({
+  baseUrl: 'https://quiver.example.com',
+  appSlug: 'my-app',
+  channel: 'main',          // Quiver release-channel routing field
+  clientKey: 'qk_…',
+});
+```
+
+Call it as early as possible (UIAbility `onCreate`). The app also needs the
+`ohos.permission.INTERNET` permission declared in its `module.json5`.
+
+## Feedback
+
+```ts
+import { QuiverFeedbackClient } from '@oranix/quiver';
+
+const ticketId = await QuiverFeedbackClient.submit(
+  context,                    // common.UIAbilityContext
+  'Feed does not refresh',    // message
+  'bug',                      // 'feedback' | 'bug' | 'crash'
+  [logFilePath],              // up to 3 files, 10 MB each
+  [],                         // extras: Array<{ key, value }>
+);
+```
+
+Device metadata (version, model, OS, ABI, locale, per-install device id) is
+attached automatically.
+
+## Crash reporting (store-then-send)
+
+At crash time (e.g. an `errorManager` observer), write the crash log and its
+signature sidecar — no network in the dying process:
+
+```ts
+import { QuiverCrashUploader } from '@oranix/quiver';
+
+QuiverCrashUploader.writeMeta(crashLogPath, {
+  exception_class: error.name,
+  exception_message: error.message,
+  top_frame: topFrame,
+  reason: 'uncaught_error',
+  crash_at: Date.now(),
+});
+```
+
+On the next launch (a few seconds after startup):
+
+```ts
+QuiverCrashUploader.enforceRetention(context);
+await QuiverCrashUploader.uploadPending(context);
+```
+
+Pending crashes upload as `kind=crash` tickets, grouped by signature
+server-side; local retention cap is 5.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -415,6 +415,8 @@ const publicDocs = new Set([
   "/docs/agent-guide/",
   "/docs/admin-user-guide/",
   "/docs/android-sdk/",
+  "/docs/ios-sdk/",
+  "/docs/ohos-sdk/",
   "/docs/cli-reference/",
   "/docs/agent-cli-feedback/",
   "/docs/public-api-reference/",


### PR DESCRIPTION
New /docs/ios-sdk (Quiver CocoaPod) and /docs/ohos-sdk (@oranix/quiver
ohpm HAR) under SDKs & API, adapted from the client READMEs. OHOS page
notes the package is pending its first ohpm publish. Registered in the
docs build + worker allowlist.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
