### PR TITLE
chore(ios-sdk): 0.1.4 (presign attachments) + LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Oranix
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Quiver.podspec
+++ b/Quiver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Quiver'
-  s.version          = '0.1.3'
+  s.version          = '0.1.4'
   s.summary          = 'Quiver feedback + crash reporting for iOS.'
   s.description      = <<-DESC
     Native iOS reporting layer for Quiver: in-app feedback tickets
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     parameters, never compiled into the SDK.
   DESC
   s.homepage         = 'https://github.com/oranix-io/quiver'
-  s.license          = { :type => 'MIT' }
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Oranix' => 'artin@cat.ms' }
   s.source           = { :git => 'https://github.com/oranix-io/quiver.git', :tag => "ios-v#{s.version}" }
 


### PR DESCRIPTION
Bump the iOS pod to 0.1.4 to publish the presigned large-attachment upload (#90, landed after ios-v0.1.3). Adds a root MIT LICENSE + podspec `:file` reference to clear the pod lint warning. Tag `ios-v0.1.4` follows after merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)