### PR TITLE
feat(perms): admin-native actionable permission errors (task #108)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -66,7 +66,19 @@ program
 
 program.parseAsync(process.argv).catch((err) => {
   if (err instanceof Error && err.name === "QuiverApiError") {
-    console.error(`error: ${err.message}`);
+    // Admin-native, actionable error print (mirrors the Raft CLI discipline):
+    // surface the server's stable Code and Next action so an agent knows what
+    // to do — request a role, or have an admin act — not just "forbidden".
+    const body = (err as { body?: unknown }).body;
+    const info =
+      body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+    console.error(`Error: ${err.message}`);
+    if (typeof info.code === "string") console.error(`Code: ${info.code}`);
+    if (typeof info.next_action === "string") {
+      console.error(`Next action: ${info.next_action}`);
+    } else if (typeof info.manage_url === "string") {
+      console.error(`Next action: see ${info.manage_url}`);
+    }
     if (process.env.QUIVER_VERBOSE === "1" && err.stack) {
       console.error(err.stack);
     }

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -165,9 +165,23 @@ function forbiddenRole(
     : ids.app_id
       ? `${origin}/apps/${ids.app_id}/access`
       : null;
+  // Admin-native, actionable error: tell the caller (agent or human) exactly
+  // what to do next — who can grant the role, where, and that an admin can
+  // perform the action on their behalf — instead of a bare "forbidden". Code is
+  // a stable UPPER_SNAKE machine token; next_action is a ready-to-print
+  // sentence. admin_can_grant signals an admin path exists.
+  const target = scope === "org" ? "this org" : "this app";
+  const nextAction =
+    `You have role '${currentRole ?? "none"}' but '${requiredRole}' is required for ${target}. ` +
+    `Ask an admin of ${target} to grant you the '${requiredRole}' role` +
+    (manageUrl ? ` (manage roles at ${manageUrl})` : "") +
+    `, or have an admin perform this action for you.`;
   return c.json(
     {
       error: scope === "org" ? "insufficient_org_role" : "insufficient_app_role",
+      code: scope === "org" ? "INSUFFICIENT_ORG_ROLE" : "INSUFFICIENT_APP_ROLE",
+      next_action: nextAction,
+      admin_can_grant: true,
       required_role: requiredRole,
       current_role: currentRole,
       resource,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -756,12 +756,20 @@ describe("quiver route handlers — SQL smoke", () => {
       env as any,
     );
     expect(viewerResponse.status).toBe(403);
-    await expect(viewerResponse.json()).resolves.toMatchObject({
+    const viewerBody = (await viewerResponse.json()) as Record<string, unknown>;
+    expect(viewerBody).toMatchObject({
       error: "insufficient_org_role",
+      code: "INSUFFICIENT_ORG_ROLE",
       required_role: "member",
       current_role: "viewer",
       resource: "POST /api/apps",
+      admin_can_grant: true,
     });
+    // Admin-native actionable error: next_action names the required role and
+    // points at where an admin grants it.
+    expect(typeof viewerBody.next_action).toBe("string");
+    expect(viewerBody.next_action as string).toContain("member");
+    expect(viewerBody.next_action as string).toContain("/members");
 
     const memberResponse = await testApp.request(
       "https://quiver-worker.test/api/apps",


### PR DESCRIPTION
## Why
artin: "我们的所有接口也要 admin native" — surfaced when an agent (@XX) hit `403 insufficient_app_role, current_role=null` trying to mint a deploy token and couldn't tell *what to do next* (who to ask, whether an admin can do it for them).

## What
Enriched the **central** `forbiddenRole` descriptor (`worker/src/lib/permissions.ts`) — one change covers every admin-gated endpoint and manifest action:
- `code` — stable machine token (`INSUFFICIENT_APP_ROLE` / `INSUFFICIENT_ORG_ROLE`)
- `next_action` — ready-to-print sentence: names the required role, points at `manage_url`, and says an admin can grant it or perform the action for you
- `admin_can_grant: true`
- (existing `required_role`/`current_role`/`org_id`/`app_id`/`manage_url` kept)

The **CLI** top-level handler now prints `Error: / Code: / Next action:` (mirrors the Raft CLI error discipline) so agents get an actionable next step, not a bare "forbidden".

## Tests
Extended the existing 403 test to assert `code`, `admin_can_grant`, and that `next_action` names the role + points at the members URL. All 90 worker tests pass.

## Follow-up (task #108, next PR)
Self-serve deploy tokens: `create-deploy-token` manifest action + `quiver deploy-tokens create/list/revoke` CLI, and CLI accepting a deploy token for auth (CI currently can't use `QUIVER_BEARER_TOKEN` via the CLI, per @XX — had to fall back to raw curl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)