### PR TITLE
fix(feedback): guard ticket_url origin against missing request URL

### DIFF
--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -397,7 +397,12 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     : versionCode != null
       ? String(versionCode)
       : null;
-  const ticketUrl = `${new URL(c.req.url).origin}/apps/${app.id}/feedback/${ticketId}`;
+  let ticketUrl: string | null = null;
+  try {
+    ticketUrl = `${new URL(c.req.url).origin}/apps/${app.id}/feedback/${ticketId}`;
+  } catch {
+    ticketUrl = null;
+  }
   const reference = [app.slug, versionLabel, `ticket ${ticketId.slice(0, 8)}`]
     .filter(Boolean)
     .join(" · ");


### PR DESCRIPTION
new URL(c.req.url) threw ERR_INVALID_URL when c.req.url is undefined
(broke the worker tests). Wrap it so ticket_url degrades to null instead
of throwing; the reference string (slug/version/id) is unaffected.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
