### PR TITLE
docs(product): Quiver is a client (not mobile-only) release platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 **Ship it, roll it out, hear it break, fix it.**
 
-The mobile release platform, full loop.
+The release platform for client apps, full loop.
 
-Quiver runs the whole release loop: CI lands builds as drafts, agents review and publish with bilingual changelogs, staged rollouts meter exposure by device cohort, share pages handle ad-hoc distribution, and in-app feedback and crash reports come back as tickets — grouped by signature, auto-deobfuscated, and triageable by humans and AI agents through the same API. Reporting SDKs cover Android and HarmonyOS today (iOS next) — fully Cloudflare-native (Workers + Container + D1 + R2).
+Quiver runs the whole release loop: CI lands builds as drafts, agents review and publish with bilingual changelogs, staged rollouts meter exposure by device cohort, share pages handle ad-hoc distribution, and in-app feedback and crash reports come back as tickets — grouped by signature, symbolicated, and triageable by humans and AI agents through the same API. Reporting SDKs cover Android, iOS, HarmonyOS, and Electron — fully Cloudflare-native (Workers + Container + D1 + R2).
 
 - **Live instance:** <https://quiver.oranix.io>
 - **Docs:** <https://quiver.oranix.io/docs> · [Admin guide](https://quiver.oranix.io/docs/admin-user-guide/) · [CLI reference](https://quiver.oranix.io/docs/cli-reference/)
 - **API explorer:** <https://quiver.oranix.io/api-docs>
 - **CLI on npm:** [`@oranix/quiver-cli`](https://www.npmjs.com/package/@oranix/quiver-cli)
 
-The "quiver" metaphor: admins load APK arrows into channels; clients pick the right one for their channel — and tell you where it landed.
+The "quiver" metaphor: admins load build arrows into channels; clients pick the right one for their channel — and tell you where it landed.
 
 ## Features
 
 - **Channels** — keep main, preview, nightly, or debug releases separated by app. Publish to `main` for stable users, `preview` for validation, `nightly` for fast internal iteration.
-- **Update checks & staged rollouts** — public latest/update responses with signed APK downloads, percentage rollouts bucketed by stable device id, and per-language changelogs; the Android SDK (`clients/android`) handles in-app checks, installation, and feedback and crash submission; a HarmonyOS (ArkTS) reporting layer mirrors it.
+- **Update checks & staged rollouts** — public latest/update responses with signed downloads, percentage rollouts bucketed by stable device id, and per-language changelogs; the Android SDK (`clients/android`) handles in-app checks, installation, and feedback/crash submission; iOS, HarmonyOS (ArkTS), and Electron (`@oranix/quiver-electron`) SDKs mirror the feedback and crash lanes.
 - **Share pages & version history** — revocable, expiring, optionally password-protected download pages with QR codes and view/download stats, plus an opt-in public version history page per app.
 - **Feedback tickets** — in-app feedback (attachments, device context) lands in a built-in ticket system with assignees, statuses, comments, and webhooks; submissions are authenticated with a per-app client key.
-- **Crash reporting** — store-then-send crash capture on Android and HarmonyOS uploads on next launch, groups by signature, and auto-retraces stacks against uploaded R8/ProGuard mappings.
+- **Crash reporting** — crash capture across Android, iOS, HarmonyOS, and Electron uploads on next launch, groups by signature, and symbolicates stacks server-side against uploaded R8/ProGuard mappings, native symbols, dSYMs, or Breakpad symbols (minidumps).
 - **Draft-first releases** — CI creates draft releases with generated changelogs; an agent reviews, writes bilingual notes, and publishes explicitly (`docs/release-runbook.md`).
 - **Raft access** — Login with Raft, org roles, direct app members, per-server visibility grants, and app-level deploy tokens for CI and agents.
 - **CI-friendly publishing** — the public npm CLI publishes Android releases and creates share links from GitHub Actions, local packaging lanes, or Raft agents:

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -481,7 +481,7 @@ function AuthGate() {
 
 function PublicLanding({ account }: { account?: AuthAccount }) {
   useEffect(() => {
-    document.title = "Quiver - Mobile release operations";
+    document.title = "Quiver - Client release operations";
   }, []);
 
   return (
@@ -521,7 +521,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
           <div className="mx-auto grid max-w-6xl gap-10 px-4 py-14 md:grid-cols-[1.1fr_0.9fr] md:items-center md:py-20">
             <div className="max-w-2xl">
               <div className="mb-4 inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
-                The mobile release platform for Raft-built apps
+                The release platform for Raft-built client apps
               </div>
               <h1 className="text-4xl font-bold leading-tight sm:text-5xl">
                 Ship it, roll it out, hear it break, fix it.
@@ -591,18 +591,19 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
           />
           <LandingFeature
             title="Crash reporting"
-            body="Store-then-send crash capture on Android and HarmonyOS, grouped by signature and auto-deobfuscated via mapping files."
+            body="Crash capture across Android, iOS, HarmonyOS, and Electron — grouped by signature and symbolicated server-side (R8 mappings, native symbols, dSYM, minidumps)."
           />
         </section>
 
         <section className="border-t border-slate-200 bg-white">
           <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-8 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 className="text-lg font-semibold">Integrate the SDK, build from CI.</h2>
+              <h2 className="text-lg font-semibold">Integrate an SDK, build from CI.</h2>
               <p className="mt-1 text-sm text-slate-600">
-                The Android SDK adds in-app update checks, staged rollouts,
-                feedback, and crash reporting; the public npm CLI publishes
-                releases and share links from CI or Raft agents.
+                SDKs for Android, iOS, HarmonyOS, and Electron add feedback and
+                crash reporting (plus in-app update checks and staged rollouts
+                on Android); the public npm CLI publishes releases and share
+                links from CI or Raft agents.
               </p>
             </div>
             <div className="flex flex-none flex-col gap-2 sm:flex-row">
@@ -611,6 +612,12 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
                 href="/docs/android-sdk/"
               >
                 Android SDK
+              </a>
+              <a
+                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
+                href="/docs/electron-sdk/"
+              >
+                Electron SDK
               </a>
               <a
                 className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"


### PR DESCRIPTION
Per @artin — Quiver now serves **client apps** across Android, iOS, HarmonyOS, **and Electron**, not just mobile. Updates the product positioning + related copy (task #98):

**Admin landing (`admin/src/App.tsx`)**
- Page title: "Mobile release operations" → "Client release operations"
- Hero tagline: "The mobile release platform for Raft-built apps" → "The release platform for Raft-built client apps"
- Crash-reporting feature: now lists Android / iOS / HarmonyOS / Electron and server-side symbolication (R8 mappings, native symbols, dSYM, minidumps)
- SDK section: "The Android SDK…" → "SDKs for Android, iOS, HarmonyOS, and Electron…"; added an **Electron SDK** doc link

**README**
- Tagline, SDK coverage, crash-reporting, update-checks lines, and the "quiver" metaphor generalized off Android/mobile-only wording

No functional changes — copy only. `admin` tsc clean; no remaining "mobile" strings in user-facing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)