### PR TITLE
feat(ios,ohos,android): fold device-analytics ping into the single install/start

### DIFF
--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverCrash.kt
@@ -49,6 +49,7 @@ object QuiverCrash {
         copyToClipboard: Boolean = true,
         uploadOnLaunch: Boolean = true,
         captureNativeCrashes: Boolean = true,
+        reportDeviceAnalytics: Boolean = true,
         extraContext: (() -> String)? = null,
     ) {
         if (captureNativeCrashes) {
@@ -82,9 +83,18 @@ object QuiverCrash {
                 }
         }
 
-        if (uploadOnLaunch) {
+        if (uploadOnLaunch || reportDeviceAnalytics) {
             thread(name = "quiver-crash-upload", isDaemon = true) {
-                runCatching {
+                if (reportDeviceAnalytics) {
+                    runCatching {
+                        kotlinx.coroutines.runBlocking {
+                            QuiverAnalytics.reportDevice(
+                                appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey,
+                            )
+                        }
+                    }
+                }
+                if (uploadOnLaunch) runCatching {
                     uploadPending(appContext, baseUrl, appSlug, versionName, versionCode, channel, clientKey)
                     if (captureNativeCrashes) {
                         // Dedicated background thread — blocking here is fine.

--- a/clients/ios/Sources/QuiverReport/QuiverReport.h
+++ b/clients/ios/Sources/QuiverReport/QuiverReport.h
@@ -59,6 +59,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Stable per-install device id (random UUID persisted in NSUserDefaults).
 + (NSString *)deviceId;
 
+/// Lightweight launch ping for active-device / version-distribution
+/// analytics. Throttled to once per 24h per install; safe to call every
+/// launch. startWithConfig: already calls this — call it directly only to
+/// force an extra ping. No PII: device id + build/OS metadata only.
++ (void)reportDevice;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/clients/ios/Sources/QuiverReport/QuiverReport.m
+++ b/clients/ios/Sources/QuiverReport/QuiverReport.m
@@ -4,7 +4,12 @@
 #import "QuiverDeviceId.h"
 #import "QuiverFeedbackClient.h"
 
+#import <UIKit/UIKit.h>
+#import <sys/utsname.h>
+
 static NSTimeInterval const QuiverPendingUploadDelay = 3.0;
+static NSTimeInterval const QuiverDevicePingInterval = 24 * 60 * 60;
+static NSString *const QuiverLastPingDefaultsKey = @"quiver_last_device_ping_at";
 
 @interface QuiverReportConfig ()
 @property (nonatomic, copy, readwrite) NSString *baseUrl;
@@ -52,6 +57,60 @@ static QuiverReportConfig *gQuiverReportConfig = nil;
     gQuiverReportConfig = config;
     [QuiverCrashReporter install];
     [QuiverCrashReporter uploadPendingAfterDelay:QuiverPendingUploadDelay];
+    [self reportDevice];
+}
+
++ (void)reportDevice {
+    QuiverReportConfig *config = gQuiverReportConfig;
+    if (!config) return;
+
+    NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+    NSTimeInterval last = [defaults doubleForKey:QuiverLastPingDefaultsKey];
+    NSTimeInterval nowSecs = NSDate.date.timeIntervalSince1970;
+    if (last > 0 && nowSecs - last < QuiverDevicePingInterval) return;
+
+    NSDictionary *info = NSBundle.mainBundle.infoDictionary ?: @{};
+    UIDevice *device = UIDevice.currentDevice;
+    struct utsname systemInfo;
+    NSString *model = uname(&systemInfo) == 0
+        ? [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding]
+        : (device.model ?: @"iOS");
+    NSDictionary *metadata = @{
+        @"version_name": info[@"CFBundleShortVersionString"] ?: @"",
+        @"version_code": @([(info[@"CFBundleVersion"] ?: @"0") longLongValue]),
+        @"channel": config.channel ?: @"",
+        @"platform": @"ios",
+#if defined(__arm64__)
+        @"arch": @"arm64",
+#else
+        @"arch": @"x86_64",
+#endif
+        @"os_version": [NSString stringWithFormat:@"%@ %@", device.systemName ?: @"iOS", device.systemVersion ?: @""],
+        @"device_model": model ?: @"iOS",
+        @"locale": NSLocale.currentLocale.localeIdentifier ?: @"",
+    };
+    NSData *bodyData = [NSJSONSerialization dataWithJSONObject:metadata options:0 error:nil];
+    if (!bodyData) return;
+
+    NSString *urlText = [NSString stringWithFormat:@"%@/public/v2/apps/%@/devices",
+                                                   config.baseUrl, config.appSlug];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlText]];
+    request.HTTPMethod = @"POST";
+    request.timeoutInterval = 15;
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    [request setValue:config.clientKey forHTTPHeaderField:@"X-Quiver-Client-Key"];
+    [request setValue:[QuiverDeviceId deviceId] forHTTPHeaderField:@"X-Quiver-Device-Id"];
+
+    NSURLSessionUploadTask *task = [NSURLSession.sharedSession
+        uploadTaskWithRequest:request
+                     fromData:bodyData
+            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                NSInteger code = [(NSHTTPURLResponse *)response statusCode];
+                if (!error && code >= 200 && code < 300) {
+                    [defaults setDouble:nowSecs forKey:QuiverLastPingDefaultsKey];
+                }
+            }];
+    [task resume];
 }
 
 + (QuiverReportConfig *)config {

--- a/clients/ohos/quiver/Index.ets
+++ b/clients/ohos/quiver/Index.ets
@@ -2,3 +2,4 @@ export { Quiver, QuiverConfig } from './src/main/ets/Quiver';
 export { QuiverFeedbackClient, QuiverFeedbackExtras } from './src/main/ets/QuiverFeedbackClient';
 export { QuiverCrashUploader, CrashMeta } from './src/main/ets/QuiverCrashUploader';
 export { QuiverDeviceId } from './src/main/ets/QuiverDeviceId';
+export { QuiverAnalytics } from './src/main/ets/QuiverAnalytics';

--- a/clients/ohos/quiver/src/main/ets/Quiver.ets
+++ b/clients/ohos/quiver/src/main/ets/Quiver.ets
@@ -1,3 +1,7 @@
+import { common } from '@kit.AbilityKit';
+import { QuiverAnalytics } from './QuiverAnalytics';
+import { QuiverCrashUploader } from './QuiverCrashUploader';
+
 /**
  * Quiver SDK entry point for HarmonyOS. All configuration is runtime
  * parameters — the SDK ships nothing app-specific; the client key follows
@@ -18,8 +22,13 @@ export interface QuiverConfig {
 export class Quiver {
   private static current: QuiverConfig | null = null;
 
-  /** Call once, as early as possible (ability onCreate). */
-  static start(config: QuiverConfig): void {
+  /**
+   * Call once, as early as possible (UIAbility onCreate). Passing the
+   * ability context also wires the internal launch logic — a throttled
+   * device-analytics ping and upload of any pending crash reports — so the
+   * app only calls this one method.
+   */
+  static start(config: QuiverConfig, context?: common.UIAbilityContext): void {
     const trimmed: QuiverConfig = {
       baseUrl: config.baseUrl.endsWith('/')
         ? config.baseUrl.substring(0, config.baseUrl.length - 1)
@@ -29,6 +38,14 @@ export class Quiver {
       clientKey: config.clientKey,
     };
     Quiver.current = trimmed;
+    if (context) {
+      // Fire-and-forget; off the launch critical path.
+      setTimeout(() => {
+        QuiverAnalytics.reportDevice(context).catch((): void => {});
+        QuiverCrashUploader.enforceRetention(context);
+        QuiverCrashUploader.uploadPending(context).catch((): void => {});
+      }, 3000);
+    }
   }
 
   static get config(): QuiverConfig {

--- a/clients/ohos/quiver/src/main/ets/QuiverAnalytics.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverAnalytics.ets
@@ -1,0 +1,76 @@
+import { bundleManager, common } from '@kit.AbilityKit';
+import deviceInfo from '@ohos.deviceInfo';
+import http from '@ohos.net.http';
+import i18n from '@ohos.i18n';
+import preferences from '@ohos.data.preferences';
+import hilog from '@ohos.hilog';
+import { Quiver } from './Quiver';
+import { QuiverDeviceId } from './QuiverDeviceId';
+
+const TAG: string = 'QuiverAnalytics';
+const PREFS_NAME: string = 'quiver_update';
+const KEY_LAST_PING: string = 'last_device_ping_at';
+const MIN_INTERVAL_MS: number = 24 * 60 * 60 * 1000;
+const REQUEST_TIMEOUT_MS: number = 15000;
+
+/**
+ * Device registration ping for active-device / version-distribution
+ * analytics. Throttled to once per 24h per install (timestamp in the same
+ * preferences store as the device id). No PII — random device id + build/OS
+ * metadata only. Fired automatically by Quiver.start().
+ */
+export class QuiverAnalytics {
+  static async reportDevice(context: common.UIAbilityContext, force: boolean = false): Promise<boolean> {
+    const store = preferences.getPreferencesSync(context, { name: PREFS_NAME });
+    const now = Date.now();
+    if (!force) {
+      const last = store.getSync(KEY_LAST_PING, 0) as number;
+      if (last > 0 && now - last < MIN_INTERVAL_MS) {
+        return false;
+      }
+    }
+
+    const bundleInfo = bundleManager.getBundleInfoForSelfSync(bundleManager.BundleFlag.GET_BUNDLE_INFO_DEFAULT);
+    const metadata: Record<string, string | number> = {
+      'version_name': bundleInfo.versionName,
+      'version_code': bundleInfo.versionCode,
+      'channel': Quiver.config.channel,
+      'platform': 'ohos',
+      'arch': deviceInfo.abiList ?? 'unknown',
+      'os_version': `${deviceInfo.osFullName} (API ${deviceInfo.sdkApiVersion})`,
+      'device_model': `${deviceInfo.manufacture} ${deviceInfo.productModel}`.trim(),
+      'locale': i18n.System.getSystemLocale(),
+    };
+
+    const client = http.createHttp();
+    try {
+      const response = await client.request(
+        `${Quiver.config.baseUrl}/public/v2/apps/${Quiver.config.appSlug}/devices`,
+        {
+          method: http.RequestMethod.POST,
+          header: {
+            'Content-Type': 'application/json',
+            'X-Quiver-Client-Key': Quiver.config.clientKey,
+            'X-Quiver-Device-Id': QuiverDeviceId.get(context),
+          },
+          extraData: JSON.stringify(metadata),
+          connectTimeout: REQUEST_TIMEOUT_MS,
+          readTimeout: REQUEST_TIMEOUT_MS,
+        },
+      );
+      const code = Number(response.responseCode ?? 0);
+      if (code >= 200 && code < 300) {
+        store.putSync(KEY_LAST_PING, now);
+        store.flush();
+        return true;
+      }
+      hilog.warn(0x0000, TAG, 'device ping failed code=%{public}d', code);
+      return false;
+    } catch (error) {
+      hilog.warn(0x0000, TAG, 'device ping error: %{public}s', String(error));
+      return false;
+    } finally {
+      client.destroy();
+    }
+  }
+}

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -118,23 +118,11 @@ retraces crash reports for that `versionCode` automatically.
 
 ## Device analytics
 
-`QuiverAnalytics.reportDevice(...)` sends a lightweight launch ping
-(throttled to ≤1/day/install) that powers the console's active-device and
-version-distribution views. No PII — only the random per-install device id
-and build/OS metadata.
-
-```kotlin
-// e.g. from Application.onCreate, in a coroutine
-QuiverAnalytics.reportDevice(
-    context = this,
-    baseUrl = BuildConfig.QUIVER_BASE_URL,
-    appSlug = BuildConfig.QUIVER_APP_SLUG,
-    versionName = BuildConfig.VERSION_NAME,
-    versionCode = BuildConfig.VERSION_CODE.toLong(),
-    channel = BuildConfig.QUIVER_CHANNEL,
-    clientKey = BuildConfig.QUIVER_CLIENT_KEY,
-)
-```
+`QuiverCrash.install(...)` already sends a lightweight launch ping (throttled
+to ≤1/day/install) that powers the console's active-device and
+version-distribution views — no separate call needed. No PII: only the
+random per-install device id and build/OS metadata. Pass
+`reportDeviceAnalytics = false` to `install` to opt out.
 
 ## Notes
 

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -24,16 +24,20 @@ console if it leaks).
 ```ts
 import { Quiver } from '@oranix/quiver';
 
+// In UIAbility onCreate — pass the context to wire the internal launch
+// logic (throttled device-analytics ping + pending-crash upload).
 Quiver.start({
   baseUrl: 'https://quiver.example.com',
   appSlug: 'my-app',
   channel: 'main',          // Quiver release-channel routing field
   clientKey: 'qk_…',
-});
+}, this.context);
 ```
 
-Call it as early as possible (UIAbility `onCreate`). The app also needs the
-`ohos.permission.INTERNET` permission declared in its `module.json5`.
+Call it as early as possible (UIAbility `onCreate`). The app needs the
+`ohos.permission.INTERNET` permission declared in its `module.json5`. With
+the context passed, `start` handles device analytics and pending-crash
+upload for you — no separate calls needed.
 
 ## Feedback
 
@@ -78,3 +82,10 @@ await QuiverCrashUploader.uploadPending(context);
 
 Pending crashes upload as `kind=crash` tickets, grouped by signature
 server-side; local retention cap is 5.
+
+## Device analytics
+
+`Quiver.start(config, context)` sends a throttled launch ping
+(≤1/day/install) that powers the console's active-device and
+version-distribution views — no separate call. No PII: random device id +
+build/OS metadata only.


### PR DESCRIPTION
Per owner: one install method wires everything. Android
QuiverCrash.install now fires the throttled device ping alongside crash
upload; iOS QuiverReport.start already calls reportDevice; OHOS
Quiver.start(config, context) fires the ping + pending-crash upload.
reportDevice stays exposed only for a forced extra ping.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
