### PR TITLE
fix(worker): allow agent members to create apps

### DIFF
--- a/admin/src/pages/OrgSettings.tsx
+++ b/admin/src/pages/OrgSettings.tsx
@@ -600,8 +600,8 @@ function CreateInviteDialog({
                 setRole(e.target.value as "member" | "viewer")
               }
             >
-              <option value="member">member (humans default)</option>
-              <option value="viewer">viewer (agents / read-only)</option>
+              <option value="member">member (default)</option>
+              <option value="viewer">viewer (read-only)</option>
             </select>
           </div>
           <div>

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -132,7 +132,7 @@ Your account or deploy token does not have the required role for the action. The
 ```json
 {
   "error": "insufficient_org_role",       // or "insufficient_app_role"
-  "required_role": "admin",
+  "required_role": "member",
   "current_role": "viewer",
   "resource": "POST /api/apps",            // the action you attempted
   "org_id": "…", "app_id": null,
@@ -142,4 +142,4 @@ Your account or deploy token does not have the required role for the action. The
 
 To resolve, an organization **admin/owner** opens `manage_url` — **Org → Members** for org roles, or an app's **Access** tab for app-level roles — and raises the account's role to `required_role`. Then retry the same request.
 
-Note: creating an app (`POST /api/apps`) requires an **org admin/owner** — an app-level member role or a deploy token is not enough. A newly Agent-Login'd account usually starts as **viewer**, so this 403 is expected on the first admin-scoped call.
+Note: creating an app (`POST /api/apps`) requires an **org member or higher** — an app-level member role or a deploy token is not enough. Newly Agent-Login'd agents normally start as **member**; **viewer** is a read-only role that an org admin can assign manually.

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -10,7 +10,7 @@ Two options, by scope:
 
 | Method | Scope | Use for |
 |---|---|---|
-| **Raft Agent Login** | Your org-wide role (viewer/admin/owner) | Admin operations: creating apps, reviewing/publishing releases, triaging tickets, managing shares. |
+| **Raft Agent Login** | Your org-wide role (viewer/member/admin/owner) | Admin operations: creating apps, reviewing/publishing releases, triaging tickets, managing shares. |
 | **Deploy token** | One app, viewer or publisher role | CI and narrow automation: publishing builds, creating shares for a single app. |
 
 ### Raft Agent Login
@@ -88,7 +88,7 @@ quiver releases revoke-share <app> <releaseId> <shareId>
 
 The share URL is printed once; tokens are stored hashed.
 
-### Apps (admin role)
+### Apps (org member role)
 
 ```bash
 # create (API; CLI covers list/get)
@@ -114,14 +114,13 @@ with the new one.
 
 ## Handling permission (403) errors
 
-Right after Agent Login your org role is usually **viewer**, so the first
-admin-scoped call (e.g. creating an app) will 403. Quiver's role-403s are
-**machine-readable** — act on them instead of failing silently:
+Quiver's role-403s are **machine-readable** — act on them instead of failing
+silently:
 
 ```json
 {
   "error": "insufficient_org_role",       // or "insufficient_app_role"
-  "required_role": "admin",
+  "required_role": "member",
   "current_role": "viewer",
   "resource": "POST /api/apps",            // the action you attempted
   "org_id": "…", "app_id": null,
@@ -138,9 +137,11 @@ On this response:
    admin can raise my role at `<manage_url>`, then I'll retry."
 3. **Retry the same request** once they confirm the role change.
 
-App creation (`POST /api/apps`) needs an **org** admin/owner specifically — an
-app-member role or deploy token is not enough. If an app should live under a
-different organization, that org's admin creates it there rather than bumping
+App creation (`POST /api/apps`) needs an **org member or higher** specifically —
+an app-member role or deploy token is not enough. New Agent Login accounts
+normally start as org members; an org admin can manually downgrade an account to
+viewer for read-only access. If an app should live under a different
+organization, that org's member/admin creates it there rather than changing
 your role in this one.
 
 ## Rules for agents

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -545,7 +545,7 @@ admin.get("/api/orgs/:orgId/webhooks/:webhookId/deliveries", requireOrgRole("org
 admin.post("/api/invites/:token/accept", handleAcceptInvite);
 
 admin.get("/api/apps", requireCurrentOrgRole("viewer"), handleListApps);
-admin.post("/api/apps", requireCurrentOrgRole("admin"), handleCreateApp);
+admin.post("/api/apps", requireCurrentOrgRole("member"), handleCreateApp);
 admin.get("/api/apps/:appId", requireAppRole("viewer"), handleGetApp);
 admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -298,7 +298,7 @@ async function defaultOrgRoleForAccount(
   }
   return (await isFirstPrincipalInServer(db, account.server_id, account.id))
     ? "admin"
-    : "viewer";
+    : "member";
 }
 
 async function upsertRaftOrgMembership(

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -18,8 +18,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import Database from "better-sqlite3";
 import { createHash } from "node:crypto";
+import { Hono } from "hono";
+import { authMiddleware } from "../src/middleware/auth";
+import { requireCurrentOrgRole } from "../src/lib/permissions";
 import { httpsRedirectUrl, isSecureRequest, requestOrigin } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
+import { handleCreateApp } from "../src/routes/apps";
 
 // ---------- Test harness ----------
 
@@ -92,6 +96,21 @@ function makeMockDb() {
       metadata_json TEXT NOT NULL DEFAULT '{}',
       created_at INTEGER NOT NULL,
       UNIQUE (app_id, slug),
+      FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
+    );
+    CREATE TABLE product_types (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      description TEXT,
+      supported_platforms_json TEXT NOT NULL DEFAULT '[]',
+      default_assets_json TEXT NOT NULL DEFAULT '[]',
+      parser_kind TEXT,
+      schema_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (app_id, name),
       FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
     );
     CREATE TABLE versions (
@@ -650,7 +669,7 @@ describe("quiver route handlers — SQL smoke", () => {
       .prepare(
         "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)",
       )
-      .bind("m2", "raft_s1", "agent1", "viewer", now)
+      .bind("m2", "raft_s1", "agent1", "member", now)
       .run();
 
     const members = await env.DB
@@ -665,9 +684,110 @@ describe("quiver route handlers — SQL smoke", () => {
       .all();
 
     expect(members.results).toEqual([
-      { principal_type: "agent", org_role: "viewer" },
+      { principal_type: "agent", org_role: "member" },
       { principal_type: "human", org_role: "owner" },
     ]);
+  });
+
+  it("lets org members create apps while viewers remain read-only", async () => {
+    const now = Date.now();
+    const memberToken = "member-create-token";
+    const viewerToken = "viewer-create-token";
+
+    await env.DB
+      .prepare(
+        `INSERT INTO organizations
+         (id, slug, name, external_provider, external_id, created_at, archived)
+         VALUES (?, ?, ?, 'raft', ?, ?, 0)`,
+      )
+      .bind("raft_create", "create-org", "Create Org", "create-server", now)
+      .run();
+
+    for (const account of [
+      { id: "member-agent", subject: "member-sub", role: "member", token: memberToken },
+      { id: "viewer-agent", subject: "viewer-sub", role: "viewer", token: viewerToken },
+    ]) {
+      await env.DB
+        .prepare(
+          `INSERT INTO raft_accounts
+           (id, provider, provider_subject, server_id, server_slug, principal_type,
+            server_role, username, display_name, avatar_url, raw_profile,
+            created_at, updated_at, last_login_at)
+           VALUES (?, 'raft', ?, 'create-server', 'create-org', 'agent',
+                   NULL, ?, ?, NULL, '{}', ?, ?, ?)`,
+        )
+        .bind(account.id, account.subject, account.id, account.id, now, now, now)
+        .run();
+      await env.DB
+        .prepare(
+          "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(`orgmem-${account.id}`, "raft_create", account.id, account.role, now)
+        .run();
+      await env.DB
+        .prepare(
+          "INSERT INTO raft_sessions (id, account_id, token_hash, created_at, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+          `session-${account.id}`,
+          account.id,
+          createHash("sha256").update(account.token).digest("hex"),
+          now,
+          now + 60_000,
+          now,
+        )
+        .run();
+    }
+
+    const testApp = new Hono<{ Bindings: Env }>();
+    testApp.use("*", authMiddleware as any);
+    testApp.post("/api/apps", requireCurrentOrgRole("member") as any, handleCreateApp as any);
+
+    const viewerResponse = await testApp.request(
+      "https://quiver-worker.test/api/apps",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${viewerToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "viewer-app", name: "Viewer App", platform: "android" }),
+      },
+      env as any,
+    );
+    expect(viewerResponse.status).toBe(403);
+    await expect(viewerResponse.json()).resolves.toMatchObject({
+      error: "insufficient_org_role",
+      required_role: "member",
+      current_role: "viewer",
+      resource: "POST /api/apps",
+    });
+
+    const memberResponse = await testApp.request(
+      "https://quiver-worker.test/api/apps",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${memberToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "member-app", name: "Member App", platform: "android" }),
+      },
+      env as any,
+    );
+    expect(memberResponse.status).toBe(201);
+    await expect(memberResponse.json()).resolves.toMatchObject({
+      org_id: "raft_create",
+      slug: "member-app",
+      name: "Member App",
+      platform: "android",
+    });
+
+    const seededChannels = await env.DB
+      .prepare("SELECT slug FROM channels WHERE app_id = (SELECT id FROM apps WHERE slug = ?) ORDER BY slug")
+      .bind("member-app")
+      .all();
+    expect(seededChannels.results.map((row: any) => row.slug)).toEqual(["main", "nightly", "preview"]);
   });
 
   it("apps are scoped by org_id", async () => {
@@ -1221,7 +1341,7 @@ describe("quiver Hono app — auth + dispatch", () => {
     ).run();
     await env.DB.prepare(
       "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)",
-    ).bind("orgmem-token", "raft_server1", "acct-token", "viewer", now).run();
+    ).bind("orgmem-token", "raft_server1", "acct-token", "member", now).run();
     await env.DB.prepare(
       `INSERT INTO raft_sessions
        (id, account_id, token_hash, created_at, expires_at, last_seen_at)
@@ -1234,7 +1354,7 @@ describe("quiver Hono app — auth + dispatch", () => {
       principal_type: "agent",
       username: "qa-agent",
       org_id: "raft_server1",
-      org_role: "viewer",
+      org_role: "member",
     });
   });
 


### PR DESCRIPTION
## Summary
- change app creation from org admin-only to org member-or-higher
- default newly Agent-Login'd non-first agents to org member instead of viewer
- update public docs and org invite role labels to match the new policy
- add a route-level regression test that blocks viewer and allows member app creation through bearer auth

## Validation
- pnpm --filter @oranix/quiver-worker test
- pnpm --filter @oranix/quiver-worker build
- pnpm --filter @oranix/quiver-admin build
- git diff --check