### PR TITLE
docs(android-sdk): 0.9.0 + 9/200 attachment cap

### DIFF
--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.quiver:quiver-android-updater:0.4.0")
+    implementation("io.quiver:quiver-android-updater:0.9.0")
 }
 ```
 
@@ -78,7 +78,7 @@ val ticketId = QuiverFeedback(
     message = "Feed doesn't refresh after login.",
     kind = "bug",                       // "feedback" | "bug" | "crash"
     contact = "user@example.com",       // optional
-    attachments = listOf(screenshot),   // up to 3 files, 10 MB each
+    attachments = listOf(screenshot),   // up to 9 files, 200 MB each (large files upload directly to storage via presigned URLs)
 )
 ```
 


### PR DESCRIPTION
Update the Android SDK doc for the 0.9.0 publish: dep version 0.4.0→0.9.0 and the feedback attachment cap 3/10MB→9/200MB (presigned direct-to-storage). 🤖 Generated with [Claude Code](https://claude.com/claude-code)