### PR TITLE
fix: make feedback references directly queryable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,26 @@ design — that is not a bug. To read/triage a ticket: `raft integration login
 `/api/apps/:appId/feedback*` REST endpoints. Full walkthrough:
 [/docs/agent-cli-feedback/](https://quiver.oranix.io/docs/agent-cli-feedback/).
 
+Quick lookup when someone gives you a Quiver feedback id. Newer Quiver
+feedback references include the full ticket UUID; if you get an older short
+id from chat, expand it first:
+
+```bash
+# Detail/attachment API routes require the full ticket UUID.
+TICKET_ID="$(quiver feedback list raft-android --json \
+  | python3 -c 'import json,sys; p=sys.argv[1]; print(next(t["id"] for t in json.load(sys.stdin)["tickets"] if t["id"].startswith(p)))' 389d855b)"
+
+# Show message, device context, comments, and attachment ids.
+quiver feedback show raft-android "$TICKET_ID"
+
+# Logs/diagnostics are ticket attachments. Quiver transports and stores them;
+# the producing app owns the file layout inside the downloaded archive.
+APP_ID="$(quiver apps get raft-android --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
+  -o diagnostics.zip
+```
+
 ## First-Day Checklist
 
 - Confirm `gh auth status` works.

--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -57,20 +57,66 @@ quiver feedback list raft-android --status open --kind crash
 quiver feedback list raft-android --kind bug
 
 # Show one ticket: description, device context, attachments, comments.
-# The ticket id can be the short 8-char prefix or the full UUID.
-quiver feedback show raft-android 389d855b
+# Use the full UUID from the submitted ticket response/reference.
+quiver feedback show raft-android 389d855b-0000-0000-0000-000000000000
 
 # Triage: change status and/or (re)assign
-quiver feedback update raft-android 389d855b --status in_progress --assignee me
-quiver feedback update raft-android 389d855b --status resolved
-quiver feedback update raft-android 389d855b --assignee none   # unassign
+quiver feedback update raft-android 389d855b-0000-0000-0000-000000000000 --status in_progress --assignee me
+quiver feedback update raft-android 389d855b-0000-0000-0000-000000000000 --status resolved
+quiver feedback update raft-android 389d855b-0000-0000-0000-000000000000 --assignee none   # unassign
 
 # Leave an internal comment (also where auto-retrace/symbolication land)
-quiver feedback comment raft-android 389d855b "reproduced on SGT-AL10; fix in progress"
+quiver feedback comment raft-android 389d855b-0000-0000-0000-000000000000 "reproduced on SGT-AL10; fix in progress"
 ```
 
 Status flow: `open → in_progress → resolved → closed`. Assignee is
 independent of status.
+
+## Quick lookup by feedback id
+
+When a user pastes a Quiver feedback id, first identify the app slug. For
+Raft Android/mobile, that slug is normally `raft-android`.
+
+New Quiver feedback responses include the full UUID in both `id` and the
+copyable `reference` field, for example:
+
+```text
+raft-android · 1.0.4 (1000400) · ticket 389d855b-0000-0000-0000-000000000000
+```
+
+Use that UUID directly:
+
+```bash
+TICKET_ID=389d855b-0000-0000-0000-000000000000
+APP=raft-android
+
+quiver feedback show "$APP" "$TICKET_ID"
+```
+
+The CLI now prints full UUIDs in human output. If you are working from an
+older copied reference that has only an 8-character short id, expand it to the
+full ticket UUID first:
+
+```bash
+SHORT_ID=389d855b
+APP=raft-android
+
+TICKET_ID="$(quiver feedback list "$APP" --json \
+  | python3 -c 'import json,sys; p=sys.argv[1]; print(next(t["id"] for t in json.load(sys.stdin)["tickets"] if t["id"].startswith(p)))' "$SHORT_ID")"
+
+quiver feedback show "$APP" "$TICKET_ID"
+```
+
+The `show` output is the first place to check for diagnostics: it includes
+the user message, version/channel, device context, comments, and all
+attachment ids. Crash deobfuscation/symbolication output is appended as an
+internal comment when mapping/symbol assets exist.
+
+For scripts, keep the raw JSON:
+
+```bash
+quiver feedback show "$APP" "$TICKET_ID" --json > ticket.json
+```
 
 ## Crashes
 
@@ -88,16 +134,35 @@ curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
 ## Attachments (diagnostics zips, logs)
 
 `feedback show` lists each attachment's id, filename, and size. Download one
