### PR TITLE
feat(feedback): rich environment metadata + generic admin display (task #105)

### DIFF
--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -3,7 +3,7 @@
  * per-ticket page (/apps/:appId/feedback/:ticketId) so tickets are
  * shareable links. Tickets carry an assignee, status flow, and comments.
  */
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -185,7 +185,7 @@ export function AppFeedback({ appId }: { appId: string }) {
                     {t.version_name ?? "—"}{t.version_code ? ` (${t.version_code})` : ""}
                   </td>
                   <td className="py-2 pr-3 text-xs text-slate-600">
-                    {[t.device_model, t.os_version && `Android ${t.os_version}`].filter(Boolean).join(" · ") || "—"}
+                    {[t.device_model, t.os_version].filter(Boolean).join(" · ") || "—"}
                   </td>
                   <td className="py-2 pr-3 text-xs text-slate-600">
                     {new Date(t.created_at).toLocaleString()}
@@ -608,44 +608,84 @@ export function FeedbackTicketPage({
           </div>
 
           <div className="card">
-            <h4 className="text-sm font-semibold mb-2">Device context</h4>
-            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-              <dt className="text-slate-500">App version</dt>
-              <dd>
-                {t.version_name ?? "—"}{" "}
-                {t.version_code ? (
-                  <button
-                    className="text-blue-600 hover:underline"
-                    title="All feedback on this version"
-                    onClick={() => navigate(`/apps/${appId}/feedback?version_code=${t.version_code}`)}
-                  >
-                    ({t.version_code})
-                  </button>
-                ) : null}
-              </dd>
-              <dt className="text-slate-500">Channel</dt>
-              <dd>{t.channel ?? "—"}</dd>
-              <dt className="text-slate-500">Device</dt>
-              <dd>{t.device_model ?? "—"}</dd>
-              <dt className="text-slate-500">OS / arch</dt>
-              <dd>{[t.os_version, t.arch].filter(Boolean).join(" / ") || "—"}</dd>
-              <dt className="text-slate-500">Locale</dt>
-              <dd>{t.locale ?? "—"}</dd>
-              <dt className="text-slate-500">Device id</dt>
-              <dd className="font-mono">
-                {t.device_id ? (
-                  <button
-                    className="text-blue-600 hover:underline font-mono"
-                    title="This device's history"
-                    onClick={() => navigate(`/apps/${appId}/feedback?device_id=${encodeURIComponent(t.device_id!)}`)}
-                  >
-                    {t.device_id}
-                  </button>
-                ) : (
-                  "—"
-                )}
-              </dd>
-            </dl>
+            <h4 className="text-sm font-semibold mb-2">Environment</h4>
+            {(() => {
+              // Generic render of every reported environment field (task #105):
+              // no hardcoded property allowlist — parse the ticket metadata and
+              // list each field, so new SDK-reported fields show up with zero
+              // UI changes. crash_* keys feed the symbolication panel below and
+              // are excluded here. version_code / device_id keep their filter
+              // links; commit is shown monospace.
+              let meta: Record<string, unknown> = {};
+              try {
+                const parsed = JSON.parse(t.metadata_json || "{}");
+                if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                  meta = parsed as Record<string, unknown>;
+                }
+              } catch {
+                /* malformed metadata — fall through to empty */
+              }
+              const entries = Object.entries(meta)
+                .filter(
+                  ([k, v]) =>
+                    !k.startsWith("crash_") &&
+                    v !== null &&
+                    v !== undefined &&
+                    v !== "",
+                )
+                .sort(([a], [b]) => a.localeCompare(b));
+              if (entries.length === 0) {
+                return (
+                  <p className="text-xs text-slate-500">
+                    No environment data reported.
+                  </p>
+                );
+              }
+              const label = (k: string) =>
+                k.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+              const format = (v: unknown) =>
+                typeof v === "object" ? JSON.stringify(v) : String(v);
+              const mono = (k: string) =>
+                k === "device_id" || k === "commit" || k === "git_commit";
+              return (
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                  {entries.map(([k, v]) => (
+                    <Fragment key={k}>
+                      <dt className="text-slate-500">{label(k)}</dt>
+                      <dd className={mono(k) ? "font-mono break-all" : "break-all"}>
+                        {k === "version_code" ? (
+                          <button
+                            className="text-blue-600 hover:underline"
+                            title="All feedback on this version"
+                            onClick={() =>
+                              navigate(
+                                `/apps/${appId}/feedback?version_code=${encodeURIComponent(format(v))}`,
+                              )
+                            }
+                          >
+                            {format(v)}
+                          </button>
+                        ) : k === "device_id" ? (
+                          <button
+                            className="text-blue-600 hover:underline font-mono break-all"
+                            title="This device's history"
+                            onClick={() =>
+                              navigate(
+                                `/apps/${appId}/feedback?device_id=${encodeURIComponent(format(v))}`,
+                              )
+                            }
+                          >
+                            {format(v)}
+                          </button>
+                        ) : (
+                          format(v)
+                        )}
+                      </dd>
+                    </Fragment>
+                  ))}
+                </dl>
+              );
+            })()}
           </div>
 
           {t.kind === "crash" &&

--- a/clients/ios/Sources/Quiver/QuiverFeedbackClient.m
+++ b/clients/ios/Sources/Quiver/QuiverFeedbackClient.m
@@ -2,6 +2,7 @@
 
 #import "Quiver.h"
 
+#import <TargetConditionals.h>
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
@@ -10,6 +11,10 @@
 static NSString *const QuiverErrorDomain = @"Quiver";
 static NSTimeInterval const QuiverRequestTimeout = 30.0;
 static NSTimeInterval const QuiverUploadTimeout = 120.0;
+
+// Quiver iOS SDK version — reported in feedback/crash environment metadata.
+// Keep in sync with Quiver.podspec on release.
+static NSString *const kQuiverSDKVersion = @"0.1.5";
 
 // Server-enforced: at most 9 attachments per ticket.
 static NSUInteger const QuiverMaxAttachments = 9;
@@ -35,6 +40,47 @@ static NSString *QuiverArch(void) {
 #else
     return @"unknown";
 #endif
+}
+
+static BOOL QuiverIsSimulator(void) {
+#if TARGET_OS_SIMULATOR
+    return YES;
+#else
+    return NSProcessInfo.processInfo.environment[@"SIMULATOR_DEVICE_NAME"] != nil;
+#endif
+}
+
+static NSString *QuiverThermalState(void) {
+    switch (NSProcessInfo.processInfo.thermalState) {
+        case NSProcessInfoThermalStateNominal: return @"nominal";
+        case NSProcessInfoThermalStateFair: return @"fair";
+        case NSProcessInfoThermalStateSerious: return @"serious";
+        case NSProcessInfoThermalStateCritical: return @"critical";
+    }
+    return @"unknown";
+}
+
+static NSString *QuiverBatteryStateString(UIDeviceBatteryState state) {
+    switch (state) {
+        case UIDeviceBatteryStateUnplugged: return @"unplugged";
+        case UIDeviceBatteryStateCharging: return @"charging";
+        case UIDeviceBatteryStateFull: return @"full";
+        case UIDeviceBatteryStateUnknown:
+        default: return @"unknown";
+    }
+}
+
+// The app's build git commit, injected into Info.plist at build time. The SDK
+// only reports it; the host build is responsible for setting one of these keys
+// (preferred: QuiverBuildCommit). Returns nil when not injected.
+static NSString *QuiverBuildCommit(NSDictionary *info) {
+    for (NSString *key in @[ @"QuiverBuildCommit", @"GitCommit", @"CommitHash" ]) {
+        id value = info[key];
+        if ([value isKindOfClass:NSString.class] && [(NSString *)value length] > 0) {
+            return value;
+        }
+    }
+    return nil;
 }
 
 static NSString *QuiverContentType(NSString *name) {
@@ -75,15 +121,57 @@ static NSError *QuiverErrorWithMessage(NSInteger code, NSString *detail) {
     NSDictionary *info = NSBundle.mainBundle.infoDictionary ?: @{};
     UIDevice *device = UIDevice.currentDevice;
     NSMutableDictionary<NSString *, id> *metadata = [NSMutableDictionary dictionary];
+    NSProcessInfo *process = NSProcessInfo.processInfo;
+
+    // App / build identity
     metadata[@"version_name"] = info[@"CFBundleShortVersionString"] ?: @"";
     metadata[@"version_code"] = @([(info[@"CFBundleVersion"] ?: @"0") longLongValue]);
+    metadata[@"bundle_id"] = info[@"CFBundleIdentifier"] ?: @"";
+    NSString *commit = QuiverBuildCommit(info);
+    if (commit) metadata[@"commit"] = commit;
     metadata[@"channel"] = (Quiver.config.channel ?: @"");
-    metadata[@"device_id"] = [QuiverDeviceId deviceId];
-    metadata[@"device_model"] = QuiverHardwareModel();
+    metadata[@"quiver_sdk"] = kQuiverSDKVersion;
+
+    // Platform / OS
+    metadata[@"platform"] = @"ios";
+    metadata[@"os"] = device.systemName ?: @"iOS";
     metadata[@"os_version"] = [NSString stringWithFormat:@"%@ %@", device.systemName ?: @"iOS", device.systemVersion ?: @""];
     metadata[@"arch"] = QuiverArch();
     metadata[@"locale"] = NSLocale.currentLocale.localeIdentifier ?: @"";
-    metadata[@"platform"] = @"ios";
+    metadata[@"timezone"] = NSTimeZone.localTimeZone.name ?: @"";
+    NSArray<NSString *> *languages = NSLocale.preferredLanguages;
+    if (languages.count > 0) {
+        metadata[@"preferred_languages"] = [languages componentsJoinedByString:@","];
+    }
+
+    // Device
+    metadata[@"device_id"] = [QuiverDeviceId deviceId];
+    metadata[@"device_model"] = QuiverHardwareModel();
+    metadata[@"device_name"] = device.name ?: @"";
+    metadata[@"is_simulator"] = QuiverIsSimulator() ? @"true" : @"false";
+    CGRect bounds = UIScreen.mainScreen.bounds;
+    CGFloat scale = UIScreen.mainScreen.scale;
+    metadata[@"screen"] = [NSString stringWithFormat:@"%.0fx%.0f@%.0fx",
+                           bounds.size.width * scale, bounds.size.height * scale, scale];
+
+    // Runtime state
+    metadata[@"physical_memory"] = @(process.physicalMemory);
+    metadata[@"uptime_seconds"] = @((long long)process.systemUptime);
+    metadata[@"low_power_mode"] = process.isLowPowerModeEnabled ? @"true" : @"false";
+    metadata[@"thermal_state"] = QuiverThermalState();
+    NSDictionary *fsAttrs = [NSFileManager.defaultManager attributesOfFileSystemForPath:NSHomeDirectory() error:nil];
+    if (fsAttrs[NSFileSystemSize]) metadata[@"disk_total"] = fsAttrs[NSFileSystemSize];
+    if (fsAttrs[NSFileSystemFreeSize]) metadata[@"disk_free"] = fsAttrs[NSFileSystemFreeSize];
+    // Only read battery when the host already enabled monitoring — toggling it
+    // is a main-thread-only UIKit mutation and this runs on a background queue
+    // during crash upload.
+    if (device.batteryMonitoringEnabled) {
+        float batteryLevel = device.batteryLevel;
+        if (batteryLevel >= 0) metadata[@"battery_level"] = @((int)(batteryLevel * 100));
+        metadata[@"battery_state"] = QuiverBatteryStateString(device.batteryState);
+    }
+
+    // Caller-supplied extras (crash_* fields etc.) override/augment the above.
     [extras enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
         metadata[key] = value;
     }];


### PR DESCRIPTION
## Why
artin: crash/feedback reports capture too little (no commit, placeholder version), and the admin UI should **not hardcode each property** — use a generic `environment` view that lists every reported field, so new SDK fields show up with zero UI changes.

## Admin UI (works with existing data immediately)
- Replaced the hardcoded "Device context" `<dl>` with a generic **Environment** section: parses the ticket `metadata_json` and renders **every** non-`crash_*` field as key→value. New SDK-reported fields appear automatically. `version_code`/`device_id` keep their filter links; `commit`/`device_id` render monospace.
- Fixed a latent bug: the list-page OS column hardcoded `Android ${os_version}`, so iOS tickets showed "Android iOS 26.1". Now platform-agnostic.
- `crash_*` keys stay out of Environment (they feed the symbolication panel).

## iOS SDK — collect more (`multi-采集`)
`QuiverFeedbackClient` metadata now includes: `bundle_id`, `commit` (from Info.plist `QuiverBuildCommit`/`GitCommit`), `quiver_sdk`, `os`, `timezone`, `preferred_languages`, `device_name`, `is_simulator`, `screen`, `physical_memory`, `uptime_seconds`, `low_power_mode`, `thermal_state`, `disk_total`/`disk_free`, `battery_level`/`battery_state`. Battery is read only when the host already enabled monitoring (toggling is main-thread-only; this runs on the crash-upload background queue).

## Data flow (no migration needed)
`metadata_json` already stores the full SDK blob; the generic UI reads from it. So the moment the SDK sends richer fields, they render.

## Follow-ups (noted, not in this PR)
- **Build-side commit injection**: the host iOS build must set `QuiverBuildCommit` (git SHA) + a real app version in Info.plist — @KMP-专家, aligned with mobile #456. Until then `commit` is simply absent.
- **First-class `git_commit` column + list summary + filtering**: deferred until commit data actually flows (empty column has nothing to hold yet); the generic Environment section already surfaces commit meanwhile.
- Android/OHOS `environment` enrichment for parity (the generic admin UI already covers them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)