### PR TITLE
fix(notes): hide versions without curated release notes

### DIFF
--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -98,6 +98,18 @@ export async function handlePublicAppHistory(c: Context<{ Bindings: Env }>) {
  * bilingual JSON object ({"zh-cn":…,"en":…}); null means "no notes yet". Only
  * raw strings are hidden from the public release-notes page.
  */
+/**
+ * A curated bilingual note is required for a version to appear on the public
+ * release-notes page. Null or blank changelogs (versions never given release
+ * notes, incl. redundant same-version rebuild records) are hidden rather than
+ * rendered as a noisy "No release notes for this version." row — this also
+ * collapses duplicate records of one version_code down to the single one that
+ * actually carries notes.
+ */
+function isEmptyChangelog(changelog: string | null): boolean {
+  return changelog == null || changelog.trim() === "";
+}
+
 function isRawChangelog(changelog: string | null): boolean {
   if (changelog == null) return false;
   const trimmed = changelog.trim();
@@ -149,7 +161,8 @@ export async function handlePublicReleaseNotes(c: Context<{ Bindings: Env }>) {
   const visible = (results ?? []).filter(
     (r) =>
       (requestedCode == null || r.version_code <= requestedCode) &&
-      !isRawChangelog(r.changelog),
+      !isRawChangelog(r.changelog) &&
+      !isEmptyChangelog(r.changelog),
   );
 
   const lang =
@@ -186,7 +199,8 @@ export async function handlePublicReleaseNotesJson(c: Context<{ Bindings: Env }>
     .filter(
       (row) =>
         (requestedCode == null || row.version_code <= requestedCode) &&
-        !isRawChangelog(row.changelog),
+        !isRawChangelog(row.changelog) &&
+        !isEmptyChangelog(row.changelog),
     )
     .map((row) => ({
       release_id: row.release_id,


### PR DESCRIPTION
## What
The public release-notes page (`/notes/:slug`, task #90) rendered a "No release notes for this version." row for any release whose changelog is null/blank. When one version has multiple release records (e.g. a same-day rebuild of **1.0.0** that superseded an earlier 1.0.0 build), the empty extra record surfaced as a **duplicate version entry** on the page.

## Fix
Hide null/blank changelogs the same way raw CI changelogs are already hidden (`isEmptyChangelog` alongside `isRawChangelog`), in both the HTML notes page and its JSON endpoint. Each version now appears once — via the record that actually carries curated notes.

## Effect
- `raft-android` 1.0.0 no longer shows twice; the redundant empty `716445f1` record drops off, leaving the canonical `14998dba` (now backfilled with notes).
- Users no longer see empty "No release notes" rows.
- History is preserved — every version with curated notes still shows (this does **not** hide superseded/older versions).

Backfilled the 1.0.0 (canonical) and 1.0.1 changelogs via API separately, so no real version disappears once this deploys.

Scoped to the `/notes` surface; the older `/history` page is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)