### PR TITLE
feat(ohos): fold crash capture into Quiver.install; hide SDK internals in docs

### DIFF
--- a/clients/ohos/quiver/Index.ets
+++ b/clients/ohos/quiver/Index.ets
@@ -3,3 +3,4 @@ export { QuiverFeedbackClient, QuiverFeedbackExtras } from './src/main/ets/Quive
 export { QuiverCrashUploader, CrashMeta } from './src/main/ets/QuiverCrashUploader';
 export { QuiverDeviceId } from './src/main/ets/QuiverDeviceId';
 export { QuiverAnalytics } from './src/main/ets/QuiverAnalytics';
+export { QuiverCrashReporter } from './src/main/ets/QuiverCrashReporter';

--- a/clients/ohos/quiver/src/main/ets/Quiver.ets
+++ b/clients/ohos/quiver/src/main/ets/Quiver.ets
@@ -1,6 +1,7 @@
 import { common } from '@kit.AbilityKit';
 import { QuiverAnalytics } from './QuiverAnalytics';
 import { QuiverCrashUploader } from './QuiverCrashUploader';
+import { QuiverCrashReporter } from './QuiverCrashReporter';
 
 /**
  * Quiver SDK entry point for HarmonyOS. All configuration is runtime
@@ -39,7 +40,10 @@ export class Quiver {
     };
     Quiver.current = trimmed;
     if (context) {
-      // Fire-and-forget; off the launch critical path.
+      // Register the crash observer synchronously so a crash during startup
+      // is still captured.
+      QuiverCrashReporter.install(context);
+      // Device ping + pending-crash upload off the launch critical path.
       setTimeout(() => {
         QuiverAnalytics.reportDevice(context).catch((): void => {});
         QuiverCrashUploader.enforceRetention(context);

--- a/clients/ohos/quiver/src/main/ets/QuiverCrashReporter.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverCrashReporter.ets
@@ -1,0 +1,91 @@
+import { bundleManager, common, errorManager } from '@kit.AbilityKit';
+import deviceInfo from '@ohos.deviceInfo';
+import fs from '@ohos.file.fs';
+import hilog from '@ohos.hilog';
+import { QuiverCrashUploader } from './QuiverCrashUploader';
+
+const TAG: string = 'QuiverCrashReporter';
+const CRASH_LOG_MAX_CHARS: number = 180000;
+
+/**
+ * ArkTS crash capture for HarmonyOS: registers an errorManager observer that
+ * writes a crash log + signature sidecar at crash time (store-then-send).
+ * Quiver.install() calls this — apps do not use it directly.
+ */
+export class QuiverCrashReporter {
+  private static installed: boolean = false;
+
+  static install(context: common.UIAbilityContext): void {
+    if (QuiverCrashReporter.installed) {
+      return;
+    }
+    QuiverCrashReporter.installed = true;
+    const observer: errorManager.ErrorObserver = {
+      onUnhandledException: (errMsg: string): void => {
+        QuiverCrashReporter.capture(context, 'unhandledException', errMsg);
+      },
+      onException: (errObject: Error): void => {
+        QuiverCrashReporter.capture(context, 'exception', QuiverCrashReporter.errorToText(errObject));
+      },
+    };
+    errorManager.on('error', observer);
+    hilog.info(0x0000, TAG, 'crash reporter installed');
+  }
+
+  private static capture(context: common.UIAbilityContext, reason: string, errorText: string): void {
+    try {
+      const crashLog = QuiverCrashReporter.buildCrashLog(context, reason, errorText).slice(0, CRASH_LOG_MAX_CHARS);
+      const crashPath = QuiverCrashReporter.writeCrashLog(context, crashLog);
+      QuiverCrashUploader.enforceRetention(context);
+      const firstLine = errorText.split('\n')[0] ?? '';
+      const exceptionClass = firstLine.split(':')[0]?.trim() ?? 'OhosCrash';
+      const exceptionMessage = firstLine.slice(exceptionClass.length + 1).trim();
+      const frameLine = errorText.split('\n').find((line: string): boolean => line.trim().startsWith('at ')) ?? '';
+      QuiverCrashUploader.writeMeta(crashPath, {
+        exception_class: exceptionClass.length > 0 ? exceptionClass : 'OhosCrash',
+        exception_message: exceptionMessage,
+        top_frame: frameLine.trim().replace(/^at\s+/, ''),
+        reason: reason,
+        crash_at: Date.now(),
+      });
+    } catch (error) {
+      hilog.error(0x0000, TAG, 'failed to write crash: %{public}s', String(error));
+    }
+  }
+
+  private static buildCrashLog(context: common.UIAbilityContext, reason: string, errorText: string): string {
+    const bundleInfo = bundleManager.getBundleInfoForSelfSync(bundleManager.BundleFlag.GET_BUNDLE_INFO_DEFAULT);
+    const lines: string[] = [
+      'Quiver OHOS crash log',
+      `Crash at: ${new Date().toString()}`,
+      `Bundle: ${bundleInfo.name}`,
+      `Version name: ${bundleInfo.versionName}`,
+      `Version code: ${bundleInfo.versionCode}`,
+      `Device: ${deviceInfo.manufacture} ${deviceInfo.productModel}`.trim(),
+      `OS: ${deviceInfo.osFullName} / API ${deviceInfo.sdkApiVersion}`,
+      `Reason: ${reason}`,
+      '',
+      'Error:',
+      errorText,
+    ];
+    return lines.join('\n');
+  }
+
+  private static writeCrashLog(context: common.UIAbilityContext, crashLog: string): string {
+    const crashDir = `${context.filesDir}/crashes`;
+    fs.mkdirSync(crashDir, true);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const crashPath = `${crashDir}/crash-${timestamp}.txt`;
+    const file = fs.openSync(crashPath, fs.OpenMode.CREATE | fs.OpenMode.TRUNC | fs.OpenMode.WRITE_ONLY);
+    try {
+      fs.writeSync(file.fd, crashLog);
+    } finally {
+      fs.closeSync(file);
+    }
+    return crashPath;
+  }
+
+  private static errorToText(error: Error): string {
+    return `${error.name}: ${error.message ?? ''}\n${error.stack ?? ''}`;
+  }
+}

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -87,10 +87,9 @@ admin console or the CLI (`quiver feedback ...`).
 
 ## Crash reporting
 
