### PR TITLE
feat(admin): inline crash stack trace + separate crashes from feedback list

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1168,6 +1168,20 @@ export const feedbackAttachmentUrl = (appId: string, ticketId: string, attachmen
 export const feedbackAttachmentInlineUrl = (appId: string, ticketId: string, attachmentId: string) =>
   `/api/apps/${appId}/feedback/${ticketId}/attachments/${attachmentId}?inline=1`;
 
+export const getFeedbackAttachmentText = async (
+  appId: string,
+  ticketId: string,
+  attachmentId: string,
+  maxBytes = 200_000,
+): Promise<string> => {
+  const res = await fetch(feedbackAttachmentUrl(appId, ticketId, attachmentId), {
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(`attachment ${res.status}`);
+  const text = await res.text();
+  return text.length > maxBytes ? text.slice(0, maxBytes) + "\n…(truncated)" : text;
+};
+
 export const updateAppPublicHistory = (appId: string, enabled: boolean) =>
   request<{ ok: boolean }>(`/api/apps/${appId}`, {
     method: "PATCH",

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -14,6 +14,7 @@ import {
   getFeedback,
   listFeedback,
   getDeviceDetail,
+  getFeedbackAttachmentText,
   updateFeedbackTicket,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
@@ -48,7 +49,9 @@ export function AppFeedback({ appId }: { appId: string }) {
     queryFn: () =>
       listFeedback(appId, {
         status: statusFilter || undefined,
-        kind: kindFilter || undefined,
+        // Feedback tab = user feedback + bugs; crashes live in the Crashes
+        // tab. An explicit kind/signature filter overrides this.
+        kind: kindFilter || (signatureFilter ? "crash" : "feedback,bug"),
         deviceId: deviceFilter || undefined,
         versionCode: versionFilter ? Number(versionFilter) : undefined,
         signature: signatureFilter || undefined,
@@ -195,6 +198,35 @@ export function AppFeedback({ appId }: { appId: string }) {
           </table>
         )}
       </div>
+    </div>
+  );
+}
+
+function CrashLogView({
+  appId,
+  ticketId,
+  attachmentId,
+}: {
+  appId: string;
+  ticketId: string;
+  attachmentId: string;
+}) {
+  const log = useQuery({
+    queryKey: ["crash-log", appId, ticketId, attachmentId],
+    queryFn: () => getFeedbackAttachmentText(appId, ticketId, attachmentId),
+  });
+  return (
+    <div className="card">
+      <h4 className="text-sm font-semibold mb-2">Stack trace</h4>
+      {log.isLoading && <p className="text-xs text-slate-500">Loading…</p>}
+      {log.error && (
+        <p className="text-xs text-red-600">Could not load crash log.</p>
+      )}
+      {log.data && (
+        <pre className="max-h-[28rem] overflow-auto rounded-md bg-slate-950 p-3 text-xs leading-relaxed text-slate-100">
+          {log.data}
+        </pre>
+      )}
     </div>
   );
 }
@@ -536,6 +568,16 @@ export function FeedbackTicketPage({
               </dd>
             </dl>
           </div>
+
+          {t.kind === "crash" &&
+            (() => {
+              const log = detail.data!.attachments.find(
+                (a) => (a.content_type?.startsWith("text/") ?? false) || /\.txt$/i.test(a.filename),
+              );
+              return log ? (
+                <CrashLogView appId={appId} ticketId={ticketId} attachmentId={log.id} />
+              ) : null;
+            })()}
 
           {detail.data!.attachments.length > 0 && (
             <AttachmentList

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -550,9 +550,19 @@ export async function handleListFeedback(c: AdminContext) {
     binds.push(status);
     where += ` AND status = ?${binds.length}`;
   }
-  if (kind && (TICKET_KINDS as readonly string[]).includes(kind)) {
-    binds.push(kind);
-    where += ` AND kind = ?${binds.length}`;
+  if (kind) {
+    const kinds = kind
+      .split(",")
+      .filter((k) => (TICKET_KINDS as readonly string[]).includes(k));
+    if (kinds.length > 0) {
+      const inList = kinds
+        .map((k) => {
+          binds.push(k);
+          return `?${binds.length}`;
+        })
+        .join(", ");
+      where += ` AND kind IN (${inList})`;
+    }
   }
   const deviceId = c.req.query("device_id");
   if (deviceId) {


### PR DESCRIPTION
Crash tickets render the crash-log attachment inline as a scrollable
stack-trace panel (no download needed). The Feedback tab now lists only
feedback + bug tickets (crashes live in the Crashes tab); an explicit
kind/signature filter still reaches crashes. Feedback list kind filter
accepts a comma list.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
