### PR TITLE
feat(electron): @oranix/quiver-electron SDK (main + renderer) + docs

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -65,6 +65,13 @@ const pages = [
     source: "ohos-sdk.md",
   },
   {
+    slug: "electron-sdk",
+    title: "Electron SDK",
+    category: "SDKs & API",
+    description: "Crashpad minidump crash reporting for Electron apps (main + renderer) via @oranix/quiver-electron.",
+    source: "electron-sdk.md",
+  },
+  {
     slug: "public-api-reference",
     title: "Public API Reference",
     category: "SDKs & API",

--- a/clients/electron/.gitignore
+++ b/clients/electron/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/clients/electron/README.md
+++ b/clients/electron/README.md
@@ -1,0 +1,103 @@
+# @oranix/quiver-electron
+
+Crash reporting for Electron apps, backed by [Quiver](https://quiver.oranix.io).
+
+Electron's built-in [Crashpad](https://www.electronjs.org/docs/latest/api/crash-reporter)
+captures native minidumps for **both the main and renderer processes** and
+uploads them straight to Quiver, where they're stored as crash tickets and
+symbolicated server-side against your uploaded Breakpad symbols. This SDK wires
+that up, adds renderer/child-process crash listeners, and manages a crash scope
+(user / tags / extra / breadcrumbs) that rides along on the next dump.
+
+The SDK has two entry points, like `@sentry/electron`: one for the **main**
+process and one for the **renderer**.
+
+## Install
+
+```bash
+npm install @oranix/quiver-electron
+```
+
+`electron` is a peer dependency (provided by your app).
+
+## Main process
+
+Call `init()` once, before the app is ready:
+
+```ts
+import { app } from "electron";
+import * as Quiver from "@oranix/quiver-electron/main";
+
+Quiver.init({
+  appSlug: "my-desktop-app",     // your Quiver app slug
+  clientKey: "qk_live_...",      // public client key (safe to ship)
+  release: app.getVersion(),     // version_name (defaults to app.getVersion())
+  versionCode: 1020300,          // Quiver version_code → picks the symbol set
+  environment: "stable",         // channel
+  extra: { deployment: "ga" },   // static annotations on every crash
+  onCrash: (info) => {
+    // renderer / child-process termination (incl. oom / killed, which produce
+    // no minidump) — log, show a dialog, etc.
+    console.warn("process gone:", info.processType, info.reason);
+  },
+});
+
+// Attach context that rides along on the next crash:
+Quiver.setUser({ id: "u_123", email: "a@b.com" });
+Quiver.setTag("feature", "editor");
+Quiver.setExtra("open_docs", 3);
+Quiver.addBreadcrumb({ message: "opened project", category: "ui" });
+```
+
+## Renderer process
+
+Renderer crashes are captured by the main-process Crashpad automatically — the
+renderer entry only manages scope and forwards it to main over IPC:
+
+```ts
+import * as Quiver from "@oranix/quiver-electron/renderer";
+
+Quiver.setTag("route", location.pathname);
+Quiver.addBreadcrumb({ message: "clicked export" });
+```
+
+For sandboxed renderers (`contextIsolation: true`), expose the API from your
+preload script instead:
+
+```ts
+// preload.ts
+import { exposeQuiver } from "@oranix/quiver-electron/preload";
+exposeQuiver(); // → window.quiver.setTag(...), window.quiver.addBreadcrumb(...)
+```
+
+## Symbols (server-side symbolication)
+
+Minidumps only become readable stacks when Quiver has your app's Breakpad
+symbols for that `version_code`. In CI, generate them with
+[`dump_syms`](https://github.com/mozilla/dump_syms) and upload alongside the
+release:
+
+```bash
+# produce .sym files for your app + Electron framework binaries
+dump_syms path/to/MyApp > syms/MyApp.sym
+# … repeat per binary, then zip them (flat is fine — Quiver reads each
+#    file's MODULE header to place it correctly) …
+zip -r symbols.zip syms/
+
+quiver builds publish-electron my-desktop-app \
+  --version-name 1.2.3 --version-code 1020300 \
+  --installer dist/MyApp-1.2.3.exe \
+  --symbols symbols.zip
+```
+
+Once symbols are present, each crash ticket gets a symbolicated stack posted as
+a comment. Without symbols, Quiver still records the crash with module+offset
+frames.
+
+## What gets sent
+
+Every minidump carries a Sentry-electron-style annotation set the server folds
+into the ticket: `product_type=electron`, `version`, `version_code`,
+`environment`/`channel`, `platform`, `arch`, `process_type`,
+`electron_version`, `chrome_version`, plus any `extra` and the current
+user/tags/breadcrumbs.

--- a/clients/electron/package.json
+++ b/clients/electron/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@oranix/quiver-electron",
+  "version": "0.1.0",
+  "description": "Quiver crash reporting for Electron apps — main + renderer, Crashpad minidumps auto-uploaded and symbolicated server-side.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./main": {
+      "types": "./dist/main.d.ts",
+      "import": "./dist/main.js"
+    },
+    "./renderer": {
+      "types": "./dist/renderer.d.ts",
+      "import": "./dist/renderer.js"
+    },
+    "./preload": {
+      "types": "./dist/preload.d.ts",
+      "import": "./dist/preload.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "electron": ">=22"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/clients/electron/src/common.ts
+++ b/clients/electron/src/common.ts
@@ -1,0 +1,104 @@
+// Shared, electron-free helpers and types for the Quiver Electron SDK. Kept
+// pure so it can be unit-tested without an Electron runtime.
+
+/** IPC channel renderers use to forward scope updates to the main process. */
+export const CONTEXT_CHANNEL = "quiver:context";
+
+export interface QuiverBreadcrumb {
+  message: string;
+  category?: string;
+  level?: "debug" | "info" | "warning" | "error";
+  timestamp?: number;
+  data?: Record<string, unknown>;
+}
+
+export interface CrashContext {
+  tags: Record<string, string>;
+  extra: Record<string, unknown>;
+  user: Record<string, string> | null;
+  breadcrumbs: QuiverBreadcrumb[];
+}
+
+export interface QuiverElectronOptions {
+  /** Quiver app slug (the distribution target). */
+  appSlug: string;
+  /** Public client key (Sentry-DSN model). Safe to ship in the app bundle. */
+  clientKey: string;
+  /** Quiver origin. Defaults to https://quiver.oranix.io. */
+  endpoint?: string;
+  /** Crashpad productName; defaults to appSlug. */
+  productName?: string;
+  /** App release / version (version_name). Defaults to app.getVersion(). */
+  release?: string;
+  /** Quiver version_code (integer) — used to look up the breakpad-symbols asset. */
+  versionCode?: number;
+  /** Deployment environment / channel, e.g. "stable" | "beta". */
+  environment?: string;
+  /** Whether Crashpad uploads dumps. Defaults to true. */
+  uploadToServer?: boolean;
+  /** Static annotations attached to every crash (Crashpad globalExtra). */
+  extra?: Record<string, string>;
+  /** Called on renderer / child-process termination (incl. non-dump reasons). */
+  onCrash?: (info: CrashInfo) => void;
+}
+
+export interface CrashInfo {
+  processType: string;
+  reason: string;
+  exitCode: number;
+}
+
+/** Runtime facts the main process reads off `process` / `app`. */
+export interface RuntimeInfo {
+  platform: string;
+  arch: string;
+  versions: Record<string, string | undefined>;
+}
+
+/** Coerce any value to the string that Crashpad annotations require. */
+export function toParam(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Build the Sentry-electron-style annotation set sent with every minidump.
+ * The server folds these into the crash ticket's metadata.
+ */
+export function buildGlobalExtra(
+  options: QuiverElectronOptions,
+  runtime: RuntimeInfo,
+  appVersion: string,
+): Record<string, string> {
+  const env = options.environment ?? "production";
+  const extra: Record<string, string> = {
+    product_type: "electron",
+    version: options.release ?? appVersion,
+    environment: env,
+    channel: env,
+    platform: runtime.platform,
+    arch: runtime.arch,
+    process_type: "main",
+  };
+  if (options.versionCode !== undefined) extra.version_code = String(options.versionCode);
+  if (runtime.versions.electron) extra.electron_version = runtime.versions.electron;
+  if (runtime.versions.chrome) extra.chrome_version = runtime.versions.chrome;
+  if (runtime.versions.node) extra.node_version = runtime.versions.node;
+  for (const [key, value] of Object.entries(options.extra ?? {})) extra[key] = toParam(value);
+  return extra;
+}
+
+/** Build the minidump submit URL Crashpad POSTs to (client key in the query). */
+export function buildSubmitURL(options: QuiverElectronOptions): string {
+  const endpoint = (options.endpoint ?? "https://quiver.oranix.io").replace(/\/+$/, "");
+  return (
+    `${endpoint}/public/v2/apps/${encodeURIComponent(options.appSlug)}/minidump` +
+    `?client_key=${encodeURIComponent(options.clientKey)}`
+  );
+}

--- a/clients/electron/src/electron-shim.d.ts
+++ b/clients/electron/src/electron-shim.d.ts
@@ -1,0 +1,70 @@
+// Minimal ambient typing for the Electron surface this SDK uses, so the package
+// typechecks and builds standalone in CI without pulling electron's full types
+// (and its ~100MB binary download). At runtime the host app's real `electron`
+// is used — it's declared as a peerDependency, not installed here.
+
+declare module "electron" {
+  export interface CrashReporterStartOptions {
+    productName?: string;
+    submitURL: string;
+    uploadToServer?: boolean;
+    compress?: boolean;
+    globalExtra?: Record<string, string>;
+    extra?: Record<string, string>;
+  }
+  export interface CrashReporter {
+    start(options: CrashReporterStartOptions): void;
+    addExtraParameter(key: string, value: string): void;
+  }
+  export const crashReporter: CrashReporter;
+
+  export interface WebContents {
+    id: number;
+    getURL(): string;
+  }
+  export interface RenderProcessGoneDetails {
+    reason: string;
+    exitCode: number;
+  }
+  export interface ChildProcessGoneDetails {
+    type: string;
+    reason: string;
+    exitCode: number;
+    name?: string;
+  }
+  export interface App {
+    getVersion(): string;
+    getName(): string;
+    on(
+      event: "render-process-gone",
+      listener: (event: unknown, webContents: WebContents, details: RenderProcessGoneDetails) => void,
+    ): App;
+    on(
+      event: "child-process-gone",
+      listener: (event: unknown, details: ChildProcessGoneDetails) => void,
+    ): App;
+  }
+  export const app: App;
+
+  export interface IpcMain {
+    on(channel: string, listener: (event: unknown, ...args: any[]) => void): void;
+  }
+  export const ipcMain: IpcMain;
+
+  export interface IpcRenderer {
+    send(channel: string, ...args: any[]): void;
+  }
+  export const ipcRenderer: IpcRenderer;
+
+  export interface ContextBridge {
+    exposeInMainWorld(apiKey: string, api: unknown): void;
+  }
+  export const contextBridge: ContextBridge;
+}
+
+// Node's `process` — typed locally to avoid an @types/node dependency.
+declare const process: {
+  platform: string;
+  arch: string;
+  versions: Record<string, string | undefined>;
+};

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -1,0 +1,98 @@
+// Quiver Electron SDK — main-process entry.
+//
+//   import * as Quiver from "@oranix/quiver-electron/main";
+//   Quiver.init({ appSlug: "my-app", clientKey: "qk_...", versionCode: 1020300 });
+//
+// Starts Crashpad (which captures both main- and renderer-process minidumps and
+// uploads them to Quiver), listens for renderer/child-process termination, and
+// manages a crash scope (user/tags/extra/breadcrumbs) that rides along on the
+// next dump. Renderers forward their scope here over IPC (see ./renderer).
+
+import { app, crashReporter, ipcMain } from "electron";
+import type { ChildProcessGoneDetails, RenderProcessGoneDetails, WebContents } from "electron";
+import {
+  CONTEXT_CHANNEL,
+  buildGlobalExtra,
+  buildSubmitURL,
+  toParam,
+  type CrashContext,
+  type QuiverBreadcrumb,
+  type QuiverElectronOptions,
+} from "./common.js";
+
+const MAX_BREADCRUMBS = 100;
+
+let started = false;
+const context: CrashContext = { tags: {}, extra: {}, user: null, breadcrumbs: [] };
+
+/** Initialise crash reporting. Call once in the main process before app ready. */
+export function init(options: QuiverElectronOptions): void {
+  if (started) return;
+  started = true;
+
+  crashReporter.start({
+    productName: options.productName ?? options.appSlug,
+    submitURL: buildSubmitURL(options),
+    uploadToServer: options.uploadToServer ?? true,
+    compress: true,
+    globalExtra: buildGlobalExtra(options, process, app.getVersion()),
+  });
+
+  // Renderer / child-process crashes: Crashpad already captured a minidump for
+  // real crashes; annotate the reason and surface every termination (including
+  // the dump-less ones: oom / killed / launch-failed) via onCrash.
+  app.on(
+    "render-process-gone",
+    (_event: unknown, _webContents: WebContents, details: RenderProcessGoneDetails) => {
+      crashReporter.addExtraParameter("process_type", "renderer");
+      crashReporter.addExtraParameter("crash_reason", details.reason);
+      options.onCrash?.({
+        processType: "renderer",
+        reason: details.reason,
+        exitCode: details.exitCode,
+      });
+    },
+  );
+  app.on("child-process-gone", (_event: unknown, details: ChildProcessGoneDetails) => {
+    options.onCrash?.({
+      processType: details.type,
+      reason: details.reason,
+      exitCode: details.exitCode,
+    });
+  });
+
+  // Scope forwarded from renderer processes.
+  ipcMain.on(CONTEXT_CHANNEL, (_event: unknown, patch: Partial<CrashContext>) => applyContext(patch));
+}
+
+/** Attach user identity to subsequent crashes (or clear with null). */
+export function setUser(user: Record<string, string> | null): void {
+  context.user = user;
+  crashReporter.addExtraParameter("user", user ? JSON.stringify(user).slice(0, 2000) : "");
+}
+
+/** Set an indexed tag on subsequent crashes. */
+export function setTag(key: string, value: string): void {
+  context.tags[key] = value;
+  crashReporter.addExtraParameter(`tag.${key}`.slice(0, 120), toParam(value).slice(0, 2000));
+}
+
+/** Set an arbitrary extra annotation on subsequent crashes. */
+export function setExtra(key: string, value: unknown): void {
+  context.extra[key] = value;
+  crashReporter.addExtraParameter(`extra.${key}`.slice(0, 120), toParam(value).slice(0, 2000));
+}
+
+/** Record a breadcrumb; the most recent are attached to the next crash. */
+export function addBreadcrumb(crumb: QuiverBreadcrumb): void {
+  context.breadcrumbs.push({ timestamp: Date.now(), ...crumb });
+  while (context.breadcrumbs.length > MAX_BREADCRUMBS) context.breadcrumbs.shift();
+  crashReporter.addExtraParameter("breadcrumbs", JSON.stringify(context.breadcrumbs).slice(0, 8000));
+}
+
+function applyContext(patch: Partial<CrashContext>): void {
+  if (patch.user !== undefined) setUser(patch.user);
+  if (patch.tags) for (const [k, v] of Object.entries(patch.tags)) setTag(k, v);
+  if (patch.extra) for (const [k, v] of Object.entries(patch.extra)) setExtra(k, v);
+  if (patch.breadcrumbs) for (const b of patch.breadcrumbs) addBreadcrumb(b);
+}

--- a/clients/electron/src/preload.ts
+++ b/clients/electron/src/preload.ts
@@ -1,0 +1,26 @@
+// Quiver Electron SDK — preload helper.
+//
+// For sandboxed renderers (contextIsolation: true), import this from your
+// preload script to expose a safe `window.quiver` scope API:
+//
+//   import { exposeQuiver } from "@oranix/quiver-electron/preload";
+//   exposeQuiver();
+//
+// then in renderer code: window.quiver.setTag("route", location.pathname).
+
+import { contextBridge, ipcRenderer } from "electron";
+import { CONTEXT_CHANNEL } from "./common.js";
+
+/** Expose the Quiver scope API on `window.quiver` for isolated renderers. */
+export function exposeQuiver(): void {
+  contextBridge.exposeInMainWorld("quiver", {
+    setUser: (user: Record<string, string> | null) =>
+      ipcRenderer.send(CONTEXT_CHANNEL, { user }),
+    setTag: (key: string, value: string) =>
+      ipcRenderer.send(CONTEXT_CHANNEL, { tags: { [key]: value } }),
+    setExtra: (key: string, value: unknown) =>
+      ipcRenderer.send(CONTEXT_CHANNEL, { extra: { [key]: value } }),
+    addBreadcrumb: (crumb: unknown) =>
+      ipcRenderer.send(CONTEXT_CHANNEL, { breadcrumbs: [crumb] }),
+  });
+}

--- a/clients/electron/src/renderer.ts
+++ b/clients/electron/src/renderer.ts
@@ -1,0 +1,35 @@
+// Quiver Electron SDK — renderer-process entry.
+//
+//   import * as Quiver from "@oranix/quiver-electron/renderer";
+//   Quiver.setTag("route", location.pathname);
+//
+// Modern Electron captures renderer crashes through the main-process Crashpad
+// automatically, so this module does NOT start a second reporter. It manages
+// scope and forwards it to the main process over IPC, where it's attached to
+// the next minidump. Requires the main process to have called the main entry's
+// init(), and (with contextIsolation) `nodeIntegration`/IPC exposure — or use
+// the ./preload helper.
+
+import { ipcRenderer } from "electron";
+import { CONTEXT_CHANNEL, type QuiverBreadcrumb } from "./common.js";
+
+/** Reserved hook — a place to wire renderer JS-error capture in the future. */
+export function init(): void {
+  /* no-op for now: renderer minidumps are handled by the main Crashpad. */
+}
+
+export function setUser(user: Record<string, string> | null): void {
+  ipcRenderer.send(CONTEXT_CHANNEL, { user });
+}
+
+export function setTag(key: string, value: string): void {
+  ipcRenderer.send(CONTEXT_CHANNEL, { tags: { [key]: value } });
+}
+
+export function setExtra(key: string, value: unknown): void {
+  ipcRenderer.send(CONTEXT_CHANNEL, { extra: { [key]: value } });
+}
+
+export function addBreadcrumb(crumb: QuiverBreadcrumb): void {
+  ipcRenderer.send(CONTEXT_CHANNEL, { breadcrumbs: [crumb] });
+}

--- a/clients/electron/tsconfig.json
+++ b/clients/electron/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/docs/public/electron-sdk.md
+++ b/docs/public/electron-sdk.md
@@ -1,0 +1,112 @@
+# Electron SDK
+
+`@oranix/quiver-electron` adds crash reporting to Electron apps. Electron's
+built-in [Crashpad](https://www.electronjs.org/docs/latest/api/crash-reporter)
+captures native minidumps for **both the main and renderer processes** and
+uploads them directly to Quiver, where they become crash tickets and are
+symbolicated server-side against your uploaded Breakpad symbols.
+
+Like `@sentry/electron`, the SDK has two entry points — one imported in the
+**main** process, one in the **renderer**.
+
+## Install
+
+```bash
+npm install @oranix/quiver-electron
+```
+
+`electron` is a peer dependency provided by your app.
+
+## Main process
+
+Call `init()` once, before the app is ready:
+
+```ts
+import { app } from "electron";
+import * as Quiver from "@oranix/quiver-electron/main";
+
+Quiver.init({
+  appSlug: "my-desktop-app",   // your Quiver app slug
+  clientKey: "qk_live_...",    // public client key (safe to ship)
+  release: app.getVersion(),   // version_name; defaults to app.getVersion()
+  versionCode: 1020300,        // Quiver version_code → selects the symbol set
+  environment: "stable",       // channel
+  extra: { deployment: "ga" }, // static annotations on every crash
+  onCrash: (info) => {
+    // renderer / child-process termination, including oom / killed exits that
+    // produce no minidump — log it, show a recovery dialog, etc.
+    console.warn("process gone:", info.processType, info.reason);
+  },
+});
+```
+
+Attach context that rides along on the next crash:
+
+```ts
+Quiver.setUser({ id: "u_123" });
+Quiver.setTag("feature", "editor");
+Quiver.setExtra("open_docs", 3);
+Quiver.addBreadcrumb({ message: "opened project", category: "ui" });
+```
+
+The main entry starts Crashpad, listens for `render-process-gone` and
+`child-process-gone`, and receives scope forwarded from renderers.
+
+## Renderer process
+
+Renderer crashes are captured by the main-process Crashpad automatically. The
+renderer entry only manages scope and forwards it to main over IPC:
+
+```ts
+import * as Quiver from "@oranix/quiver-electron/renderer";
+
+Quiver.setTag("route", location.pathname);
+Quiver.addBreadcrumb({ message: "clicked export" });
+```
+
+For sandboxed renderers (`contextIsolation: true`), expose the API from your
+preload script instead:
+
+```ts
+// preload.ts
+import { exposeQuiver } from "@oranix/quiver-electron/preload";
+exposeQuiver(); // → window.quiver.setTag(...), window.quiver.addBreadcrumb(...)
+```
+
+## Symbols
+
+Minidumps become readable stacks only when Quiver has your app's Breakpad
+symbols for that `version_code`. In CI:
+
+1. Generate `.sym` files with [`dump_syms`](https://github.com/mozilla/dump_syms)
+   for your app and the Electron framework binaries.
+2. Zip them (a flat zip is fine — Quiver reads each file's `MODULE` header to
+   place it in the Breakpad tree).
+3. Upload alongside the release:
+
+```bash
+quiver builds publish-electron my-desktop-app \
+  --version-name 1.2.3 --version-code 1020300 \
+  --installer dist/MyApp-1.2.3.exe \
+  --symbols symbols.zip
+```
+
+Each crash ticket then gets a symbolicated stack posted as a comment. Without
+symbols, Quiver still records the crash with module+offset frames and leaves a
+tip to upload them.
+
+## What gets sent
+
+Every minidump carries a Sentry-style annotation set the server folds into the
+ticket: `product_type=electron`, `version`, `version_code`,
+`environment`/`channel`, `platform`, `arch`, `process_type`,
+`electron_version`, `chrome_version`, plus any `extra` and the current
+user / tags / breadcrumbs.
+
+## How it reaches Quiver
+
+The SDK points Electron's `crashReporter.submitURL` at
+`POST /public/v2/apps/<slug>/minidump?client_key=<key>`. Crashpad POSTs the
+minidump as `upload_file_minidump` with the annotations as form fields; Quiver
+stores the dump as a crash-ticket attachment and runs the symbolication lane.
+No update-check or feedback wiring is required for crash reporting.

--- a/docs/symbolication-matrix.md
+++ b/docs/symbolication-matrix.md
@@ -14,7 +14,7 @@ lane exists.
 | Android Java/R8 | stack text (kind=crash ticket, `crash_*` signature fields) | `proguard-mapping` (mapping.txt) | container `retrace` → internal ticket comment | ✅ |
 | Android native (NDK) | `metadata.crash_native_frames`: `[{ index, offset, soname, build_id }]` (plus the human-readable dump as attachment) | `native-symbols` (zip of unstripped `.so`) | ✅ container `/symbolicate-native`: unzip → BuildId verify (`readelf -n`) → `llvm-symbolizer` per frame → internal ticket comment (missing asset ⇒ actionable comment). `symbolic` upgrade slot reserved. | server ✅ · SDK capture 🔨 |
 | iOS | crash record with a **binary images section** (image UUID + load address + slide) and frame addresses — `backtrace_symbols` text alone is NOT symbolicatable | `dsym` (zip of dSYM bundles) | container: `symbolic` by image UUID + address-slide; no mac/atos dependency | 📐 (SDK prerequisite: images section) |
-| Electron / Crashpad | minidump | Breakpad `.sym` files | `minidump-stackwalk` (rust-minidump) | ⏸ no electron lane yet |
+| Electron / Crashpad | minidump POSTed by Electron's built-in `crashReporter` to `POST /public/v2/apps/:slug/minidump` (`upload_file_minidump` + Sentry-electron-style annotations) | `breakpad-symbols` (zip of `dump_syms` `.sym`) | ✅ container `/symbolicate-minidump`: rebuild Breakpad tree from each `.sym` MODULE header → `minidump-stackwalk --json` → internal ticket comment (no symbols ⇒ module+offset + upload tip) | server ✅ · SDK ✅ (`@oranix/quiver-electron`, main+renderer) |
 
 ## Decisions
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - "admin"
   - "migrations"
   - "packages/*"
+  - "clients/electron"


### PR DESCRIPTION
## What

The **client half** of the Electron crash lane (task #97) — a real SDK with two entry points referenced in both processes, like `@sentry/electron`. Pairs with the server foundation in #110.

## The SDK — `@oranix/quiver-electron` (`clients/electron`)

- **`/main`** — `init()` starts Electron's `crashReporter` (Crashpad) with `submitURL` pointed at Quiver's minidump ingest and a Sentry-style `globalExtra` param set (release, version_code, environment/channel, platform, arch, process_type, electron/chrome versions, custom extras). Listens for `render-process-gone` / `child-process-gone` (surfacing dump-less oom/killed exits via `onCrash`). Manages a crash scope — `setUser` / `setTag` / `setExtra` / `addBreadcrumb` — attached to the next dump via `crashReporter.addExtraParameter`.
- **`/renderer`** — scope helpers that forward to main over IPC (renderer minidumps are captured by the main-process Crashpad automatically, so no second reporter).
- **`/preload`** — `exposeQuiver()` exposes a safe `window.quiver` scope API for sandboxed renderers via `contextBridge`.

`electron` is a **peerDependency**; the package ships a small ambient electron shim so it typechecks and builds standalone in CI **without** pulling electron's ~100MB binary. `tsc --noEmit` clean, `tsc` emits all three entry points + `.d.ts`.

## Docs

- New **Electron SDK** docs page (`docs/public/electron-sdk.md` + build-docs registration).
- `docs/symbolication-matrix.md` Electron/Crashpad row → ✅ (server + SDK), replacing "no electron lane yet".

## Client usage

```ts
// main
import * as Quiver from "@oranix/quiver-electron/main";
Quiver.init({ appSlug: "my-app", clientKey: "qk_...", versionCode: 1020300, environment: "stable" });

// renderer
import * as Quiver from "@oranix/quiver-electron/renderer";
Quiver.setTag("route", location.pathname);
```

## Notes

- Added `clients/electron` to the pnpm workspace so CI typechecks it.
- Symbols upload + server symbolication land in #110 (`publish-electron --symbols` → `breakpad-symbols` asset → `minidump-stackwalk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)