-`QuiverCrash` captures uncaught exceptions, stores them locally, and uploads
-them as `kind=crash` tickets on the next launch (store-then-send, so no
-network runs in the dying process). Crash tickets are grouped by signature
-and auto-deobfuscated when the build's `mapping.txt` was uploaded.
+`Quiver.install(...)` captures uncaught JVM exceptions and NDK/native
+crashes and uploads them as `kind=crash` tickets, grouped by signature and
+symbolicated in the console.
 
 ```kotlin
 class App : Application() {
@@ -111,10 +110,10 @@ class App : Application() {
 }
 ```
 
-The crash log includes an all-threads dump and process uptime. To get
-readable (deobfuscated) stacks in the console, publish the release with its
-R8/ProGuard `mapping.txt` as a `proguard-mapping` build asset — Quiver
-retraces crash reports for that `versionCode` automatically.
+To get readable (deobfuscated) stacks in the console, publish the release
+with its R8/ProGuard `mapping.txt` (and, for NDK crashes, the unstripped
+`.so` archive) — Quiver symbolicates crash reports for that `versionCode`
+automatically.
 
 ## Device analytics
 

--- a/docs/public/ios-sdk.md
+++ b/docs/public/ios-sdk.md
@@ -1,7 +1,7 @@
 # iOS SDK
 
 `Quiver` is the iOS SDK for Quiver: in-app **feedback tickets** and
-store-then-send **crash reporting** posted to a Quiver server's public
+**crash reporting** posted to a Quiver server's public
 feedback endpoint. Objective-C, no dependencies, iOS 14.1+.
 
 ## Install (CocoaPods, via git)
@@ -47,20 +47,13 @@ attached automatically.
 
 ## Crash reporting
 
-- Uncaught `NSException`s: full `callStackSymbols` plus a signature sidecar.
-- Fatal signals (SIGABRT/SEGV/BUS/ILL/FPE/TRAP): the guaranteed record is
-  written with async-signal-safe calls only; stack capture runs last as
-  best-effort.
-- Reports upload as `kind=crash` tickets on the next launch and are grouped
-  by signature server-side; retention cap 5 pending reports on disk.
-
-Known v1 gaps: no all-threads dump, no Mach exception handling, no dSYM
-symbolication server-side yet.
+`Quiver.install(with:)` captures uncaught `NSException`s and fatal signals
+and uploads them as `kind=crash` tickets, grouped by signature in the
+console. Nothing else to wire.
 
 ## Notes
 
 - The client key (`qk_…`) authenticates feedback/crash submissions. It ships
   inside the app bundle (Sentry-DSN model — app identifier, not a user
   secret); it is never logged or included in diagnostics exports.
-- The device id is a random UUID in `NSUserDefaults`, not a hardware id; it
-  resets on reinstall.
+- The device id is a random UUID, not a hardware id; it resets on reinstall.

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -1,7 +1,7 @@
 # HarmonyOS SDK
 
 `@oranix/quiver` is the HarmonyOS SDK for Quiver (ArkTS HAR): **feedback
-tickets** and store-then-send **crash reporting** against a Quiver server's
+tickets** and **crash reporting** against a Quiver server's
 public feedback endpoint. Mirrors the Android and iOS SDKs.
 
 > **Status:** the package is being published to ohpm. Until it's live,
@@ -56,36 +56,14 @@ const ticketId = await QuiverFeedbackClient.submit(
 Device metadata (version, model, OS, ABI, locale, per-install device id) is
 attached automatically.
 
-## Crash reporting (store-then-send)
+## Crash reporting
 
-At crash time (e.g. an `errorManager` observer), write the crash log and its
-signature sidecar — no network in the dying process:
-
-```ts
-import { QuiverCrashUploader } from '@oranix/quiver';
-
-QuiverCrashUploader.writeMeta(crashLogPath, {
-  exception_class: error.name,
-  exception_message: error.message,
-  top_frame: topFrame,
-  reason: 'uncaught_error',
-  crash_at: Date.now(),
-});
-```
-
-On the next launch (a few seconds after startup):
-
-```ts
-QuiverCrashUploader.enforceRetention(context);
-await QuiverCrashUploader.uploadPending(context);
-```
-
-Pending crashes upload as `kind=crash` tickets, grouped by signature
-server-side; local retention cap is 5.
+`Quiver.install(config, context)` captures uncaught ArkTS errors and uploads
+them as `kind=crash` tickets, grouped by signature in the console. Nothing
+else to wire.
 
 ## Device analytics
 
-`Quiver.install(config, context)` sends a throttled launch ping
-(≤1/day/install) that powers the console's active-device and
-version-distribution views — no separate call. No PII: random device id +
-build/OS metadata only.
+`Quiver.install(config, context)` also reports active-device and
+version-distribution analytics automatically (no PII — a random per-install
+device id and build/OS metadata). No separate call.


### PR DESCRIPTION
OHOS SDK gains QuiverCrashReporter (errorManager observer → crash log +
sidecar), registered by Quiver.install so the app no longer wires its own
observer. All three SDK docs stop exposing store-then-send / next-launch /
manual writeMeta mechanics — install does everything; only feedback stays
a shown call.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
