### PR TITLE
fix(admin): pin the left rail to the viewport so the account avatar stays visible

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -125,7 +125,7 @@ function Header({ account }: { account: AuthAccount }) {
     }`;
 
   return (
-    <header className="flex w-16 flex-none flex-col items-center border-r border-slate-200 bg-white py-3">
+    <header className="sticky top-0 h-screen flex w-16 flex-none flex-col items-center border-r border-slate-200 bg-white py-3">
       <Link to="/" aria-label="Quiver" className="mb-4">
         <QuiverMark className="h-9 w-9" />
       </Link>


### PR DESCRIPTION
The rail (Header) had no height cap, so on tall pages (e.g. app detail)
it stretched to the full content height and the bottom-anchored account
avatar/menu was pushed far below the fold — you couldn't reach it to
switch accounts. Make the rail sticky top-0 h-screen so it's always
viewport-height with the avatar at the bottom of the visible area.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
