### PR TITLE
feat(docs): serve raw .md twins + /docs.md machine index (task #107)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ coverage/
 *.tsbuildinfo
 worker-configuration.d.ts
 admin/public/docs/
+admin/public/docs.md

--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -363,6 +363,28 @@ function indexPage() {
   });
 }
 
+// Agent-facing machine index (mirrors exe.dev's /docs.md): every page listed
+// with its description and a link to its raw-markdown twin. Generated from the
+// same pages[] as the HTML, so it never drifts.
+function markdownIndex() {
+  const lines = [
+    "# Quiver Documentation",
+    "",
+    "Machine-readable index. Every page below has a raw-markdown twin at",
+    "`/docs/<slug>.md` (this index is `/docs.md`). Fetch those for clean,",
+    "chrome-free content — no HTML or JavaScript.",
+    "",
+  ];
+  for (const [category, list] of pagesByCategory()) {
+    lines.push(`## ${category}`, "");
+    for (const page of list) {
+      lines.push(`- [${page.title}](/docs/${page.slug}.md) — ${page.description}`);
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
 await rm(outRoot, { recursive: true, force: true });
 await mkdir(outRoot, { recursive: true });
 await writeFile(path.join(outRoot, "index.html"), indexPage());
@@ -380,6 +402,14 @@ for (const page of pages) {
       activeSlug: page.slug,
     }),
   );
+  // Raw-markdown twin at /docs/<slug>.md — the exact source, always in sync.
+  await writeFile(path.join(outRoot, `${page.slug}.md`), markdown);
 }
 
-console.log(`Built ${pages.length + 1} docs pages in ${path.relative(repoRoot, outRoot)}`);
+// /docs.md machine index lives one level up (admin/public/docs.md) so its URL
+// is /docs.md, alongside the /docs/ HTML tree.
+await writeFile(path.join(outRoot, "..", "docs.md"), markdownIndex());
+
+console.log(
+  `Built ${pages.length + 1} docs pages + ${pages.length} markdown twins + docs.md index in ${path.relative(repoRoot, outRoot)}`,
+);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -431,6 +431,17 @@ const publicDocs = new Set([
 
 async function handlePublicDocs(c: Context<{ Bindings: Env }>) {
   const path = new URL(c.req.url).pathname;
+  // Raw-markdown twins: /docs.md (machine index) and /docs/<slug>.md. The build
+  // (admin/scripts/build-docs.mjs) emits these from the same source as the HTML,
+  // so they stay in lockstep. Serve the asset as-is (ASSETS 404s for unknown
+  // files) with a markdown content type — no trailing-slash normalization.
+  if (path.endsWith(".md")) {
+    const asset = await c.env.ASSETS.fetch(new Request(new URL(path, c.req.url), c.req.raw));
+    if (asset.status === 404) return c.text("Not found", 404);
+    const headers = new Headers(asset.headers);
+    headers.set("content-type", "text/markdown; charset=utf-8");
+    return new Response(asset.body, { status: asset.status, headers });
+  }
   const normalizedPath = path.endsWith("/") ? path : `${path}/`;
   if (!publicDocs.has(normalizedPath)) {
     return c.text("Not found", 404);
@@ -439,6 +450,7 @@ async function handlePublicDocs(c: Context<{ Bindings: Env }>) {
 }
 
 app.get("/docs", handlePublicDocs);
+app.get("/docs.md", handlePublicDocs);
 app.get("/docs/*", handlePublicDocs);
 
 app.get("/api/auth/config", handleAuthConfig);


### PR DESCRIPTION
## Why
From the exe.dev docs evaluation (task #107): their strongest agent-friendliness lever is that every page has a raw-markdown twin at a predictable URL. Quiver docs were HTML-only, so agents fetching them got JS/SPA chrome instead of content.

## What
- **`/docs/<slug>.md`** — raw-markdown twin of every docs page (the exact source).
- **`/docs.md`** — a machine-readable index: all pages grouped by category, each with its description and a link to its `.md` twin.
- Worker serves `.md` from ASSETS with `text/markdown` content type (ASSETS 404s for unknown files); no trailing-slash normalization for `.md`.

## Automated — no hand-maintained files (artin: "看看能不能自动化掉这个过程")
`admin/scripts/build-docs.mjs` already builds HTML from `docs/public/*.md`. It now *also*:
- writes each page's raw source to `/docs/<slug>.md`, and
- generates `/docs.md` from the **same `pages[]`** used for the HTML.

So the twins + index can never drift from the HTML or the source. Build output stays gitignored (added `admin/public/docs.md`).

## Verify after deploy
`curl https://quiver.oranix.io/docs.md` and `curl https://quiver.oranix.io/docs/agent-guide.md` → clean markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)