### PR TITLE
fix(notes): don't auto-scroll to the requested version

### DIFF
--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -330,12 +330,6 @@ function renderReleaseNotesPage(
     })
     .join("\n");
 
-  // Auto-scroll the requested version into view when it isn't the first entry.
-  const anchor =
-    requestedCode != null && rows.some((r) => r.version_code === requestedCode)
-      ? `v${requestedCode}`
-      : "";
-
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -400,11 +394,6 @@ function renderReleaseNotesPage(
         el.textContent = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(new Date(ms));
       } catch { el.textContent = new Date(ms).toLocaleDateString(); }
     });
-    ${
-      anchor
-        ? `try { document.getElementById(${JSON.stringify(anchor)})?.scrollIntoView({ block: "start" }); } catch {}`
-        : ""
-    }
   </script>
 </body>
 </html>`;


### PR DESCRIPTION
The release-notes page scrolled the requested version into view, which
pushed the 'What's new in {app}' header and intro off-screen. The
requested version is already the featured top entry, so just keep the
page at the top.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
