### PR TITLE
chore(cli): bump version to 0.3.2

### DIFF
--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -44,7 +44,7 @@ No global install needed:
 npm exec --package @oranix/quiver-cli -- quiver whoami
 ```
 
-(Pin a version with `@oranix/quiver-cli@0.3.1` if you want reproducibility.)
+(Pin a version with `@oranix/quiver-cli@0.3.2` if you want reproducibility.)
 Every command below takes `--json` for scripting.
 
 ## Triage commands

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -13,7 +13,7 @@ npm install -g @oranix/quiver-cli
 Or run it without a permanent install:
 
 ```bash
-npm exec --package @oranix/quiver-cli@0.2.1 -- quiver --help
+npm exec --package @oranix/quiver-cli@0.3.2 -- quiver --help
 ```
 
 In CI, pin a version so release scripts stay reproducible.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,7 +14,7 @@ npm install -g @oranix/quiver-cli
 quiver --help
 
 # Or run without installing globally:
-npm exec --package @oranix/quiver-cli@0.1.1 -- quiver --help
+npm exec --package @oranix/quiver-cli@0.3.2 -- quiver --help
 
 # Local repo development:
 pnpm --filter @oranix/quiver-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oranix/quiver-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Quiver CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump `@oranix/quiver-cli` to `0.3.2` so the merged Electron CLI can be published to npm
- update public pinned CLI install examples to `0.3.2`

## Context
`0.3.1` is already published on npm from July 5, before `quiver builds publish-electron` merged. npm versions are immutable, so publishing the current merged CLI requires a patch bump.

## Validation
- `pnpm --filter @oranix/quiver-cli test`
- `pnpm --filter @oranix/quiver-cli build`
- `pnpm --filter @oranix/quiver-admin build`
- `git diff --check`
