### PR TITLE
feat(worker): serve Electron generic updates

### DIFF
--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -90,6 +90,48 @@ Returns the latest compatible installable release for the channel,
 independent of the client's installed version. Accepts the same `lang` and
 `device_id` inputs as the update check.
 
+## Electron Generic Provider
+
+Electron apps using `electron-updater` can point the generic provider at
+Quiver:
+
+```ts
+autoUpdater.setFeedURL({
+  provider: "generic",
+  url: "https://quiver.oranix.io/electron/:appSlug/:channel"
+});
+```
+
+The app then requests electron-builder's standard files directly:
+
+```http
+GET /electron/:appSlug/:channel/latest.yml
+GET /electron/:appSlug/:channel/latest-mac.yml
+GET /electron/:appSlug/:channel/latest-linux.yml
+GET /electron/:appSlug/:channel/:installerFile
+GET /electron/:appSlug/:channel/:installerFile.blockmap
+```
+
+Quiver serves these from the active `electron-installer` release on that
+channel. Phase 1 intentionally hosts electron-builder's generated files
+as-is: upload `latest*.yml`, installers, and `.blockmap` files as build
+assets. Use `artifact_kind = electron-metadata` for `latest*.yml`; use the
+original filename in `variant` or `metadata_json.filename` so relative URLs
+inside the yml resolve unchanged.
+
+Example asset conventions:
+
+| File | `platform` | `arch` | `filetype` | `artifact_kind` |
+|---|---|---|---|---|
+| `latest.yml` | `win32` | `x64` or null | `yml` | `electron-metadata` |
+| `latest-mac.yml` | `darwin` | `arm64` or `x64` | `yml` | `electron-metadata` |
+| `latest-linux.yml` | `linux` | `x64` or `arm64` | `yml` | `electron-metadata` |
+| `Raft Setup 1.2.3.exe` | `win32` | `x64` | `exe` | `installable` |
+| `Raft Setup 1.2.3.exe.blockmap` | `win32` | `x64` | `blockmap` | `electron-blockmap` |
+
+macOS updates still require signed app artifacts. Quiver only hosts the
+already-built and signed files; it does not sign Electron applications.
+
 ## Submit Feedback
 
 ```http

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -44,6 +44,7 @@ import {
   handlePublicV2Latest,
   handlePublicV2UpdateCheck,
 } from "./routes/public_v2";
+import { handleElectronGenericAsset } from "./routes/electron";
 import {
   handleCreateReleaseShare,
   handleListReleaseShares,
@@ -450,6 +451,7 @@ app.get("/public/apps/:slug/channels", handlePublicListChannels);
 app.get("/public/v2/apps/:slug/latest", handlePublicV2Latest);
 app.get("/public/v2/apps/:slug/updates/check", handlePublicV2UpdateCheck);
 app.get("/public/r2/:key", handlePublicR2Download);
+app.get("/electron/:slug/:channel/:file", handleElectronGenericAsset);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
@@ -470,6 +472,7 @@ function isWorkerRoute(pathname: string): boolean {
     pathname === "/docs" ||
     pathname === "/login/raft/callback" ||
     pathname.startsWith("/api/") ||
+    pathname.startsWith("/electron/") ||
     pathname.startsWith("/public/") ||
     pathname.startsWith("/share/") ||
     pathname.startsWith("/docs/") ||

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -250,6 +250,32 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
 
   register(registry, {
     method: "get",
+    path: "/electron/{slug}/{channel}/{file}",
+    tags: ["Public update"],
+    summary: "Serve Electron generic-provider update metadata or artifacts",
+    description:
+      "Hosts electron-builder generated files as-is for electron-updater's generic provider. Store latest*.yml, installers, and .blockmap files as build assets on an active electron-installer release.",
+    request: {
+      params: z.object({
+        slug: z.string().openapi({ param: { name: "slug", in: "path" } }),
+        channel: z.string().openapi({ param: { name: "channel", in: "path" } }),
+        file: z.string().openapi({
+          param: { name: "file", in: "path" },
+          example: "latest.yml",
+        }),
+      }),
+      query: z.object({
+        product_type: z.string().default("electron-installer").optional(),
+      }),
+    },
+    responses: {
+      200: { description: "Electron updater metadata or binary artifact.", content: binary() },
+      404: error("No active Electron release or matching asset was found."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
     path: "/public/r2/{key}",
     tags: ["Public downloads"],
     summary: "Download a signed public release artifact",
@@ -372,4 +398,3 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
 }
 
 export { ErrorResponse };
-

--- a/worker/src/routes/electron.ts
+++ b/worker/src/routes/electron.ts
@@ -1,0 +1,217 @@
+import type { Context } from "hono";
+
+type ElectronAssetRow = {
+  id: string;
+  artifact_kind: string;
+  platform: string;
+  arch: string | null;
+  variant: string | null;
+  filetype: string;
+  r2_key: string;
+  size_bytes: number;
+  metadata_json: string;
+};
+
+const DEFAULT_PRODUCT_TYPE = "electron-installer";
+const ELECTRON_METADATA_KINDS = new Set([
+  "electron-metadata",
+  "update-metadata",
+  "metadata",
+]);
+
+export async function handleElectronGenericAsset(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  const channel = c.req.param("channel") || "main";
+  const rawFile = c.req.param("file");
+  const file = normalizeFileName(rawFile);
+  const productType = c.req.query("product_type") || DEFAULT_PRODUCT_TYPE;
+
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  if (!file) return c.json({ error: "file required" }, 400);
+
+  const build = await c.env.DB.prepare(
+    `SELECT b.id AS build_id
+     FROM apps a
+     JOIN channels ch ON ch.app_id = a.id
+     JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
+     JOIN builds b ON b.id = r.build_id
+     WHERE a.slug = ?1
+       AND ch.slug = ?2
+       AND r.product_type = ?3
+       AND r.status = 'active'
+     ORDER BY r.created_at DESC, r.id ASC
+     LIMIT 1`,
+  )
+    .bind(slug, channel, productType)
+    .first<{ build_id: string }>();
+
+  if (!build) {
+    return c.json(
+      {
+        error: "no active Electron release found",
+        app: slug,
+        channel,
+        product_type: productType,
+      },
+      404,
+    );
+  }
+
+  const { results } = await c.env.DB.prepare(
+    `SELECT id, artifact_kind, platform, arch, variant, filetype, r2_key,
+            size_bytes, metadata_json
+     FROM build_assets
+     WHERE build_id = ?1
+     ORDER BY artifact_kind DESC, platform ASC, arch ASC, filetype ASC, created_at ASC`,
+  )
+    .bind(build.build_id)
+    .all<ElectronAssetRow>();
+
+  const asset = selectElectronAsset(file, results);
+  if (!asset) {
+    return c.json(
+      {
+        error: "Electron release asset not found",
+        app: slug,
+        channel,
+        product_type: productType,
+        file,
+      },
+      404,
+    );
+  }
+
+  const object = await c.env.APK_BUCKET.get(asset.r2_key);
+  if (!object) return c.json({ error: "object not found" }, 404);
+
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+  headers.set("etag", object.httpEtag);
+  headers.set("cache-control", cacheControlForElectronAsset(asset));
+  headers.set("content-type", contentTypeForElectronAsset(asset));
+  headers.set("content-length", String(asset.size_bytes));
+  headers.set("content-disposition", contentDispositionForElectronAsset(file, asset));
+  return new Response(object.body, { headers });
+}
+
+function normalizeFileName(raw: string | undefined): string {
+  if (!raw) return "";
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function selectElectronAsset(
+  requestedFile: string,
+  assets: ElectronAssetRow[],
+): ElectronAssetRow | null {
+  const metadataTarget = electronMetadataTarget(requestedFile);
+  if (metadataTarget) {
+    return findByName(
+      assets.filter((asset) => isElectronMetadataAsset(asset)),
+      requestedFile,
+      metadataTarget.platform,
+    );
+  }
+  return findByName(
+    assets.filter((asset) => !isElectronMetadataAsset(asset)),
+    requestedFile,
+    null,
+  );
+}
+
+function electronMetadataTarget(file: string): { platform: string | null } | null {
+  if (!/\.ya?ml$/i.test(file)) return null;
+  if (file.endsWith("-mac.yml") || file.endsWith("-mac.yaml")) {
+    return { platform: "darwin" };
+  }
+  if (file.endsWith("-linux.yml") || file.endsWith("-linux.yaml")) {
+    return { platform: "linux" };
+  }
+  return { platform: "win32" };
+}
+
+function isElectronMetadataAsset(asset: ElectronAssetRow): boolean {
+  return ELECTRON_METADATA_KINDS.has(asset.artifact_kind) ||
+    asset.filetype === "yml" ||
+    asset.filetype === "yaml";
+}
+
+function findByName(
+  assets: ElectronAssetRow[],
+  requestedFile: string,
+  platform: string | null,
+): ElectronAssetRow | null {
+  const platformMatches = platform
+    ? assets.filter((asset) => asset.platform === platform)
+    : assets;
+  const pool = platformMatches.length > 0 ? platformMatches : assets;
+  return pool.find((asset) => candidateNames(asset).has(requestedFile)) ?? null;
+}
+
+function candidateNames(asset: ElectronAssetRow): Set<string> {
+  const names = new Set<string>();
+  if (asset.variant) names.add(asset.variant);
+  const basename = asset.r2_key.split("/").pop();
+  if (basename) names.add(basename);
+  const metadata = parseMetadata(asset.metadata_json);
+  for (const key of ["filename", "name", "path", "url"]) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim()) {
+      const leaf = value.split("/").pop();
+      names.add(value);
+      if (leaf) names.add(leaf);
+    }
+  }
+  return names;
+}
+
+function parseMetadata(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw || "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function cacheControlForElectronAsset(asset: ElectronAssetRow): string {
+  if (isElectronMetadataAsset(asset)) {
+    return "public, max-age=60, must-revalidate";
+  }
+  return "public, max-age=31536000, immutable";
+}
+
+function contentDispositionForElectronAsset(
+  file: string,
+  asset: ElectronAssetRow,
+): string {
+  const disposition = isElectronMetadataAsset(asset) ? "inline" : "attachment";
+  return `${disposition}; filename="${asciiFilename(file)}"; filename*=UTF-8''${encodeURIComponent(file)}`;
+}
+
+function asciiFilename(value: string): string {
+  return value.replace(/[^A-Za-z0-9._ -]+/g, "_").replace(/"/g, "_") || "artifact";
+}
+
+function contentTypeForElectronAsset(asset: ElectronAssetRow): string {
+  if (isElectronMetadataAsset(asset)) return "text/yaml; charset=utf-8";
+  switch (asset.filetype.toLowerCase()) {
+    case "blockmap":
+      return "application/octet-stream";
+    case "dmg":
+      return "application/x-apple-diskimage";
+    case "exe":
+      return "application/vnd.microsoft.portable-executable";
+    case "appimage":
+      return "application/octet-stream";
+    case "zip":
+      return "application/zip";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -51,6 +51,7 @@ describe("quiver OpenAPI document", () => {
 
     for (const path of [
       "/public/v2/apps/{slug}/updates/check",
+      "/electron/{slug}/{channel}/{file}",
       "/public/v2/apps/{slug}/feedback",
       "/apps/{slug}/history",
       "/api/apps",
@@ -1934,6 +1935,9 @@ describe("quiver public API v2 — scope resolution", () => {
       arch?: string | null;
       filetype?: string;
       sizeBytes?: number;
+      variant?: string | null;
+      r2Key?: string;
+      metadata?: Record<string, unknown>;
     } = {},
   ) {
     await env.DB.prepare(
@@ -1947,13 +1951,13 @@ describe("quiver public API v2 — scope resolution", () => {
         opts.artifactKind ?? "installable",
         opts.platform ?? "android",
         opts.arch ?? null,
-        null,
+        opts.variant ?? null,
         opts.filetype ?? "apk",
-        `apps/app-scope/${assetId}.apk`,
+        opts.r2Key ?? `apps/app-scope/${assetId}.apk`,
         `${assetId}-hash`,
         opts.sizeBytes ?? 42,
         `${assetId}-sig`,
-        "{}",
+        JSON.stringify(opts.metadata ?? {}),
         Date.now(),
       )
       .run();
@@ -2001,6 +2005,30 @@ describe("quiver public API v2 — scope resolution", () => {
         new Response(null, {
           status,
           headers: { location: url },
+        }),
+    } as any;
+  }
+
+  function makeElectronContext(
+    env: MockEnv,
+    file: string,
+    query: Record<string, string | undefined> = {},
+  ) {
+    return {
+      env,
+      req: {
+        param: (name: string) => {
+          if (name === "slug") return "scope-app";
+          if (name === "channel") return "production";
+          if (name === "file") return file;
+          return "";
+        },
+        query: (name: string) => query[name],
+      },
+      json: (data: unknown, status = 200) =>
+        new Response(JSON.stringify(data), {
+          status,
+          headers: { "content-type": "application/json" },
         }),
     } as any;
   }
@@ -2865,6 +2893,108 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(location.searchParams.get("X-Amz-Expires")).toBe("600");
     expect(location.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
     expect(location.searchParams.get("response-content-disposition")).toContain("scope-app-1.0.0-11.apk");
+  });
+
+  it("serves electron-updater generic metadata from the active release", async () => {
+    const env = makeEnv();
+    const { handleElectronGenericAsset } = await import("../src/routes/electron");
+    await seedRelease(env, "rel-electron", "build-electron", [["full", "all"]], {
+      productType: "electron-installer",
+      versionCode: 10203,
+      versionName: "1.2.3",
+    });
+    await seedAsset(env, "build-electron", "asset-latest-yml", {
+      artifactKind: "electron-metadata",
+      platform: "win32",
+      filetype: "yml",
+      variant: "latest.yml",
+      r2Key: "apps/scope-app/electron/latest.yml",
+      sizeBytes: 121,
+      metadata: { filename: "latest.yml" },
+    });
+    env.APK_BUCKET = {
+      get: async (requestedKey: string) => {
+        if (requestedKey !== "apps/scope-app/electron/latest.yml") return null;
+        return {
+          body: new Blob(["version: 1.2.3\nfiles: []\n"]).stream(),
+          httpEtag: "\"latest-yml\"",
+          writeHttpMetadata: (headers: Headers) => {
+            headers.set("content-type", "application/octet-stream");
+          },
+        };
+      },
+    };
+
+    const response = await handleElectronGenericAsset(makeElectronContext(env, "latest.yml"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/yaml; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(response.headers.get("content-disposition")).toContain("inline");
+    expect(await response.text()).toBe("version: 1.2.3\nfiles: []\n");
+  });
+
+  it("serves electron-updater installer and blockmap assets by original filename", async () => {
+    const env = makeEnv();
+    const { handleElectronGenericAsset } = await import("../src/routes/electron");
+    await seedRelease(env, "rel-electron-files", "build-electron-files", [["full", "all"]], {
+      productType: "electron-installer",
+      versionCode: 10203,
+      versionName: "1.2.3",
+    });
+    await seedAsset(env, "build-electron-files", "asset-exe", {
+      artifactKind: "installable",
+      platform: "win32",
+      arch: "x64",
+      filetype: "exe",
+      r2Key: "apps/scope-app/electron/Raft Setup 1.2.3.exe",
+      sizeBytes: 3,
+      metadata: { filename: "Raft Setup 1.2.3.exe" },
+    });
+    await seedAsset(env, "build-electron-files", "asset-blockmap", {
+      artifactKind: "electron-blockmap",
+      platform: "win32",
+      arch: "x64",
+      filetype: "blockmap",
+      r2Key: "apps/scope-app/electron/Raft Setup 1.2.3.exe.blockmap",
+      sizeBytes: 8,
+      metadata: { filename: "Raft Setup 1.2.3.exe.blockmap" },
+    });
+    env.APK_BUCKET = {
+      get: async (requestedKey: string) => {
+        if (requestedKey.endsWith(".blockmap")) {
+          return {
+            body: new Blob(["blockmap"]).stream(),
+            httpEtag: "\"blockmap\"",
+            writeHttpMetadata: () => undefined,
+          };
+        }
+        if (requestedKey.endsWith(".exe")) {
+          return {
+            body: new Blob(["exe"]).stream(),
+            httpEtag: "\"exe\"",
+            writeHttpMetadata: () => undefined,
+          };
+        }
+        return null;
+      },
+    };
+
+    const installer = await handleElectronGenericAsset(
+      makeElectronContext(env, "Raft%20Setup%201.2.3.exe"),
+    );
+    expect(installer.status).toBe(200);
+    expect(installer.headers.get("content-type")).toBe("application/vnd.microsoft.portable-executable");
+    expect(installer.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(installer.headers.get("content-disposition")).toContain("attachment");
+    expect(await installer.text()).toBe("exe");
+
+    const blockmap = await handleElectronGenericAsset(
+      makeElectronContext(env, "Raft%20Setup%201.2.3.exe.blockmap"),
+    );
+    expect(blockmap.status).toBe(200);
+    expect(blockmap.headers.get("content-type")).toBe("application/octet-stream");
+    expect(await blockmap.text()).toBe("blockmap");
   });
 
   it("authenticated build asset download serves support artifacts", async () => {


### PR DESCRIPTION
## Summary
- add public Electron generic-provider route `/electron/:slug/:channel/:file`
- serve uploaded electron-builder `latest*.yml`, installers, and `.blockmap` files from the active `electron-installer` release
- document Phase 1 original-hosting asset conventions in the public API reference, CLI reference, and release runbook
- add OpenAPI coverage and Worker route tests for metadata, installer, and blockmap responses

## Validation
- `pnpm --filter @oranix/quiver-worker test`
- `pnpm --filter @oranix/quiver-worker build`
- `pnpm --filter @oranix/quiver-admin build`
- `git diff --check`
