### PR TITLE
feat(electron): Crashpad minidump crash ingest + symbolication (server side)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,7 +9,18 @@
 # Uses `aapt` + `apksigner` from Android SDK build-tools (NOT full Android SDK).
 # These are small standalone binaries that read APK files, which is all we need.
 
+# Build minidump-stackwalk (Mozilla rust-minidump) for the Electron/Crashpad
+# crash-symbolication lane. Built on bookworm so the resulting glibc binary
+# runs unmodified in the node:24-bookworm-slim runtime below.
+FROM rust:1-bookworm AS minidump-builder
+ARG MINIDUMP_STACKWALK_VERSION=0.22.0
+RUN cargo install minidump-stackwalk --version ${MINIDUMP_STACKWALK_VERSION} \
+    && cp "$(command -v minidump-stackwalk)" /minidump-stackwalk
+
 FROM node:24-bookworm-slim AS base
+
+# minidump-stackwalk binary for the Electron/Crashpad symbolication lane.
+COPY --from=minidump-builder /minidump-stackwalk /usr/local/bin/minidump-stackwalk
 
 # Install aapt + apksigner from Android SDK build-tools
 # Source: https://github.com/iBotPeaches/Apktool/blob/master/INSTALL.md

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -21,7 +21,7 @@
 
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { writeFile, unlink, mkdir, rm, readdir } from "node:fs/promises";
+import { writeFile, readFile, unlink, mkdir, rm, readdir } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { tmpdir } from "node:os";
@@ -37,6 +37,22 @@ const app = new Hono();
 const execFileAsync = promisify(execFile);
 
 const RETRACE_BIN = "/opt/android-sdk/cmdline-tools/latest/bin/retrace";
+
+/** Subset of minidump-stackwalk --json output we consume (rust-minidump). */
+interface MinidumpFrame {
+  frame: number;
+  module?: string;
+  function?: string;
+  file?: string;
+  line?: number;
+  offset?: string;
+  module_offset?: string;
+  trust?: string;
+}
+interface MinidumpReport {
+  crash_info?: { type?: string; address?: string; crashing_thread?: number };
+  crashing_thread?: { thread_index?: number; frames?: MinidumpFrame[] };
+}
 
 app.get("/health", (c) => c.json({ ok: true, service: "multi-parser" }));
 
