### PR TITLE
feat(admin): crash-signature drill-down

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1084,6 +1084,7 @@ export interface FeedbackTicket {
   version_name: string | null;
   version_code: number | null;
   channel: string | null;
+  device_id: string | null;
   device_model: string | null;
   os_version: string | null;
   created_at: number;
@@ -1094,7 +1095,6 @@ export interface FeedbackTicket {
 
 export interface FeedbackDetail {
   ticket: FeedbackTicket & {
-    device_id: string | null;
     arch: string | null;
     locale: string | null;
     metadata_json: string;
@@ -1122,6 +1122,7 @@ export const listFeedback = (
     kind?: string | undefined;
     deviceId?: string | undefined;
     versionCode?: number | undefined;
+    signature?: string | undefined;
   },
 ) => {
   const params = new URLSearchParams();
@@ -1129,6 +1130,7 @@ export const listFeedback = (
   if (filters?.kind) params.set("kind", filters.kind);
   if (filters?.deviceId) params.set("device_id", filters.deviceId);
   if (filters?.versionCode != null) params.set("version_code", String(filters.versionCode));
+  if (filters?.signature) params.set("signature", filters.signature);
   const qs = params.toString();
   return request<{ tickets: FeedbackTicket[] }>(
     `/api/apps/${appId}/feedback${qs ? `?${qs}` : ""}`,

--- a/admin/src/pages/Crashes.tsx
+++ b/admin/src/pages/Crashes.tsx
@@ -66,7 +66,11 @@ export function AppCrashes({ appId }: { appId: string }) {
                 <tr
                   key={g.signature}
                   className="border-b border-slate-100 last:border-0 cursor-pointer hover:bg-slate-50"
-                  onClick={() => navigate(`/apps/${appId}/feedback?kind=crash`)}
+                  onClick={() =>
+                    navigate(
+                      `/apps/${appId}/feedback?kind=crash&signature=${encodeURIComponent(g.signature)}`,
+                    )
+                  }
                 >
                   <td className="py-2 pr-3 max-w-lg">
                     <code className="text-xs break-all">{g.signature}</code>

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -41,19 +41,21 @@ export function AppFeedback({ appId }: { appId: string }) {
   const [kindFilter, setKindFilter] = useState<string>(searchParams.get("kind") ?? "");
   const deviceFilter = searchParams.get("device_id") ?? "";
   const versionFilter = searchParams.get("version_code") ?? "";
+  const signatureFilter = searchParams.get("signature") ?? "";
 
   const tickets = useQuery({
-    queryKey: ["feedback", appId, statusFilter, kindFilter, deviceFilter, versionFilter],
+    queryKey: ["feedback", appId, statusFilter, kindFilter, deviceFilter, versionFilter, signatureFilter],
     queryFn: () =>
       listFeedback(appId, {
         status: statusFilter || undefined,
         kind: kindFilter || undefined,
         deviceId: deviceFilter || undefined,
         versionCode: versionFilter ? Number(versionFilter) : undefined,
+        signature: signatureFilter || undefined,
       }),
   });
 
-  const clearScopeFilter = (key: "device_id" | "version_code") => {
+  const clearScopeFilter = (key: "device_id" | "version_code" | "signature") => {
     const next = new URLSearchParams(searchParams);
     next.delete(key);
     setSearchParams(next);
@@ -80,7 +82,27 @@ export function AppFeedback({ appId }: { appId: string }) {
           </button>
         </div>
       )}
-      {!deviceFilter && !versionFilter && <FeedbackTrends appId={appId} />}
+      {signatureFilter && (
+        <div className="card !p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-xs text-slate-500">Crash signature</div>
+              <code className="text-xs break-all">{signatureFilter}</code>
+              {rows.length > 0 && (
+                <div className="mt-1 text-xs text-slate-500">
+                  {rows.length} instance{rows.length === 1 ? "" : "s"} ·{" "}
+                  {new Set(rows.map((r) => r.version_code).filter(Boolean)).size} version(s) ·{" "}
+                  {new Set(rows.map((r) => r.device_id).filter(Boolean)).size} device(s)
+                </div>
+              )}
+            </div>
+            <button className="text-blue-600 hover:underline text-xs flex-none" onClick={() => clearScopeFilter("signature")}>
+              clear
+            </button>
+          </div>
+        </div>
+      )}
+      {!deviceFilter && !versionFilter && !signatureFilter && <FeedbackTrends appId={appId} />}
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h2 className="text-lg font-semibold">Feedback</h2>

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -564,9 +564,14 @@ export async function handleListFeedback(c: AdminContext) {
     binds.push(Number(versionCodeFilter));
     where += ` AND version_code = ?${binds.length}`;
   }
+  const signatureFilter = c.req.query("signature");
+  if (signatureFilter) {
+    binds.push(signatureFilter);
+    where += ` AND signature = ?${binds.length}`;
+  }
   const { results } = await c.env.DB.prepare(
     `SELECT t.id, t.kind, t.status, t.assignee, t.message, t.contact, t.version_name,
-            t.version_code, t.channel, t.device_model, t.os_version,
+            t.version_code, t.channel, t.device_id, t.device_model, t.os_version,
             t.created_at, t.updated_at,
             (SELECT COUNT(*) FROM feedback_attachments fa WHERE fa.ticket_id = t.id) AS attachment_count,
             (SELECT COUNT(*) FROM feedback_comments fc WHERE fc.ticket_id = t.id) AS comment_count


### PR DESCRIPTION
Clicking a crash group opens the feedback list scoped to that signature,
with a banner summarizing instance/version/device counts. Adds a
signature filter to the feedback list and device_id to the list row.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
