### PR TITLE
feat(feedback): resolve short/prefix ticket ids + CLI attachment download

### DIFF
--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -93,18 +93,13 @@ APP=raft-android
 quiver feedback show "$APP" "$TICKET_ID"
 ```
 
-The CLI now prints full UUIDs in human output. If you are working from an
-older copied reference that has only an 8-character short id, expand it to the
-full ticket UUID first:
+The CLI now prints full UUIDs in human output. You can also pass a **short id
+or any unique prefix** — the feedback read/detail/attachment endpoints resolve
+it to the full ticket automatically (an ambiguous prefix returns `409`; use a
+longer prefix or the full UUID):
 
 ```bash
-SHORT_ID=389d855b
-APP=raft-android
-
-TICKET_ID="$(quiver feedback list "$APP" --json \
-  | python3 -c 'import json,sys; p=sys.argv[1]; print(next(t["id"] for t in json.load(sys.stdin)["tickets"] if t["id"].startswith(p)))' "$SHORT_ID")"
-
-quiver feedback show "$APP" "$TICKET_ID"
+quiver feedback show raft-android 389d855b   # 8-char short id works
 ```
 
 The `show` output is the first place to check for diagnostics: it includes
@@ -134,35 +129,32 @@ curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
 ## Attachments (diagnostics zips, logs)
 
 `feedback show` lists each attachment's id, filename, and size. Download one
-through the authenticated API endpoint (the CLI doesn't wrap this yet). The
-API path requires the app UUID, not just the slug:
+with the CLI (accepts a slug and a short/prefix ticket id):
+
+```bash
+quiver feedback download-attachment raft-android 389d855b <attachmentId>
+# → Saved 445539 bytes to slock-feedback-....zip   (use -o to choose the path)
+```
+
+Quiver saves the **raw bytes as-is** — it does not unzip or interpret the
+contents. Quiver does not define the files inside an app's diagnostics archive;
+it stores and serves the attachment, and the producing app owns the log format
+and archive layout (how to open a given app's zip is documented in that app's
+repo, not here).
+
+The same downloads and ticket detail can also be fetched directly via REST
+(the API path uses the app **UUID**, not the slug):
 
 ```bash
 APP_ID="$(quiver apps get "$APP" --json \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 
 curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
-  -o diagnostics.zip
-```
-
-Find `<appId>` with `quiver apps list` (the slug is stable; the id is the
-UUID the API paths use).
-
-Quiver does not define the files inside an app's diagnostics archive. It
-stores and serves the attachment; the producing app owns the log format and
-archive layout.
-
-The same ticket detail call can be made directly without the CLI:
-
-```bash
+  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID"                       # ticket detail
 curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID"