-through the authenticated API endpoint (the CLI doesn't wrap this yet):
+through the authenticated API endpoint (the CLI doesn't wrap this yet). The
+API path requires the app UUID, not just the slug:
 
 ```bash
+APP_ID="$(quiver apps get "$APP" --json \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+
 curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  "https://quiver.oranix.io/api/apps/<appId>/feedback/<ticketId>/attachments/<attachmentId>" \
+  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
   -o diagnostics.zip
 ```
 
 Find `<appId>` with `quiver apps list` (the slug is stable; the id is the
 UUID the API paths use).
+
+Quiver does not define the files inside an app's diagnostics archive. It
+stores and serves the attachment; the producing app owns the log format and
+archive layout.
+
+The same ticket detail call can be made directly without the CLI:
+
+```bash
+curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID"
+```
+
+Known current limitation: the CLI can list attachment ids but does not yet
+wrap attachment downloads; use the authenticated REST call above until a
+`quiver feedback download-attachment` command exists.
 
 ## Other environment knobs
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -216,12 +216,15 @@ find and rotate the key in the app's Settings tab or via
 | `attachments` | No | Inline files (multipart), up to 10 MB each, ≤9 total. |
 | `presigned` | No | JSON array of `{ r2_key, filename, content_type, size }` for files already uploaded via the presign flow (below). |
 
-Returns `201` with `{ "id": "<ticket id>", "status": "open" }`. Rate limit:
-10 submissions per hour per app + client IP. Tickets appear in the admin
-Feedback tab; a `feedback:new` webhook fires for subscribed endpoints (crash
-tickets can additionally trigger `crash:new_group` / `crash:spike`). The
-Android SDK's `QuiverFeedback.submit(...)` wraps this endpoint and attaches
-device metadata automatically.
+Returns `201` with the full ticket UUID in `id`, plus a copyable `reference`
+and `ticket_url`, for example `{ "id": "<ticket UUID>", "status": "open",
+"reference": "raft-android · 1.0.4 (1000400) · ticket <ticket UUID>",
+"ticket_url": "https://quiver.oranix.io/apps/<appId>/feedback/<ticket UUID>" }`.
+Rate limit: 10 submissions per hour per app + client IP. Tickets appear in
+the admin Feedback tab; a `feedback:new` webhook fires for subscribed
+endpoints (crash tickets can additionally trigger `crash:new_group` /
+`crash:spike`). The Android SDK's `QuiverFeedback.submit(...)` wraps this
+endpoint and attaches device metadata automatically.
 
 ## Device Register (telemetry)
 

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -62,7 +62,7 @@ export function registerFeedbackCommands(program: Command): void {
       for (const t of res.tickets) {
         const preview = t.message.replace(/\s+/g, " ").slice(0, 60);
         console.log(
-          `${t.id.slice(0, 8)}  ${t.status.padEnd(11)} ${t.kind.padEnd(8)} ` +
+          `${t.id}  ${t.status.padEnd(11)} ${t.kind.padEnd(8)} ` +
             `${(t.assignee ?? "-").padEnd(16)} v${t.version_name ?? "?"} ` +
             `[${t.attachment_count}📎 ${t.comment_count}💬]  ${preview}`,
         );
@@ -85,7 +85,7 @@ export function registerFeedbackCommands(program: Command): void {
         return;
       }
       const t = res.ticket as Record<string, unknown>;
-      console.log(`Ticket ${String(t["id"]).slice(0, 8)} (${t["kind"]}, ${t["status"]})`);
+      console.log(`Ticket ${String(t["id"])} (${t["kind"]}, ${t["status"]})`);
       console.log(`  assignee: ${t["assignee"] ?? "-"}`);
       console.log(`  version:  ${t["version_name"] ?? "?"} (${t["version_code"] ?? "?"}) · ${t["channel"] ?? "?"}`);
       console.log(`  device:   ${t["device_model"] ?? "?"} · Android ${t["os_version"] ?? "?"} · ${t["arch"] ?? "?"} · ${t["locale"] ?? "?"}`);

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -137,6 +137,9 @@ const FeedbackSubmitResponse = z
   .object({
     id: z.string(),
     status: z.string(),
+    attachments: z.number().int().optional(),
+    reference: z.string().optional(),
+    ticket_url: z.string().nullable().optional(),
   })
   .openapi("FeedbackSubmitResponse");
 

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -400,8 +400,8 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   }
 
   // A ready-to-copy reference so a pasted ticket can be located by an agent:
-  // slug + version + short id, plus a direct admin link. The app copies this
-  // instead of a bare ticket id.
+  // slug + version + full id, plus a direct admin link. Keep the full UUID
+  // here because detail/attachment API routes require it.
   const versionName = meta("version_name");
   const versionLabel = versionName
     ? versionCode != null
@@ -416,7 +416,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   } catch {
     ticketUrl = null;
   }
-  const reference = [app.slug, versionLabel, `ticket ${ticketId.slice(0, 8)}`]
+  const reference = [app.slug, versionLabel, `ticket ${ticketId}`]
     .filter(Boolean)
     .join(" · ");
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3878,6 +3878,7 @@ describe("quiver public API v2 — scope resolution", () => {
     const submitContext = {
       env,
       req: {
+        url: "https://quiver.oranix.io/public/v2/apps/scope-app/feedback",
         param: (name: string) => (name === "slug" ? "scope-app" : ""),
         header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
         query: () => undefined,
@@ -3892,6 +3893,9 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(submitted.status).toBe(201);
     const submittedBody = await responseJson<any>(submitted);
     expect(submittedBody.attachments).toBe(1);
+    expect(submittedBody.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(submittedBody.reference).toContain(`ticket ${submittedBody.id}`);
+    expect(submittedBody.ticket_url).toContain(`/apps/app-scope/feedback/${submittedBody.id}`);
     expect(putCalls.length).toBe(1);
     expect(putCalls[0]!.key).toContain("feedback/app-scope/");
 


### PR DESCRIPTION
## Summary
- return full ticket UUIDs in public feedback `reference` values so copied feedback references are directly queryable
- include `reference`, `attachments`, and `ticket_url` in the OpenAPI response schema for feedback submissions
- print full ticket ids in `quiver feedback list` / `show` human output instead of 8-character prefixes
- update agent/public docs with the full-id flow, legacy short-id expansion, REST ticket/attachment retrieval, and the boundary that Quiver transports attachments while the producing app owns archive contents/log format

## Validation
- `pnpm --filter @oranix/quiver-worker test`
- `pnpm --filter @oranix/quiver-cli test`
- `pnpm --filter @oranix/quiver-admin build`
- `git diff --check`
