### PR TITLE
fix(docs): serve /docs/electron-sdk/ (worker allowlist)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -423,6 +423,7 @@ const publicDocs = new Set([
   "/docs/android-sdk/",
   "/docs/ios-sdk/",
   "/docs/ohos-sdk/",
+  "/docs/electron-sdk/",
   "/docs/cli-reference/",
   "/docs/agent-cli-feedback/",
   "/docs/public-api-reference/",


### PR DESCRIPTION
PR #111 added the Electron SDK docs page + build-docs entry but not the worker's `publicDocs` allowlist, so `/docs/electron-sdk/` 404'd (including the new landing link). One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)