### PR TITLE
feat(notes): raft-style release-notes page at /notes/:slug

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -70,6 +70,7 @@ import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail } from 
 import {
   handlePublicAppHistory,
   handlePublicAppHistoryDownload,
+  handlePublicReleaseNotes,
 } from "./routes/history";
 import {
   handleCreateAppDeployToken,
@@ -459,6 +460,7 @@ app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachme
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/apps/:slug/history", handlePublicAppHistory);
 app.get("/apps/:slug/history/:releaseId/download", handlePublicAppHistoryDownload);
+app.get("/notes/:slug", handlePublicReleaseNotes);
 app.get("/api/invites/:token", handleGetInvite);
 
 function isWorkerRoute(pathname: string): boolean {

--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -67,6 +67,49 @@ export async function handlePublicAppHistory(c: Context<{ Bindings: Env }>) {
   });
 }
 
+/**
+ * Public raft-style release-notes page (task #90). Same data as the history
+ * page (non-cancelled published releases, bilingual changelog) but
+ * changelog-first and addressable by ?version_code=: the requested version is
+ * featured + anchored at the top, followed by the previous non-cancelled
+ * versions. Without version_code, shows the full history. ?lang= (or
+ * Accept-Language) selects the changelog language. Embedded via WebView in the
+ * app's Settings → About; public, no auth.
+ */
+export async function handlePublicReleaseNotes(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await loadHistoryApp(c.env.DB, slug);
+  if (!app || !app.public_history) {
+    return new Response("Not found", { status: 404 });
+  }
+  const { results } = await c.env.DB.prepare(HISTORY_SQL)
+    .bind(app.id)
+    .all<HistoryRow>();
+
+  const rawVc = c.req.query("version_code");
+  const requestedCode =
+    rawVc != null && rawVc !== "" && Number.isFinite(Number(rawVc))
+      ? Number(rawVc)
+      : null;
+  // With a version_code: show that version and everything older (previous
+  // non-cancelled versions). Without it: the full history.
+  const visible =
+    requestedCode != null
+      ? (results ?? []).filter((r) => r.version_code <= requestedCode)
+      : (results ?? []);
+
+  const lang =
+    c.req.query("lang")?.trim() ||
+    (c.req.header("accept-language") ?? "").split(",")[0]?.trim().split(";")[0] ||
+    null;
+
+  return new Response(
+    renderReleaseNotesPage(app, visible, requestedCode, lang),
+    { headers: { "content-type": "text/html; charset=utf-8" } },
+  );
+}
+
 export async function handlePublicAppHistoryDownload(
   c: Context<{ Bindings: Env }>,
 ) {
@@ -189,6 +232,118 @@ function renderHistoryPage(
         el.textContent = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(ms));
       } catch { el.textContent = new Date(ms).toLocaleString(); }
     });
