### PR TITLE
feat(feedback): presigned direct-to-R2 upload for large attachments

### DIFF
--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -110,7 +110,8 @@ find and rotate the key in the app's Settings tab or via
 | `kind` | No | `feedback` (default), `bug`, or `crash`. |
 | `contact` | No | Reply-to handle (email, Raft name, …). |
 | `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. Crash tickets add `crash_exception_class` / `crash_top_frame` (grouping signature) and, for native crashes, `crash_native_frames` — an array of `{ index, offset, soname, build_id }` that the server symbolicates against the build's `native-symbols` asset. |
-| `attachments` | No | Up to 3 files, 10 MB each (screenshots, logs). |
+| `attachments` | No | Inline files (multipart), up to 10 MB each, ≤9 total. |
+| `presigned` | No | JSON array of `{ r2_key, filename, content_type, size }` for files already uploaded via the presign flow (below). |
 
 Returns `201` with `{ "id": "<ticket id>", "status": "open" }`. Rate limit:
 10 submissions per hour per app + client IP. Tickets appear in the admin
@@ -134,6 +135,28 @@ object (`version_name`, `version_code`, `channel`, `platform`, `arch`,
 `os_version`, `device_model`, `locale`). The server upserts one row per
 `(app, device id)` — no PII; the device id is a random per-install UUID.
 Requires the app **client key** (same as feedback). Returns `202`.
+
+## Presigned attachment upload (large files)
+
+For attachments too large for an inline multipart submit (up to **200 MB**),
+request a direct-to-R2 upload URL, PUT the bytes to it, then submit the
+ticket referencing the uploaded object.
+
+```http
+POST /public/v2/apps/:appSlug/feedback/presign
+Content-Type: application/json
+X-Quiver-Client-Key: qk_...
+```
+
+Body: `{ "files": [{ "filename": "...", "content_type": "...", "size": <bytes> }] }`
+(≤9 files). Returns `{ "uploads": [{ attachment_id, r2_key, upload_url, expires_at }] }`.
+
+1. `PUT` each file's bytes to its `upload_url` with the same `Content-Type`.
+2. Submit feedback with a `presigned` form field = JSON array of
+   `{ r2_key, filename, content_type, size }` for the uploaded files.
+
+Returns `501` if direct upload isn't configured on the server. Total
+attachments (inline + presigned) may not exceed 9.
 
 ## Share Pages
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -64,6 +64,7 @@ import {
   handleDownloadFeedbackAttachment,
   handleListCrashGroups,
   handleFeedbackStats,
+  handlePresignFeedbackAttachments,
 } from "./routes/feedback";
 import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail } from "./routes/analytics";
 import {
@@ -454,6 +455,7 @@ app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
 app.get("/share/:token/icon", handlePublicReleaseShareIcon);
 app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
 app.post("/public/v2/apps/:slug/devices", handleDeviceRegister);
+app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/apps/:slug/history", handlePublicAppHistory);
 app.get("/apps/:slug/history/:releaseId/download", handlePublicAppHistoryDownload);

--- a/worker/src/lib/r2_presign.ts
+++ b/worker/src/lib/r2_presign.ts
@@ -46,6 +46,39 @@ export async function presignR2DownloadUrl(
   return request.url;
 }
 
+/**
+ * Presign a direct-to-R2 PUT so large attachments upload straight to the
+ * bucket, bypassing the Worker's request-size limits. The client must PUT
+ * with the same Content-Type it declared. Returns null if R2 S3 creds are
+ * unconfigured.
+ */
+export async function presignR2UploadUrl(
+  env: Env,
+  key: string,
+  contentType: string,
+  ttlSeconds: number,
+): Promise<string | null> {
+  if (!canPresignR2Download(env)) return null;
+  const expires = String(Math.max(1, Math.min(Math.floor(ttlSeconds), 3600)));
+  const url = new URL(
+    `${r2Endpoint(env)}/${encodeURIComponent(env.R2_BUCKET_NAME!)}/${key.split("/").map(encodeURIComponent).join("/")}`,
+  );
+  url.searchParams.set("X-Amz-Expires", expires);
+  const aws = new AwsClient({
+    accessKeyId: env.R2_S3_ACCESS_KEY_ID!,
+    secretAccessKey: env.R2_S3_SECRET_ACCESS_KEY!,
+    service: "s3",
+    region: "auto",
+    retries: 0,
+  });
+  const request = await aws.sign(url.toString(), {
+    method: "PUT",
+    headers: { "content-type": contentType || "application/octet-stream" },
+    aws: { signQuery: true, service: "s3", region: "auto" },
+  });
+  return request.url;
+}
+
 function r2Endpoint(env: Env): string {
   const configured = env.R2_S3_ENDPOINT?.replace(/\/+$/, "");
   if (configured) return configured;

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -10,16 +10,87 @@
 import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { emitWebhookEvent } from "./webhooks";
+import { presignR2UploadUrl } from "../lib/r2_presign";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
-const MAX_ATTACHMENTS = 3;
-const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const MAX_ATTACHMENTS = 9;
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // inline multipart cap (through the Worker)
+const MAX_PRESIGNED_BYTES = 200 * 1024 * 1024; // direct-to-R2 cap
+const PRESIGN_TTL_SECONDS = 900;
 const MAX_MESSAGE_CHARS = 10_000;
 const RATE_LIMIT_PER_HOUR = 10;
 
 const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
 const TICKET_KINDS = ["feedback", "bug", "crash"] as const;
+
+/**
+ * Presigned direct-to-R2 upload for large feedback attachments. Client-key
+ * gated (same as submit). Body: { files: [{ filename, content_type, size }] }.
+ * Returns per-file { attachment_id, r2_key, upload_url, expires_at }; the
+ * client PUTs bytes to upload_url, then submits the ticket referencing the
+ * r2_keys via the `presigned` form field.
+ */
+export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await c.env.DB.prepare(
+    "SELECT id, client_key FROM apps WHERE slug = ?1 AND archived = 0",
+  )
+    .bind(slug)
+    .first<{ id: string; client_key: string | null }>();
+  if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
+  const presented =
+    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+  if (!app.client_key || presented !== app.client_key) {
+    return c.json({ error: "invalid or missing client key" }, 401);
+  }
+
+  let body: { files?: Array<{ filename?: string; content_type?: string; size?: number }> };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "JSON body required" }, 400);
+  }
+  const files = Array.isArray(body.files) ? body.files : [];
+  if (files.length === 0 || files.length > MAX_ATTACHMENTS) {
+    return c.json({ error: `files must contain 1-${MAX_ATTACHMENTS} entries` }, 400);
+  }
+
+  const now = Date.now();
+  const out: Array<{
+    attachment_id: string;
+    r2_key: string;
+    upload_url: string;
+    expires_at: number;
+  }> = [];
+  for (const [index, file] of files.entries()) {
+    const size = typeof file.size === "number" ? file.size : 0;
+    if (size <= 0 || size > MAX_PRESIGNED_BYTES) {
+      return c.json(
+        { error: `file ${index} size must be 1-${MAX_PRESIGNED_BYTES} bytes` },
+        400,
+      );
+    }
+    const safeName =
+      String(file.filename ?? "").replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) ||
+      `attachment-${index}`;
+    const contentType = String(file.content_type ?? "application/octet-stream").slice(0, 100);
+    const attachmentId = crypto.randomUUID();
+    const r2Key = `feedback/${app.id}/presigned/${attachmentId}-${safeName}`;
+    const uploadUrl = await presignR2UploadUrl(c.env, r2Key, contentType, PRESIGN_TTL_SECONDS);
+    if (!uploadUrl) {
+      return c.json({ error: "direct upload is not configured on this server" }, 501);
+    }
+    out.push({
+      attachment_id: attachmentId,
+      r2_key: r2Key,
+      upload_url: uploadUrl,
+      expires_at: now + PRESIGN_TTL_SECONDS * 1000,
+    });
+  }
+  return c.json({ uploads: out });
+}
 
 export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) {
   const slug = c.req.param("slug");
@@ -140,6 +211,44 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       contentType: file.type || null,
       sizeBytes: file.size,
     });
+  }
+
+  // Presigned attachments: already PUT directly to R2 by the client. We only
+  // record them (namespace-guarded, existence-verified), never re-upload.
+  const presignedRaw = form.get("presigned");
+  if (typeof presignedRaw === "string" && presignedRaw.trim()) {
+    let presigned: Array<{ r2_key?: string; filename?: string; content_type?: string; size?: number }>;
+    try {
+      const parsed = JSON.parse(presignedRaw);
+      presigned = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return c.json({ error: "presigned must be a JSON array" }, 400);
+    }
+    for (const item of presigned) {
+      if (attachmentRows.length >= MAX_ATTACHMENTS) {
+        return c.json({ error: `too many attachments (max ${MAX_ATTACHMENTS})` }, 400);
+      }
+      const r2Key = String(item.r2_key ?? "");
+      // Namespace guard: only this app's presigned prefix.
+      if (!r2Key.startsWith(`feedback/${app.id}/presigned/`)) {
+        return c.json({ error: "invalid presigned r2_key" }, 400);
+      }
+      const head = await c.env.APK_BUCKET.head(r2Key);
+      if (!head) {
+        return c.json({ error: `presigned upload not found: ${r2Key}` }, 400);
+      }
+      const filename =
+        String(item.filename ?? "").replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) ||
+        r2Key.split("/").pop() ||
+        "attachment";
+      attachmentRows.push({
+        id: crypto.randomUUID(),
+        r2Key,
+        filename,
+        contentType: (item.content_type ? String(item.content_type).slice(0, 100) : null),
+        sizeBytes: head.size ?? (typeof item.size === "number" ? item.size : 0),
+      });
+    }
   }
 
   const statements = [

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3443,6 +3443,49 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(body.by_platform[0].devices).toBe(3);
   });
 
+  it("feedback: presigned attachments are namespace-guarded and existence-checked", async () => {
+    const env = makeEnv();
+    const stored = new Map<string, number>();
+    stored.set("feedback/app-scope/presigned/good-file.bin", 1024);
+    env.APK_BUCKET = {
+      put: async () => {},
+      get: async () => null,
+      head: async (key: string) =>
+        stored.has(key) ? { size: stored.get(key)! } : null,
+    };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+
+    const submit = (presigned: unknown) => {
+      const form = new FormData();
+      form.set("message", "big upload");
+      form.set("presigned", JSON.stringify(presigned));
+      return handlePublicFeedbackSubmit({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: (n: string) => (n === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.50" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+    };
+
+    // wrong namespace -> 400
+    expect((await submit([{ r2_key: "feedback/other-app/presigned/x.bin" }])).status).toBe(400);
+    // missing object -> 400
+    expect((await submit([{ r2_key: "feedback/app-scope/presigned/missing.bin" }])).status).toBe(400);
+    // valid presigned object -> 201, recorded with the real size from head
+    const ok = await submit([
+      { r2_key: "feedback/app-scope/presigned/good-file.bin", filename: "good-file.bin", content_type: "application/octet-stream", size: 999 },
+    ]);
+    expect(ok.status).toBe(201);
+    const body = await responseJson<any>(ok);
+    expect(body.attachments).toBe(1);
+  });
+
   it("feedback: client key is always required", async () => {
     const env = makeEnv();
     const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");


### PR DESCRIPTION
Raises the attachment cap to 9 and adds POST /feedback/presign (client-key
gated) returning presigned R2 PUT URLs for files up to 200 MB — the client
uploads straight to the bucket, bypassing the Worker's request-size limit.
Submit accepts a 'presigned' field listing the uploaded objects, which are
namespace-guarded and existence-checked (never re-uploaded). Adds
presignR2UploadUrl (aws4fetch PUT).

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
