### PR TITLE
rename(sdk): Android + OHOS publish coordinates → Hands

### DIFF
--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("maven-publish")
 }
 
-group = "io.quiver"
+group = "build.hands"
 version = providers.gradleProperty("VERSION_NAME").orElse("0.1.0-SNAPSHOT").get()
 
 android {
@@ -51,8 +51,8 @@ afterEvaluate {
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])
-                groupId = "io.quiver"
-                artifactId = "quiver-android-updater"
+                groupId = "build.hands"
+                artifactId = "hands-android-updater"
                 version = project.version.toString()
 
                 pom {

--- a/clients/ohos/quiver/oh-package.json5
+++ b/clients/ohos/quiver/oh-package.json5
@@ -1,7 +1,7 @@
 {
-  "name": "@oranix/quiver",
-  "version": "0.1.0",
-  "description": "Quiver feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
+  "name": "@botiverse/hands",
+  "version": "0.2.0",
+  "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "Oranix",
   "license": "MIT",


### PR DESCRIPTION
Part of the Quiver → Hands rebrand. Android Maven `io.quiver`→`build.hands` (+ artifactId `hands-android-updater`), OHOS ohpm `@oranix/quiver`→`@botiverse/hands`. Publish-coordinate/metadata only (no code identifiers), so builds are unaffected; consumers adopt the new coordinate at migration/publish.

**Deferred (consumer-import-breaking, need real builds + KMP coordination):** iOS pod name + ObjC `Quiver*` class prefixes, Android Kotlin package `io.quiver.update` move. Those go with the publish/migration phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)