### PR TITLE
feat(worker,container): symbolicate iOS crashes against dSYM assets

### DIFF
--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -195,6 +195,106 @@ app.post("/symbolicate-native", async (c) => {
   }
 });
 
+/**
+ * POST /symbolicate-dsym — body = raw dSYM zip (one or more .dSYM bundles),
+ * X-Quiver-Frames header = JSON array of { index, offset, image } where
+ * `offset` is the address minus the image's runtime load address (hex) and
+ * `image` is the binary/image name. Extracts the zip, indexes the DWARF
+ * Mach-O binaries (`*.dSYM/Contents/Resources/DWARF/*`) by basename, and
+ * resolves each frame with llvm-symbolizer at `IOS_TEXT_VMADDR + offset`.
+ * Returns { frames: [{ index, resolved | error }] }.
+ *
+ * IOS_TEXT_VMADDR is the standard arm64 iOS PIE __TEXT base (0x100000000),
+ * which is the link-time base every app main executable's offsets are
+ * relative to. (Reading it per-binary is a robustness follow-up; system
+ * frameworks usually ship no dSYM and fall back to name+offset anyway.)
+ */
+const IOS_TEXT_VMADDR = 0x100000000n;
+app.post("/symbolicate-dsym", async (c) => {
+  const framesHeader = c.req.header("X-Quiver-Frames") ?? "[]";
+  let frames: Array<{ index: number; offset: string; image: string }>;
+  try {
+    frames = JSON.parse(framesHeader);
+    if (!Array.isArray(frames)) throw new Error("not an array");
+  } catch {
+    return c.json({ error: "X-Quiver-Frames must be a JSON array" }, 400);
+  }
+  if (frames.length === 0 || frames.length > 256) {
+    return c.json({ error: "frames must contain 1-256 entries" }, 400);
+  }
+  const ab = await c.req.arrayBuffer();
+  if (ab.byteLength === 0) return c.json({ error: "empty dSYM zip" }, 400);
+  if (ab.byteLength > 500 * 1024 * 1024) return c.json({ error: "dSYM zip too large" }, 413);
+
+  const dir = join(tmpdir(), `dsym-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const zipPath = join(dir, "dsym.zip");
+  const outDir = join(dir, "dsym");
+  try {
+    await mkdir(outDir, { recursive: true });
+    await writeFile(zipPath, Buffer.from(ab));
+    await execFileAsync("unzip", ["-o", "-q", zipPath, "-d", outDir], {
+      maxBuffer: 8 * 1024 * 1024,
+    });
+
+    // Index DWARF Mach-O binaries (…/Contents/Resources/DWARF/<name>) by name.
+    const dwarfByName = new Map<string, string>();
+    const walk = async (d: string): Promise<void> => {
+      for (const entry of await readdir(d, { withFileTypes: true })) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else if (full.includes("/DWARF/") && !dwarfByName.has(entry.name)) {
+          dwarfByName.set(entry.name, full);
+        }
+      }
+    };
+    await walk(outDir);
+
+    const results: Array<{ index: number; resolved?: string; error?: string }> = [];
+    for (const frame of frames) {
+      const image = String(frame.image ?? "").split("/").pop() ?? "";
+      const dwarfPath = image ? dwarfByName.get(image) : undefined;
+      if (!dwarfPath) {
+        results.push({ index: frame.index, error: `no dSYM for ${image || "(missing image)"}` });
+        continue;
+      }
+      let offsetBig: bigint;
+      try {
+        const raw = String(frame.offset ?? "").trim();
+        offsetBig = BigInt(raw.startsWith("0x") ? raw : `0x${raw}`);
+      } catch {
+        results.push({ index: frame.index, error: `bad offset: ${frame.offset}` });
+        continue;
+      }
+      const staticAddr = "0x" + (IOS_TEXT_VMADDR + offsetBig).toString(16);
+      try {
+        const { stdout } = await execFileAsync(
+          "llvm-symbolizer",
+          ["--obj=" + dwarfPath, "--output-style=GNU", "--demangle", "--functions=linkage", staticAddr],
+          { maxBuffer: 4 * 1024 * 1024 },
+        );
+        const lines = stdout.trim().split("\n").filter(Boolean);
+        results.push({
+          index: frame.index,
+          resolved: lines.length > 0 ? `${lines[0]}${lines[1] ? ` (${lines[1]})` : ""}` : "??",
+        });
+      } catch (err) {
+        results.push({
+          index: frame.index,
+          error: `symbolizer failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+    return c.json({ frames: results });
+  } catch (err) {
+    return c.json(
+      { error: `symbolicate-dsym failed: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 app.post("/parse", async (c) => {
   const ab = await c.req.arrayBuffer();
   if (ab.byteLength === 0) return c.json({ error: "empty body" }, 400);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -312,6 +312,19 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     }
   }
 
+  // iOS crashes: symbolicate frames against the dSYM asset.
+  const dsymImages = parseBinaryImages(metadata["crash_binary_images"]);
+  const dsymFrames = parseCrashFrames(metadata["crash_frames"]);
+  if (kind === "crash" && dsymImages.length > 0 && dsymFrames.length > 0) {
+    const run = () =>
+      symbolicateDsymCrashTicket(c.env, app.id, ticketId, versionCode, dsymImages, dsymFrames);
+    try {
+      c.executionCtx.waitUntil(run());
+    } catch {
+      run().catch(() => {});
+    }
+  }
+
   // Crash alerting: fire webhooks when a signature is first seen or when it
   // spikes (10/50/100 tickets within an hour — fires once per tier as the
   // count crosses it, so no extra state table is needed).
@@ -623,6 +636,195 @@ export async function symbolicateNativeCrashTicket(
   } catch (err) {
     console.error(
       `[symbolicate] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export interface DsymImage {
+  uuid: string;
+  load_address: bigint;
+  end_address: bigint;
+  name: string;
+}
+
+export interface DsymFrame {
+  index: number;
+  address: bigint;
+}
+
+function parseHexBig(v: unknown): bigint | null {
+  if (typeof v !== "string" && typeof v !== "number") return null;
+  const s = String(v).trim();
+  if (!s) return null;
+  try {
+    if (s.startsWith("0x") || s.startsWith("0X")) return BigInt(s);
+    if (/^\d+$/.test(s)) return BigInt(s);
+    if (/^[0-9a-fA-F]+$/.test(s)) return BigInt("0x" + s);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * SDK contract (symbolication matrix, iOS lane): metadata.crash_binary_images
+ * is a JSON array of { uuid, load_address, base_address, end_address, slide,
+ * path, name }. load_address / end_address are RUNTIME addresses (already
+ * include the ASLR slide), so a frame address inside [load, end] maps to that
+ * image and its file offset is `address - load_address`.
+ */
+export function parseBinaryImages(raw: unknown): DsymImage[] {
+  let value = raw;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(value)) return [];
+  const out: DsymImage[] = [];
+  for (const entry of value.slice(0, 512)) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const load = parseHexBig(e["load_address"]);
+    if (load === null) continue;
+    const end = parseHexBig(e["end_address"]) ?? load;
+    const pathName =
+      typeof e["path"] === "string" ? (e["path"] as string).split("/").pop() ?? "" : "";
+    const name = String(e["name"] ?? pathName ?? "").trim();
+    if (!name) continue;
+    out.push({ uuid: String(e["uuid"] ?? "").trim(), load_address: load, end_address: end, name });
+  }
+  return out;
+}
+
+/**
+ * metadata.crash_frames is a JSON array of { index, address } where address is
+ * the RUNTIME instruction address (post-slide). Bounded and shape-checked.
+ */
+export function parseCrashFrames(raw: unknown): DsymFrame[] {
+  let value = raw;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(value)) return [];
+  const out: DsymFrame[] = [];
+  for (const entry of value.slice(0, 256)) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const address = parseHexBig(e["address"]);
+    const index = typeof e["index"] === "number" ? e["index"] : Number(e["index"]);
+    if (address === null || !Number.isFinite(index)) continue;
+    out.push({ index, address });
+  }
+  return out;
+}
+
+/**
+ * Resolve iOS crash frames against the build's dSYM asset via the container's
+ * llvm-symbolizer endpoint and append the result as an internal comment —
+ * mirrors symbolicateNativeCrashTicket. Missing dSYM leaves an
+ * operator-actionable comment.
+ */
+export async function symbolicateDsymCrashTicket(
+  env: Env,
+  appId: string,
+  ticketId: string,
+  versionCode: number | null,
+  images: DsymImage[],
+  frames: DsymFrame[],
+): Promise<void> {
+  try {
+    if (versionCode === null || frames.length === 0 || images.length === 0) return;
+    const appendComment = async (body: string) => {
+      await env.DB.batch([
+        env.DB.prepare(
+          `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
+           VALUES (?1, ?2, 'quiver-symbolicate', ?3, 1, ?4)`,
+        ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
+        env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
+          Date.now(),
+          ticketId,
+        ),
+      ]);
+    };
+
+    // Map each frame to its containing image → { index, offset(hex), image }.
+    const containerFrames: Array<{ index: number; offset: string; image: string }> = [];
+    for (const f of frames) {
+      const img =
+        images.find((i) => f.address >= i.load_address && f.address <= i.end_address) ?? images[0];
+      if (!img) continue;
+      const offset = f.address - img.load_address;
+      if (offset < 0n) continue;
+      containerFrames.push({
+        index: f.index,
+        offset: "0x" + offset.toString(16),
+        image: img.name,
+      });
+    }
+    if (containerFrames.length === 0) return;
+
+    const dsym = await env.DB.prepare(
+      `SELECT ba.r2_key FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       WHERE b.app_id = ?1 AND b.version_code = ?2
+         AND ba.artifact_kind = 'dsym'
+       ORDER BY ba.created_at DESC LIMIT 1`,
+    )
+      .bind(appId, versionCode)
+      .first<{ r2_key: string }>();
+    if (!dsym) {
+      const uuids = [...new Set(images.map((i) => i.uuid).filter(Boolean))].slice(0, 6).join(", ");
+      await appendComment(
+        `iOS crash could not be symbolicated: no 'dsym' build asset for ` +
+          `version_code ${versionCode}${uuids ? ` (image UUIDs: ${uuids})` : ""}. ` +
+          `Publish the build with its dSYM archive (quiver builds publish-android --dsym).`,
+      );
+      return;
+    }
+
+    const zipObj = await env.APK_BUCKET.get(dsym.r2_key);
+    if (!zipObj) return;
+    const zipBytes = await zipObj.arrayBuffer();
+
+    const { getRandom } = await import("@cloudflare/containers");
+    const container = await getRandom(env.APK_PARSER, 1);
+    const res = await container.fetch(
+      new Request("http://container/symbolicate-dsym", {
+        method: "POST",
+        body: zipBytes,
+        headers: {
+          "content-type": "application/zip",
+          "X-Quiver-Frames": JSON.stringify(containerFrames),
+        },
+      }),
+    );
+    if (!res.ok) return;
+    const parsed = (await res.json()) as {
+      frames?: Array<{ index: number; resolved?: string; error?: string }>;
+    };
+    const resolved = parsed.frames ?? [];
+    if (resolved.length === 0) return;
+
+    const byIndex = new Map(resolved.map((f) => [f.index, f]));
+    const lines = containerFrames.map((cf) => {
+      const r = byIndex.get(cf.index);
+      const outcome = r?.resolved ?? (r?.error ? `?? (${r.error})` : "??");
+      return `#${String(cf.index).padStart(2, "0")} ${cf.image} ${cf.offset} — ${outcome}`;
+    });
+    await appendComment(
+      "Symbolicated iOS stack (auto-resolved from dSYM):\n\n" +
+        lines.join("\n").slice(0, 20_000),
+    );
+  } catch (err) {
+    console.error(
+      `[symbolicate-dsym] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3472,6 +3472,58 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(comment.body).toContain("abcd1234");
   });
 
+  it("parseBinaryImages/parseCrashFrames bound and shape-check SDK input", async () => {
+    const { parseBinaryImages, parseCrashFrames } = await import("../src/routes/feedback");
+    const images = parseBinaryImages(JSON.stringify([
+      { uuid: "A1", load_address: "0x104abc000", end_address: "0x104b00000", name: "Raft" },
+      { uuid: "B2", load_address: "nonsense", name: "Bad" },
+      { uuid: "C3", load_address: "0x1", name: "" },
+      { path: "/x/y/UIKit", load_address: 4368 },
+      "garbage",
+    ]));
+    expect(images).toEqual([
+      { uuid: "A1", load_address: 0x104abc000n, end_address: 0x104b00000n, name: "Raft" },
+      { uuid: "", load_address: 4368n, end_address: 4368n, name: "UIKit" },
+    ]);
+    expect(parseBinaryImages("not json")).toEqual([]);
+
+    const frames = parseCrashFrames(JSON.stringify([
+      { index: 0, address: "0x104abc123" },
+      { index: 1, address: "junk" },
+      { address: "0x2" },
+      { index: 2, address: 100 },
+    ]));
+    expect(frames).toEqual([
+      { index: 0, address: 0x104abc123n },
+      { index: 2, address: 100n },
+    ]);
+    expect(parseCrashFrames(42)).toEqual([]);
+  });
+
+  it("symbolicateDsymCrashTicket leaves an actionable comment when dSYM is missing", async () => {
+    const env = makeEnv();
+    const { symbolicateDsymCrashTicket } = await import("../src/routes/feedback");
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?1, ?2, 'crash', 'open', 'ios crash', '{}', ?3, ?4)`,
+    ).bind("tick-dsym", "app-scope", 1, 1).run();
+    await symbolicateDsymCrashTicket(
+      env as any,
+      "app-scope",
+      "tick-dsym",
+      1000200,
+      [{ uuid: "DEADBEEF", load_address: 0x100000000n, end_address: 0x100100000n, name: "Raft" }],
+      [{ index: 0, address: 0x100004000n }],
+    );
+    const comment = (await env.DB.prepare(
+      "SELECT author_actor, body FROM feedback_comments WHERE ticket_id = ?1",
+    ).bind("tick-dsym").all()).results[0] as { author_actor: string; body: string };
+    expect(comment.author_actor).toBe("quiver-symbolicate");
+    expect(comment.body).toContain("dsym");
+    expect(comment.body).toContain("1000200");
+    expect(comment.body).toContain("DEADBEEF");
+  });
+
   it("changelogToHtml renders bullets safely", async () => {
     const { changelogToHtml } = await import("../src/routes/public_v2");
     const html = changelogToHtml("- one **bold**\n- two <script>x</script>\n\nplain `c`");


### PR DESCRIPTION
## What

Server-side dSYM resolver (block #2 of the iOS symbolication work; block #1 = CLI `--dsym` upload in #108). Closes the loop so an iOS crash ticket auto-symbolicates the same way native/R8 crashes already do.

## How

**Container — `POST /symbolicate-dsym`**
- Body = raw dSYM zip; `X-Quiver-Frames` header = JSON array of `{ index, offset, image }`.
- Unzips, indexes the DWARF Mach-O binaries (`*.dSYM/Contents/Resources/DWARF/*`) by basename, resolves each frame with `llvm-symbolizer` at `IOS_TEXT_VMADDR (0x100000000) + offset`.
- Returns `{ frames: [{ index, resolved | error }] }`.

**Worker — `feedback.ts`**
- `parseBinaryImages` / `parseCrashFrames` read the SDK crash contract: `metadata.crash_binary_images` (`{uuid, load_address, end_address, name, …}`, runtime addresses that already include the ASLR slide) and `metadata.crash_frames` (`{index, address}`, runtime addresses). Both bounded + shape-checked.
- `symbolicateDsymCrashTicket` maps each frame to its containing image (`offset = address - load_address`), fetches the build's `dsym` asset from R2, POSTs to the container, and appends the symbolicated stack as an **internal** ticket comment. Missing dSYM → operator-actionable comment naming the asset and image UUIDs (points at `quiver builds publish-android --dsym`).
- Fired from `handlePublicFeedbackSubmit` when a crash ticket carries both `crash_binary_images` and `crash_frames` (same `waitUntil` pattern as the native lane).

## Tests

`parseBinaryImages`/`parseCrashFrames` bounds + the missing-dSYM comment path. `85 passed`. Worker + container both `tsc --noEmit` clean.

## Follow-up

Block #3: iOS crash-detail symbolicated-stack UI in the admin console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)