@@ -288,6 +304,113 @@ app.post("/symbolicate-dsym", async (c) => {
   } catch (err) {
     return c.json(
       { error: `symbolicate-dsym failed: ${err instanceof Error ? err.message : String(err)}` },
+      500,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+/**
+ * POST /symbolicate-minidump — multipart/form-data with two files:
+ *   - `minidump`: the raw Crashpad/Breakpad .dmp
+ *   - `symbols`:  a zip of Breakpad `.sym` files (dump_syms output), any layout
+ * Rebuilds the Breakpad symbol tree (`<name>/<id>/<name>.sym`, keyed off each
+ * file's `MODULE <os> <arch> <id> <name>` header so CI can zip them flat),
+ * runs `minidump-stackwalk --json` and returns the crashing thread's
+ * symbolicated frames + a rendered text stack. (Electron/Crashpad lane.)
+ */
+app.post("/symbolicate-minidump", async (c) => {
+  let form: FormData;
+  try {
+    form = await c.req.formData();
+  } catch {
+    return c.json({ error: "expected multipart/form-data" }, 400);
+  }
+  const minidump = form.get("minidump");
+  const symbols = form.get("symbols");
+  if (!(minidump instanceof File) || minidump.size === 0) {
+    return c.json({ error: "missing `minidump` file" }, 400);
+  }
+  if (minidump.size > 128 * 1024 * 1024) return c.json({ error: "minidump too large" }, 413);
+
+  const dir = join(tmpdir(), `mdump-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const dmpPath = join(dir, "crash.dmp");
+  const symZip = join(dir, "symbols.zip");
+  const symRaw = join(dir, "raw");
+  const symTree = join(dir, "symbols");
+  try {
+    await mkdir(symRaw, { recursive: true });
+    await mkdir(symTree, { recursive: true });
+    await writeFile(dmpPath, Buffer.from(await minidump.arrayBuffer()));
+
+    // Lay out uploaded .sym files into the Breakpad tree minidump-stackwalk
+    // expects. Reading the MODULE header makes us layout-agnostic.
+    let symbolCount = 0;
+    if (symbols instanceof File && symbols.size > 0) {
+      if (symbols.size > 512 * 1024 * 1024) return c.json({ error: "symbols zip too large" }, 413);
+      await writeFile(symZip, Buffer.from(await symbols.arrayBuffer()));
+      await execFileAsync("unzip", ["-o", "-q", symZip, "-d", symRaw], {
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      const symFiles: string[] = [];
+      const walk = async (d: string): Promise<void> => {
+        for (const entry of await readdir(d, { withFileTypes: true })) {
+          const full = join(d, entry.name);
+          if (entry.isDirectory()) await walk(full);
+          else if (entry.name.endsWith(".sym")) symFiles.push(full);
+        }
+      };
+      await walk(symRaw);
+      for (const symFile of symFiles) {
+        // MODULE <os> <arch> <id> <name> — must be the first line.
+        const head = (await readFile(symFile, "utf8")).slice(0, 4096).split("\n")[0]?.trim() ?? "";
+        const m = /^MODULE\s+\S+\s+\S+\s+(\S+)\s+(.+)$/.exec(head);
+        if (!m || !m[1] || !m[2]) continue;
+        const debugId = m[1];
+        const debugName = m[2].trim();
+        const dest = join(symTree, debugName, debugId);
+        await mkdir(dest, { recursive: true });
+        await writeFile(join(dest, `${debugName}.sym`), await readFile(symFile));
+        symbolCount++;
+      }
+    }
+
+    const { stdout } = await execFileAsync(
+      "minidump-stackwalk",
+      ["--json", "--symbols-path", symTree, dmpPath],
+      { maxBuffer: 32 * 1024 * 1024 },
+    );
+    const report = JSON.parse(stdout) as MinidumpReport;
+
+    const crashing = report.crashing_thread;
+    const frames = (crashing?.frames ?? []).map((f) => ({
+      index: f.frame,
+      module: f.module ?? null,
+      function: f.function ?? null,
+      file: f.file ?? null,
+      line: f.line ?? null,
+      offset: f.module_offset ?? f.offset ?? null,
+      trust: f.trust ?? null,
+    }));
+    const textLines = frames.map((f) => {
+      const loc = f.function
+        ? `${f.function}${f.file ? ` (${f.file}${f.line ? `:${f.line}` : ""})` : ""}`
+        : `${f.module ?? "?"}${f.offset ? ` + ${f.offset}` : ""}`;
+      return `#${String(f.index).padStart(2, "0")} ${f.module ?? "?"} — ${loc}`;
+    });
+
+    return c.json({
+      crash_reason: report.crash_info?.type ?? null,
+      crash_address: report.crash_info?.address ?? null,
+      crashing_thread: report.crash_info?.crashing_thread ?? crashing?.thread_index ?? null,
+      symbol_modules: symbolCount,
+      frames,
+      stack_text: textLines.join("\n"),
+    });
+  } catch (err) {
+    return c.json(
+      { error: `symbolicate-minidump failed: ${err instanceof Error ? err.message : String(err)}` },
       500,
     );
   } finally {

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -300,6 +300,12 @@ export function registerBuildCommands(program: Command): void {
     .option("--metadata <path>", "electron-builder latest*.yml file. Repeatable.", collect, [])
     .option("--installer <path>", "Electron installer/update artifact. Repeatable.", collect, [])
     .option("--blockmap <path>", "Electron .blockmap artifact. Repeatable.", collect, [])
+    .option(
+      "--symbols <path>",
+      "Breakpad symbols archive (dump_syms output, .zip) for crash symbolication. Repeatable.",
+      collect,
+      [],
+    )
     .option("--channel <slug>", "Quiver channel slug.", "main")
     .option("--platform <platform>", "Electron platform metadata. Defaults from metadata filename or win32.")
     .option("--arch <arch>", "Electron arch metadata.")
@@ -325,6 +331,7 @@ export function registerBuildCommands(program: Command): void {
           metadata: string[];
           installer: string[];
           blockmap: string[];
+          symbols: string[];
           channel: string;
           platform?: string;
           arch?: string;
@@ -343,13 +350,14 @@ export function registerBuildCommands(program: Command): void {
           json?: boolean;
         },
       ) => {
-        const files = [...opts.metadata, ...opts.installer, ...opts.blockmap];
+        const files = [...opts.metadata, ...opts.installer, ...opts.blockmap, ...opts.symbols];
         if (files.length === 0) {
-          throw new Error("provide at least one --metadata, --installer, or --blockmap file");
+          throw new Error("provide at least one --metadata, --installer, --blockmap, or --symbols file");
         }
         const metadataFiles = opts.metadata;
         const installerFiles = opts.installer;
         const blockmapFiles = opts.blockmap;
+        const symbolsFiles = opts.symbols;
         for (const file of files) {
           if (!existsSync(file)) throw new Error(`missing file: ${file}`);
         }
@@ -436,6 +444,18 @@ export function registerBuildCommands(program: Command): void {
               platform: primaryPlatform,
               arch,
               filetype: "blockmap",
+              metadata_json: { filename: fileName },
+            }),
+          );
+        }
+        for (const file of symbolsFiles) {
+          const fileName = basename(file);
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, file, {
+              artifact_kind: "breakpad-symbols",
+              platform: primaryPlatform,
+              arch,
+              filetype: "breakpad.zip",
               metadata_json: { filename: fileName },
             }),
           );

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -58,6 +58,7 @@ import {
 } from "./routes/shares";
 import {
   handlePublicFeedbackSubmit,
+  handlePublicMinidumpSubmit,
   handleListFeedback,
   handleGetFeedback,
   handleUpdateFeedback,
@@ -459,6 +460,7 @@ app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);
 app.get("/share/:token/icon", handlePublicReleaseShareIcon);
 app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
+app.post("/public/v2/apps/:slug/minidump", handlePublicMinidumpSubmit);
 app.post("/public/v2/apps/:slug/devices", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -432,6 +432,168 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   );
 }
 
+const MINIDUMP_MAX_BYTES = 64 * 1024 * 1024; // Crashpad dumps are usually < a few MB
+
+/**
+ * Electron/Crashpad crash ingest. Electron's built-in crashReporter POSTs a
+ * multipart/form-data with the minidump under `upload_file_minidump` plus a
+ * flat set of annotation fields (productName, version, and any `extra`/
+ * `globalExtra` the SDK set). We store the dump as a crash-ticket attachment,
+ * fold every annotation into metadata (product_type=electron), and fire the
+ * minidump symbolication lane against the version's breakpad-symbols asset.
+ *
+ * Client-key gate: the SDK puts it in the submitURL query (`?client_key=`),
+ * which Crashpad preserves, or an X-Quiver-Client-Key header.
+ */
+export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await c.env.DB.prepare(
+    "SELECT id, org_id, slug, client_key FROM apps WHERE slug = ?1 AND archived = 0",
+  )
+    .bind(slug)
+    .first<{ id: string; org_id: string | null; slug: string; client_key: string | null }>();
+  if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
+
+  const presented =
+    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+  if (!app.client_key || presented !== app.client_key) {
+    return c.json({ error: "invalid or missing client key" }, 401);
+  }
+
+  let form: FormData;
+  try {
+    form = await c.req.formData();
+  } catch {
+    return c.json({ error: "multipart/form-data body required" }, 400);
+  }
+
+  // Crashpad names the dump field `upload_file_minidump`; accept `minidump` too.
+  const dumpEntry = form.get("upload_file_minidump") ?? form.get("minidump");
+  if (dumpEntry === null || typeof dumpEntry === "string") {
+    return c.json({ error: "missing minidump (upload_file_minidump)" }, 400);
+  }
+  const dump = dumpEntry as File;
+  if (dump.size === 0) {
+    return c.json({ error: "missing minidump (upload_file_minidump)" }, 400);
+  }
+  if (dump.size > MINIDUMP_MAX_BYTES) {
+    return c.json({ error: `minidump too large (max ${MINIDUMP_MAX_BYTES} bytes)` }, 413);
+  }
+
+  // Every other string field is a Crashpad annotation → metadata. Map the
+  // Sentry-electron-style well-known keys to ticket columns.
+  const annotations: Record<string, string> = {};
+  for (const [key, value] of form.entries()) {
+    if (typeof value !== "string") continue;
+    if (key === "upload_file_minidump" || key === "minidump") continue;
+    annotations[key] = value.slice(0, 2000);
+  }
+  const pick = (...keys: string[]): string | null => {
+    for (const k of keys) {
+      const v = annotations[k];
+      if (v !== undefined && v !== null && v !== "") return v;
+    }
+    return null;
+  };
+
+  const versionName = pick("version", "app_version", "appVersion", "version_name", "release");
+  const versionCodeRaw = pick("version_code", "versionCode", "build");
+  const versionCode =
+    versionCodeRaw && /^\d+$/.test(versionCodeRaw) ? Math.trunc(Number(versionCodeRaw)) : null;
+  const processType = pick("process_type", "ptype", "type"); // main / renderer / gpu / utility
+  const metadata: Record<string, unknown> = {
+    ...annotations,
+    product_type: "electron",
+    process_type: processType,
+    crash_platform: pick("platform", "os") ?? "electron",
+  };
+
+  const clientIp =
+    (c.req.raw?.cf as { clientIp?: string } | undefined)?.clientIp ??
+    c.req.header("cf-connecting-ip") ??
+    "unknown";
+  const clientIpHash = await sha256Hex(`feedback:${app.id}:${clientIp}`);
+  const recent = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS count FROM feedback_tickets
+     WHERE app_id = ?1 AND client_ip_hash = ?2 AND created_at > ?3`,
+  )
+    .bind(app.id, clientIpHash, Date.now() - 3600_000)
+    .first<{ count: number }>();
+  if ((recent?.count ?? 0) >= RATE_LIMIT_PER_HOUR) {
+    return c.json({ error: "too many crash reports; try again later" }, 429);
+  }
+
+  const now = Date.now();
+  const ticketId = crypto.randomUUID();
+  const dumpKey = `feedback/${app.id}/${ticketId}/minidump.dmp`;
+  await c.env.APK_BUCKET.put(dumpKey, await dump.arrayBuffer(), {
+    httpMetadata: { contentType: "application/x-minidump" },
+  });
+
+  const reasonBits = [processType, versionName].filter(Boolean).join(" · ");
+  const message = `Electron crash${reasonBits ? ` (${reasonBits})` : ""}`;
+
+  await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, contact, version_name, version_code,
+        channel, device_id, device_model, os_version, arch, locale,
+        metadata_json, client_ip_hash, signature, created_at, updated_at)
+       VALUES (?1, ?2, 'crash', 'open', ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, NULL, ?14, ?15)`,
+    ).bind(
+      ticketId,
+      app.id,
+      message,
+      versionName,
+      versionCode,
+      pick("channel", "environment"),
+      pick("device_id", "guid"),
+      pick("device_model", "model"),
+      pick("os_version", "os_release"),
+      pick("arch", "cpu_arch"),
+      (pick("locale") ?? "").slice(0, 40) || null,
+      JSON.stringify(metadata),
+      clientIpHash,
+      now,
+      now,
+    ),
+    c.env.DB.prepare(
+      `INSERT INTO feedback_attachments
+       (id, ticket_id, r2_key, filename, content_type, size_bytes, created_at)
+       VALUES (?1, ?2, ?3, 'minidump.dmp', 'application/x-minidump', ?4, ?5)`,
+    ).bind(crypto.randomUUID(), ticketId, dumpKey, dump.size, now),
+  ]);
+
+  // Symbolicate against the version's breakpad-symbols asset (background).
+  const run = () => symbolicateMinidumpCrashTicket(c.env, app.id, ticketId, versionCode, dumpKey);
+  try {
+    c.executionCtx.waitUntil(run());
+  } catch {
+    run().catch(() => {});
+  }
+
+  if (app.org_id) {
+    await emitWebhookEvent(c.env.DB, {
+      orgId: app.org_id,
+      appId: app.id,
+      event: "feedback:new",
+      body: {
+        ticket_id: ticketId,
+        app_slug: app.slug,
+        kind: "crash",
+        message,
+        version_name: versionName,
+        version_code: versionCode,
+        attachments: 1,
+      },
+    }).catch(() => {});
+  }
+
+  // Crashpad only checks for a 2xx; a short id body is conventional.
+  return c.json({ id: ticketId, status: "open" }, 201);
+}
+
 /** Signature = "<ExceptionClass>@<top app frame>", trimmed and bounded. */
 function crashSignature(metadata: Record<string, unknown>): string | null {
   const exc = String(metadata["crash_exception_class"] ?? metadata["exception_class"] ?? "").trim();
@@ -825,6 +987,98 @@ export async function symbolicateDsymCrashTicket(
   } catch (err) {
     console.error(
       `[symbolicate-dsym] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Resolve an Electron/Crashpad minidump against the version's breakpad-symbols
+ * asset via the container's minidump-stackwalk lane and append the result as an
+ * internal comment — mirrors the native/dSYM symbolication flows. Missing
+ * symbols leaves an operator-actionable comment.
+ */
+export async function symbolicateMinidumpCrashTicket(
+  env: Env,
+  appId: string,
+  ticketId: string,
+  versionCode: number | null,
+  minidumpR2Key: string,
+): Promise<void> {
+  try {
+    const appendComment = async (body: string) => {
+      await env.DB.batch([
+        env.DB.prepare(
+          `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
+           VALUES (?1, ?2, 'quiver-symbolicate', ?3, 1, ?4)`,
+        ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
+        env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
+          Date.now(),
+          ticketId,
+        ),
+      ]);
+    };
+
+    const dumpObj = await env.APK_BUCKET.get(minidumpR2Key);
+    if (!dumpObj) return;
+    const dumpBytes = await dumpObj.arrayBuffer();
+
+    // breakpad-symbols asset for this version (optional — stackwalk still
+    // returns module+offset frames without it, which is worth posting).
+    let symBytes: ArrayBuffer | null = null;
+    if (versionCode !== null) {
+      const sym = await env.DB.prepare(
+        `SELECT ba.r2_key FROM build_assets ba
+         JOIN builds b ON b.id = ba.build_id
+         WHERE b.app_id = ?1 AND b.version_code = ?2
+           AND ba.artifact_kind = 'breakpad-symbols'
+         ORDER BY ba.created_at DESC LIMIT 1`,
+      )
+        .bind(appId, versionCode)
+        .first<{ r2_key: string }>();
+      if (sym) {
+        const symObj = await env.APK_BUCKET.get(sym.r2_key);
+        if (symObj) symBytes = await symObj.arrayBuffer();
+      }
+    }
+
+    const form = new FormData();
+    form.append("minidump", new Blob([dumpBytes], { type: "application/x-minidump" }), "crash.dmp");
+    if (symBytes) {
+      form.append("symbols", new Blob([symBytes], { type: "application/zip" }), "symbols.zip");
+    }
+
+    const { getRandom } = await import("@cloudflare/containers");
+    const container = await getRandom(env.APK_PARSER, 1);
+    const res = await container.fetch(
+      new Request("http://container/symbolicate-minidump", { method: "POST", body: form }),
+    );
+    if (!res.ok) return;
+    const parsed = (await res.json()) as {
+      crash_reason?: string | null;
+      crash_address?: string | null;
+      symbol_modules?: number;
+      stack_text?: string;
+      frames?: unknown[];
+    };
+    const stack = (parsed.stack_text ?? "").trim();
+    if (!stack) return;
+
+    const header =
+      `Symbolicated Electron crash (minidump-stackwalk` +
+      `${symBytes ? "" : ", no breakpad-symbols asset — module+offset only"}):` +
+      `${parsed.crash_reason ? `\nReason: ${parsed.crash_reason}${parsed.crash_address ? ` @ ${parsed.crash_address}` : ""}` : ""}`;
+    await appendComment(`${header}\n\n${stack}`.slice(0, 20_000));
+
+    if (!symBytes && versionCode !== null) {
+      await appendComment(
+        `Tip: upload the version's Breakpad symbols (dump_syms → quiver builds ` +
+          `publish-electron --symbols) for version_code ${versionCode} to get ` +
+          `function/file:line resolution instead of raw module+offset.`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      `[symbolicate-minidump] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3524,6 +3524,88 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(comment.body).toContain("DEADBEEF");
   });
 
+  it("handlePublicMinidumpSubmit ingests a Crashpad minidump as an electron crash ticket", async () => {
+    const env = makeEnv();
+    const store = new Map<string, Uint8Array>();
+    env.APK_BUCKET = {
+      put: async (key: string, body: ArrayBuffer) => { store.set(key, new Uint8Array(body)); },
+      get: async (key: string) =>
+        store.has(key) ? { arrayBuffer: async () => store.get(key)!.buffer } : null,
+      head: async (key: string) =>
+        store.has(key) ? { size: store.get(key)!.byteLength } : null,
+    } as any;
+    const { handlePublicMinidumpSubmit } = await import("../src/routes/feedback");
+
+    const form = new FormData();
+    form.set(
+      "upload_file_minidump",
+      new File([new Uint8Array([77, 68, 77, 80])], "crash.dmp", { type: "application/x-minidump" }),
+    );
+    form.set("version", "1.2.3");
+    form.set("version_code", "1020300");
+    form.set("process_type", "renderer");
+    form.set("channel", "stable");
+    form.set("guid", "abc-guid");
+    form.set("custom_note", "hello");
+
+    const waited: Promise<unknown>[] = [];
+    const res = await handlePublicMinidumpSubmit({
+      env,
+      executionCtx: { waitUntil: (p: Promise<unknown>) => waited.push(p) },
+      req: {
+        param: (n: string) => (n === "slug" ? "scope-app" : ""),
+        header: (n: string) => (n === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+        query: () => undefined,
+        formData: async () => form,
+        raw: { cf: { clientIp: "203.0.113.7" } },
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    expect(res.status).toBe(201);
+    await Promise.all(waited).catch(() => {});
+    const body = await responseJson<any>(res);
+
+    const ticket = (await env.DB.prepare(
+      "SELECT kind, version_name, version_code, channel, device_id, metadata_json FROM feedback_tickets WHERE id = ?1",
+    ).bind(body.id).first()) as any;
+    expect(ticket.kind).toBe("crash");
+    expect(ticket.version_name).toBe("1.2.3");
+    expect(ticket.version_code).toBe(1020300);
+    expect(ticket.channel).toBe("stable");
+    expect(ticket.device_id).toBe("abc-guid");
+    const meta = JSON.parse(ticket.metadata_json);
+    expect(meta.product_type).toBe("electron");
+    expect(meta.process_type).toBe("renderer");
+    expect(meta.custom_note).toBe("hello");
+
+    const att = (await env.DB.prepare(
+      "SELECT filename, content_type, size_bytes FROM feedback_attachments WHERE ticket_id = ?1",
+    ).bind(body.id).first()) as any;
+    expect(att.filename).toBe("minidump.dmp");
+    expect(att.content_type).toBe("application/x-minidump");
+    expect(att.size_bytes).toBe(4);
+  });
+
+  it("handlePublicMinidumpSubmit rejects an invalid client key", async () => {
+    const env = makeEnv();
+    const { handlePublicMinidumpSubmit } = await import("../src/routes/feedback");
+    const form = new FormData();
+    form.set("upload_file_minidump", new File([new Uint8Array([1])], "c.dmp"));
+    const res = await handlePublicMinidumpSubmit({
+      env,
+      executionCtx: { waitUntil: () => {} },
+      req: {
+        param: (n: string) => (n === "slug" ? "scope-app" : ""),
+        header: () => "wrong-key",
+        query: () => undefined,
+        formData: async () => form,
+        raw: { cf: {} },
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    expect(res.status).toBe(401);
+  });
+
   it("changelogToHtml renders bullets safely", async () => {
     const { changelogToHtml } = await import("../src/routes/public_v2");
     const html = changelogToHtml("- one **bold**\n- two <script>x</script>\n\nplain `c`");


### PR DESCRIPTION
## What

Server-side foundation for the **Electron/Crashpad crash lane** (task #97), completing the last row of the symbolication matrix. Mirrors the existing native/dSYM flows so Electron crashes auto-symbolicate into a `quiver-symbolicate` ticket comment.

This is blocks 1–3 of 5. Follow-up PR: the Electron SDK (`clients/electron`, main+renderer entry points) + integration docs.

## How

**Ingest — `POST /public/v2/apps/:slug/minidump`**
- Accepts Electron `crashReporter`'s multipart (`upload_file_minidump` + flat Sentry-electron-style annotations: version, version_code, channel/environment, process_type, guid, arbitrary `extra`/`globalExtra`).
- Stores the dump as a crash-ticket attachment, folds every annotation into metadata (`product_type=electron`, mapped well-known keys to columns), fires symbolication in the background.
- Client-key gated (`?client_key=` query — Crashpad preserves the submitURL query — or `X-Quiver-Client-Key`), rate-limited like feedback.

**Symbolicate — `symbolicateMinidumpCrashTicket` + container `POST /symbolicate-minidump`**
- Worker fetches the minidump + the version's `breakpad-symbols` asset, POSTs both to the container, appends the crashing-thread stack as a `quiver-symbolicate` internal comment (renders in the existing crash panel). No symbols → still posts module+offset frames + an actionable upload tip.
- Container rebuilds the Breakpad symbol tree from each `.sym` `MODULE` header (so CI can zip them flat), runs `minidump-stackwalk --json` (rust-minidump), returns crashing-thread frames + rendered text. Dockerfile installs `minidump-stackwalk` via a bookworm builder stage (glibc matches runtime).

**CLI — `publish-electron --symbols`**
- Uploads Breakpad symbols (dump_syms output, `.zip`) as a `breakpad-symbols` support asset per version.

## Tests

Minidump ingest → electron crash ticket + attachment, annotation mapping (product_type/process_type/version/channel/guid/extras); bad client key → 401. **87 worker tests pass.** worker + container + cli `tsc --noEmit` clean.

## Client side (next PR)

Real `@oranix/quiver-electron` SDK with `/main` (crashReporter init + `render-process-gone`/`child-process-gone` listeners + scope/context) and `/renderer` (scope + IPC forward) entry points, à la `@sentry/electron` — the client is referenced in both main and renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)