### PR TITLE
fix(worker): tighten release notes contract

### DIFF
--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -148,7 +148,8 @@ Content-Type: application/json
 }
 ```
 
-The legacy `changelog` string field remains for backward compatibility.
+`changelog` remains the localized display string. `release_notes` is the
+canonical structured object for consumers that need every language.
 
 ## Electron Generic Provider
 

--- a/worker/src/lib/release_notes.ts
+++ b/worker/src/lib/release_notes.ts
@@ -26,11 +26,11 @@ export function parseReleaseNotes(raw: string | null): ReleaseNotes | null {
   if (!raw) return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
-  if (!trimmed.startsWith("{")) return { en: raw };
+  if (!trimmed.startsWith("{")) return null;
   try {
     return normalizeReleaseNotes(JSON.parse(trimmed));
   } catch {
-    return { en: raw };
+    return null;
   }
 }
 
@@ -40,7 +40,15 @@ export function stringifyReleaseNotes(value: unknown): string | null {
 }
 
 export function resolveReleaseNote(raw: string | null, lang: string | null): string | null {
-  const notes = parseReleaseNotes(raw);
+  if (!raw) return raw;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) return raw;
+  let notes: ReleaseNotes | null;
+  try {
+    notes = normalizeReleaseNotes(JSON.parse(trimmed));
+  } catch {
+    return raw;
+  }
   if (!notes) return null;
   const entries = Object.entries(notes).filter(([, value]) => value.length > 0);
   if (entries.length === 0) return null;

--- a/worker/src/openapi/releases.ts
+++ b/worker/src/openapi/releases.ts
@@ -30,7 +30,6 @@ const ReleaseInput = z
     status: z.enum(["draft", "active"]).optional(),
     changelog: z.string().nullable().optional(),
     release_notes: z.record(z.string(), z.string()).nullable().optional(),
-    changelog_i18n: z.record(z.string(), z.string()).optional(),
     rollout_cohort_count: z.number().int().nullable().optional(),
     should_force_update: z.boolean().optional(),
     scopes: z.array(GenericObject).optional(),

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -19,7 +19,6 @@ export interface ReleaseInput {
   status?: "draft" | "active";
   changelog?: string | null;
   release_notes?: ReleaseNotes | null;
-  changelog_i18n?: ReleaseNotes | null;
   should_force_update?: boolean;
   rollout_cohort_count?: number | null;
   rollout_target_cohorts_json?: unknown;
@@ -31,7 +30,6 @@ export interface ReleaseInput {
 interface ReleaseUpdateInput {
   changelog?: string | null;
   release_notes?: ReleaseNotes | null;
-  changelog_i18n?: ReleaseNotes | null;
   should_force_update?: boolean;
   rollout_cohort_count?: number | null;
   rollout_target_cohorts_json?: unknown;
@@ -107,10 +105,8 @@ function releaseStatus(inputStatus: ReleaseInput["status"] | undefined): "draft"
 function inputChangelog(input: {
   changelog?: string | null;
   release_notes?: ReleaseNotes | null;
-  changelog_i18n?: ReleaseNotes | null;
 }): string | null | undefined {
   if (input.release_notes !== undefined) return stringifyReleaseNotes(input.release_notes);
-  if (input.changelog_i18n !== undefined) return stringifyReleaseNotes(input.changelog_i18n);
   return input.changelog;
 }
 
@@ -240,8 +236,7 @@ async function updateReleaseFields(
     // rollout/scope/availability semantics.
     const onlyChangelog =
       (input.changelog !== undefined ||
-        input.release_notes !== undefined ||
-        input.changelog_i18n !== undefined) &&
+        input.release_notes !== undefined) &&
       input.should_force_update === undefined &&
       input.rollout_cohort_count === undefined &&
       input.rollout_target_cohorts_json === undefined &&
@@ -257,7 +252,7 @@ async function updateReleaseFields(
   const now = Date.now();
   const sets: string[] = [];
   const binds: (string | number | null)[] = [];
-  if (input.release_notes !== undefined || input.changelog_i18n !== undefined) {
+  if (input.release_notes !== undefined) {
     sets.push(`changelog = ?${binds.length + 1}`);
     binds.push(inputChangelog(input) ?? null);
   } else if (input.changelog !== undefined) {


### PR DESCRIPTION
## Summary
- remove the loose `changelog_i18n` write alias from the release API
- stop mapping plain legacy changelog strings into `release_notes`
- keep `changelog` as the localized display string and reserve `release_notes` for structured JSON objects only

## Contract
- `release_notes` is the canonical structured object: `{ "en": "...", "zh-CN": "..." }`
- plain `changelog` text remains available as `changelog`, but produces `release_notes: null`
- invalid JSON-looking changelog text is still returned as display `changelog`, not parsed as structured release notes

## Validation
- `pnpm --filter @oranix/quiver-worker test`
- `pnpm --filter @oranix/quiver-worker build`
- `pnpm --filter @oranix/quiver-admin build`
- `git diff --check`
