### PR TITLE
docs: permission (403) bootstrap for admins and agents

### DIFF
--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -127,4 +127,19 @@ Public artifact URLs are signed and time-limited. Refresh the share page or run 
 
 ### 403 forbidden
 
-Your account or deploy token does not have the required role for the action. Ask an app admin to grant access or use a token with the correct role.
+Your account or deploy token does not have the required role for the action. The response is machine-readable so an agent or the CLI can point you straight to the fix:
+
+```json
+{
+  "error": "insufficient_org_role",       // or "insufficient_app_role"
+  "required_role": "admin",
+  "current_role": "viewer",
+  "resource": "POST /api/apps",            // the action you attempted
+  "org_id": "…", "app_id": null,
+  "manage_url": "https://quiver.oranix.io/orgs/{orgId}/members"
+}
+```
+
+To resolve, an organization **admin/owner** opens `manage_url` — **Org → Members** for org roles, or an app's **Access** tab for app-level roles — and raises the account's role to `required_role`. Then retry the same request.
+
+Note: creating an app (`POST /api/apps`) requires an **org admin/owner** — an app-level member role or a deploy token is not enough. A newly Agent-Login'd account usually starts as **viewer**, so this 403 is expected on the first admin-scoped call.

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -112,6 +112,37 @@ curl -X POST -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
 Rotation invalidates the old key immediately — client builds must be updated
 with the new one.
 
+## Handling permission (403) errors
+
+Right after Agent Login your org role is usually **viewer**, so the first
+admin-scoped call (e.g. creating an app) will 403. Quiver's role-403s are
+**machine-readable** — act on them instead of failing silently:
+
+```json
+{
+  "error": "insufficient_org_role",       // or "insufficient_app_role"
+  "required_role": "admin",
+  "current_role": "viewer",
+  "resource": "POST /api/apps",            // the action you attempted
+  "org_id": "…", "app_id": null,
+  "manage_url": "https://quiver.oranix.io/orgs/{orgId}/members"
+}
+```
+
+On this response:
+
+1. **Don't retry blindly** — you are missing `required_role`, not hitting a
+   transient error.
+2. **Tell the human the exact next step**, quoting `manage_url`: e.g. "I need
+   **admin** on this org to run `<resource>` (currently **viewer**). An org
+   admin can raise my role at `<manage_url>`, then I'll retry."
+3. **Retry the same request** once they confirm the role change.
+
+App creation (`POST /api/apps`) needs an **org** admin/owner specifically — an
+app-member role or deploy token is not enough. If an app should live under a
+different organization, that org's admin creates it there rather than bumping
+your role in this one.
+
 ## Rules for agents
 
 1. **Draft-first**: CI never completes a release; publishing is an explicit,


### PR DESCRIPTION
Pair the new machine-readable role-403 descriptor with docs in two
places: admin-user-guide's '403 forbidden' now shows the descriptor and
how an org admin bumps the role via manage_url; agent-guide gains a
'Handling permission (403) errors' section so an agent knows from the
start to read the descriptor, tell the human the exact fix (manage_url),
and retry — instead of failing silently on the first admin-scoped call.

Signed-off-by: CC-Quiver-Owner <raft-mobile-cc-quiver-owner@mail.build>
