### PR TITLE
feat(cli): add Electron generic publishing

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -85,6 +85,66 @@ quiver builds publish-android raft-android \
 
 Public update checks only use the installable artifact. Mapping files, native symbols, and metadata stay available through authenticated admin APIs.
 
+## Publish Electron (generic provider)
+
+Quiver can host Electron apps that use `electron-updater` with the generic
+provider:
+
+```ts
+autoUpdater.setFeedURL({
+  provider: "generic",
+  url: "https://quiver.oranix.io/electron/raft-desktop/main"
+});
+```
+
+Quiver hosts electron-builder output **as-is**. Use
+`builds publish-electron` to upload the files from `dist/` as build assets on
+an `electron-installer` build/release, then create a draft release for review:
+
+```bash
+quiver builds publish-electron raft-desktop \
+  --channel main \
+  --version-name 1.2.3 \
+  --version-code 10203 \
+  --platform win32 \
+  --arch x64 \
+  --metadata dist/latest.yml \
+  --installer "dist/Raft Setup 1.2.3.exe" \
+  --blockmap "dist/Raft Setup 1.2.3.exe.blockmap" \
+  --changelog-file ./changelog.txt \
+  --draft
+```
+
+`--metadata`, `--installer`, and `--blockmap` are repeatable. For multi-platform
+Electron apps, run the command once per platform/channel so each release has a
+clear `platform`/`arch` pair. The command preserves original filenames through
+`variant` and `metadata_json.filename`, which lets relative URLs inside
+`latest*.yml` resolve unchanged.
+
+Required files depend on target OS:
+
+| Target | Required files |
+|---|---|
+| Windows NSIS | `latest.yml`, installer `.exe`, optional `.exe.blockmap` |
+| macOS | `latest-mac.yml`, signed `.zip` for auto-update, optional `.dmg` for downloads, `.blockmap` files if generated |
+| Linux | `latest-linux.yml`, `AppImage` or other configured target, `.blockmap` files if generated |
+
+CI systems that need custom orchestration can also call the build, asset, and
+release APIs directly. Register the original filenames using the same fields:
+
+| File | `platform` | `arch` | `filetype` | `artifact_kind` | Filename field |
+|---|---|---|---|---|---|
+| `latest.yml` | `win32` | `x64` or null | `yml` | `electron-metadata` | `variant` or `metadata_json.filename` |
+| `latest-mac.yml` | `darwin` | `arm64` or `x64` | `yml` | `electron-metadata` | `variant` or `metadata_json.filename` |
+| `latest-linux.yml` | `linux` | `x64` or `arm64` | `yml` | `electron-metadata` | `variant` or `metadata_json.filename` |
+| `Raft Setup 1.2.3.exe` | `win32` | `x64` | `exe` | `installable` | `metadata_json.filename` |
+| `Raft Setup 1.2.3.exe.blockmap` | `win32` | `x64` | `blockmap` | `electron-blockmap` | `metadata_json.filename` |
+
+Keep the same draft-first policy as Android: CI creates a draft Electron
+release, then a human or agent reviews release notes and explicitly publishes.
+macOS update artifacts must be signed before upload; Quiver hosts the signed
+files but does not sign Electron applications.
+
 ## Review and Publish (draft flow)
 
 CI creates drafts; publishing is an explicit step after changelog review:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -16,6 +16,46 @@ publishes explicitly.
   **draft** release (invisible to update checks and share pages)
 - job summary shows the draft release id and the raw changelog
 
