### PR TITLE
rename(ui): Quiver → Hands brand strings (console, landing, docs chrome)

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -263,7 +263,7 @@ function layout({ title, description, body, activeSlug }) {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${escapeHtml(title)} - Quiver Docs</title>
+  <title>${escapeHtml(title)} - Hands Docs</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <style>
     :root { color-scheme: light; --ink:#020617; --muted:#475569; --line:#e2e8f0; --bg:#f8fafc; --panel:#fff; --accent:#0f172a; }
@@ -322,7 +322,7 @@ function layout({ title, description, body, activeSlug }) {
 <body>
   <header>
     <div class="top">
-      <a class="brand" href="/"><img src="/favicon.svg" alt="" /> Quiver</a>
+      <a class="brand" href="/"><img src="/favicon.svg" alt="" /> Hands</a>
       <nav>
         <a href="/docs/">Docs</a>
         <a href="/api-docs">API explorer</a>
@@ -333,7 +333,7 @@ function layout({ title, description, body, activeSlug }) {
   <div class="shell">
     <aside>${nav}</aside>
     <main>
-      <div class="eyebrow">Quiver Docs</div>
+      <div class="eyebrow">Hands Docs</div>
       <h1>${escapeHtml(title)}</h1>
       <p class="lede">${escapeHtml(description)}</p>
       ${body}

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -126,7 +126,7 @@ function Header({ account }: { account: AuthAccount }) {
 
   return (
     <header className="sticky top-0 h-screen flex w-16 flex-none flex-col items-center border-r border-slate-200 bg-white py-3">
-      <Link to="/" aria-label="Quiver" className="mb-4">
+      <Link to="/" aria-label="Hands" className="mb-4">
         <QuiverMark className="h-9 w-9" />
       </Link>
       <nav className="flex w-full flex-col items-stretch gap-1 px-2">
@@ -437,7 +437,7 @@ function PageTitle() {
   const title = appId && appName ? `${section} - ${appName}` : section;
 
   useEffect(() => {
-    document.title = `${title} - Quiver`;
+    document.title = `${title} - Hands`;
   }, [title]);
 
   return null;
@@ -481,7 +481,7 @@ function AuthGate() {
 
 function PublicLanding({ account }: { account?: AuthAccount }) {
   useEffect(() => {
-    document.title = "Quiver - Client release operations";
+    document.title = "Hands - Client release operations";
   }, []);
 
   return (
@@ -490,7 +490,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
           <a href="/" className="inline-flex items-center gap-2 font-medium">
             <QuiverMark className="h-9 w-9 flex-none" />
-            <span className="text-xl leading-none">Quiver</span>
+            <span className="text-xl leading-none">Hands</span>
           </a>
           <nav className="flex items-center gap-2 text-sm">
             <a
@@ -527,7 +527,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
                 Ship it, roll it out, hear it break, fix it.
               </h1>
               <p className="mt-5 text-lg leading-8 text-slate-600">
-                Quiver runs the whole release loop: builds land as drafts,
+                Hands runs the whole release loop: builds land as drafts,
                 agents review and publish with bilingual changelogs, staged
                 rollouts meter exposure, and in-app feedback and crash
                 reports come back as tickets — grouped, deobfuscated, and
@@ -709,13 +709,13 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
       </Routes>
       <footer className="bg-white border-t border-slate-200 py-4 mt-8">
         <div className="max-w-5xl mx-auto px-4 text-xs text-slate-500 flex items-center justify-between">
-          <span>Quiver - Login with Raft</span>
+          <span>Hands - Login with Raft</span>
           <a
             href="https://github.com/oranix-io/quiver"
             target="_blank"
             rel="noopener noreferrer"
             className="btn-secondary !py-1 !px-2 !text-xs inline-flex items-center gap-1.5"
-            title="View Quiver source on GitHub"
+            title="View Hands source on GitHub"
           >
             <svg
               viewBox="0 0 24 24"

--- a/admin/src/components/AppCreationWizard.tsx
+++ b/admin/src/components/AppCreationWizard.tsx
@@ -257,7 +257,7 @@ export function AppCreationWizard({
             <h2 className="text-lg font-bold mb-4">Create app — Channels</h2>
             <p className="text-sm text-slate-500 mb-4">
               Channels are the delivery lanes clients use to fetch updates.
-              Quiver keeps maturity simple: publish to main for stable users,
+              Hands keeps maturity simple: publish to main for stable users,
               preview for validation, and nightly for fast internal iteration.
             </p>
 

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -205,7 +205,7 @@ export function AppFeedback({ appId }: { appId: string }) {
 type CrashSection = { key: string; label: string; body: string };
 
 /**
- * Split a Quiver crash log into sections by its known headers, so the ticket
+ * Split a Hands crash log into sections by its known headers, so the ticket
  * UI can present them as tabs (like Bugly's stack / scene / logs panels).
  */
 function parseCrashLog(text: string): CrashSection[] {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -370,7 +370,7 @@ app.get("/openapi.json", (c) => c.json({
 app.get("/api-docs", (c) => c.html(`<!doctype html>
 <html lang="en">
   <head>
-    <title>Quiver API Reference</title>
+    <title>Hands API Reference</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -400,9 +400,9 @@ app.get("/api-docs", (c) => c.html(`<!doctype html>
   </head>
   <body>
     <header class="quiver-api-header">
-      <a href="/" aria-label="Quiver home">
+      <a href="/" aria-label="Hands home">
         <img src="/favicon.svg" alt="" />
-        <span>Quiver</span>
+        <span>Hands</span>
       </a>
     </header>
     <div id="app"></div>

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -22,7 +22,7 @@ registerSettingsRoutes(docs.openAPIRegistry);
 export const openApiDocument = docs.getOpenAPI31Document({
   openapi: "3.1.0",
   info: {
-    title: "Quiver API",
+    title: "Hands API",
     version: "0.1.0",
     description:
       "Interactive API reference for Quiver. Generated from modular Hono/Zod route definitions.",


### PR DESCRIPTION
Visible product rebrand — the console, landing page, and docs-page chrome now say **Hands**.

- Admin UI brand/titles + hero copy → Hands (word-boundary replace; `QuiverMark`/`QuiverConfig` identifiers untouched).
- Worker: API-reference title, landing `<span>`/aria, OpenAPI title → Hands.
- `build-docs`: docs-page chrome → "Hands Docs".

**Kept as-is (contract / migration-phase):** all `X-Quiver-*` protocol headers (shipped clients send them), `quiver.oranix.io`, `quiver-db`, code identifiers, repo URLs.

**Deferred:** `docs/public/*.md` prose (Quiver.podspec/Quiver.h/QuiverConfig refs need care) + SDK `[Quiver]` log prefixes + iOS/Android code-identifier renames.

admin + worker typecheck, docs build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)