### PR TITLE
feat(cli): quiver deploy-tokens create/list/revoke (task #108)

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -29,7 +29,27 @@ export QUIVER_BEARER_TOKEN=<deploy-token>
 
 `QUIVER_AUTH_TOKEN` is also accepted as an alias for `QUIVER_BEARER_TOKEN`.
 
-Use app-scoped deploy tokens for CI. Create them in the app's Access page, choose the minimum role required, and store the raw token in your CI secret store.
+Use app-scoped deploy tokens for CI. Mint them with `quiver deploy-tokens create` (below) or in the app's Access page, choose the minimum role required, and store the raw token in your CI secret store.
+
+## Deploy Tokens
+
+App-scoped tokens for CI to publish (`publisher`) or read (`viewer`). Managing them requires **app admin**; if you lack it, the CLI prints an actionable error (which role you need, who can grant it, and that an admin can do it for you).
+
+```bash
+# Mint a publisher token for CI (printed ONCE — capture it immediately)
+quiver deploy-tokens create raft-android --name github-ci --role publisher
+
+# Optional expiry, and machine-readable output for scripting
+quiver deploy-tokens create raft-android --name github-ci --expires-in-days 90 --json
+
+# List an app's tokens (metadata only, never the secret)
+quiver deploy-tokens list raft-android
+
+# Revoke by id
+quiver deploy-tokens revoke raft-android <tokenId>
+```
+
+The created token is what you set as `QUIVER_BEARER_TOKEN` in CI. The server stores only a hash, so a lost token can only be revoked and re-minted, never recovered.
 
 ## Basic Commands
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oranix/quiver-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Quiver CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/deploy_tokens.ts
+++ b/packages/cli/src/commands/deploy_tokens.ts
@@ -1,0 +1,144 @@
+/**
+ * `quiver deploy-tokens` — mint / list / revoke app-scoped deploy tokens.
+ *
+ * Wires GET/POST/DELETE /api/apps/:appId/deploy-tokens. Requires app admin
+ * (otherwise the API returns an admin-native error telling you who can grant
+ * the role). A created token is printed once — the server stores only a hash —
+ * so capture it immediately (e.g. into a CI secret). Deploy tokens authenticate
+ * against the Quiver API as `Authorization: Bearer <token>`, which the CLI also
+ * reads from the QUIVER_BEARER_TOKEN env var.
+ */
+
+import type { Command } from "commander";
+import { apiRequest } from "../lib/api.js";
+
+interface AppRow {
+  id: string;
+  slug: string;
+}
+
+interface DeployToken {
+  id: string;
+  name: string;
+  token_prefix: string;
+  app_role: string;
+  created_at: number;
+  expires_at: number | null;
+  last_used_at: number | null;
+  revoked_at: number | null;
+}
+
+async function resolveAppId(appIdOrSlug: string): Promise<string> {
+  const isUuid =
+    appIdOrSlug.length === 36 && appIdOrSlug.split("-").length === 5;
+  if (isUuid) return appIdOrSlug;
+  const res = await apiRequest<{ apps: AppRow[] }>("/api/apps");
+  const match = res.apps.find((a) => a.slug === appIdOrSlug);
+  if (!match) {
+    console.error(`No app with slug '${appIdOrSlug}'.`);
+    process.exit(1);
+  }
+  return match.id;
+}
+
+export function registerDeployTokenCommands(program: Command): void {
+  const dt = program
+    .command("deploy-tokens")
+    .description(
+      "Mint, list, and revoke app-scoped deploy tokens (requires app admin).",
+    );
+
+  dt.command("list <appIdOrSlug>")
+    .alias("ls")
+    .description("List an app's deploy tokens (metadata only, no secret values).")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const res = await apiRequest<{ deploy_tokens: DeployToken[] }>(
+        `/api/apps/${appId}/deploy-tokens`,
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      if (res.deploy_tokens.length === 0) {
+        console.log("No deploy tokens.");
+        return;
+      }
+      console.log(["NAME", "ROLE", "PREFIX", "EXPIRES", "REVOKED", "ID"].join("\t"));
+      for (const t of res.deploy_tokens) {
+        console.log(
+          [
+            t.name,
+            t.app_role,
+            t.token_prefix,
+            t.expires_at ? new Date(t.expires_at).toISOString() : "never",
+            t.revoked_at ? "yes" : "no",
+            t.id.slice(0, 8),
+          ].join("\t"),
+        );
+      }
+    });
+
+  dt.command("create <appIdOrSlug>")
+    .description("Mint a new deploy token. The token is printed once — capture it now.")
+    .requiredOption("--name <name>", "Human label for the token (e.g. github-ci).")
+    .option("--role <role>", "publisher | viewer", "publisher")
+    .option(
+      "--expires-in-days <days>",
+      "Expiry in days from now (default: never expires).",
+    )
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        opts: {
+          name: string;
+          role?: string;
+          expiresInDays?: string;
+          json?: boolean;
+        },
+      ) => {
+        const appId = await resolveAppId(appIdOrSlug);
+        let expiresAt: number | null = null;
+        if (opts.expiresInDays != null) {
+          const days = Number(opts.expiresInDays);
+          if (!Number.isFinite(days) || days <= 0) {
+            console.error("--expires-in-days must be a positive number.");
+            process.exit(1);
+          }
+          expiresAt = Date.now() + days * 24 * 60 * 60 * 1000;
+        }
+        const res = await apiRequest<{ token: string; deploy_token: DeployToken }>(
+          `/api/apps/${appId}/deploy-tokens`,
+          {
+            method: "POST",
+            body: { name: opts.name, app_role: opts.role, expires_at: expiresAt },
+          },
+        );
+        if (opts.json) {
+          console.log(JSON.stringify(res, null, 2));
+          return;
+        }
+        const t = res.deploy_token;
+        console.log(`Deploy token '${t.name}' (${t.app_role}) created.`);
+        console.log(`  id: ${t.id}`);
+        console.log(
+          `  expires: ${t.expires_at ? new Date(t.expires_at).toISOString() : "never"}`,
+        );
+        console.log("");
+        console.log("  token (shown once — store it now, e.g. as a CI secret):");
+        console.log(`  ${res.token}`);
+      },
+    );
+
+  dt.command("revoke <appIdOrSlug> <tokenId>")
+    .description("Revoke a deploy token by id.")
+    .action(async (appIdOrSlug: string, tokenId: string) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      await apiRequest(`/api/apps/${appId}/deploy-tokens/${tokenId}`, {
+        method: "DELETE",
+      });
+      console.log(`Revoked deploy token ${tokenId}.`);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { registerBuildCommands } from "./commands/builds.js";
 import { registerLoginCommands } from "./commands/login.js";
 import { registerReleaseCommands } from "./commands/releases.js";
 import { registerFeedbackCommands } from "./commands/feedback.js";
+import { registerDeployTokenCommands } from "./commands/deploy_tokens.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { getConfig } from "./lib/config.js";
 import { setApiBase } from "./lib/api.js";
@@ -56,6 +57,7 @@ registerAppCommands(program);
 registerBuildCommands(program);
 registerReleaseCommands(program);
 registerFeedbackCommands(program);
+registerDeployTokenCommands(program);
 
 program
   .command("version")


### PR DESCRIPTION
## Why
Answers artin's original question — "agent 怎么获取某个 app 的 deploy token，有 cli 吗" — with: yes, `quiver deploy-tokens create`. Completes the self-serve half of task #108 (admin-native errors shipped in #139).

## What
New `quiver deploy-tokens` command group wiring the existing admin-gated `GET/POST/DELETE /api/apps/:appId/deploy-tokens`:
- `create <app> --name <n> [--role publisher|viewer] [--expires-in-days N] [--json]` — mints a token, printed **once** (server stores only a hash).
- `list <app> [--json]` — metadata only, never the secret.
- `revoke <app> <tokenId>`.

Accepts app slug or UUID. Without app admin, the caller gets the admin-native actionable error from #139 (which role, who grants it, that an admin can do it). Documented in `cli-reference.md` (+ its auto `.md` twin). CLI bumped 0.3.3 → 0.3.4.

## Notes
- The CLI already reads `QUIVER_BEARER_TOKEN` (and `QUIVER_AUTH_TOKEN`) for auth — that was a discoverability gap, not a code gap; it's documented in Authentication.
- Deferred (noted): a `create-deploy-token` **manifest action** for `raft integration invoke` — carries live-manifest risk (POST body-param support unverified) and the CLI already covers the need. Follow-up if wanted.
- Usable once the CLI is published to npm (0.3.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)