+  </script>
+</body>
+</html>`;
+}
+
+function renderReleaseNotesPage(
+  app: { slug: string; name: string; platform: string; icon_r2_key: string | null },
+  rows: HistoryRow[],
+  requestedCode: number | null,
+  lang: string | null,
+): string {
+  const items = rows
+    .map((row) => {
+      const changelog = resolveChangelog(row.changelog, lang);
+      const featured = requestedCode != null && row.version_code === requestedCode;
+      const isLatest = row.release_status === "active";
+      return `
+    <li class="entry${featured ? " featured" : ""}" id="v${row.version_code}">
+      <div class="rail"><span class="dot"></span></div>
+      <div class="card">
+        <div class="head">
+          <div class="title">
+            <strong>${esc(row.version_name)}</strong>
+            <span class="meta">build ${row.version_code}</span>
+            ${featured ? '<span class="badge you">Current</span>' : isLatest ? '<span class="badge latest">Latest</span>' : ""}
+          </div>
+          <span class="date" data-ts="${row.released_at}"></span>
+        </div>
+        ${
+          changelog
+            ? `<div class="notes">${changelogToHtml(changelog)}</div>`
+            : '<div class="notes muted">No release notes for this version.</div>'
+        }
+      </div>
+    </li>`;
+    })
+    .join("\n");
+
+  // Auto-scroll the requested version into view when it isn't the first entry.
+  const anchor =
+    requestedCode != null && rows.some((r) => r.version_code === requestedCode)
+      ? `v${requestedCode}`
+      : "";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${esc(app.name)} — Release Notes</title>
+  <style>
+    :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --accent: #176f5d; }
+    body { margin: 0; background: #f5f5f2; color: #1e1f22; }
+    main { max-width: 640px; margin: 0 auto; padding: 28px 16px 56px; }
+    header { margin-bottom: 20px; }
+    h1 { margin: 0; font-size: 22px; letter-spacing: -0.01em; }
+    .sub { color: #707782; font-size: 13px; margin-top: 3px; }
+    ul { list-style: none; margin: 0; padding: 0; }
+    .entry { display: grid; grid-template-columns: 20px 1fr; gap: 0; }
+    .rail { position: relative; }
+    .rail .dot { position: absolute; top: 22px; left: 4px; width: 9px; height: 9px; border-radius: 50%; background: #c3c7cd; box-shadow: 0 0 0 4px #f5f5f2; }
+    .entry::before { content: ""; grid-column: 1; justify-self: center; width: 2px; background: #e0e0dc; }
+    .entry:first-child::before { margin-top: 22px; }
+    .entry:last-child::before { margin-bottom: calc(100% - 22px); }
+    .card { padding: 14px 0 22px 8px; min-width: 0; }
+    .featured .rail .dot { background: var(--accent); }
+    .featured .card { background: rgba(23,111,93,0.06); border-radius: 10px; padding: 14px 16px 18px; margin-bottom: 8px; }
+    .head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+    .title strong { font-size: 16px; }
+    .meta { color: #707782; font-size: 13px; margin-left: 8px; }
+    .badge { border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 600; margin-left: 8px; vertical-align: middle; }
+    .badge.latest { background: #d8f3e8; color: var(--accent); }
+    .badge.you { background: var(--accent); color: #fff; }
+    .date { color: #9aa0a9; font-size: 12px; white-space: nowrap; }
+    .notes { margin: 8px 0 0; font-size: 14px; line-height: 1.55; color: #3b3f45; overflow-wrap: anywhere; }
+    .notes.muted { color: #9aa0a9; }
+    .notes ul { margin: 6px 0; padding-left: 20px; list-style: disc; }
+    .notes li { margin: 3px 0; }
+    .notes p { margin: 6px 0; }
+    .notes code { background: rgba(125,125,125,0.15); border-radius: 4px; padding: 1px 4px; font-size: 0.92em; }
+    .empty { color: #707782; font-size: 14px; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #17191c; color: #f5f5f2; }
+      .sub, .meta, .date, .notes.muted { color: #aeb5bf; }
+      .notes { color: #d2d6dc; }
+      .rail .dot { box-shadow: 0 0 0 4px #17191c; }
+      .entry::before { background: #33373d; }
+      .featured .card { background: rgba(23,111,93,0.14); }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>What's new in ${esc(app.name)}</h1>
+      <div class="sub">Release notes</div>
+    </header>
+    ${rows.length === 0 ? '<p class="empty">No release notes yet.</p>' : `<ul>${items}</ul>`}
+  </main>
+  <script>
+    document.querySelectorAll(".date").forEach((el) => {
+      const ms = Number(el.dataset.ts);
+      if (!Number.isFinite(ms)) return;
+      try {
+        el.textContent = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(new Date(ms));
+      } catch { el.textContent = new Date(ms).toLocaleDateString(); }
+    });
+    ${
+      anchor
+        ? `try { document.getElementById(${JSON.stringify(anchor)})?.scrollIntoView({ block: "start" }); } catch {}`
+        : ""
+    }
   </script>
 </body>
 </html>`;


### PR DESCRIPTION
Task #90. Serves a public, changelog-first release-notes page embedded
via WebView in the app's Settings. Reuses the history data source
(non-cancelled active+superseded releases, bilingual changelog) but:
- addressable by ?version_code= — features + anchors that version, then
  lists the previous non-cancelled versions; without it, full history
- ?lang= / Accept-Language selects the changelog language
- vertical-timeline raft-style layout, light/dark, no JS framework

Gated by apps.public_history (same opt-in as the history page).

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
