### PR TITLE
chore(cli): bump to 0.3.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oranix/quiver-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Quiver CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bump @oranix/quiver-cli to 0.3.3 to publish the CLI features merged since 0.3.2: `feedback download-attachment` + short-id/prefix ticket resolution (#116). 🤖 Generated with [Claude Code](https://claude.com/claude-code)