### PR TITLE
feat(analytics): device register telemetry + active-device/version-distribution

### DIFF
--- a/admin/src/components/DeviceAnalytics.tsx
+++ b/admin/src/components/DeviceAnalytics.tsx
@@ -1,0 +1,89 @@
+/**
+ * Active-device analytics on the app overview: total active devices in the
+ * window plus a version-distribution bar list and platform breakdown.
+ * Inline SVG-free (CSS bars); colors use the validated categorical blue.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { getDeviceAnalytics } from "../lib/api";
+
+const BAR_COLOR = "#2a78d6";
+
+export function DeviceAnalytics({ appId }: { appId: string }) {
+  const analytics = useQuery({
+    queryKey: ["device-analytics", appId],
+    queryFn: () => getDeviceAnalytics(appId, 30),
+  });
+
+  if (analytics.isLoading) return null;
+  const data = analytics.data;
+  if (!data || data.active_devices === 0) return null;
+
+  const maxVersion = Math.max(1, ...data.by_version.map((v) => v.devices));
+
+  return (
+    <div className="card !p-4">
+      <div className="flex items-baseline justify-between mb-3">
+        <h3 className="text-sm font-semibold">Active devices</h3>
+        <span className="text-xs text-slate-500">last 30 days</span>
+      </div>
+
+      <div className="flex items-end gap-2 mb-4">
+        <span className="text-3xl font-semibold tabular-nums">{data.active_devices}</span>
+        <span className="text-xs text-slate-500 mb-1">
+          device{data.active_devices === 1 ? "" : "s"} reported in
+        </span>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-[1fr_200px]">
+        <div>
+          <h4 className="text-xs font-medium text-slate-600 mb-2">Version distribution</h4>
+          <div className="space-y-1.5">
+            {data.by_version.map((v) => {
+              const pct = Math.round((v.devices / data.active_devices) * 100);
+              return (
+                <div
+                  key={`${v.version_name}-${v.version_code}`}
+                  className="flex items-center gap-2 text-xs"
+                >
+                  <span
+                    className="w-24 truncate text-slate-600"
+                    title={`${v.version_name} (${v.version_code ?? "?"})`}
+                  >
+                    {v.version_name}
+                  </span>
+                  <div className="flex-1 h-3.5">
+                    <div
+                      className="h-full rounded-r-[4px]"
+                      style={{
+                        width: `${(v.devices / maxVersion) * 100}%`,
+                        background: BAR_COLOR,
+                        minWidth: 2,
+                      }}
+                    />
+                  </div>
+                  <span className="w-14 text-right tabular-nums text-slate-700">
+                    {v.devices} · {pct}%
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {data.by_platform.length > 1 && (
+          <div>
+            <h4 className="text-xs font-medium text-slate-600 mb-2">Platform</h4>
+            <div className="space-y-1">
+              {data.by_platform.map((p) => (
+                <div key={p.platform} className="flex justify-between text-xs text-slate-600">
+                  <span>{p.platform}</span>
+                  <span className="tabular-nums">{p.devices}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1186,6 +1186,20 @@ export interface CrashGroup {
   open_count: number;
 }
 
+export interface DeviceAnalytics {
+  active_devices: number;
+  window_start: number;
+  by_version: Array<{ version_name: string; version_code: number | null; devices: number }>;
+  by_platform: Array<{ platform: string; devices: number }>;
+  by_channel: Array<{ channel: string; devices: number }>;
+}
+
+export const getDeviceAnalytics = (appId: string, windowDays = 30) =>
+  request<DeviceAnalytics>(
+    `/api/apps/${appId}/analytics/devices?window_days=${windowDays}`,
+    { admin: true },
+  );
+
 export interface FeedbackStats {
   daily: Array<{ day: string; kind: string; n: number }>;
   crashes_by_version: Array<{ version_name: string; version_code: number | null; n: number }>;

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -1,3 +1,4 @@
+import { DeviceAnalytics } from "../components/DeviceAnalytics";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { ConfirmActionDialog, TypedConfirmField } from "../components/ConfirmActionDialog";
@@ -80,6 +81,10 @@ export function AppDetail({ appId }: { appId: string }) {
             </a>
           )}
         </div>
+      </section>
+
+      <section className="mt-6">
+        <DeviceAnalytics appId={appId} />
       </section>
 
       <section className="mt-8">

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -115,6 +115,22 @@ tickets can additionally trigger `crash:new_group` / `crash:spike`). The
 Android SDK's `QuiverFeedback.submit(...)` wraps this endpoint and attaches
 device metadata automatically.
 
+## Device Register (telemetry)
+
+```http
+POST /public/v2/apps/:appSlug/devices
+Content-Type: application/json
+X-Quiver-Client-Key: qk_...
+X-Quiver-Device-Id: <stable per-install uuid>
+```
+
+A lightweight launch ping (client throttles to ≤1/day/device) that powers
+active-device and version-distribution analytics. Body is a JSON metadata
+object (`version_name`, `version_code`, `channel`, `platform`, `arch`,
+`os_version`, `device_model`, `locale`). The server upserts one row per
+`(app, device id)` — no PII; the device id is a random per-install UUID.
+Requires the app **client key** (same as feedback). Returns `202`.
+
 ## Share Pages
 
 - `GET /share/:token` — public download page for one release (view/download

--- a/migrations/sql/0033_device_pings.sql
+++ b/migrations/sql/0033_device_pings.sql
@@ -1,0 +1,28 @@
+-- Migration 0033: device_pings
+-- Lightweight active-device / version-distribution telemetry. The SDK sends
+-- a throttled (≤1/day/device) ping on launch; the server upserts one row per
+-- (app_id, device_id). Row count converges to the active device count, so no
+-- retention job is needed. device_id is a random per-install UUID, not a
+-- hardware id — no PII.
+
+CREATE TABLE IF NOT EXISTS device_pings (
+  app_id        TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  device_id     TEXT NOT NULL,
+  version_name  TEXT,
+  version_code  INTEGER,
+  channel       TEXT,
+  platform      TEXT,
+  arch          TEXT,
+  os_version    TEXT,
+  device_model  TEXT,
+  locale        TEXT,
+  first_seen    INTEGER NOT NULL,
+  last_seen     INTEGER NOT NULL,
+  ping_count    INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (app_id, device_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_pings_app_seen
+  ON device_pings(app_id, last_seen DESC);
+CREATE INDEX IF NOT EXISTS idx_device_pings_app_version
+  ON device_pings(app_id, version_code);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -65,6 +65,7 @@ import {
   handleListCrashGroups,
   handleFeedbackStats,
 } from "./routes/feedback";
+import { handleDeviceRegister, handleDeviceAnalytics } from "./routes/analytics";
 import {
   handlePublicAppHistory,
   handlePublicAppHistoryDownload,
@@ -452,6 +453,7 @@ app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
 app.get("/share/:token/icon", handlePublicReleaseShareIcon);
 app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
+app.post("/public/v2/apps/:slug/devices", handleDeviceRegister);
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/apps/:slug/history", handlePublicAppHistory);
 app.get("/apps/:slug/history/:releaseId/download", handlePublicAppHistoryDownload);
@@ -570,6 +572,7 @@ admin.get("/api/apps/:appId/client-key", requireAppRole("admin"), handleGetClien
 admin.post("/api/apps/:appId/rotate-client-key", requireAppRole("admin"), handleRotateClientKey);
 admin.get("/api/apps/:appId/feedback/crash-groups", requireAppRole("viewer"), handleListCrashGroups);
 admin.get("/api/apps/:appId/feedback/stats", requireAppRole("viewer"), handleFeedbackStats);
+admin.get("/api/apps/:appId/analytics/devices", requireAppRole("viewer"), handleDeviceAnalytics);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);

--- a/worker/src/routes/analytics.ts
+++ b/worker/src/routes/analytics.ts
@@ -1,0 +1,154 @@
+/**
+ * Device telemetry (task #84): SDK-facing device registration/heartbeat and
+ * admin-facing active-device / version-distribution queries.
+ *
+ * The public ping upserts one row per (app_id, device_id) — gated by the same
+ * client key as feedback. It carries no PII: device_id is a random
+ * per-install UUID.
+ */
+import type { Context } from "hono";
+import type { AdminEnv } from "../middleware/auth";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+const WINDOW_DEFAULT_DAYS = 30;
+const WINDOW_MAX_DAYS = 365;
+
+export async function handleDeviceRegister(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await c.env.DB.prepare(
+    "SELECT id, client_key FROM apps WHERE slug = ?1 AND archived = 0",
+  )
+    .bind(slug)
+    .first<{ id: string; client_key: string | null }>();
+  if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
+
+  // Same DSN-model client-key gate as feedback.
+  const presented =
+    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+  if (!app.client_key || presented !== app.client_key) {
+    return c.json({ error: "invalid or missing client key" }, 401);
+  }
+
+  const deviceId =
+    c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? "";
+  if (!deviceId || deviceId.length > 200) {
+    return c.json({ error: "device id required" }, 400);
+  }
+
+  let metadata: Record<string, unknown> = {};
+  try {
+    const raw = await c.req.json();
+    if (raw && typeof raw === "object") metadata = raw as Record<string, unknown>;
+  } catch {
+    // empty/invalid body is fine — headers alone can carry the ping
+  }
+  const str = (key: string, max = 200): string | null => {
+    const v = metadata[key];
+    if (v === undefined || v === null) return null;
+    return String(v).slice(0, max) || null;
+  };
+  const versionCodeRaw = metadata["version_code"];
+  const versionCode =
+    typeof versionCodeRaw === "number" && Number.isFinite(versionCodeRaw)
+      ? Math.trunc(versionCodeRaw)
+      : Number.isFinite(Number(versionCodeRaw))
+        ? Math.trunc(Number(versionCodeRaw))
+        : null;
+
+  const now = Date.now();
+  // Upsert: first row sets first_seen; subsequent pings update the rest and
+  // bump ping_count. Distinct numbered params for the better-sqlite3 mock.
+  await c.env.DB.prepare(
+    `INSERT INTO device_pings
+       (app_id, device_id, version_name, version_code, channel, platform,
+        arch, os_version, device_model, locale, first_seen, last_seen, ping_count)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 1)
+     ON CONFLICT(app_id, device_id) DO UPDATE SET
+       version_name = excluded.version_name, version_code = excluded.version_code,
+       channel = excluded.channel, platform = excluded.platform,
+       arch = excluded.arch, os_version = excluded.os_version,
+       device_model = excluded.device_model, locale = excluded.locale,
+       last_seen = excluded.last_seen, ping_count = device_pings.ping_count + 1`,
+  )
+    .bind(
+      app.id,
+      deviceId,
+      str("version_name"),
+      versionCode,
+      str("channel"),
+      str("platform"),
+      str("arch"),
+      str("os_version"),
+      str("device_model"),
+      str("locale", 40),
+      now,
+      now,
+    )
+    .run();
+
+  return c.json({ ok: true }, 202);
+}
+
+function windowStart(c: AdminContext): number {
+  const raw = c.req.query("window_days");
+  let days = raw ? Number(raw) : WINDOW_DEFAULT_DAYS;
+  if (!Number.isFinite(days) || days <= 0) days = WINDOW_DEFAULT_DAYS;
+  days = Math.min(days, WINDOW_MAX_DAYS);
+  return Date.now() - days * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Active-device analytics: total active devices in the window, plus version,
+ * platform, and channel breakdowns. "Active" = last_seen within the window.
+ */
+export async function handleDeviceAnalytics(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const since = windowStart(c);
+
+  const [total, byVersion, byPlatform, byChannel] = await Promise.all([
+    c.env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM device_pings WHERE app_id = ?1 AND last_seen >= ?2",
+    )
+      .bind(appId, since)
+      .first<{ n: number }>(),
+    c.env.DB.prepare(
+      `SELECT COALESCE(version_name, 'unknown') AS version_name, version_code,
+              COUNT(*) AS devices
+       FROM device_pings
+       WHERE app_id = ?1 AND last_seen >= ?2
+       GROUP BY COALESCE(version_name, 'unknown'), version_code
+       ORDER BY COALESCE(version_code, 0) DESC
+       LIMIT 30`,
+    )
+      .bind(appId, since)
+      .all<{ version_name: string; version_code: number | null; devices: number }>(),
+    c.env.DB.prepare(
+      `SELECT COALESCE(platform, 'unknown') AS platform, COUNT(*) AS devices
+       FROM device_pings
+       WHERE app_id = ?1 AND last_seen >= ?2
+       GROUP BY COALESCE(platform, 'unknown')
+       ORDER BY devices DESC`,
+    )
+      .bind(appId, since)
+      .all<{ platform: string; devices: number }>(),
+    c.env.DB.prepare(
+      `SELECT COALESCE(channel, 'unknown') AS channel, COUNT(*) AS devices
+       FROM device_pings
+       WHERE app_id = ?1 AND last_seen >= ?2
+       GROUP BY COALESCE(channel, 'unknown')
+       ORDER BY devices DESC`,
+    )
+      .bind(appId, since)
+      .all<{ channel: string; devices: number }>(),
+  ]);
+
+  return c.json({
+    active_devices: total?.n ?? 0,
+    window_start: since,
+    by_version: byVersion.results,
+    by_platform: byPlatform.results,
+    by_channel: byChannel.results,
+  });
+}

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -257,6 +257,22 @@ function makeMockDb() {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
+    CREATE TABLE device_pings (
+      app_id TEXT NOT NULL,
+      device_id TEXT NOT NULL,
+      version_name TEXT,
+      version_code INTEGER,
+      channel TEXT,
+      platform TEXT,
+      arch TEXT,
+      os_version TEXT,
+      device_model TEXT,
+      locale TEXT,
+      first_seen INTEGER NOT NULL,
+      last_seen INTEGER NOT NULL,
+      ping_count INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (app_id, device_id)
+    );
     CREATE TABLE feedback_attachments (
       id TEXT PRIMARY KEY,
       ticket_id TEXT NOT NULL,
@@ -3377,6 +3393,54 @@ describe("quiver public API v2 — scope resolution", () => {
     ).bind("wh-crash").all()).results as Array<{ event_type: string }>;
     expect(deliveries.filter((d) => d.event_type === "crash:new_group").length).toBe(2);
     expect(deliveries.filter((d) => d.event_type === "crash:spike").length).toBe(0);
+  });
+
+  it("devices: register upserts per device and analytics aggregates by version", async () => {
+    const env = makeEnv();
+    const { handleDeviceRegister, handleDeviceAnalytics } = await import("../src/routes/analytics");
+    const ping = (deviceId: string, versionName: string, versionCode: number, platform: string) => {
+      const body = { version_name: versionName, version_code: versionCode, platform, channel: "main" };
+      return handleDeviceRegister({
+        env,
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: (n: string) =>
+            n === "X-Quiver-Client-Key" ? "qk_test" : n === "X-Quiver-Device-Id" ? deviceId : undefined,
+          query: () => undefined,
+          json: async () => body,
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+    };
+    // wrong key -> 401
+    const bad = await handleDeviceRegister({
+      env,
+      req: {
+        param: (n: string) => (n === "slug" ? "scope-app" : ""),
+        header: () => undefined,
+        query: () => undefined,
+        json: async () => ({}),
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    expect(bad.status).toBe(401);
+
+    expect((await ping("devA", "1.0.2", 1000200, "android")).status).toBe(202);
+    expect((await ping("devB", "1.0.2", 1000200, "android")).status).toBe(202);
+    expect((await ping("devA", "1.0.2", 1000200, "android")).status).toBe(202); // upsert, not a new row
+    expect((await ping("devC", "1.0.1", 1000101, "android")).status).toBe(202);
+
+    const res = await handleDeviceAnalytics({
+      env,
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: () => undefined },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    const body = await responseJson<any>(res);
+    expect(body.active_devices).toBe(3); // devA (deduped), devB, devC
+    const v102 = body.by_version.find((v: any) => v.version_code === 1000200);
+    expect(v102.devices).toBe(2);
+    expect(body.by_platform[0].platform).toBe("android");
+    expect(body.by_platform[0].devices).toBe(3);
   });
 
   it("feedback: client key is always required", async () => {


### PR DESCRIPTION
Public POST /public/v2/apps/:slug/devices (client-key gated, ≤1/day/device
launch ping) upserts one row per (app, device id) into device_pings
(migration 0033) — no PII. Admin GET /api/apps/:id/analytics/devices
returns active-device count + version/platform/channel breakdowns over a
window; an Active Devices card with version distribution lands on the app
overview.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
