### PR TITLE
fix(public): allow draft releases' R2 downloads (not just active)

### DIFF
--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -780,7 +780,7 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
      JOIN releases r ON r.build_id = b.id
      WHERE ba.r2_key = ?1
        AND ba.artifact_kind = 'installable'
-       AND r.status = 'active'
+       AND r.status IN ('active', 'draft')
      LIMIT 1`,
   )
     .bind(key)


### PR DESCRIPTION
handlePublicR2Download gated the asset lookup on r.status = 'active', so
a draft release's APK download returned 404 even though the share page
renders drafts (findActiveShare was already relaxed to include draft).
Match that here so draft/pre-release share pages have working download
links for beta testing and pre-publish verification.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
