### PR TITLE
feat(feedback): Android + OHOS environment metadata parity (task #105)

### DIFF
--- a/clients/android/src/main/kotlin/io/quiver/update/QuiverFeedback.kt
+++ b/clients/android/src/main/kotlin/io/quiver/update/QuiverFeedback.kt
@@ -1,9 +1,18 @@
 package io.quiver.update
 
+import android.app.ActivityManager
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.BatteryManager
 import android.os.Build
+import android.os.PowerManager
+import android.os.StatFs
+import android.os.SystemClock
 import java.io.File
 import java.util.Locale
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -74,14 +83,34 @@ class QuiverFeedback(
         val presignedRefs = if (large.isNotEmpty()) uploadLargeAttachments(large) else emptyList()
 
         val metadata = JSONObject().apply {
+            // App / build identity
             versionName?.let { put("version_name", it) }
             versionCode?.let { put("version_code", it) }
+            put("platform", "android")
+            put("bundle_id", context.packageName)
+            put("quiver_sdk", SDK_VERSION)
             channel?.let { put("channel", it) }
+            buildCommit(context)?.let { put("commit", it) }
+
+            // Device
             put("device_id", QuiverDeviceId.get(context))
             put("device_model", "${Build.MANUFACTURER} ${Build.MODEL}".trim())
+            put("device_manufacturer", Build.MANUFACTURER ?: "")
+            put("device_brand", Build.BRAND ?: "")
+            put("is_emulator", isProbablyEmulator())
+
+            // OS
+            put("os", "Android")
             put("os_version", Build.VERSION.RELEASE ?: Build.VERSION.SDK_INT.toString())
+            put("sdk_int", Build.VERSION.SDK_INT)
             put("arch", Build.SUPPORTED_ABIS.firstOrNull() ?: "unknown")
             put("locale", Locale.getDefault().toLanguageTag())
+            put("timezone", TimeZone.getDefault().id)
+
+            // Runtime state (best-effort; a metadata read must never fail submit)
+            putRuntimeEnvironment(context)
+
+            // Caller extras (crash_* fields etc.) override/augment the above.
             for ((key, value) in extras) put(key, value ?: JSONObject.NULL)
         }
 
@@ -219,6 +248,10 @@ class QuiverFeedback(
     }
 
     companion object {
+        /** Quiver Android SDK version — reported in feedback/crash environment
+         *  metadata. Keep in sync with the SDK's published version. */
+        const val SDK_VERSION = "0.9.0"
+
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9
 
@@ -238,3 +271,100 @@ class QuiverFeedback(
 
 class QuiverFeedbackException(val code: Int, detail: String) :
     RuntimeException("feedback submission failed (HTTP $code): $detail")
+
+/**
+ * The app's build git commit, read from an AndroidManifest <meta-data> the host
+ * app injects (mirrors iOS Info.plist QuiverBuildCommit). The SDK only reports
+ * it; the host build sets it. Returns null when not present.
+ */
+private fun buildCommit(context: Context): String? = runCatching {
+    val info = context.packageManager.getApplicationInfo(
+        context.packageName,
+        PackageManager.GET_META_DATA,
+    )
+    info.metaData?.getString("io.quiver.build_commit")?.takeIf { it.isNotBlank() }
+}.getOrNull()
+
+/** Heuristic emulator detection for the environment report. */
+private fun isProbablyEmulator(): Boolean {
+    val fingerprint = Build.FINGERPRINT ?: ""
+    val model = Build.MODEL ?: ""
+    val product = Build.PRODUCT ?: ""
+    val hardware = Build.HARDWARE ?: ""
+    return fingerprint.startsWith("generic") ||
+        fingerprint.startsWith("unknown") ||
+        fingerprint.contains("emulator") ||
+        model.contains("google_sdk") ||
+        model.contains("Emulator") ||
+        model.contains("Android SDK") ||
+        product.contains("sdk") ||
+        hardware == "goldfish" ||
+        hardware == "ranchu" ||
+        (Build.MANUFACTURER ?: "").contains("Genymotion")
+}
+
+private fun thermalStatusName(status: Int): String = when (status) {
+    PowerManager.THERMAL_STATUS_NONE -> "none"
+    PowerManager.THERMAL_STATUS_LIGHT -> "light"
+    PowerManager.THERMAL_STATUS_MODERATE -> "moderate"
+    PowerManager.THERMAL_STATUS_SEVERE -> "severe"
+    PowerManager.THERMAL_STATUS_CRITICAL -> "critical"
+    PowerManager.THERMAL_STATUS_EMERGENCY -> "emergency"
+    PowerManager.THERMAL_STATUS_SHUTDOWN -> "shutdown"
+    else -> "unknown"
+}
+
+private fun batteryStatusName(status: Int): String = when (status) {
+    BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
+    BatteryManager.BATTERY_STATUS_DISCHARGING -> "discharging"
+    BatteryManager.BATTERY_STATUS_FULL -> "full"
+    BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "not_charging"
+    else -> "unknown"
+}
+
+/**
+ * Best-effort runtime environment facts (screen, memory, disk, battery, power,
+ * uptime). Each group is guarded so a failing system-service read can never
+ * break feedback/crash submission.
+ */
+private fun JSONObject.putRuntimeEnvironment(context: Context) {
+    runCatching { put("uptime_seconds", SystemClock.elapsedRealtime() / 1000) }
+    runCatching {
+        val dm = context.resources.displayMetrics
+        put("screen", "${dm.widthPixels}x${dm.heightPixels}@${dm.density}")
+        put("density_dpi", dm.densityDpi)
+    }
+    runCatching {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        if (am != null) {
+            val info = ActivityManager.MemoryInfo()
+            am.getMemoryInfo(info)
+            put("physical_memory", info.totalMem)
+            put("available_memory", info.availMem)
+            put("low_memory", info.lowMemory)
+        }
+    }
+    runCatching {
+        val stat = StatFs(context.filesDir.absolutePath)
+        put("disk_total", stat.totalBytes)
+        put("disk_free", stat.availableBytes)
+    }
+    runCatching {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        if (pm != null) {
+            put("low_power_mode", pm.isPowerSaveMode)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put("thermal_state", thermalStatusName(pm.currentThermalStatus))
+            }
+        }
+    }
+    runCatching {
+        val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        if (intent != null) {
+            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            if (level >= 0 && scale > 0) put("battery_level", level * 100 / scale)
+            put("battery_state", batteryStatusName(intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)))
+        }
+    }
+}

--- a/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
+++ b/clients/ohos/quiver/src/main/ets/QuiverFeedbackClient.ets
@@ -4,10 +4,27 @@ import http from '@ohos.net.http';
 import fs from '@ohos.file.fs';
 import i18n from '@ohos.i18n';
 import hilog from '@ohos.hilog';
+import display from '@ohos.display';
+import statvfs from '@ohos.file.statvfs';
+import batteryInfo from '@ohos.batteryInfo';
 import { Quiver } from './Quiver';
 import { QuiverDeviceId } from './QuiverDeviceId';
 
 const TAG: string = 'QuiverFeedbackClient';
+
+// Quiver OHOS SDK version — reported in feedback/crash environment metadata.
+// Keep in sync with oh-package.json5 on release.
+const QUIVER_SDK_VERSION: string = '0.1.0';
+
+// @ohos.batteryInfo BatteryChargeState: NONE=0, ENABLE=1, DISABLE=2, FULL=3.
+function ohBatteryStateName(status: number): string {
+  switch (status) {
+    case 1: return 'charging';
+    case 2: return 'discharging';
+    case 3: return 'full';
+    default: return 'unknown';
+  }
+}
 const REQUEST_TIMEOUT_MS: number = 30000;
 const UPLOAD_TIMEOUT_MS: number = 120000;
 
@@ -110,16 +127,47 @@ export class QuiverFeedbackClient {
   ): Promise<string> {
     const bundleInfo = bundleManager.getBundleInfoForSelfSync(bundleManager.BundleFlag.GET_BUNDLE_INFO_DEFAULT);
     const metadata: Record<string, string | number> = {
+      // App / build identity
       'version_name': bundleInfo.versionName,
       'version_code': bundleInfo.versionCode,
+      'bundle_id': bundleInfo.name,
+      'platform': 'ohos',
+      'quiver_sdk': QUIVER_SDK_VERSION,
       'channel': Quiver.config.channel,
+      // Device
       'device_id': QuiverDeviceId.get(context),
       'device_model': `${deviceInfo.manufacture} ${deviceInfo.productModel}`.trim(),
+      'device_manufacturer': deviceInfo.manufacture,
+      'device_brand': deviceInfo.brand,
+      'device_type': deviceInfo.deviceType,
+      'market_name': deviceInfo.marketName,
+      // OS
+      'os': deviceInfo.osFullName,
       'os_version': `${deviceInfo.osFullName} (API ${deviceInfo.sdkApiVersion})`,
+      'sdk_api_version': deviceInfo.sdkApiVersion,
       'arch': deviceInfo.abiList ?? 'unknown',
       'locale': i18n.System.getSystemLocale(),
-      'platform': 'ohos',
+      'system_language': i18n.System.getSystemLanguage(),
     };
+
+    // Runtime state (best-effort; a metadata read must never fail submit).
+    try {
+      metadata['timezone'] = i18n.getTimeZone().getID();
+    } catch (e) { /* ignore */ }
+    try {
+      const screen = display.getDefaultDisplaySync();
+      metadata['screen'] = `${screen.width}x${screen.height}@${screen.densityDPI}`;
+    } catch (e) { /* ignore */ }
+    try {
+      metadata['disk_total'] = statvfs.getTotalSizeSync(context.filesDir);
+      metadata['disk_free'] = statvfs.getFreeSizeSync(context.filesDir);
+    } catch (e) { /* ignore */ }
+    try {
+      metadata['battery_level'] = batteryInfo.batterySOC;
+      metadata['battery_state'] = ohBatteryStateName(batteryInfo.chargingStatus);
+    } catch (e) { /* ignore */ }
+
+    // Caller extras (crash_* fields etc.) override/augment the above.
     for (const extra of extras) {
       metadata[extra.key] = extra.value;
     }


### PR DESCRIPTION
## Why
Follow-up to #135 (iOS + generic admin UI). artin: bring OHOS/Android to parity. The generic admin Environment section renders whatever any platform reports, so enriching the Android/OHOS metadata makes their tickets equally rich.

## Android (`QuiverFeedback`)
Both crash and feedback route through `QuiverFeedback.submit`, so one metadata block covers both. Added: `platform`, `bundle_id`, `quiver_sdk`, `commit` (from `AndroidManifest` `io.quiver.build_commit` meta-data), `device_manufacturer`/`device_brand`, `is_emulator`, `os`, `sdk_int`, `timezone`, and best-effort runtime facts — `screen`/`density_dpi`, `physical_memory`/`available_memory`/`low_memory`, `disk_total`/`disk_free`, `battery_level`/`battery_state`, `low_power_mode`, `thermal_state`, `uptime_seconds`. Each system-service read is `runCatching`-guarded so it can never break submit.

## OHOS (`QuiverFeedbackClient`)
Crash also routes through `submit`. Added: `bundle_id`, `quiver_sdk`, `device_manufacturer`/`device_brand`/`device_type`, `market_name`, `os`, `sdk_api_version`, `system_language`, `timezone`, and guarded `screen`, `disk_total`/`disk_free`, `battery_level`/`battery_state`.

## Notes
- `commit` + real app version depend on the host build injecting them (Android manifest meta-data `io.quiver.build_commit`; OHOS build). Until then those fields are simply absent — consistent with iOS.
- No worker/UI change needed — the generic Environment section (shipped in #135) already renders these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)