### PR TITLE
feat(admin): device-id and version reverse lookup drill-downs

### DIFF
--- a/admin/src/components/DeviceAnalytics.tsx
+++ b/admin/src/components/DeviceAnalytics.tsx
@@ -4,11 +4,13 @@
  * Inline SVG-free (CSS bars); colors use the validated categorical blue.
  */
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import { getDeviceAnalytics } from "../lib/api";
 
 const BAR_COLOR = "#2a78d6";
 
 export function DeviceAnalytics({ appId }: { appId: string }) {
+  const navigate = useNavigate();
   const analytics = useQuery({
     queryKey: ["device-analytics", appId],
     queryFn: () => getDeviceAnalytics(appId, 30),
@@ -41,14 +43,17 @@ export function DeviceAnalytics({ appId }: { appId: string }) {
             {data.by_version.map((v) => {
               const pct = Math.round((v.devices / data.active_devices) * 100);
               return (
-                <div
+                <button
                   key={`${v.version_name}-${v.version_code}`}
-                  className="flex items-center gap-2 text-xs"
+                  type="button"
+                  className="flex w-full items-center gap-2 text-xs hover:opacity-80"
+                  title={v.version_code ? `Feedback on version ${v.version_code}` : v.version_name}
+                  onClick={() =>
+                    v.version_code != null &&
+                    navigate(`/apps/${appId}/feedback?version_code=${v.version_code}`)
+                  }
                 >
-                  <span
-                    className="w-24 truncate text-slate-600"
-                    title={`${v.version_name} (${v.version_code ?? "?"})`}
-                  >
+                  <span className="w-24 truncate text-left text-slate-600">
                     {v.version_name}
                   </span>
                   <div className="flex-1 h-3.5">
@@ -64,7 +69,7 @@ export function DeviceAnalytics({ appId }: { appId: string }) {
                   <span className="w-14 text-right tabular-nums text-slate-700">
                     {v.devices} · {pct}%
                   </span>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1115,10 +1115,20 @@ export interface FeedbackDetail {
   }>;
 }
 
-export const listFeedback = (appId: string, filters?: { status?: string | undefined; kind?: string | undefined }) => {
+export const listFeedback = (
+  appId: string,
+  filters?: {
+    status?: string | undefined;
+    kind?: string | undefined;
+    deviceId?: string | undefined;
+    versionCode?: number | undefined;
+  },
+) => {
   const params = new URLSearchParams();
   if (filters?.status) params.set("status", filters.status);
   if (filters?.kind) params.set("kind", filters.kind);
+  if (filters?.deviceId) params.set("device_id", filters.deviceId);
+  if (filters?.versionCode != null) params.set("version_code", String(filters.versionCode));
   const qs = params.toString();
   return request<{ tickets: FeedbackTicket[] }>(
     `/api/apps/${appId}/feedback${qs ? `?${qs}` : ""}`,
@@ -1196,6 +1206,27 @@ export interface DeviceAnalytics {
   by_platform: Array<{ platform: string; devices: number }>;
   by_channel: Array<{ channel: string; devices: number }>;
 }
+
+export interface DeviceDetail {
+  device_id: string;
+  version_name: string | null;
+  version_code: number | null;
+  channel: string | null;
+  platform: string | null;
+  arch: string | null;
+  os_version: string | null;
+  device_model: string | null;
+  locale: string | null;
+  first_seen: number;
+  last_seen: number;
+  ping_count: number;
+}
+
+export const getDeviceDetail = (appId: string, deviceId: string) =>
+  request<{ device: DeviceDetail | null }>(
+    `/api/apps/${appId}/analytics/devices/${encodeURIComponent(deviceId)}`,
+    { admin: true },
+  );
 
 export const getDeviceAnalytics = (appId: string, windowDays = 30) =>
   request<DeviceAnalytics>(

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -13,6 +13,7 @@ import {
   getAuthMe,
   getFeedback,
   listFeedback,
+  getDeviceDetail,
   updateFeedbackTicket,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
@@ -35,24 +36,51 @@ const KIND_STYLES: Record<string, string> = {
 
 export function AppFeedback({ appId }: { appId: string }) {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [kindFilter, setKindFilter] = useState<string>(searchParams.get("kind") ?? "");
+  const deviceFilter = searchParams.get("device_id") ?? "";
+  const versionFilter = searchParams.get("version_code") ?? "";
 
   const tickets = useQuery({
-    queryKey: ["feedback", appId, statusFilter, kindFilter],
+    queryKey: ["feedback", appId, statusFilter, kindFilter, deviceFilter, versionFilter],
     queryFn: () =>
       listFeedback(appId, {
         status: statusFilter || undefined,
         kind: kindFilter || undefined,
+        deviceId: deviceFilter || undefined,
+        versionCode: versionFilter ? Number(versionFilter) : undefined,
       }),
   });
+
+  const clearScopeFilter = (key: "device_id" | "version_code") => {
+    const next = new URLSearchParams(searchParams);
+    next.delete(key);
+    setSearchParams(next);
+  };
 
   const rows = tickets.data?.tickets ?? [];
 
   return (
     <div className="space-y-4">
-      <FeedbackTrends appId={appId} />
+      {deviceFilter && (
+        <DeviceScopeBanner
+          appId={appId}
+          deviceId={deviceFilter}
+          onClear={() => clearScopeFilter("device_id")}
+        />
+      )}
+      {versionFilter && (
+        <div className="card !py-2 !px-3 flex items-center justify-between text-sm">
+          <span>
+            Filtered to version code <span className="font-mono">{versionFilter}</span>
+          </span>
+          <button className="text-blue-600 hover:underline text-xs" onClick={() => clearScopeFilter("version_code")}>
+            clear
+          </button>
+        </div>
+      )}
+      {!deviceFilter && !versionFilter && <FeedbackTrends appId={appId} />}
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h2 className="text-lg font-semibold">Feedback</h2>
@@ -145,6 +173,58 @@ export function AppFeedback({ appId }: { appId: string }) {
           </table>
         )}
       </div>
+    </div>
+  );
+}
+
+function DeviceScopeBanner({
+  appId,
+  deviceId,
+  onClear,
+}: {
+  appId: string;
+  deviceId: string;
+  onClear: () => void;
+}) {
+  const detail = useQuery({
+    queryKey: ["device-detail", appId, deviceId],
+    queryFn: () => getDeviceDetail(appId, deviceId),
+  });
+  const d = detail.data?.device;
+  return (
+    <div className="card !p-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold">
+          Device <span className="font-mono text-xs">{deviceId}</span>
+        </h4>
+        <button className="text-blue-600 hover:underline text-xs" onClick={onClear}>
+          clear
+        </button>
+      </div>
+      {d ? (
+        <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-4">
+          <div>
+            <dt className="text-slate-500">Latest version</dt>
+            <dd>{d.version_name ?? "—"}{d.version_code ? ` (${d.version_code})` : ""}</dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Model</dt>
+            <dd>{d.device_model ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Platform / OS</dt>
+            <dd>{[d.platform, d.os_version].filter(Boolean).join(" · ") || "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">Last seen</dt>
+            <dd>{new Date(d.last_seen).toLocaleString()}</dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="mt-1 text-xs text-slate-500">
+          No analytics ping from this device yet — showing its tickets below.
+        </p>
+      )}
     </div>
   );
 }
@@ -248,6 +328,7 @@ export function FeedbackTicketPage({
   ticketId: string;
 }) {
   const toast = useToast();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [comment, setComment] = useState("");
   const [assigneeDraft, setAssigneeDraft] = useState<string | null>(null);
@@ -397,7 +478,18 @@ export function FeedbackTicketPage({
             <h4 className="text-sm font-semibold mb-2">Device context</h4>
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
               <dt className="text-slate-500">App version</dt>
-              <dd>{t.version_name ?? "—"} {t.version_code ? `(${t.version_code})` : ""}</dd>
+              <dd>
+                {t.version_name ?? "—"}{" "}
+                {t.version_code ? (
+                  <button
+                    className="text-blue-600 hover:underline"
+                    title="All feedback on this version"
+                    onClick={() => navigate(`/apps/${appId}/feedback?version_code=${t.version_code}`)}
+                  >
+                    ({t.version_code})
+                  </button>
+                ) : null}
+              </dd>
               <dt className="text-slate-500">Channel</dt>
               <dd>{t.channel ?? "—"}</dd>
               <dt className="text-slate-500">Device</dt>
@@ -407,7 +499,19 @@ export function FeedbackTicketPage({
               <dt className="text-slate-500">Locale</dt>
               <dd>{t.locale ?? "—"}</dd>
               <dt className="text-slate-500">Device id</dt>
-              <dd className="font-mono">{t.device_id ?? "—"}</dd>
+              <dd className="font-mono">
+                {t.device_id ? (
+                  <button
+                    className="text-blue-600 hover:underline font-mono"
+                    title="This device's history"
+                    onClick={() => navigate(`/apps/${appId}/feedback?device_id=${encodeURIComponent(t.device_id!)}`)}
+                  >
+                    {t.device_id}
+                  </button>
+                ) : (
+                  "—"
+                )}
+              </dd>
             </dl>
           </div>
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -65,7 +65,7 @@ import {
   handleListCrashGroups,
   handleFeedbackStats,
 } from "./routes/feedback";
-import { handleDeviceRegister, handleDeviceAnalytics } from "./routes/analytics";
+import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail } from "./routes/analytics";
 import {
   handlePublicAppHistory,
   handlePublicAppHistoryDownload,
@@ -573,6 +573,7 @@ admin.post("/api/apps/:appId/rotate-client-key", requireAppRole("admin"), handle
 admin.get("/api/apps/:appId/feedback/crash-groups", requireAppRole("viewer"), handleListCrashGroups);
 admin.get("/api/apps/:appId/feedback/stats", requireAppRole("viewer"), handleFeedbackStats);
 admin.get("/api/apps/:appId/analytics/devices", requireAppRole("viewer"), handleDeviceAnalytics);
+admin.get("/api/apps/:appId/analytics/devices/:deviceId", requireAppRole("viewer"), handleDeviceDetail);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);

--- a/worker/src/routes/analytics.ts
+++ b/worker/src/routes/analytics.ts
@@ -103,6 +103,21 @@ function windowStart(c: AdminContext): number {
  * Active-device analytics: total active devices in the window, plus version,
  * platform, and channel breakdowns. "Active" = last_seen within the window.
  */
+/** One device's telemetry row (version, model, seen times, ping count). */
+export async function handleDeviceDetail(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const deviceId = c.req.param("deviceId");
+  const row = await c.env.DB.prepare(
+    `SELECT device_id, version_name, version_code, channel, platform, arch,
+            os_version, device_model, locale, first_seen, last_seen, ping_count
+     FROM device_pings WHERE app_id = ?1 AND device_id = ?2`,
+  )
+    .bind(appId, deviceId)
+    .first();
+  if (!row) return c.json({ device: null });
+  return c.json({ device: row });
+}
+
 export async function handleDeviceAnalytics(c: AdminContext) {
   const appId = c.req.param("appId");
   const since = windowStart(c);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -554,6 +554,16 @@ export async function handleListFeedback(c: AdminContext) {
     binds.push(kind);
     where += ` AND kind = ?${binds.length}`;
   }
+  const deviceId = c.req.query("device_id");
+  if (deviceId) {
+    binds.push(deviceId);
+    where += ` AND device_id = ?${binds.length}`;
+  }
+  const versionCodeFilter = c.req.query("version_code");
+  if (versionCodeFilter && /^\d+$/.test(versionCodeFilter)) {
+    binds.push(Number(versionCodeFilter));
+    where += ` AND version_code = ?${binds.length}`;
+  }
   const { results } = await c.env.DB.prepare(
     `SELECT t.id, t.kind, t.status, t.assignee, t.message, t.contact, t.version_name,
             t.version_code, t.channel, t.device_model, t.os_version,


### PR DESCRIPTION
Feedback list gains device_id + version_code filters. Ticket detail makes
device id and version code clickable → scoped feedback view; a device
scope banner shows that device's telemetry (latest version, model, last
seen) from device_pings (new /analytics/devices/:deviceId endpoint). The
Active Devices version-distribution bars link to the version-scoped view.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
