### PR TITLE
fix(docs): preserve wrapped ordered list items

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -207,6 +207,10 @@ function renderMarkdown(markdown) {
       flushList();
       continue;
     }
+    if (list.length > 0) {
+      list[list.length - 1] += ` ${line.trim()}`;
+      continue;
+    }
     paragraph.push(line.trim());
   }
   flushTable();


### PR DESCRIPTION
## Summary
- append nonblank continuation lines to the current open list item in the docs markdown renderer
- keeps wrapped numbered-list entries as complete <li> content instead of emitting the wrapped text as earlier paragraphs

## Validation
- node admin/scripts/build-docs.mjs
- rg -n "Handling permission|Don't retry blindly|transient error|Rules for agents|Draft-first|reviewed step|<ol" admin/public/docs/agent-guide/index.html -C 2
- pnpm --filter @oranix/quiver-admin build
- git diff --check