+For Electron apps, CI should follow the same draft-first rule. Build with
+electron-builder, then publish the generated generic-provider files through
+the CLI:
+
+```sh
+quiver builds publish-electron raft-desktop \
+  --channel main \
+  --version-name 1.2.3 \
+  --version-code 10203 \
+  --platform win32 \
+  --arch x64 \
+  --metadata dist/latest.yml \
+  --installer "dist/Raft Setup 1.2.3.exe" \
+  --blockmap "dist/Raft Setup 1.2.3.exe.blockmap" \
+  --changelog-file ./changelog.txt \
+  --draft
+```
+
+Upload the files electron-builder generated for the target platform:
+
+- `latest.yml`, `latest-mac.yml`, or `latest-linux.yml`
+- installer artifacts such as `.exe`, signed macOS `.zip` / `.dmg`, or
+  `AppImage`
+- `.blockmap` files when electron-builder generated them
+
+Quiver serves the active release at
+`/electron/:appSlug/:channel/:file`, so the Electron app can configure:
+
+```ts
+autoUpdater.setFeedURL({
+  provider: "generic",
+  url: "https://quiver.oranix.io/electron/<appSlug>/<channel>"
+});
+```
+
+`quiver builds publish-electron` preserves original filenames in `variant` and
+`metadata_json.filename`. Advanced CI can also call the build, asset, and
+release APIs directly using the same asset conventions. The Electron release
+should remain `draft` until changelog review is complete.
+
 ## 2. Review + bilingual changelog (agent/human)
 
 ```sh

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -110,3 +110,22 @@ describe("apiRequest", () => {
     delete process.env.QUIVER_API;
   });
 });
+
+describe("electron build helpers", () => {
+  it("infers Electron platforms from metadata and artifact filenames", async () => {
+    const { inferElectronPlatform } = await import("../src/commands/builds.js");
+    expect(inferElectronPlatform("dist/latest.yml")).toBe("win32");
+    expect(inferElectronPlatform("dist/latest-mac.yml")).toBe("darwin");
+    expect(inferElectronPlatform("dist/latest-linux.yml")).toBe("linux");
+    expect(inferElectronPlatform("dist/Raft-1.2.3.AppImage")).toBe("linux");
+    expect(inferElectronPlatform("dist/Raft-1.2.3.dmg")).toBe("darwin");
+  });
+
+  it("infers Electron filetypes without lowercasing AppImage", async () => {
+    const { inferElectronFiletype } = await import("../src/commands/builds.js");
+    expect(inferElectronFiletype("dist/latest.yml")).toBe("yml");
+    expect(inferElectronFiletype("dist/Raft Setup 1.2.3.exe")).toBe("exe");
+    expect(inferElectronFiletype("dist/Raft-1.2.3.AppImage")).toBe("AppImage");
+    expect(inferElectronFiletype("dist/Raft Setup 1.2.3.exe.blockmap")).toBe("blockmap");
+  });
+});

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -6,6 +6,7 @@
 
 import type { Command } from "commander";
 import { existsSync, readFileSync } from "node:fs";
+import { basename, extname } from "node:path";
 import { apiRequest, apiUploadFile } from "../lib/api.js";
 
 interface BuildRow {
@@ -34,6 +35,10 @@ interface ChannelRow {
   id: string;
   slug: string;
   name: string;
+}
+
+function collect(value: string, previous: string[]): string[] {
+  return previous.concat(value);
 }
 
 export function registerBuildCommands(program: Command): void {
@@ -274,6 +279,191 @@ export function registerBuildCommands(program: Command): void {
         console.log(`  assets:  ${assets.map((a) => `${a.artifact_kind}:${a.filetype}`).join(", ")}`);
       },
     );
+
+  builds
+    .command("publish-electron <appIdOrSlug>")
+    .description("Create an Electron generic-provider build/release and upload electron-builder output.")
+    .requiredOption("--version-name <name>", "Electron app version.")
+    .requiredOption("--version-code <code>", "Quiver version code used for ordering.")
+    .option("--metadata <path>", "electron-builder latest*.yml file. Repeatable.", collect, [])
+    .option("--installer <path>", "Electron installer/update artifact. Repeatable.", collect, [])
+    .option("--blockmap <path>", "Electron .blockmap artifact. Repeatable.", collect, [])
+    .option("--channel <slug>", "Quiver channel slug.", "main")
+    .option("--platform <platform>", "Electron platform metadata. Defaults from metadata filename or win32.")
+    .option("--arch <arch>", "Electron arch metadata.")
+    .option("--release-type <type>", "Release type metadata.", "stable")
+    .option("--product-type <type>", "Product type metadata.", "electron-installer")
+    .option("--changelog <text>", "Inline changelog.")
+    .option("--changelog-file <path>", "Read changelog from file.")
+    .option("--source-commit <sha>", "Source commit SHA.")
+    .option("--source-branch <branch>", "Source branch.")
+    .option("--build-time <iso>", "Build time. Defaults to now.")
+    .option("--ci-provider <name>", "CI provider name.")
+    .option("--ci-run-id <id>", "CI run id.")
+    .option("--ci-url <url>", "CI run URL.")
+    .option("--force-update", "Mark release as force update.", false)
+    .option("--draft", "Create draft release instead of active.", false)
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        opts: {
+          versionName: string;
+          versionCode: string;
+          metadata: string[];
+          installer: string[];
+          blockmap: string[];
+          channel: string;
+          platform?: string;
+          arch?: string;
+          releaseType: string;
+          productType: string;
+          changelog?: string;
+          changelogFile?: string;
+          sourceCommit?: string;
+          sourceBranch?: string;
+          buildTime?: string;
+          ciProvider?: string;
+          ciRunId?: string;
+          ciUrl?: string;
+          forceUpdate?: boolean;
+          draft?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        const files = [...opts.metadata, ...opts.installer, ...opts.blockmap];
+        if (files.length === 0) {
+          throw new Error("provide at least one --metadata, --installer, or --blockmap file");
+        }
+        const metadataFiles = opts.metadata;
+        const installerFiles = opts.installer;
+        const blockmapFiles = opts.blockmap;
+        for (const file of files) {
+          if (!existsSync(file)) throw new Error(`missing file: ${file}`);
+        }
+
+        const appId = await resolveAppId(appIdOrSlug);
+        const channelId = await resolveChannelId(appId, opts.channel);
+        const versionCode = Number(opts.versionCode);
+        if (!Number.isFinite(versionCode) || versionCode < 0) {
+          throw new Error("--version-code must be a non-negative number");
+        }
+
+        const primaryPlatform = opts.platform ?? inferElectronPlatform(metadataFiles[0] ?? installerFiles[0]);
+        const arch = opts.arch ?? null;
+        const changelog = opts.changelogFile
+          ? readFileSync(opts.changelogFile, "utf8")
+          : opts.changelog ?? null;
+        const provenance = {
+          source_commit: opts.sourceCommit ?? null,
+          source_branch: opts.sourceBranch ?? null,
+          build_time: opts.buildTime ?? new Date().toISOString(),
+          ci_provider: opts.ciProvider ?? null,
+          ci_run_id: opts.ciRunId ?? null,
+          ci_url: opts.ciUrl ?? null,
+        };
+        const buildMetadata = {
+          electron: {
+            metadata_files: metadataFiles.map((file) => basename(file)),
+            installer_files: installerFiles.map((file) => basename(file)),
+            blockmap_files: blockmapFiles.map((file) => basename(file)),
+            platform: primaryPlatform,
+            arch,
+          },
+        };
+
+        const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
+          method: "POST",
+          body: {
+            channel_id: channelId,
+            product_type: opts.productType,
+            release_type: opts.releaseType,
+            version_name: opts.versionName,
+            version_code: versionCode,
+            changelog,
+            source: "cli",
+            status: "succeeded",
+            build_metadata_json: buildMetadata,
+            provenance_json: provenance,
+            should_force_update: Boolean(opts.forceUpdate),
+          },
+        });
+
+        const assets = [];
+        for (const file of metadataFiles) {
+          const platform = opts.platform ?? inferElectronPlatform(file);
+          const fileName = basename(file);
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, file, {
+              artifact_kind: "electron-metadata",
+              platform,
+              arch,
+              filetype: inferElectronFiletype(file),
+              variant: fileName,
+              metadata_json: { filename: fileName },
+            }),
+          );
+        }
+        for (const file of installerFiles) {
+          const fileName = basename(file);
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, file, {
+              artifact_kind: "installable",
+              platform: primaryPlatform,
+              arch,
+              filetype: inferElectronFiletype(file),
+              metadata_json: { filename: fileName },
+            }),
+          );
+        }
+        for (const file of blockmapFiles) {
+          const fileName = basename(file);
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, file, {
+              artifact_kind: "electron-blockmap",
+              platform: primaryPlatform,
+              arch,
+              filetype: "blockmap",
+              metadata_json: { filename: fileName },
+            }),
+          );
+        }
+
+        const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
+          method: "POST",
+          body: {
+            build_id: build.id,
+            channel_id: channelId,
+            product_type: opts.productType,
+            release_type: opts.releaseType,
+            status: opts.draft ? "draft" : "active",
+            changelog,
+            should_force_update: Boolean(opts.forceUpdate),
+            provenance_json: provenance,
+            scopes: [{ scope_type: "full", scope_value: "all" }],
+          },
+        });
+
+        const result = {
+          app_id: appId,
+          build_id: build.id,
+          release_id: release.id,
+          channel: opts.channel,
+          version_name: opts.versionName,
+          version_code: versionCode,
+          assets,
+        };
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(`Published Electron release ${opts.versionName} (${versionCode})`);
+        console.log(`  build:   ${build.id}`);
+        console.log(`  release: ${release.id}`);
+        console.log(`  channel: ${opts.channel}`);
+        console.log(`  assets:  ${assets.map((a) => `${a.artifact_kind}:${a.filetype}`).join(", ")}`);
+      },
+    );
 }
 
 async function resolveAppId(slugOrId: string): Promise<string> {
@@ -306,10 +496,12 @@ async function uploadAndRegisterAsset(
   buildId: string,
   filePath: string,
   metadata: {
-    artifact_kind: "installable" | "proguard-mapping" | "native-symbols" | "metadata-file";
+    artifact_kind: string;
     platform: string;
     arch: string | null;
     filetype: string;
+    variant?: string | null;
+    metadata_json?: Record<string, unknown>;
   },
 ): Promise<{
   id: string;
@@ -326,8 +518,11 @@ async function uploadAndRegisterAsset(
       r2_key: uploaded.r2_key,
       file_hash: uploaded.file_hash,
       size_bytes: uploaded.size_bytes,
+      variant: metadata.variant ?? null,
       metadata_json: {
         original_filename: uploaded.original_filename,
+        filename: basename(filePath),
+        ...metadata.metadata_json,
       },
     },
   });
@@ -338,4 +533,23 @@ async function uploadAndRegisterAsset(
     file_hash: uploaded.file_hash,
     size_bytes: uploaded.size_bytes,
   };
+}
+
+export function inferElectronPlatform(filePath: string | undefined): string {
+  const name = filePath ? basename(filePath).toLowerCase() : "";
+  if (name.includes("-mac.") || name.includes("mac") || name.endsWith(".dmg")) {
+    return "darwin";
+  }
+  if (name.includes("-linux.") || name.includes("linux") || name.endsWith(".appimage")) {
+    return "linux";
+  }
+  return "win32";
+}
+
+export function inferElectronFiletype(filePath: string): string {
+  const name = basename(filePath);
+  if (name.endsWith(".blockmap")) return "blockmap";
+  if (name.endsWith(".AppImage")) return "AppImage";
+  const ext = extname(name).replace(/^\./, "");
+  return ext || "bin";
 }


### PR DESCRIPTION
## Summary
- add `quiver builds publish-electron` for electron-builder generic-provider output
- upload/register `latest*.yml`, installer artifacts, and `.blockmap` files with the filename metadata used by `/electron/:slug/:channel/:file`
- document both supported publishing paths: the CLI command and direct build/asset/release API orchestration

## Validation
- `pnpm --filter @oranix/quiver-cli test`
- `pnpm --filter @oranix/quiver-cli build`
- `pnpm --filter @oranix/quiver-admin build`
- `node packages/cli/dist/index.js builds publish-electron --help`
- `git diff --check`
