### PR TITLE
chore(ohos-sdk): add changelog.md for ohpm publish

### DIFF
--- a/clients/ohos/quiver/changelog.md
+++ b/clients/ohos/quiver/changelog.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release of the HarmonyOS Quiver SDK.
+- Feedback tickets with attachments and automatic device metadata; large
+  attachments upload via presigned direct-to-storage URLs (up to the configured
+  cap), smaller ones inline.
+- Store-then-send crash reporting, uploaded as crash tickets on next launch.
+- Stable per-install device id.


### PR DESCRIPTION
OHPM requires a non-empty changelog.md (400 after LICENSE + readme fixes). Adds it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)