### PR TITLE
chore(ohos-sdk): add README.md for ohpm publish

### DIFF
--- a/clients/ohos/quiver/README.md
+++ b/clients/ohos/quiver/README.md
@@ -1,0 +1,24 @@
+# @oranix/quiver (HarmonyOS)
+
+Quiver feedback + crash reporting SDK for HarmonyOS (ArkTS).
+
+- **Feedback tickets** — submit in-app feedback with attachments and automatic
+  device metadata. Large attachments (up to the configured cap) upload directly
+  to storage via presigned URLs; smaller ones go inline.
+- **Crash reporting** — store-then-send crash capture, uploaded as crash tickets
+  on the next launch.
+- **Device id** — a stable per-install id for rollout/analytics correlation.
+
+Configured at runtime (base URL, app slug, channel, client key are init
+parameters, never compiled in). See the Quiver docs at
+<https://quiver.oranix.io/docs> for integration details.
+
+## Install
+
+```
+ohpm install @oranix/quiver
+```
+
+## License
+
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
OHPM requires a non-empty readme.md in the package (400 after the LICENSE fix). Adds it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)