+  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
+  -o diagnostics.zip                                                                     # raw attachment
 ```
-
-Known current limitation: the CLI can list attachment ids but does not yet
-wrap attachment downloads; use the authenticated REST call above until a
-`quiver feedback download-attachment` command exists.
 
 ## Other environment knobs
 

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -4,6 +4,7 @@
  * update/comment).
  */
 import type { Command } from "commander";
+import { writeFile } from "node:fs/promises";
 import { apiRequest } from "../lib/api.js";
 
 interface TicketRow {
@@ -156,4 +157,39 @@ export function registerFeedbackCommands(program: Command): void {
       }
       console.log(`Commented on ${ticketId.slice(0, 8)}.`);
     });
+
+  feedback
+    .command("download-attachment <appIdOrSlug> <ticketId> <attachmentId>")
+    .alias("download")
+    .description(
+      "Download a feedback attachment to a file. Saves the raw bytes as-is — " +
+        "Quiver does not unzip or interpret the contents (the producing app owns the format).",
+    )
+    .option("-o, --output <path>", "Output file path. Defaults to the server filename in the cwd.")
+    .action(
+      async (
+        appIdOrSlug: string,
+        ticketId: string,
+        attachmentId: string,
+        opts: { output?: string },
+      ) => {
+        const appId = await resolveAppId(appIdOrSlug);
+        const res = await apiRequest<Response>(
+          `/api/apps/${appId}/feedback/${ticketId}/attachments/${attachmentId}`,
+          { raw: true },
+        );
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          console.error(`Download failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`);
+          process.exit(1);
+        }
+        const disposition = res.headers.get("content-disposition") ?? "";
+        const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition);
+        const serverName = match?.[1] ? decodeURIComponent(match[1]) : attachmentId;
+        const outPath = opts.output ?? serverName;
+        const bytes = Buffer.from(await res.arrayBuffer());
+        await writeFile(outPath, bytes);
+        console.log(`Saved ${bytes.length} bytes to ${outPath}`);
+      },
+    );
 }

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -1190,9 +1190,61 @@ export async function handleListFeedback(c: AdminContext) {
   return c.json({ tickets: results });
 }
 
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+type TicketResolution =
+  | { id: string }
+  | { error: "not_found" }
+  | { error: "ambiguous"; count: number };
+
+/**
+ * Resolve a ticket id that may be a full UUID or a short **prefix** (e.g. the
+ * 8-char id historically surfaced in references/UI). A full UUID takes the
+ * exact-match fast path; anything else is matched as `id LIKE prefix%` within
+ * the app and must hit exactly one ticket — 0 ⇒ not found, >1 ⇒ ambiguous.
+ * This lets agents query with whatever id they copied without a manual expand.
+ */
+async function resolveTicketId(
+  db: D1Database,
+  appId: string | undefined,
+  ticketId: string | undefined,
+): Promise<TicketResolution> {
+  if (!appId) return { error: "not_found" };
+  const raw = (ticketId ?? "").trim();
+  if (UUID_RE.test(raw)) {
+    const row = await db
+      .prepare("SELECT id FROM feedback_tickets WHERE app_id = ?1 AND id = ?2")
+      .bind(appId, raw.toLowerCase())
+      .first<{ id: string }>();
+    return row ? { id: row.id } : { error: "not_found" };
+  }
+  // Prefix mode: require a reasonably specific, id-shaped prefix.
+  if (raw.length < 4 || !/^[0-9a-fA-F-]+$/.test(raw)) return { error: "not_found" };
+  const { results } = await db
+    .prepare("SELECT id FROM feedback_tickets WHERE app_id = ?1 AND id LIKE ?2 ORDER BY id LIMIT 6")
+    .bind(appId, raw.toLowerCase() + "%")
+    .all<{ id: string }>();
+  if (results.length === 0) return { error: "not_found" };
+  if (results.length > 1) return { error: "ambiguous", count: results.length };
+  return { id: results[0]!.id };
+}
+
+/** Map a failed ticket resolution to a JSON response. */
+function ticketResolveError(c: AdminContext, r: { error: "not_found" } | { error: "ambiguous"; count: number }) {
+  if (r.error === "ambiguous") {
+    return c.json(
+      { error: `ticket id prefix matches ${r.count} tickets; use the full UUID` },
+      409,
+    );
+  }
+  return c.json({ error: "ticket not found" }, 404);
+}
+
 export async function handleGetFeedback(c: AdminContext) {
   const appId = c.req.param("appId");
-  const ticketId = c.req.param("ticketId");
+  const resolved = await resolveTicketId(c.env.DB, appId, c.req.param("ticketId"));
+  if ("error" in resolved) return ticketResolveError(c, resolved);
+  const ticketId = resolved.id;
   const ticket = await c.env.DB.prepare(
     "SELECT * FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
   )
@@ -1216,7 +1268,9 @@ export async function handleGetFeedback(c: AdminContext) {
 
 export async function handleUpdateFeedback(c: AdminContext) {
   const appId = c.req.param("appId");
-  const ticketId = c.req.param("ticketId");
+  const resolved = await resolveTicketId(c.env.DB, appId, c.req.param("ticketId"));
+  if ("error" in resolved) return ticketResolveError(c, resolved);
+  const ticketId = resolved.id;
   const body = (await c.req.json().catch(() => ({}))) as {
     status?: string;
     assignee?: string | null;
@@ -1273,7 +1327,9 @@ export async function handleUpdateFeedback(c: AdminContext) {
 
 export async function handleAddFeedbackComment(c: AdminContext) {
   const appId = c.req.param("appId");
-  const ticketId = c.req.param("ticketId");
+  const resolved = await resolveTicketId(c.env.DB, appId, c.req.param("ticketId"));
+  if ("error" in resolved) return ticketResolveError(c, resolved);
+  const ticketId = resolved.id;
   const body = (await c.req.json().catch(() => ({}))) as {
     body?: string;
     internal?: boolean;
@@ -1302,7 +1358,9 @@ export async function handleAddFeedbackComment(c: AdminContext) {
 
 export async function handleDownloadFeedbackAttachment(c: AdminContext) {
   const appId = c.req.param("appId");
-  const ticketId = c.req.param("ticketId");
+  const resolved = await resolveTicketId(c.env.DB, appId, c.req.param("ticketId"));
+  if ("error" in resolved) return ticketResolveError(c, resolved);
+  const ticketId = resolved.id;
   const attachmentId = c.req.param("attachmentId");
   const row = await c.env.DB.prepare(
     `SELECT fa.r2_key, fa.filename, fa.content_type

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3606,6 +3606,57 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(res.status).toBe(401);
   });
 
