### PR TITLE
feat(ios,ohos-sdk): presigned direct-to-R2 upload for large feedback attachments

### DIFF
--- a/clients/ios/Sources/Quiver/QuiverFeedbackClient.m
+++ b/clients/ios/Sources/Quiver/QuiverFeedbackClient.m
@@ -9,6 +9,14 @@
 
 static NSString *const QuiverErrorDomain = @"Quiver";
 static NSTimeInterval const QuiverRequestTimeout = 30.0;
+static NSTimeInterval const QuiverUploadTimeout = 120.0;
+
+// Server-enforced: at most 9 attachments per ticket.
+static NSUInteger const QuiverMaxAttachments = 9;
+// Files up to this size stream inline in the multipart body.
+static unsigned long long const QuiverMultipartMaxBytes = 10ULL * 1024 * 1024;
+// Files up to this size upload via presigned direct-to-R2 PUT.
+static unsigned long long const QuiverPresignMaxBytes = 200ULL * 1024 * 1024;
 
 static NSString *QuiverHardwareModel(void) {
     struct utsname systemInfo;
@@ -29,6 +37,22 @@ static NSString *QuiverArch(void) {
 #endif
 }
 
+static NSString *QuiverContentType(NSString *name) {
+    NSString *lower = name.lowercaseString;
+    if ([lower hasSuffix:@".png"]) return @"image/png";
+    if ([lower hasSuffix:@".jpg"] || [lower hasSuffix:@".jpeg"]) return @"image/jpeg";
+    if ([lower hasSuffix:@".webp"]) return @"image/webp";
+    if ([lower hasSuffix:@".txt"] || [lower hasSuffix:@".log"]) return @"text/plain";
+    if ([lower hasSuffix:@".json"] || [lower hasSuffix:@".jsonl"]) return @"application/json";
+    if ([lower hasSuffix:@".zip"]) return @"application/zip";
+    return @"application/octet-stream";
+}
+
+static unsigned long long QuiverFileSize(NSString *path) {
+    NSDictionary *attrs = [NSFileManager.defaultManager attributesOfItemAtPath:path error:nil];
+    return attrs ? [attrs[NSFileSize] unsignedLongLongValue] : 0;
+}
+
 static void QuiverAppendFormField(NSMutableData *body, NSString *boundary, NSString *name, NSString *value) {
     NSMutableString *part = [NSMutableString string];
     [part appendFormat:@"--%@\r\n", boundary];
@@ -37,6 +61,12 @@ static void QuiverAppendFormField(NSMutableData *body, NSString *boundary, NSStr
     [body appendData:[part dataUsingEncoding:NSUTF8StringEncoding]];
     [body appendData:[value dataUsingEncoding:NSUTF8StringEncoding]];
     [body appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+}
+
+static NSError *QuiverErrorWithMessage(NSInteger code, NSString *detail) {
+    return [NSError errorWithDomain:QuiverErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey : detail ?: @"unknown error"}];
 }
 
 @implementation QuiverFeedbackClient
@@ -65,41 +95,107 @@ static void QuiverAppendFormField(NSMutableData *body, NSString *boundary, NSStr
           attachmentPaths:(NSArray<NSString *> *)attachmentPaths
                    extras:(NSDictionary<NSString *, NSString *> *)extras
                completion:(void (^)(NSString *_Nullable, NSError *_Nullable))completion {
-    NSString *boundary = [NSString stringWithFormat:@"Quiver%@", NSUUID.UUID.UUIDString];
-    NSMutableData *body = [NSMutableData data];
-    QuiverAppendFormField(body, boundary, @"message", message ?: @"");
-    QuiverAppendFormField(body, boundary, @"kind", kind.length > 0 ? kind : @"feedback");
+    QuiverConfig *config = Quiver.config;
+    if (!config) {
+        completion(nil, QuiverErrorWithMessage(0, @"Quiver not started"));
+        return;
+    }
 
+    // Cap at 9 and split by size: small files stream inline in the multipart
+    // body, large files upload directly to R2 via a presigned PUT first.
+    NSMutableArray<NSString *> *inlinePaths = [NSMutableArray array];
+    NSMutableArray<NSString *> *largePaths = [NSMutableArray array];
+    for (NSString *path in attachmentPaths) {
+        if (![NSFileManager.defaultManager fileExistsAtPath:path]) continue;
+        if (inlinePaths.count + largePaths.count >= QuiverMaxAttachments) break;
+        unsigned long long size = QuiverFileSize(path);
+        if (size == 0) continue;
+        if (size > QuiverPresignMaxBytes) {
+            completion(nil, QuiverErrorWithMessage(0, [NSString stringWithFormat:@"attachment %@ exceeds the 200 MB limit", path.lastPathComponent]));
+            return;
+        }
+        if (size > QuiverMultipartMaxBytes) {
+            [largePaths addObject:path];
+        } else {
+            [inlinePaths addObject:path];
+        }
+    }
+
+    NSString *metadataText = [self metadataTextWithExtras:extras];
+
+    if (largePaths.count == 0) {
+        [self sendTicketWithMessage:message
+                               kind:kind
+                       metadataText:metadataText
+                        inlinePaths:inlinePaths
+                      presignedRefs:@[]
+                             config:config
+                         completion:completion];
+        return;
+    }
+
+    [self uploadLargeAttachments:largePaths
+                          config:config
+                      completion:^(NSArray<NSDictionary *> *_Nullable refs, NSError *_Nullable error) {
+        if (error) {
+            completion(nil, error);
+            return;
+        }
+        [self sendTicketWithMessage:message
+                               kind:kind
+                       metadataText:metadataText
+                        inlinePaths:inlinePaths
+                      presignedRefs:refs
+                             config:config
+                         completion:completion];
+    }];
+}
+
++ (NSString *)metadataTextWithExtras:(NSDictionary<NSString *, NSString *> *)extras {
     NSDictionary *metadata = [self metadataWithExtras:extras];
     NSData *metadataData = [NSJSONSerialization dataWithJSONObject:metadata options:0 error:nil];
     NSString *metadataText = metadataData
         ? [[NSString alloc] initWithData:metadataData encoding:NSUTF8StringEncoding]
         : @"{}";
+    return metadataText ?: @"{}";
+}
+
++ (void)sendTicketWithMessage:(NSString *)message
+                         kind:(NSString *)kind
+                 metadataText:(NSString *)metadataText
+                  inlinePaths:(NSArray<NSString *> *)inlinePaths
+                presignedRefs:(NSArray<NSDictionary *> *)presignedRefs
+                       config:(QuiverConfig *)config
+                   completion:(void (^)(NSString *_Nullable, NSError *_Nullable))completion {
+    NSString *boundary = [NSString stringWithFormat:@"Quiver%@", NSUUID.UUID.UUIDString];
+    NSMutableData *body = [NSMutableData data];
+    QuiverAppendFormField(body, boundary, @"message", message ?: @"");
+    QuiverAppendFormField(body, boundary, @"kind", kind.length > 0 ? kind : @"feedback");
     QuiverAppendFormField(body, boundary, @"metadata", metadataText ?: @"{}");
 
-    for (NSString *path in attachmentPaths) {
+    for (NSString *path in inlinePaths) {
         NSData *fileData = [NSData dataWithContentsOfFile:path];
         if (!fileData) {
             continue;
         }
-        NSString *fileName = path.lastPathComponent ?: @"attachment.txt";
+        NSString *fileName = path.lastPathComponent ?: @"attachment";
         NSMutableString *part = [NSMutableString string];
         [part appendFormat:@"--%@\r\n", boundary];
         [part appendFormat:@"Content-Disposition: form-data; name=\"attachments\"; filename=\"%@\"\r\n", fileName];
-        [part appendString:@"Content-Type: text/plain\r\n\r\n"];
+        [part appendFormat:@"Content-Type: %@\r\n\r\n", QuiverContentType(fileName)];
         [body appendData:[part dataUsingEncoding:NSUTF8StringEncoding]];
         [body appendData:fileData];
         [body appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
     }
+
+    if (presignedRefs.count > 0) {
+        NSData *refsData = [NSJSONSerialization dataWithJSONObject:presignedRefs options:0 error:nil];
+        NSString *refsText = refsData ? [[NSString alloc] initWithData:refsData encoding:NSUTF8StringEncoding] : @"[]";
+        QuiverAppendFormField(body, boundary, @"presigned", refsText ?: @"[]");
+    }
+
     [body appendData:[[NSString stringWithFormat:@"--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
 
-    QuiverConfig *config = Quiver.config;
-    if (!config) {
-        completion(nil, [NSError errorWithDomain:QuiverErrorDomain
-                                            code:0
-                                        userInfo:@{NSLocalizedDescriptionKey : @"Quiver not started"}]);
-        return;
-    }
     NSString *urlText = [NSString stringWithFormat:@"%@/public/v2/apps/%@/feedback",
                                                    config.baseUrl, config.appSlug];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlText]];
@@ -108,7 +204,7 @@ static void QuiverAppendFormField(NSMutableData *body, NSString *boundary, NSStr
     [request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary]
         forHTTPHeaderField:@"Content-Type"];
     [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    [request setValue:(Quiver.config.clientKey ?: @"") forHTTPHeaderField:@"X-Quiver-Client-Key"];
+    [request setValue:(config.clientKey ?: @"") forHTTPHeaderField:@"X-Quiver-Client-Key"];
     [request setValue:[QuiverDeviceId deviceId] forHTTPHeaderField:@"X-Quiver-Device-Id"];
 
     NSURLSessionUploadTask *task = [NSURLSession.sharedSession
@@ -129,12 +225,116 @@ static void QuiverAppendFormField(NSMutableData *body, NSString *boundary, NSStr
                     NSString *detail = [parsed isKindOfClass:NSDictionary.class] && parsed[@"error"]
                         ? [NSString stringWithFormat:@"%@", parsed[@"error"]]
                         : [NSString stringWithFormat:@"HTTP %ld", (long)statusCode];
-                    completion(nil, [NSError errorWithDomain:QuiverErrorDomain
-                                                        code:statusCode
-                                                    userInfo:@{NSLocalizedDescriptionKey : detail}]);
+                    completion(nil, QuiverErrorWithMessage(statusCode, detail));
                     return;
                 }
                 completion(ticketId, nil);
+            }];
+    [task resume];
+}
+
+/// Presign the whole batch, then PUT each large file to R2 sequentially,
+/// returning the `presigned` refs the ticket references.
++ (void)uploadLargeAttachments:(NSArray<NSString *> *)paths
+                        config:(QuiverConfig *)config
+                    completion:(void (^)(NSArray<NSDictionary *> *_Nullable, NSError *_Nullable))completion {
+    NSMutableArray<NSDictionary *> *requestFiles = [NSMutableArray array];
+    for (NSString *path in paths) {
+        NSString *fileName = path.lastPathComponent ?: @"attachment";
+        [requestFiles addObject:@{
+            @"filename" : fileName,
+            @"content_type" : QuiverContentType(fileName),
+            @"size" : @(QuiverFileSize(path)),
+        }];
+    }
+    NSData *presignBody = [NSJSONSerialization dataWithJSONObject:@{@"files" : requestFiles} options:0 error:nil];
+
+    NSString *presignUrl = [NSString stringWithFormat:@"%@/public/v2/apps/%@/feedback/presign",
+                                                      config.baseUrl, config.appSlug];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:presignUrl]];
+    request.HTTPMethod = @"POST";
+    request.timeoutInterval = QuiverRequestTimeout;
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [request setValue:(config.clientKey ?: @"") forHTTPHeaderField:@"X-Quiver-Client-Key"];
+
+    NSURLSessionUploadTask *task = [NSURLSession.sharedSession
+        uploadTaskWithRequest:request
+                     fromData:(presignBody ?: [NSData data])
+            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error) {
+                    completion(nil, error);
+                    return;
+                }
+                NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+                NSDictionary *parsed = data.length > 0
+                    ? [NSJSONSerialization JSONObjectWithData:data options:0 error:nil]
+                    : nil;
+                NSArray *uploads = [parsed isKindOfClass:NSDictionary.class] ? parsed[@"uploads"] : nil;
+                if (statusCode < 200 || statusCode >= 300 || ![uploads isKindOfClass:NSArray.class]) {
+                    completion(nil, QuiverErrorWithMessage(statusCode, [NSString stringWithFormat:@"presign failed: HTTP %ld", (long)statusCode]));
+                    return;
+                }
+                [self putFileAtIndex:0
+                               paths:paths
+                             uploads:uploads
+                         accumulated:[NSMutableArray array]
+                          completion:completion];
+            }];
+    [task resume];
+}
+
++ (void)putFileAtIndex:(NSUInteger)index
+                 paths:(NSArray<NSString *> *)paths
+               uploads:(NSArray *)uploads
+           accumulated:(NSMutableArray<NSDictionary *> *)refs
+            completion:(void (^)(NSArray<NSDictionary *> *_Nullable, NSError *_Nullable))completion {
+    if (index >= paths.count) {
+        completion(refs, nil);
+        return;
+    }
+    NSString *path = paths[index];
+    NSString *fileName = path.lastPathComponent ?: @"attachment";
+    NSDictionary *upload = index < uploads.count && [uploads[index] isKindOfClass:NSDictionary.class] ? uploads[index] : nil;
+    NSString *uploadUrl = [upload[@"upload_url"] isKindOfClass:NSString.class] ? upload[@"upload_url"] : nil;
+    NSString *r2Key = [upload[@"r2_key"] isKindOfClass:NSString.class] ? upload[@"r2_key"] : nil;
+    if (uploadUrl.length == 0 || r2Key.length == 0) {
+        completion(nil, QuiverErrorWithMessage(0, [NSString stringWithFormat:@"presign entry %lu missing upload_url/r2_key", (unsigned long)index]));
+        return;
+    }
+
+    NSString *contentType = QuiverContentType(fileName);
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:uploadUrl]];
+    request.HTTPMethod = @"PUT";
+    request.timeoutInterval = QuiverUploadTimeout;
+    // The presigned PUT signs the content-type, so it must match exactly.
+    [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+
+    NSURL *fileURL = [NSURL fileURLWithPath:path];
+    NSURLSessionUploadTask *task = [NSURLSession.sharedSession
+        uploadTaskWithRequest:request
+                     fromFile:fileURL
+            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error) {
+                    completion(nil, error);
+                    return;
+                }
+                NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+                if (statusCode < 200 || statusCode >= 300) {
+                    completion(nil, QuiverErrorWithMessage(statusCode, [NSString stringWithFormat:@"R2 upload failed for %@: HTTP %ld", fileName, (long)statusCode]));
+                    return;
+                }
+                [refs addObject:@{
+                    @"r2_key" : r2Key,
+                    @"filename" : fileName,
+                    @"content_type" : contentType,
+                    @"size" : @(QuiverFileSize(path)),
+                }];
+                [self putFileAtIndex:index + 1
+                               paths:paths
+                             uploads:uploads
+                         accumulated:refs
+                          completion:completion];
             }];
     [task resume];
 }

