### PR TITLE
feat(worker): expose version usage metrics

### DIFF
--- a/admin/src/components/DeviceAnalytics.tsx
+++ b/admin/src/components/DeviceAnalytics.tsx
@@ -30,13 +30,13 @@ export function DeviceAnalytics({ appId }: { appId: string }) {
     <div className="card !p-4">
       <div className="flex items-baseline justify-between mb-3">
         <h3 className="text-sm font-semibold">Active devices</h3>
-        <span className="text-xs text-slate-500">last 30 days</span>
+        <span className="text-xs text-slate-500">reported in last 30 days</span>
       </div>
 
       <div className="flex items-end gap-2 mb-4">
         <span className="text-3xl font-semibold tabular-nums">{data.active_devices}</span>
         <span className="text-xs text-slate-500 mb-1">
-          device{data.active_devices === 1 ? "" : "s"} reported in
+          device{data.active_devices === 1 ? "" : "s"} reported
         </span>
       </div>
 
@@ -98,7 +98,7 @@ export function DeviceAnalytics({ appId }: { appId: string }) {
         <div className="mt-5 border-t border-slate-100 pt-4">
           <div className="flex items-baseline justify-between mb-2">
             <h4 className="text-xs font-medium text-slate-600">Version metrics</h4>
-            <span className="text-xs text-slate-500">last {versionMetrics.data?.window_days ?? 30} days</span>
+            <span className="text-xs text-slate-500">reported in last {versionMetrics.data?.window_days ?? 30} days</span>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-xs">

--- a/admin/src/components/DeviceAnalytics.tsx
+++ b/admin/src/components/DeviceAnalytics.tsx
@@ -5,7 +5,7 @@
  */
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { getDeviceAnalytics } from "../lib/api";
+import { getDeviceAnalytics, getVersionMetrics } from "../lib/api";
 
 const BAR_COLOR = "#2a78d6";
 
@@ -14,6 +14,10 @@ export function DeviceAnalytics({ appId }: { appId: string }) {
   const analytics = useQuery({
     queryKey: ["device-analytics", appId],
     queryFn: () => getDeviceAnalytics(appId, 30),
+  });
+  const versionMetrics = useQuery({
+    queryKey: ["version-metrics", appId],
+    queryFn: () => getVersionMetrics(appId, 30),
   });
 
   if (analytics.isLoading) return null;
@@ -89,6 +93,65 @@ export function DeviceAnalytics({ appId }: { appId: string }) {
           </div>
         )}
       </div>
+
+      {(versionMetrics.data?.versions.length ?? 0) > 0 && (
+        <div className="mt-5 border-t border-slate-100 pt-4">
+          <div className="flex items-baseline justify-between mb-2">
+            <h4 className="text-xs font-medium text-slate-600">Version metrics</h4>
+            <span className="text-xs text-slate-500">last {versionMetrics.data?.window_days ?? 30} days</span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead className="text-slate-500">
+                <tr className="border-b border-slate-100">
+                  <th className="py-1.5 pr-3 text-left font-medium">Version</th>
+                  <th className="py-1.5 pr-3 text-left font-medium">Channel</th>
+                  <th className="py-1.5 pr-3 text-right font-medium">Active</th>
+                  <th className="py-1.5 pr-3 text-right font-medium">Seen</th>
+                  <th className="py-1.5 pr-3 text-right font-medium">Current</th>
+                  <th className="py-1.5 pr-3 text-right font-medium">Offered</th>
+                  <th className="py-1.5 pr-3 text-right font-medium">Feedback</th>
+                  <th className="py-1.5 text-right font-medium">Downloads</th>
+                </tr>
+              </thead>
+              <tbody>
+                {versionMetrics.data!.versions.slice(0, 8).map((v) => (
+                  <tr
+                    key={`${v.release_id ?? "telemetry"}-${v.version_code ?? v.version_name}-${v.channel}`}
+                    className="border-b border-slate-50 last:border-0"
+                  >
+                    <td className="py-1.5 pr-3 whitespace-nowrap">
+                      <button
+                        type="button"
+                        className="font-medium text-slate-700 hover:text-blue-700"
+                        onClick={() =>
+                          v.version_code != null &&
+                          navigate(`/apps/${appId}/feedback?version_code=${v.version_code}`)
+                        }
+                      >
+                        {v.version_name}
+                      </button>
+                      {v.version_code != null && (
+                        <span className="ml-1 text-slate-400 tabular-nums">{v.version_code}</span>
+                      )}
+                    </td>
+                    <td className="py-1.5 pr-3 text-slate-600">{v.channel}</td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums">{v.active_devices}</td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums">{v.total_devices}</td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums">{v.update_current_count}</td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums">{v.update_offered_count}</td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums">
+                      {v.feedback_count}
+                      {v.crash_count > 0 && <span className="text-slate-400"> / {v.crash_count}</span>}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">{v.download_count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1249,6 +1249,7 @@ export interface VersionMetric {
 export interface VersionMetrics {
   window_start: number;
   window_days: number;
+  window_minutes: number;
   versions: VersionMetric[];
 }
 

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1223,6 +1223,35 @@ export interface DeviceAnalytics {
   by_channel: Array<{ channel: string; devices: number }>;
 }
 
+export interface VersionMetric {
+  release_id: string | null;
+  build_id: string | null;
+  channel: string;
+  product_type: string | null;
+  release_type: string | null;
+  release_status: string | null;
+  rollout_cohort_count: number | null;
+  version_name: string;
+  version_code: number | null;
+  released_at: number | null;
+  release_updated_at: number | null;
+  active_devices: number;
+  total_devices: number;
+  update_current_count: number;
+  update_offered_count: number;
+  last_checked_at: number | null;
+  feedback_count: number;
+  crash_count: number;
+  download_count: number;
+  telemetry_only: boolean;
+}
+
+export interface VersionMetrics {
+  window_start: number;
+  window_days: number;
+  versions: VersionMetric[];
+}
+
 export interface DeviceDetail {
   device_id: string;
   version_name: string | null;
@@ -1247,6 +1276,12 @@ export const getDeviceDetail = (appId: string, deviceId: string) =>
 export const getDeviceAnalytics = (appId: string, windowDays = 30) =>
   request<DeviceAnalytics>(
     `/api/apps/${appId}/analytics/devices?window_days=${windowDays}`,
+    { admin: true },
+  );
+
+export const getVersionMetrics = (appId: string, windowDays = 30) =>
+  request<VersionMetrics>(
+    `/api/apps/${appId}/analytics/versions?window_days=${windowDays}`,
     { admin: true },
   );
 

--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverAnalytics.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverAnalytics.kt
@@ -71,7 +71,7 @@ object QuiverAnalytics {
         val url = baseUrl.trimEnd('/').toHttpUrl().newBuilder()
             .addPathSegments("public/v2/apps")
             .addPathSegment(appSlug)
-            .addPathSegment("devices")
+            .addPathSegment("metrics")
             .build()
         val requestBuilder = Request.Builder()
             .url(url)

--- a/clients/electron/README.md
+++ b/clients/electron/README.md
@@ -49,6 +49,12 @@ Quiver.setExtra("open_docs", 3);
 Quiver.addBreadcrumb({ message: "opened project", category: "ui" });
 ```
 
+`init()` also sends a throttled launch/install metrics ping to Quiver using a
+random per-install device id stored under Electron `userData`. This powers
+active-device and version-distribution analytics; it is not a true online
+heartbeat. Use `Quiver.reportDevice(options)` if you need to force a metrics
+ping outside the normal 24h throttle.
+
 ## Renderer process
 
 Renderer crashes are captured by the main-process Crashpad automatically — the

--- a/clients/electron/src/electron-shim.d.ts
+++ b/clients/electron/src/electron-shim.d.ts
@@ -35,6 +35,8 @@ declare module "electron" {
   export interface App {
     getVersion(): string;
     getName(): string;
+    getLocale(): string;
+    getPath(name: "userData"): string;
     on(
       event: "render-process-gone",
       listener: (event: unknown, webContents: WebContents, details: RenderProcessGoneDetails) => void,
@@ -68,3 +70,27 @@ declare const process: {
   arch: string;
   versions: Record<string, string | undefined>;
 };
+
+declare module "node:crypto" {
+  export function randomUUID(): string;
+}
+
+declare module "node:fs" {
+  export function existsSync(path: string): boolean;
+  export function mkdirSync(path: string, options?: { recursive?: boolean }): void;
+  export function readFileSync(path: string, encoding: "utf8"): string;
+  export function writeFileSync(path: string, data: string, encoding: "utf8"): void;
+}
+
+declare module "node:path" {
+  export function join(...parts: string[]): string;
+}
+
+declare const fetch: (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  },
+) => Promise<{ ok: boolean }>;

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -10,6 +10,9 @@
 
 import { app, crashReporter, ipcMain } from "electron";
 import type { ChildProcessGoneDetails, RenderProcessGoneDetails, WebContents } from "electron";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   CONTEXT_CHANNEL,
   buildGlobalExtra,
@@ -21,6 +24,7 @@ import {
 } from "./common.js";
 
 const MAX_BREADCRUMBS = 100;
+const METRICS_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 let started = false;
 const context: CrashContext = { tags: {}, extra: {}, user: null, breadcrumbs: [] };
@@ -37,6 +41,8 @@ export function init(options: QuiverElectronOptions): void {
     compress: true,
     globalExtra: buildGlobalExtra(options, process, app.getVersion()),
   });
+
+  void reportMetrics(options);
 
   // Renderer / child-process crashes: Crashpad already captured a minidump for
   // real crashes; annotate the reason and surface every termination (including
@@ -63,6 +69,11 @@ export function init(options: QuiverElectronOptions): void {
 
   // Scope forwarded from renderer processes.
   ipcMain.on(CONTEXT_CHANNEL, (_event: unknown, patch: Partial<CrashContext>) => applyContext(patch));
+}
+
+/** Force a runtime metrics ping outside the normal 24h throttle. */
+export function reportDevice(options: QuiverElectronOptions): Promise<boolean> {
+  return reportMetrics(options, true);
 }
 
 /** Attach user identity to subsequent crashes (or clear with null). */
@@ -95,4 +106,74 @@ function applyContext(patch: Partial<CrashContext>): void {
   if (patch.tags) for (const [k, v] of Object.entries(patch.tags)) setTag(k, v);
   if (patch.extra) for (const [k, v] of Object.entries(patch.extra)) setExtra(k, v);
   if (patch.breadcrumbs) for (const b of patch.breadcrumbs) addBreadcrumb(b);
+}
+
+async function reportMetrics(options: QuiverElectronOptions, force = false): Promise<boolean> {
+  const state = loadMetricsState();
+  const now = Date.now();
+  if (!force && state.lastPingAt > 0 && now - state.lastPingAt < METRICS_INTERVAL_MS) return false;
+
+  const deviceId = state.deviceId || randomUUID();
+  const endpoint = (options.endpoint ?? "https://quiver.oranix.io").replace(/\/+$/, "");
+  const url = `${endpoint}/public/v2/apps/${encodeURIComponent(options.appSlug)}/metrics`;
+  const env = options.environment ?? "production";
+  const metadata = {
+    version_name: options.release ?? app.getVersion(),
+    version_code: options.versionCode,
+    channel: env,
+    platform: `electron-${process.platform}`,
+    arch: process.arch,
+    os_version: process.versions.electron ? `Electron ${process.versions.electron}` : "Electron",
+    device_model: app.getName(),
+    locale: app.getLocale(),
+    product_type: "electron",
+    electron_version: process.versions.electron,
+    chrome_version: process.versions.chrome,
+    node_version: process.versions.node,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Quiver-Client-Key": options.clientKey,
+        "X-Quiver-Device-Id": deviceId,
+      },
+      body: JSON.stringify(metadata),
+    });
+    if (!response.ok) return false;
+    saveMetricsState({ deviceId, lastPingAt: now });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function statePath(): string {
+  return join(app.getPath("userData"), "quiver-metrics.json");
+}
+
+function loadMetricsState(): { deviceId: string; lastPingAt: number } {
+  const path = statePath();
+  try {
+    if (!existsSync(path)) return { deviceId: "", lastPingAt: 0 };
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { deviceId?: unknown; lastPingAt?: unknown };
+    return {
+      deviceId: typeof parsed.deviceId === "string" ? parsed.deviceId : "",
+      lastPingAt: typeof parsed.lastPingAt === "number" ? parsed.lastPingAt : 0,
+    };
+  } catch {
+    return { deviceId: "", lastPingAt: 0 };
+  }
+}
+
+function saveMetricsState(state: { deviceId: string; lastPingAt: number }): void {
+  const path = statePath();
+  try {
+    mkdirSync(app.getPath("userData"), { recursive: true });
+    writeFileSync(path, JSON.stringify(state), "utf8");
+  } catch {
+    /* metrics state is best-effort */
+  }
 }

--- a/clients/ios/Sources/Quiver/Quiver.m
+++ b/clients/ios/Sources/Quiver/Quiver.m
@@ -92,7 +92,7 @@ static QuiverConfig *gQuiverConfig = nil;
     NSData *bodyData = [NSJSONSerialization dataWithJSONObject:metadata options:0 error:nil];
     if (!bodyData) return;
 
-    NSString *urlText = [NSString stringWithFormat:@"%@/public/v2/apps/%@/devices",
+    NSString *urlText = [NSString stringWithFormat:@"%@/public/v2/apps/%@/metrics",
                                                    config.baseUrl, config.appSlug];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlText]];
     request.HTTPMethod = @"POST";

--- a/clients/ohos/quiver/src/main/ets/QuiverAnalytics.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverAnalytics.ets
@@ -45,7 +45,7 @@ export class QuiverAnalytics {
     const client = http.createHttp();
     try {
       const response = await client.request(
-        `${Quiver.config.baseUrl}/public/v2/apps/${Quiver.config.appSlug}/devices`,
+        `${Quiver.config.baseUrl}/public/v2/apps/${Quiver.config.appSlug}/metrics`,
         {
           method: http.RequestMethod.POST,
           header: {

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -47,10 +47,12 @@ Each release row shows update-check analytics: how many devices are already
 clients), so you can see real rollout coverage as the percentage climbs.
 
 The app overview also exposes version-level metrics from
-`GET /api/apps/:id/analytics/versions`: active devices in the selected window,
-total devices seen, update-check current/offered counts, feedback/crash volume,
-and artifact downloads for each version/channel. The data comes from SDK device
-pings, update checks, feedback tickets, and build asset download counters.
+`GET /api/apps/:id/analytics/versions`: devices that reported in the selected
+window, total devices seen, update-check current/offered counts,
+feedback/crash volume, and artifact downloads for each version/channel. The
+data comes from throttled SDK metrics pings, update checks, feedback tickets,
+and build asset download counters. These metrics show active/recent devices,
+not a true unthrottled online heartbeat.
 
 ## Builds
 

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -46,6 +46,12 @@ Each release row shows update-check analytics: how many devices are already
 **on this version** and how many were **offered** it (update checks from older
 clients), so you can see real rollout coverage as the percentage climbs.
 
+The app overview also exposes version-level metrics from
+`GET /api/apps/:id/analytics/versions`: active devices in the selected window,
+total devices seen, update-check current/offered counts, feedback/crash volume,
+and artifact downloads for each version/channel. The data comes from SDK device
+pings, update checks, feedback tickets, and build asset download counters.
+
 ## Builds
 
 Builds hold uploaded artifacts and provenance. Quiver distinguishes installable artifacts from support artifacts:

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -66,9 +66,11 @@ so you can watch real coverage.
 For a fuller per-version view, call
 `GET /api/apps/:id/analytics/versions?window_days=30` with Agent Login or a
 viewer-capable app token. The response includes one row per release-backed or
-telemetry-only version with active device count, total devices seen,
+telemetry-only version with devices reported in the selected window, total devices seen,
 update-check current/offered counts, feedback/crash counts, and artifact
-downloads.
+downloads. `window_minutes` is also accepted for recent-report windows, but
+SDK metrics pings are throttled, so this should not be labeled as true online
+presence.
 
 ### Ticket triage (feedback + crashes)
 

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -63,6 +63,13 @@ or `PATCH /api/apps/:id/releases/:releaseId` (`{"rollout_cohort_count": 25}`)
 as confidence grows. Release rows expose `offered_count` / `current_count`
 so you can watch real coverage.
 
+For a fuller per-version view, call
+`GET /api/apps/:id/analytics/versions?window_days=30` with Agent Login or a
+viewer-capable app token. The response includes one row per release-backed or
+telemetry-only version with active device count, total devices seen,
+update-check current/offered counts, feedback/crash counts, and artifact
+downloads.
+
 ### Ticket triage (feedback + crashes)
 
 ```bash

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -117,10 +117,11 @@ automatically.
 
 ## Device analytics
 
-`Quiver.install(...)` already sends a lightweight launch ping (throttled
+`Quiver.install(...)` already sends a lightweight launch/install metrics ping (throttled
 to ≤1/day/install) that powers the console's active-device and
-version-distribution views — no separate call needed. No PII: only the
-random per-install device id and build/OS metadata. Pass
+version-distribution views — no separate call needed. This is not a true
+online heartbeat. No PII: only the random per-install device id and build/OS
+metadata. Pass
 `reportDeviceAnalytics = false` to `Quiver.install` to opt out.
 
 ## Notes

--- a/docs/public/ios-sdk.md
+++ b/docs/public/ios-sdk.md
@@ -45,6 +45,11 @@ Quiver.submitFeedback(
 Device metadata (version, model, OS, arch, locale, per-install device id) is
 attached automatically.
 
+`Quiver.install(with:)` also sends a throttled launch/install metrics ping for
+active-device and version-distribution analytics. It carries no PII beyond the
+random per-install Quiver device id and build/OS metadata, and should not be
+treated as a true online heartbeat.
+
 ## Crash reporting
 
 `Quiver.install(with:)` captures uncaught `NSException`s and fatal signals

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -65,5 +65,6 @@ else to wire.
 ## Device analytics
 
 `Quiver.install(config, context)` also reports active-device and
-version-distribution analytics automatically (no PII — a random per-install
-device id and build/OS metadata). No separate call.
+version-distribution metrics automatically (no PII — a random per-install
+device id and build/OS metadata). The ping is throttled and is not a true
+online heartbeat. No separate call.

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -226,28 +226,32 @@ endpoints (crash tickets can additionally trigger `crash:new_group` /
 `crash:spike`). The Android SDK's `QuiverFeedback.submit(...)` wraps this
 endpoint and attaches device metadata automatically.
 
-## Device Register (telemetry)
+## Metrics Ingest
 
 ```http
-POST /public/v2/apps/:appSlug/devices
+POST /public/v2/apps/:appSlug/metrics
 Content-Type: application/json
 X-Quiver-Client-Key: qk_...
 X-Quiver-Device-Id: <stable per-install uuid>
 ```
 
-A lightweight launch ping (client throttles to ≤1/day/device) that powers
+A lightweight launch/install ping (client throttles to ≤1/day/device) that powers
 active-device and version-distribution analytics. Body is a JSON metadata
 object (`version_name`, `version_code`, `channel`, `platform`, `arch`,
 `os_version`, `device_model`, `locale`). The server upserts one row per
 `(app, device id)` — no PII; the device id is a random per-install UUID.
-Requires the app **client key** (same as feedback). Returns `202`.
+Requires the app **client key** (same as feedback). Returns `202`. Legacy SDKs
+may still post the same payload to `/public/v2/apps/:appSlug/devices`; new SDKs
+should use `/metrics`.
 
 Authenticated admins and agents can read the aggregated version view at
-`GET /api/apps/:id/analytics/versions?window_days=30`. It joins these device
+`GET /api/apps/:id/analytics/versions?window_days=30`. It joins these metrics
 pings with release update-check counters, feedback/crash tickets, and artifact
 download counters to report per-version metrics such as `active_devices`,
 `total_devices`, `update_current_count`, `update_offered_count`,
-`feedback_count`, `crash_count`, and `download_count`.
+`feedback_count`, `crash_count`, and `download_count`. `window_minutes` is
+available for recent-report windows, but the SDK ping is throttled and should
+not be treated as true online presence.
 
 ## Presigned attachment upload (large files)
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -242,6 +242,13 @@ object (`version_name`, `version_code`, `channel`, `platform`, `arch`,
 `(app, device id)` — no PII; the device id is a random per-install UUID.
 Requires the app **client key** (same as feedback). Returns `202`.
 
+Authenticated admins and agents can read the aggregated version view at
+`GET /api/apps/:id/analytics/versions?window_days=30`. It joins these device
+pings with release update-check counters, feedback/crash tickets, and artifact
+download counters to report per-version metrics such as `active_devices`,
+`total_devices`, `update_current_count`, `update_offered_count`,
+`feedback_count`, `crash_count`, and `download_count`.
+
 ## Presigned attachment upload (large files)
 
 For attachments too large for an inline multipart submit (up to **200 MB**),

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -463,6 +463,7 @@ app.get("/share/:token/icon", handlePublicReleaseShareIcon);
 app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
 app.post("/public/v2/apps/:slug/minidump", handlePublicMinidumpSubmit);
 app.post("/public/v2/apps/:slug/devices", handleDeviceRegister);
+app.post("/public/v2/apps/:slug/metrics", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/apps/:slug/history", handlePublicAppHistory);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -68,7 +68,7 @@ import {
   handleFeedbackStats,
   handlePresignFeedbackAttachments,
 } from "./routes/feedback";
-import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail } from "./routes/analytics";
+import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail, handleVersionAnalytics } from "./routes/analytics";
 import {
   handlePublicAppHistory,
   handlePublicAppHistoryDownload,
@@ -585,6 +585,7 @@ admin.post("/api/apps/:appId/rotate-client-key", requireAppRole("admin"), handle
 admin.get("/api/apps/:appId/feedback/crash-groups", requireAppRole("viewer"), handleListCrashGroups);
 admin.get("/api/apps/:appId/feedback/stats", requireAppRole("viewer"), handleFeedbackStats);
 admin.get("/api/apps/:appId/analytics/devices", requireAppRole("viewer"), handleDeviceAnalytics);
+admin.get("/api/apps/:appId/analytics/versions", requireAppRole("viewer"), handleVersionAnalytics);
 admin.get("/api/apps/:appId/analytics/devices/:deviceId", requireAppRole("viewer"), handleDeviceDetail);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -67,6 +67,10 @@ export const openApiDocument = docs.getOpenAPI31Document({
       description: "App lifecycle and app-level public client configuration.",
     },
     {
+      name: "Analytics",
+      description: "Authenticated app usage, device, and version metrics.",
+    },
+    {
       name: "Builds",
       description: "Create, inspect, and download build artifacts.",
     },

--- a/worker/src/openapi/apps.ts
+++ b/worker/src/openapi/apps.ts
@@ -35,12 +35,17 @@ const WindowDaysQuery = z.object({
     param: { name: "window_days", in: "query" },
     example: 30,
   }),
+  window_minutes: z.coerce.number().int().positive().max(525600).optional().openapi({
+    param: { name: "window_minutes", in: "query" },
+    example: 15,
+  }),
 });
 
 const VersionMetricsResponse = z
   .object({
     window_start: z.number().int(),
     window_days: z.number().int(),
+    window_minutes: z.number().int(),
     versions: z.array(
       z.object({
         release_id: z.string().nullable(),

--- a/worker/src/openapi/apps.ts
+++ b/worker/src/openapi/apps.ts
@@ -30,6 +30,44 @@ const ClientKeyResponse = z
   .catchall(z.unknown())
   .openapi("ClientKeyResponse");
 
+const WindowDaysQuery = z.object({
+  window_days: z.coerce.number().int().positive().max(365).optional().openapi({
+    param: { name: "window_days", in: "query" },
+    example: 30,
+  }),
+});
+
+const VersionMetricsResponse = z
+  .object({
+    window_start: z.number().int(),
+    window_days: z.number().int(),
+    versions: z.array(
+      z.object({
+        release_id: z.string().nullable(),
+        build_id: z.string().nullable(),
+        channel: z.string(),
+        product_type: z.string().nullable(),
+        release_type: z.string().nullable(),
+        release_status: z.string().nullable(),
+        rollout_cohort_count: z.number().int().nullable(),
+        version_name: z.string(),
+        version_code: z.number().int().nullable(),
+        released_at: z.number().int().nullable(),
+        release_updated_at: z.number().int().nullable(),
+        active_devices: z.number().int(),
+        total_devices: z.number().int(),
+        update_current_count: z.number().int(),
+        update_offered_count: z.number().int(),
+        last_checked_at: z.number().int().nullable(),
+        feedback_count: z.number().int(),
+        crash_count: z.number().int(),
+        download_count: z.number().int(),
+        telemetry_only: z.boolean(),
+      }),
+    ),
+  })
+  .openapi("VersionMetricsResponse");
+
 export function registerAppRoutes(registry: OpenApiRegistry) {
   register(registry, {
     method: "get",
@@ -153,6 +191,22 @@ export function registerAppRoutes(registry: OpenApiRegistry) {
 
   register(registry, {
     method: "get",
+    path: "/api/apps/{appId}/analytics/versions",
+    tags: ["Analytics"],
+    summary: "List per-version usage metrics",
+    description:
+      "Aggregates release update-check counters, active device pings, feedback/crash volume, and artifact download counts by app version.",
+    security: auth,
+    request: { params: AppIdParam, query: WindowDaysQuery },
+    responses: {
+      200: success("Version metrics.", VersionMetricsResponse),
+      403: error("Current principal cannot view analytics for the app."),
+      404: error("App was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
     path: "/api/apps/{appId}/client-key",
     tags: ["Apps"],
     summary: "Read the app public client key",
@@ -180,4 +234,3 @@ export function registerAppRoutes(registry: OpenApiRegistry) {
     },
   });
 }
-

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -143,6 +143,22 @@ const FeedbackSubmitResponse = z
   })
   .openapi("FeedbackSubmitResponse");
 
+const MetricsIngestRequest = z
+  .object({
+    version_name: z.string().optional(),
+    version_code: z.number().int().optional(),
+    channel: z.string().optional(),
+    platform: z.string().optional(),
+    arch: z.string().optional(),
+    os_version: z.string().optional(),
+    device_model: z.string().optional(),
+    locale: z.string().optional(),
+  })
+  .catchall(z.unknown())
+  .openapi("MetricsIngestRequest");
+
+const MetricsIngestResponse = z.object({ ok: z.boolean() }).openapi("MetricsIngestResponse");
+
 const InviteResponse = GenericObject.openapi("InviteResponse");
 
 export function registerPublicRoutes(registry: OpenApiRegistry) {
@@ -259,6 +275,54 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     request: { params: SlugParam },
     responses: {
       200: success("Channel list.", PublicChannelsResponse),
+      404: error("App was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/public/v2/apps/{slug}/metrics",
+    tags: ["Public metrics"],
+    summary: "Report SDK runtime metrics",
+    description:
+      "Canonical SDK metrics ingest endpoint. Clients send a throttled launch/install ping with a stable per-install X-Quiver-Device-Id and build/runtime metadata. This powers active-device and version-distribution analytics; it is not an unthrottled online heartbeat.",
+    request: {
+      params: SlugParam,
+      query: z.object({ client_key: z.string().optional(), device_id: z.string().optional() }),
+      headers: z.object({
+        "X-Quiver-Client-Key": z.string().optional(),
+        "X-Quiver-Device-Id": z.string().optional(),
+      }),
+      body: { content: json(MetricsIngestRequest), required: false },
+    },
+    responses: {
+      202: success("Metrics accepted.", MetricsIngestResponse),
+      400: error("Device id is missing or invalid."),
+      401: error("Missing or invalid client key."),
+      404: error("App was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/public/v2/apps/{slug}/devices",
+    tags: ["Public metrics"],
+    summary: "Compatibility alias for SDK runtime metrics",
+    description:
+      "Legacy alias for /public/v2/apps/{slug}/metrics. New SDKs should use /metrics.",
+    request: {
+      params: SlugParam,
+      query: z.object({ client_key: z.string().optional(), device_id: z.string().optional() }),
+      headers: z.object({
+        "X-Quiver-Client-Key": z.string().optional(),
+        "X-Quiver-Device-Id": z.string().optional(),
+      }),
+      body: { content: json(MetricsIngestRequest), required: false },
+    },
+    responses: {
+      202: success("Metrics accepted.", MetricsIngestResponse),
+      400: error("Device id is missing or invalid."),
+      401: error("Missing or invalid client key."),
       404: error("App was not found."),
     },
   });

--- a/worker/src/routes/analytics.ts
+++ b/worker/src/routes/analytics.ts
@@ -13,6 +13,7 @@ type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
 const WINDOW_DEFAULT_DAYS = 30;
 const WINDOW_MAX_DAYS = 365;
+const WINDOW_MAX_MINUTES = WINDOW_MAX_DAYS * 24 * 60;
 
 export async function handleDeviceRegister(c: Context<{ Bindings: Env }>) {
   const slug = c.req.param("slug");
@@ -91,12 +92,28 @@ export async function handleDeviceRegister(c: Context<{ Bindings: Env }>) {
   return c.json({ ok: true }, 202);
 }
 
-function windowStart(c: AdminContext): number {
+function windowRange(c: AdminContext): { since: number; windowDays: number; windowMinutes: number } {
+  const minuteRaw = c.req.query("window_minutes");
+  if (minuteRaw) {
+    let minutes = Number(minuteRaw);
+    if (!Number.isFinite(minutes) || minutes <= 0) minutes = WINDOW_DEFAULT_DAYS * 24 * 60;
+    minutes = Math.min(Math.ceil(minutes), WINDOW_MAX_MINUTES);
+    return {
+      since: Date.now() - minutes * 60 * 1000,
+      windowDays: Math.max(1, Math.ceil(minutes / (24 * 60))),
+      windowMinutes: minutes,
+    };
+  }
   const raw = c.req.query("window_days");
   let days = raw ? Number(raw) : WINDOW_DEFAULT_DAYS;
   if (!Number.isFinite(days) || days <= 0) days = WINDOW_DEFAULT_DAYS;
   days = Math.min(days, WINDOW_MAX_DAYS);
-  return Date.now() - days * 24 * 60 * 60 * 1000;
+  days = Math.ceil(days);
+  return {
+    since: Date.now() - days * 24 * 60 * 60 * 1000,
+    windowDays: days,
+    windowMinutes: days * 24 * 60,
+  };
 }
 
 /**
@@ -120,7 +137,7 @@ export async function handleDeviceDetail(c: AdminContext) {
 
 export async function handleDeviceAnalytics(c: AdminContext) {
   const appId = c.req.param("appId");
-  const since = windowStart(c);
+  const { since } = windowRange(c);
 
   const [total, byVersion, byPlatform, byChannel] = await Promise.all([
     c.env.DB.prepare(
@@ -182,8 +199,7 @@ export async function handleDeviceAnalytics(c: AdminContext) {
  */
 export async function handleVersionAnalytics(c: AdminContext) {
   const appId = c.req.param("appId");
-  const since = windowStart(c);
-  const windowDays = Math.round((Date.now() - since) / (24 * 60 * 60 * 1000));
+  const { since, windowDays, windowMinutes } = windowRange(c);
 
   const { results } = await c.env.DB.prepare(
     `WITH
@@ -324,6 +340,7 @@ export async function handleVersionAnalytics(c: AdminContext) {
   return c.json({
     window_start: since,
     window_days: windowDays,
+    window_minutes: windowMinutes,
     versions: results.map((row) => ({
       ...row,
       telemetry_only: Boolean(row.telemetry_only),

--- a/worker/src/routes/analytics.ts
+++ b/worker/src/routes/analytics.ts
@@ -167,3 +167,166 @@ export async function handleDeviceAnalytics(c: AdminContext) {
     by_channel: byChannel.results,
   });
 }
+
+/**
+ * Version/release metrics for agents and admins.
+ *
+ * Sources:
+ * - device_pings: active/current installs by version in the selected window
+ * - release_metrics: update-check counters recorded when releases are offered
+ * - feedback_tickets: feedback/crash volume by version
+ * - build_assets: artifact download counters for release builds
+ *
+ * Release-backed rows are returned first. A trailing set of telemetry-only rows
+ * covers versions seen from device pings before/without a matching release row.
+ */
+export async function handleVersionAnalytics(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const since = windowStart(c);
+  const windowDays = Math.round((Date.now() - since) / (24 * 60 * 60 * 1000));
+
+  const { results } = await c.env.DB.prepare(
+    `WITH
+       active_devices AS (
+         SELECT version_code, COALESCE(channel, 'unknown') AS channel, COUNT(*) AS active_devices
+         FROM device_pings
+         WHERE app_id = ? AND last_seen >= ?
+         GROUP BY version_code, COALESCE(channel, 'unknown')
+       ),
+       total_devices AS (
+         SELECT version_code, COALESCE(channel, 'unknown') AS channel, COUNT(*) AS total_devices
+         FROM device_pings
+         WHERE app_id = ?
+         GROUP BY version_code, COALESCE(channel, 'unknown')
+       ),
+       feedback AS (
+         SELECT version_code, COALESCE(channel, 'unknown') AS channel,
+                COUNT(*) AS feedback_count,
+                SUM(CASE WHEN kind = 'crash' THEN 1 ELSE 0 END) AS crash_count
+         FROM feedback_tickets
+         WHERE app_id = ?
+         GROUP BY version_code, COALESCE(channel, 'unknown')
+       ),
+       downloads AS (
+         SELECT build_id, SUM(download_count) AS download_count
+         FROM build_assets
+         GROUP BY build_id
+       ),
+       release_rows AS (
+         SELECT
+           r.id AS release_id,
+           b.id AS build_id,
+           COALESCE(c.slug, 'unknown') AS channel,
+           r.product_type,
+           r.release_type,
+           r.status AS release_status,
+           r.rollout_cohort_count,
+           b.version_name,
+           b.version_code,
+           r.created_at AS released_at,
+           r.updated_at AS release_updated_at,
+           COALESCE(ad.active_devices, 0) AS active_devices,
+           COALESCE(td.total_devices, 0) AS total_devices,
+           COALESCE(rm.current_count, 0) AS update_current_count,
+           COALESCE(rm.offered_count, 0) AS update_offered_count,
+           rm.last_checked_at,
+           COALESCE(f.feedback_count, 0) AS feedback_count,
+           COALESCE(f.crash_count, 0) AS crash_count,
+           COALESCE(d.download_count, 0) AS download_count,
+           0 AS telemetry_only
+         FROM releases r
+         JOIN builds b ON b.id = r.build_id
+         LEFT JOIN channels c ON c.id = r.channel_id
+         LEFT JOIN release_metrics rm ON rm.release_id = r.id
+         LEFT JOIN active_devices ad
+           ON ad.version_code = b.version_code
+          AND ad.channel = COALESCE(c.slug, 'unknown')
+         LEFT JOIN total_devices td
+           ON td.version_code = b.version_code
+          AND td.channel = COALESCE(c.slug, 'unknown')
+         LEFT JOIN feedback f
+           ON f.version_code = b.version_code
+          AND f.channel = COALESCE(c.slug, 'unknown')
+         LEFT JOIN downloads d ON d.build_id = b.id
+         WHERE r.app_id = ?
+       ),
+       telemetry_only_rows AS (
+         SELECT
+           NULL AS release_id,
+           NULL AS build_id,
+           COALESCE(dp.channel, 'unknown') AS channel,
+           NULL AS product_type,
+           NULL AS release_type,
+           NULL AS release_status,
+           NULL AS rollout_cohort_count,
+           COALESCE(dp.version_name, 'unknown') AS version_name,
+           dp.version_code,
+           NULL AS released_at,
+           MAX(dp.last_seen) AS release_updated_at,
+           COUNT(CASE WHEN dp.last_seen >= ? THEN 1 END) AS active_devices,
+           COUNT(*) AS total_devices,
+           0 AS update_current_count,
+           0 AS update_offered_count,
+           NULL AS last_checked_at,
+           COALESCE(MAX(f.feedback_count), 0) AS feedback_count,
+           COALESCE(MAX(f.crash_count), 0) AS crash_count,
+           0 AS download_count,
+           1 AS telemetry_only
+         FROM device_pings dp
+         LEFT JOIN feedback f
+           ON f.version_code = dp.version_code
+          AND f.channel = COALESCE(dp.channel, 'unknown')
+         WHERE dp.app_id = ?
+           AND NOT EXISTS (
+             SELECT 1
+             FROM releases r
+             JOIN builds b ON b.id = r.build_id
+             LEFT JOIN channels c ON c.id = r.channel_id
+             WHERE r.app_id = ?
+               AND b.version_code = dp.version_code
+               AND COALESCE(c.slug, 'unknown') = COALESCE(dp.channel, 'unknown')
+           )
+         GROUP BY COALESCE(dp.channel, 'unknown'), dp.version_code, COALESCE(dp.version_name, 'unknown')
+       )
+     SELECT *
+     FROM (
+       SELECT * FROM release_rows
+       UNION ALL
+       SELECT * FROM telemetry_only_rows
+     )
+     ORDER BY COALESCE(version_code, 0) DESC, telemetry_only ASC, COALESCE(released_at, release_updated_at, 0) DESC
+     LIMIT 200`,
+  )
+    .bind(appId, since, appId, appId, appId, since, appId, appId)
+    .all<{
+      release_id: string | null;
+      build_id: string | null;
+      channel: string;
+      product_type: string | null;
+      release_type: string | null;
+      release_status: string | null;
+      rollout_cohort_count: number | null;
+      version_name: string;
+      version_code: number | null;
+      released_at: number | null;
+      release_updated_at: number | null;
+      active_devices: number;
+      total_devices: number;
+      update_current_count: number;
+      update_offered_count: number;
+      last_checked_at: number | null;
+      feedback_count: number;
+      crash_count: number;
+      download_count: number;
+      telemetry_only: number;
+    }>();
+
+  return c.json({
+    window_start: since,
+    window_days: windowDays,
+    versions: results.map((row) => ({
+      ...row,
+      telemetry_only: Boolean(row.telemetry_only),
+    })),
+  });
+}

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -57,6 +57,7 @@ describe("quiver OpenAPI document", () => {
       "/public/v2/apps/{slug}/updates/check",
       "/electron/{slug}/{channel}/{file}",
       "/public/v2/apps/{slug}/feedback",
+      "/public/v2/apps/{slug}/metrics",
       "/apps/{slug}/history",
       "/api/apps",
       "/api/apps/{appId}/builds",
@@ -3910,6 +3911,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect((await ping("devB", "1.0.2", 1000200, "android")).status).toBe(202);
     expect((await ping("devA", "1.0.2", 1000200, "android")).status).toBe(202); // upsert, not a new row
     expect((await ping("devC", "1.0.1", 1000101, "android")).status).toBe(202);
+    expect((await ping("devD", "1.0.3", 1000300, "android")).status).toBe(202);
 
     const res = await handleDeviceAnalytics({
       env,
@@ -3917,11 +3919,11 @@ describe("quiver public API v2 — scope resolution", () => {
       json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
     } as any);
     const body = await responseJson<any>(res);
-    expect(body.active_devices).toBe(3); // devA (deduped), devB, devC
+    expect(body.active_devices).toBe(4); // devA (deduped), devB, devC, devD
     const v102 = body.by_version.find((v: any) => v.version_code === 1000200);
     expect(v102.devices).toBe(2);
     expect(body.by_platform[0].platform).toBe("android");
-    expect(body.by_platform[0].devices).toBe(3);
+    expect(body.by_platform[0].devices).toBe(4);
   });
 
   it("analytics: versions aggregates release metrics, devices, feedback, and downloads", async () => {
@@ -3972,10 +3974,19 @@ describe("quiver public API v2 — scope resolution", () => {
 
     const res = await handleVersionAnalytics({
       env,
-      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: () => "30" },
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: (n: string) => (n === "window_days" ? "30" : undefined) },
       json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
     } as any);
     const body = await responseJson<any>(res);
+    expect(body.window_minutes).toBe(30 * 24 * 60);
+    const minutesRes = await handleVersionAnalytics({
+      env,
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: (n: string) => (n === "window_minutes" ? "30" : undefined) },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    const minutesBody = await responseJson<any>(minutesRes);
+    expect(minutesBody.window_minutes).toBe(30);
+    expect(minutesBody.window_days).toBe(1);
     const releaseRow = body.versions.find((v: any) => v.release_id === "rel-metrics");
     expect(releaseRow).toMatchObject({
       build_id: "build-metrics",

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -63,6 +63,7 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/releases/{releaseId}/publish",
       "/api/apps/{appId}/feedback/{ticketId}/comments",
       "/api/apps/{appId}/client-key",
+      "/api/apps/{appId}/analytics/versions",
       "/api/orgs/{orgId}/invites",
       "/api/orgs/{orgId}/webhooks/{webhookId}/deliveries",
       "/api/apps/{appId}/channels/{channelId}",
@@ -3921,6 +3922,87 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(v102.devices).toBe(2);
     expect(body.by_platform[0].platform).toBe("android");
     expect(body.by_platform[0].devices).toBe(3);
+  });
+
+  it("analytics: versions aggregates release metrics, devices, feedback, and downloads", async () => {
+    const env = makeEnv();
+    const { handleDeviceRegister, handleVersionAnalytics } = await import("../src/routes/analytics");
+    await seedRelease(env, "rel-metrics", "build-metrics", [["full", "all"]], {
+      versionName: "1.2.0",
+      versionCode: 120,
+      createdAt: 10_000,
+      rolloutCohortCount: 50,
+    });
+    await seedAsset(env, "build-metrics", "asset-metrics");
+    await env.DB.prepare(
+      "UPDATE build_assets SET download_count = ? WHERE id = ?",
+    ).bind(7, "asset-metrics").run();
+    await env.DB.prepare(
+      "INSERT INTO release_metrics (release_id, offered_count, current_count, last_checked_at) VALUES (?, ?, ?, ?)",
+    ).bind("rel-metrics", 5, 2, 11_000).run();
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, version_name, version_code, channel,
+        device_id, metadata_json, created_at, updated_at)
+       VALUES (?, 'app-scope', ?, 'open', ?, ?, ?, 'production', ?, '{}', ?, ?)`,
+    ).bind("tick-metrics-1", "feedback", "feedback", "1.2.0", 120, "devA", 12_000, 12_000).run();
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, version_name, version_code, channel,
+        device_id, metadata_json, created_at, updated_at)
+       VALUES (?, 'app-scope', ?, 'open', ?, ?, ?, 'production', ?, '{}', ?, ?)`,
+    ).bind("tick-metrics-2", "crash", "crash", "1.2.0", 120, "devB", 12_001, 12_001).run();
+
+    const ping = (deviceId: string, versionName: string, versionCode: number, channel = "production") =>
+      handleDeviceRegister({
+        env,
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: (n: string) =>
+            n === "X-Quiver-Client-Key" ? "qk_test" : n === "X-Quiver-Device-Id" ? deviceId : undefined,
+          query: () => undefined,
+          json: async () => ({ version_name: versionName, version_code: versionCode, channel, platform: "android" }),
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+
+    expect((await ping("devA", "1.2.0", 120)).status).toBe(202);
+    expect((await ping("devB", "1.2.0", 120)).status).toBe(202);
+    expect((await ping("devC", "2.0.0-beta", 200)).status).toBe(202);
+
+    const res = await handleVersionAnalytics({
+      env,
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: () => "30" },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    const body = await responseJson<any>(res);
+    const releaseRow = body.versions.find((v: any) => v.release_id === "rel-metrics");
+    expect(releaseRow).toMatchObject({
+      build_id: "build-metrics",
+      channel: "production",
+      release_status: "active",
+      rollout_cohort_count: 50,
+      version_name: "1.2.0",
+      version_code: 120,
+      active_devices: 2,
+      total_devices: 2,
+      update_current_count: 2,
+      update_offered_count: 5,
+      feedback_count: 2,
+      crash_count: 1,
+      download_count: 7,
+      telemetry_only: false,
+    });
+    const telemetryOnly = body.versions.find((v: any) => v.version_code === 200);
+    expect(telemetryOnly).toMatchObject({
+      release_id: null,
+      build_id: null,
+      channel: "production",
+      version_name: "2.0.0-beta",
+      active_devices: 1,
+      total_devices: 1,
+      telemetry_only: true,
+    });
   });
 
   it("feedback: presigned attachments are namespace-guarded and existence-checked", async () => {


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/apps/:appId/analytics/versions?window_days=30`
- aggregate per-version release rows with active/total devices, update-check current/offered counters, feedback/crash counts, and artifact downloads
- include telemetry-only version rows when devices report versions without a matching release row
- surface the data in the app overview analytics card and document the endpoint in public docs/OpenAPI

## Validation
- pnpm --filter @oranix/quiver-worker test
- pnpm --filter @oranix/quiver-worker build
- pnpm --filter @oranix/quiver-admin build
- git diff --check