+  it("handleGetFeedback resolves a short ticket-id prefix and full UUID", async () => {
+    const env = makeEnv();
+    const { handleGetFeedback } = await import("../src/routes/feedback");
+    const fullId = "abcd1234-1111-2222-3333-444455556666";
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?1, 'app-scope', 'bug', 'open', 'hi', '{}', 1, 1)`,
+    ).bind(fullId).run();
+    const call = (tid: string) =>
+      handleGetFeedback({
+        env,
+        req: {
+          param: (n: string) => (n === "appId" ? "app-scope" : n === "ticketId" ? tid : undefined),
+          query: () => undefined,
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+
+    const short = await call("abcd1234");
+    expect(short.status).toBe(200);
+    expect((await responseJson<any>(short)).ticket.id).toBe(fullId);
+
+    const full = await call(fullId);
+    expect(full.status).toBe(200);
+    expect((await responseJson<any>(full)).ticket.id).toBe(fullId);
+
+    const missing = await call("ffffffff");
+    expect(missing.status).toBe(404);
+  });
+
+  it("handleGetFeedback returns 409 on an ambiguous ticket-id prefix", async () => {
+    const env = makeEnv();
+    const { handleGetFeedback } = await import("../src/routes/feedback");
+    const ins = (id: string) =>
+      env.DB.prepare(
+        `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+         VALUES (?1, 'app-scope', 'bug', 'open', 'x', '{}', 1, 1)`,
+      ).bind(id).run();
+    await ins("dead0001-0000-0000-0000-000000000000");
+    await ins("dead0002-0000-0000-0000-000000000000");
+    const res = await handleGetFeedback({
+      env,
+      req: {
+        param: (n: string) => (n === "appId" ? "app-scope" : n === "ticketId" ? "dead000" : undefined),
+        query: () => undefined,
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    expect(res.status).toBe(409);
+  });
+
   it("changelogToHtml renders bullets safely", async () => {
     const { changelogToHtml } = await import("../src/routes/public_v2");
     const html = changelogToHtml("- one **bold**\n- two <script>x</script>\n\nplain `c`");


### PR DESCRIPTION
Follow-up to #115 (task #99) — closes the two "current limitations" #115's docs called out, staying within Quiver's boundary: **generic retrieval, no consumer-format coupling.**

## Worker — tolerant ticket-id resolution
`feedback` GET / update / comment / attachment-download now accept a full UUID **or a unique short prefix** (the historical 8-char id). Full UUID → exact-match fast path; otherwise `id LIKE prefix%` scoped to the app, unique match required:
- 0 matches → `404`
- \>1 matches → `409` (ambiguous; use a longer prefix / full UUID)

So an agent can query with whatever id it copied — no manual `list --json | python filter` expand.

## CLI — `quiver feedback download-attachment`
```bash
quiver feedback download-attachment raft-android 389d855b <attachmentId>
# → Saved 445539 bytes to slock-feedback-....zip   (-o to choose the path)
```
Downloads the **raw bytes as-is** — no unzip/interpret. Fills the gap where the CLI could list attachment ids but not fetch them.

## Docs
`agent-cli-feedback.md` drops the manual short-id-expand and the attachment-download workaround; documents the native behavior. Reaffirms Quiver serves raw attachments and does not define archive internals (that's the producing app's repo).

## Tests
short-prefix + full-UUID resolve, ambiguous → 409. **89 worker tests pass.** worker + cli `tsc` clean.

## Not in scope (deliberate)
- Unzipping / locating `app_logs/*.jsonl` — consumer-format coupling; documented in the **mobile** repo instead.
- Manifest `actions` enumeration for `raft integration invoke` self-serve — needs the `slock-agent-manifest.v0` action schema contract confirmed; separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)