--- a/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
@@ -15,8 +15,15 @@ const UPLOAD_TIMEOUT_MS: number = 120000;
 const MAX_ATTACHMENTS: number = 9;
 /** Files up to this size stream inline in the multipart body. */
 const MULTIPART_MAX_BYTES: number = 10 * 1024 * 1024;
-/** Files up to this size upload via presigned direct-to-R2 PUT. */
-const PRESIGN_MAX_BYTES: number = 200 * 1024 * 1024;
+/**
+ * Files up to this size upload via presigned direct-to-R2 PUT. Capped at
+ * 50 MB on OHOS (vs 200 MB on Android/iOS): ArkTS has no file-path raw-PUT
+ * API, so the file is read fully into an ArrayBuffer, and a 200 MB upload can
+ * spike memory into an OOM process-kill rather than a handleable error. This
+ * returns a clean cap error instead. A follow-up will switch to a NAPI/native
+ * streaming PUT and raise this to 200 MB.
+ */
+const PRESIGN_MAX_BYTES: number = 50 * 1024 * 1024;
 
 export interface QuiverFeedbackExtras {
   key: string;
@@ -84,9 +91,11 @@ function readFileBytes(path: string): ArrayBuffer {
  * QuiverFeedback. Device and app metadata are attached automatically.
  *
  * Attachments: up to 9 files. Small files (<= 10 MB) stream inline in the
- * multipart body. Larger files (up to 200 MB) upload directly to R2 via a
- * server-issued presigned URL and are referenced in the ticket, so big logs /
- * recordings never pass through the Worker body limit.
+ * multipart body. Larger files (up to 50 MB on OHOS) upload directly to R2 via
+ * a server-issued presigned URL and are referenced in the ticket, so bigger
+ * logs / recordings never pass through the Worker body limit. (Android/iOS
+ * stream the presigned PUT and allow up to 200 MB; OHOS reads the file into
+ * memory — see PRESIGN_MAX_BYTES.)
  */
 export class QuiverFeedbackClient {
   /**

--- a/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
@@ -34,6 +34,12 @@ interface QuiverPresignResponse {
   uploads?: QuiverPresignUpload[];
 }
 
+interface QuiverPresignRequestFile {
+  filename: string;
+  content_type: string;
+  size: number;
+}
+
 interface QuiverPresignedRef {
   r2_key: string;
   filename: string;
@@ -188,7 +194,7 @@ export class QuiverFeedbackClient {
     client: http.HttpRequest,
     paths: string[],
   ): Promise<QuiverPresignedRef[]> {
-    const requestFiles = paths.map((path) => {
+    const requestFiles: QuiverPresignRequestFile[] = paths.map((path): QuiverPresignRequestFile => {
       const fileName = path.split('/').pop() ?? 'attachment';
       return {
         filename: fileName,

--- a/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
@@ -1,6 +1,7 @@
 import { bundleManager, common } from '@kit.AbilityKit';
 import deviceInfo from '@ohos.deviceInfo';
 import http from '@ohos.net.http';
+import fs from '@ohos.file.fs';
 import i18n from '@ohos.i18n';
 import hilog from '@ohos.hilog';
 import { Quiver } from './Quiver';
@@ -8,16 +9,78 @@ import { QuiverDeviceId } from './QuiverDeviceId';
 
 const TAG: string = 'QuiverFeedbackClient';
 const REQUEST_TIMEOUT_MS: number = 30000;
+const UPLOAD_TIMEOUT_MS: number = 120000;
+
+/** Server-enforced: at most 9 attachments per ticket. */
+const MAX_ATTACHMENTS: number = 9;
+/** Files up to this size stream inline in the multipart body. */
+const MULTIPART_MAX_BYTES: number = 10 * 1024 * 1024;
+/** Files up to this size upload via presigned direct-to-R2 PUT. */
+const PRESIGN_MAX_BYTES: number = 200 * 1024 * 1024;
 
 export interface QuiverFeedbackExtras {
   key: string;
   value: string;
 }
 
+interface QuiverPresignUpload {
+  attachment_id?: string;
+  r2_key?: string;
+  upload_url?: string;
+  expires_at?: number;
+}
+
+interface QuiverPresignResponse {
+  uploads?: QuiverPresignUpload[];
+}
+
+interface QuiverPresignedRef {
+  r2_key: string;
+  filename: string;
+  content_type: string;
+  size: number;
+}
+
+function guessContentType(name: string): string {
+  const lower = name.toLowerCase();
+  if (lower.endsWith('.png')) return 'image/png';
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  if (lower.endsWith('.webp')) return 'image/webp';
+  if (lower.endsWith('.txt') || lower.endsWith('.log')) return 'text/plain';
+  if (lower.endsWith('.json') || lower.endsWith('.jsonl')) return 'application/json';
+  if (lower.endsWith('.zip')) return 'application/zip';
+  return 'application/octet-stream';
+}
+
+function fileSize(path: string): number {
+  try {
+    return fs.statSync(path).size;
+  } catch (err) {
+    return 0;
+  }
+}
+
+function readFileBytes(path: string): ArrayBuffer {
+  const stat = fs.statSync(path);
+  const buffer = new ArrayBuffer(stat.size);
+  const file = fs.openSync(path, fs.OpenMode.READ_ONLY);
+  try {
+    fs.readSync(file.fd, buffer);
+  } finally {
+    fs.closeSync(file);
+  }
+  return buffer;
+}
+
 /**
  * Submits feedback / crash tickets to the Quiver feedback endpoint
  * (multipart/form-data) — the OHOS counterpart of the Android SDK's
  * QuiverFeedback. Device and app metadata are attached automatically.
+ *
+ * Attachments: up to 9 files. Small files (<= 10 MB) stream inline in the
+ * multipart body. Larger files (up to 200 MB) upload directly to R2 via a
+ * server-issued presigned URL and are referenced in the ticket, so big logs /
+ * recordings never pass through the Worker body limit.
  */
 export class QuiverFeedbackClient {
   /**
@@ -46,35 +109,44 @@ export class QuiverFeedbackClient {
       metadata[extra.key] = extra.value;
     }
 
-    const multiFormDataList: Array<http.MultiFormData> = [
-      {
-        name: 'message',
-        contentType: 'text/plain',
-        data: message,
-      },
-      {
-        name: 'kind',
-        contentType: 'text/plain',
-        data: kind,
-      },
-      {
-        name: 'metadata',
-        contentType: 'text/plain',
-        data: JSON.stringify(metadata),
-      },
-    ];
-    for (const path of attachmentPaths) {
-      const fileName = path.split('/').pop() ?? 'attachment.txt';
-      multiFormDataList.push({
-        name: 'attachments',
-        contentType: 'text/plain',
-        remoteFileName: fileName,
-        filePath: path,
-      });
+    const selected = attachmentPaths.filter((p) => fileSize(p) > 0).slice(0, MAX_ATTACHMENTS);
+    for (const path of selected) {
+      if (fileSize(path) > PRESIGN_MAX_BYTES) {
+        throw new Error(`attachment ${path} exceeds the ${PRESIGN_MAX_BYTES / (1024 * 1024)} MB limit`);
+      }
     }
+    const inline = selected.filter((p) => fileSize(p) <= MULTIPART_MAX_BYTES);
+    const large = selected.filter((p) => fileSize(p) > MULTIPART_MAX_BYTES);
 
     const client = http.createHttp();
     try {
+      // Large attachments go straight to R2 via presigned PUT before the
+      // ticket is submitted; the ticket then references them by r2_key.
+      const presignedRefs: QuiverPresignedRef[] =
+        large.length > 0 ? await QuiverFeedbackClient.uploadLargeAttachments(client, large) : [];
+
+      const multiFormDataList: Array<http.MultiFormData> = [
+        { name: 'message', contentType: 'text/plain', data: message },
+        { name: 'kind', contentType: 'text/plain', data: kind },
+        { name: 'metadata', contentType: 'text/plain', data: JSON.stringify(metadata) },
+      ];
+      for (const path of inline) {
+        const fileName = path.split('/').pop() ?? 'attachment';
+        multiFormDataList.push({
+          name: 'attachments',
+          contentType: guessContentType(fileName),
+          remoteFileName: fileName,
+          filePath: path,
+        });
+      }
+      if (presignedRefs.length > 0) {
+        multiFormDataList.push({
+          name: 'presigned',
+          contentType: 'application/json',
+          data: JSON.stringify(presignedRefs),
+        });
+      }
+
       const response = await client.request(
         `${Quiver.config.baseUrl}/public/v2/apps/${Quiver.config.appSlug}/feedback`,
         {
@@ -105,5 +177,77 @@ export class QuiverFeedbackClient {
     } finally {
       client.destroy();
     }
+  }
+
+  /**
+   * Presign + PUT each large file directly to R2, returning the `presigned`
+   * refs the submit call references. One presign request covers the batch;
+   * the server returns upload URLs in the same order as the request.
+   */
+  private static async uploadLargeAttachments(
+    client: http.HttpRequest,
+    paths: string[],
+  ): Promise<QuiverPresignedRef[]> {
+    const requestFiles = paths.map((path) => {
+      const fileName = path.split('/').pop() ?? 'attachment';
+      return {
+        filename: fileName,
+        content_type: guessContentType(fileName),
+        size: fileSize(path),
+      };
+    });
+
+    const presignResponse = await client.request(
+      `${Quiver.config.baseUrl}/public/v2/apps/${Quiver.config.appSlug}/feedback/presign`,
+      {
+        method: http.RequestMethod.POST,
+        header: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-Quiver-Client-Key': Quiver.config.clientKey,
+        },
+        extraData: JSON.stringify({ files: requestFiles }),
+        connectTimeout: REQUEST_TIMEOUT_MS,
+        readTimeout: REQUEST_TIMEOUT_MS,
+      },
+    );
+    const presignCode = Number(presignResponse.responseCode ?? 0);
+    const presignBody = typeof presignResponse.result === 'string' ? presignResponse.result : '';
+    if (presignCode < 200 || presignCode >= 300) {
+      throw new Error(`quiver presign failed: HTTP ${presignCode}`);
+    }
+    const uploads = (JSON.parse(presignBody) as QuiverPresignResponse).uploads ?? [];
+
+    const refs: QuiverPresignedRef[] = [];
+    for (let index = 0; index < paths.length; index++) {
+      const path = paths[index];
+      const fileName = path.split('/').pop() ?? 'attachment';
+      const upload = uploads[index];
+      const uploadUrl = upload?.upload_url ?? '';
+      const r2Key = upload?.r2_key ?? '';
+      if (uploadUrl.length === 0 || r2Key.length === 0) {
+        throw new Error(`quiver presign entry ${index} missing upload_url/r2_key`);
+      }
+      const contentType = guessContentType(fileName);
+      // The presigned PUT signs the content-type, so it must match exactly.
+      const putResponse = await client.request(uploadUrl, {
+        method: http.RequestMethod.PUT,
+        header: { 'Content-Type': contentType },
+        extraData: readFileBytes(path),
+        connectTimeout: REQUEST_TIMEOUT_MS,
+        readTimeout: UPLOAD_TIMEOUT_MS,
+      });
+      const putCode = Number(putResponse.responseCode ?? 0);
+      if (putCode < 200 || putCode >= 300) {
+        throw new Error(`quiver R2 upload failed for ${fileName}: HTTP ${putCode}`);
+      }
+      refs.push({
+        r2_key: r2Key,
+        filename: fileName,
+        content_type: contentType,
+        size: fileSize(path),
+      });
+    }
+    return refs;
   }
 }


### PR DESCRIPTION
Mirrors the Android SDK (PR #89): raises the feedback cap to 9 files /
200 MB. Small files (<=10 MB) stream inline in the multipart body; larger
files upload directly to R2 via a server-issued presigned PUT
(POST /feedback/presign) and are referenced by r2_key, so big logs /
recordings never hit the Worker body limit. The presigned PUT sends the
exact signed content-type. Also fixes attachment Content-Type (was
hardcoded text/plain) to a guessed type on both platforms.

iOS: NSURLSession, streams the PUT from file (fromFile:) so 200 MB never
loads into memory; sequential PUTs via a recursive completion chain.
OHOS: @ohos.net.http PUT with the file bytes read via @ohos.file.fs.

⚠️ UNVERIFIED: no iOS/OHOS PR CI and no local Xcode/DevEco to compile
these. Needs DevEco (OHOS) + Xcode (iOS) compile + on-device check before
publishing the pod/HAR. Part of task #92.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
