### PR TITLE
feat(ios): attach app diagnostics to crash tickets (task #102)

### DIFF
--- a/clients/ios/Sources/Quiver/QuiverCrashReporter.h
+++ b/clients/ios/Sources/Quiver/QuiverCrashReporter.h
@@ -8,16 +8,20 @@ NS_ASSUME_NONNULL_BEGIN
 /// disk; the next launch uploads each pending crash as a kind=crash Quiver
 /// ticket and deletes local files on success. Captures uncaught NSExceptions
 /// and fatal signals (SIGABRT/SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP).
+
 /// Supplies the host app's own diagnostics log files to attach alongside a
 /// crash. Invoked on a background queue at crash-upload time (next launch),
-/// once per pending crash. Return the absolute paths of the app-owned
-/// diagnostics files to attach (e.g. a rolling slock-diagnostics.jsonl plus a
+/// once per pending crash. `crashAtMillis` is the crash time in Unix epoch
+/// milliseconds (matching the ticket's crash_at and the on-disk crash log
+/// name), or 0 when unknown — use it to return a per-crash snapshot/slice of
+/// the app's logs. Return the absolute paths of the app-owned diagnostics
+/// files to attach (e.g. a rolling slock-diagnostics.jsonl plus a
 /// slock-diagnostics-summary.txt). Missing paths are skipped; return nil or an
 /// empty array to attach nothing. The app only writes and hands over raw file
 /// paths — the SDK owns packaging: it bundles the returned files into a single
 /// diagnostics-<ts>.zip, caps the total size, and attaches it to the crash
 /// ticket. The block must be cheap and non-blocking; do not do heavy work in it.
-typedef NSArray<NSString *> *_Nullable (^QuiverDiagnosticsProvider)(void);
+typedef NSArray<NSString *> *_Nullable (^QuiverDiagnosticsProvider)(int64_t crashAtMillis);
 
 @interface QuiverCrashReporter : NSObject
 

--- a/clients/ios/Sources/Quiver/QuiverCrashReporter.h
+++ b/clients/ios/Sources/Quiver/QuiverCrashReporter.h
@@ -8,11 +8,28 @@ NS_ASSUME_NONNULL_BEGIN
 /// disk; the next launch uploads each pending crash as a kind=crash Quiver
 /// ticket and deletes local files on success. Captures uncaught NSExceptions
 /// and fatal signals (SIGABRT/SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGTRAP).
+/// Supplies the host app's own diagnostics log files to attach alongside a
+/// crash. Invoked on a background queue at crash-upload time (next launch),
+/// once per pending crash. Return the absolute paths of the app-owned
+/// diagnostics files to attach (e.g. a rolling slock-diagnostics.jsonl plus a
+/// slock-diagnostics-summary.txt). Missing paths are skipped; return nil or an
+/// empty array to attach nothing. The app only writes and hands over raw file
+/// paths — the SDK owns packaging: it bundles the returned files into a single
+/// diagnostics-<ts>.zip, caps the total size, and attaches it to the crash
+/// ticket. The block must be cheap and non-blocking; do not do heavy work in it.
+typedef NSArray<NSString *> *_Nullable (^QuiverDiagnosticsProvider)(void);
+
 @interface QuiverCrashReporter : NSObject
 
 /// Install the exception and signal handlers. Call once, as early as
 /// possible (app init). Previous NSException handlers are chained.
 + (void)install;
+
+/// Register the app diagnostics provider (see QuiverDiagnosticsProvider).
+/// Call once during app init, BEFORE -uploadPendingAfterDelay: so pending
+/// crashes pick it up. Pass nil to clear. The SDK zips whatever the provider
+/// returns and attaches it to each crash ticket; the app never zips.
++ (void)setDiagnosticsProvider:(nullable QuiverDiagnosticsProvider)provider;
 
 /// Upload pending crash reports after a delay (off the launch critical
 /// path). Safe to call every launch; no-op when nothing is pending.

--- a/clients/ios/Sources/Quiver/QuiverCrashReporter.m
+++ b/clients/ios/Sources/Quiver/QuiverCrashReporter.m
@@ -684,9 +684,11 @@ static NSString *QuiverZipDiagnostics(NSArray<NSString *> *paths, NSString *stam
         NSString *diagnosticsZip = nil;
         QuiverDiagnosticsProvider diagnosticsProvider = QuiverCurrentDiagnosticsProvider();
         if (diagnosticsProvider) {
+            int64_t crashAtMillis = [meta[@"crash_at"] isKindOfClass:NSNumber.class]
+                ? [meta[@"crash_at"] longLongValue] : 0;
             NSArray<NSString *> *diagnosticsPaths = nil;
             @try {
-                diagnosticsPaths = diagnosticsProvider();
+                diagnosticsPaths = diagnosticsProvider(crashAtMillis);
             } @catch (NSException *exception) {
                 NSLog(@"[Quiver] diagnostics provider threw: %@", exception.reason ?: exception.name);
                 diagnosticsPaths = nil;

--- a/clients/ios/Sources/Quiver/QuiverCrashReporter.m
+++ b/clients/ios/Sources/Quiver/QuiverCrashReporter.m
@@ -29,6 +29,19 @@ enum {
 static char gQuiverCrashDir[512] = {0};
 static NSUncaughtExceptionHandler *gQuiverPreviousExceptionHandler = NULL;
 
+// App-registered diagnostics provider (see QuiverCrashReporter.h). Written
+// once at init; read at upload time on a background queue. Guarded by a lock
+// so set/get never tears across threads.
+static QuiverDiagnosticsProvider gQuiverDiagnosticsProvider = nil;
+static pthread_mutex_t gQuiverDiagnosticsProviderLock = PTHREAD_MUTEX_INITIALIZER;
+
+static QuiverDiagnosticsProvider QuiverCurrentDiagnosticsProvider(void) {
+    pthread_mutex_lock(&gQuiverDiagnosticsProviderLock);
+    QuiverDiagnosticsProvider provider = gQuiverDiagnosticsProvider;
+    pthread_mutex_unlock(&gQuiverDiagnosticsProviderLock);
+    return provider;
+}
+
 typedef struct {
     char uuid[37];
     char path[QuiverImagePathMax];
@@ -493,6 +506,66 @@ static void QuiverHandleSignal(int signalNumber) {
     raise(signalNumber);
 }
 
+// Bundles the app-provided diagnostics files into a single zip for upload.
+// The app hands over raw file paths; the SDK owns packaging. Returns the zip
+// path (inside a fresh temp dir the caller cleans up) or nil when there is
+// nothing to attach. Runs at upload time (next launch), not in the crash
+// handler, so ordinary Foundation APIs are safe. NSFileCoordinator's
+// forUploading option is the dependency-free way to produce a real .zip on
+// iOS: coordinated-reading a directory yields a zipped copy.
+static NSString *QuiverZipDiagnostics(NSArray<NSString *> *paths, NSString *stamp) {
+    if (![paths isKindOfClass:NSArray.class] || paths.count == 0) return nil;
+    NSFileManager *fm = NSFileManager.defaultManager;
+    NSString *stageRoot = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:[@"quiver-diag-" stringByAppendingString:NSUUID.UUID.UUIDString]];
+    NSString *stageDir = [stageRoot stringByAppendingPathComponent:@"diagnostics"];
+    if (![fm createDirectoryAtPath:stageDir withIntermediateDirectories:YES attributes:nil error:nil]) {
+        return nil;
+    }
+
+    NSUInteger staged = 0;
+    for (NSString *path in paths) {
+        if (![path isKindOfClass:NSString.class] || path.length == 0) continue;
+        BOOL isDir = NO;
+        if (![fm fileExistsAtPath:path isDirectory:&isDir] || isDir) continue;
+        NSString *name = path.lastPathComponent;
+        NSString *dest = [stageDir stringByAppendingPathComponent:name];
+        for (NSUInteger n = 1; [fm fileExistsAtPath:dest]; n++) {
+            NSString *ext = name.pathExtension;
+            NSString *base = name.stringByDeletingPathExtension;
+            NSString *alt = ext.length > 0
+                ? [NSString stringWithFormat:@"%@-%lu.%@", base, (unsigned long)n, ext]
+                : [NSString stringWithFormat:@"%@-%lu", base, (unsigned long)n];
+            dest = [stageDir stringByAppendingPathComponent:alt];
+        }
+        if ([fm copyItemAtPath:path toPath:dest error:nil]) staged++;
+    }
+    if (staged == 0) {
+        [fm removeItemAtPath:stageRoot error:nil];
+        return nil;
+    }
+
+    __block NSString *zipPath = nil;
+    NSFileCoordinator *coordinator = [[NSFileCoordinator alloc] initWithFilePresenter:nil];
+    NSError *coordError = nil;
+    [coordinator coordinateReadingItemAtURL:[NSURL fileURLWithPath:stageDir]
+                                    options:NSFileCoordinatorReadingForUploading
+                                      error:&coordError
+                                 byAccessor:^(NSURL *zippedURL) {
+        NSString *dest = [stageRoot stringByAppendingPathComponent:
+            [NSString stringWithFormat:@"diagnostics-%@.zip", stamp.length > 0 ? stamp : @"crash"]];
+        if ([fm copyItemAtPath:zippedURL.path toPath:dest error:nil]) {
+            zipPath = dest;
+        }
+    }];
+
+    [fm removeItemAtPath:stageDir error:nil];
+    if (!zipPath) {
+        [fm removeItemAtPath:stageRoot error:nil];
+    }
+    return zipPath;
+}
+
 @implementation QuiverCrashReporter
 
 + (void)install {
@@ -533,6 +606,12 @@ static void QuiverHandleSignal(int signalNumber) {
     [fm removeItemAtPath:logPath error:nil];
     NSString *metaPath = [[logPath stringByDeletingPathExtension] stringByAppendingString:@".meta.json"];
     [fm removeItemAtPath:metaPath error:nil];
+}
+
++ (void)setDiagnosticsProvider:(QuiverDiagnosticsProvider)provider {
+    pthread_mutex_lock(&gQuiverDiagnosticsProviderLock);
+    gQuiverDiagnosticsProvider = [provider copy];
+    pthread_mutex_unlock(&gQuiverDiagnosticsProviderLock);
 }
 
 + (void)uploadPendingAfterDelay:(NSTimeInterval)delay {
@@ -598,10 +677,32 @@ static void QuiverHandleSignal(int signalNumber) {
             extras[@"crash_frames"] = framesJSON;
         }
 
+        // Attach app-owned diagnostics (if a provider is registered): the app
+        // hands over raw file paths, the SDK zips them into a single
+        // diagnostics-<stamp>.zip alongside the crash log.
+        NSMutableArray<NSString *> *attachmentPaths = [NSMutableArray arrayWithObject:logPath];
+        NSString *diagnosticsZip = nil;
+        QuiverDiagnosticsProvider diagnosticsProvider = QuiverCurrentDiagnosticsProvider();
+        if (diagnosticsProvider) {
+            NSArray<NSString *> *diagnosticsPaths = nil;
+            @try {
+                diagnosticsPaths = diagnosticsProvider();
+            } @catch (NSException *exception) {
+                NSLog(@"[Quiver] diagnostics provider threw: %@", exception.reason ?: exception.name);
+                diagnosticsPaths = nil;
+            }
+            NSString *stamp = [[logName stringByReplacingOccurrencesOfString:@"crash-" withString:@""]
+                stringByReplacingOccurrencesOfString:@".txt" withString:@""];
+            diagnosticsZip = QuiverZipDiagnostics(diagnosticsPaths, stamp);
+            if (diagnosticsZip) {
+                [attachmentPaths addObject:diagnosticsZip];
+            }
+        }
+
         dispatch_semaphore_t done = dispatch_semaphore_create(0);
         [QuiverFeedbackClient submitWithMessage:message
                                                 kind:@"crash"
-                                     attachmentPaths:@[ logPath ]
+                                     attachmentPaths:attachmentPaths
                                               extras:extras
                                           completion:^(NSString *ticketId, NSError *error) {
             if (ticketId.length > 0 && !error) {
@@ -613,6 +714,13 @@ static void QuiverHandleSignal(int signalNumber) {
             dispatch_semaphore_signal(done);
         }];
         dispatch_semaphore_wait(done, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60 * NSEC_PER_SEC)));
+
+        // The zip lives in a throwaway temp dir; remove it whether or not the
+        // upload succeeded (the crash log itself is retained on failure so the
+        // next launch retries).
+        if (diagnosticsZip) {
+            [NSFileManager.defaultManager removeItemAtPath:diagnosticsZip.stringByDeletingLastPathComponent error:nil];
+        }
     }
 }
 


### PR DESCRIPTION
## What
Adds a **diagnostics provider hook** to the iOS crash reporter so app-owned logs ride along with crash tickets — the iOS counterpart of the feedback-diagnostics chain.

## Interface (the contract for the app/KMP side)
```objc
typedef NSArray<NSString *> *_Nullable (^QuiverDiagnosticsProvider)(void);

+ (void)setDiagnosticsProvider:(nullable QuiverDiagnosticsProvider)provider;
```
- Register once during app init, **before** `-uploadPendingAfterDelay:`.
- The block is invoked at **crash-upload time (next launch)**, once per pending crash, on a background queue.
- It returns the absolute paths of the app's raw diagnostics files (e.g. `slock-diagnostics-summary.txt`, `slock-diagnostics.jsonl`). Missing paths are skipped; return nil/empty to attach nothing.

## Division (agreed with @KMP-专家, per artin)
- **App**: writes raw `slock-diagnostics-summary.txt` + `slock-diagnostics.jsonl*` and hands the SDK the path list. **Does not zip.**
- **SDK (this PR)**: zips the returned files into `diagnostics-<crashStamp>.zip` and attaches it via the existing `attachmentPaths` multipart (auto inline <10 MB / presigned <200 MB). Packaging, naming, and de-dup of basenames are SDK-owned.

## Notes
- Zip is built with `NSFileCoordinator` `forUploading` — dependency-free, produces a real `.zip`. Runs at upload time (not in the signal handler), so ordinary Foundation APIs are safe.
- **Backward compatible**: with no provider registered, crash upload is byte-for-byte unchanged.
- One coordination point for the app side: since the provider runs at next launch, the app must not wipe its diagnostics files on launch before Quiver's upload runs.
- Podspec version bump deferred to the publish step (after the app side lands + is tested end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)