### PR TITLE
feat(headers): X-Hands-* with X-Quiver-* backward-compat

### DIFF
--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -178,10 +178,10 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
         device_id: z.string().optional(),
       }),
       headers: z.object({
-        "X-Quiver-Client-Platform": z.string().optional(),
-        "X-Quiver-Cohort": z.string().optional(),
-        "X-Quiver-Lang": z.string().optional(),
-        "X-Quiver-Device-Id": z.string().optional(),
+        "X-Hands-Client-Platform": z.string().optional(),
+        "X-Hands-Cohort": z.string().optional(),
+        "X-Hands-Lang": z.string().optional(),
+        "X-Hands-Device-Id": z.string().optional(),
       }),
     },
     responses: {
@@ -229,11 +229,11 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
         device_id: z.string().optional(),
       }),
       headers: z.object({
-        "X-Quiver-Client-Platform": z.string().optional(),
-        "X-Quiver-Client-Arch": z.string().optional(),
-        "X-Quiver-Cohort": z.string().optional(),
-        "X-Quiver-Lang": z.string().optional(),
-        "X-Quiver-Device-Id": z.string().optional(),
+        "X-Hands-Client-Platform": z.string().optional(),
+        "X-Hands-Client-Arch": z.string().optional(),
+        "X-Hands-Cohort": z.string().optional(),
+        "X-Hands-Lang": z.string().optional(),
+        "X-Hands-Device-Id": z.string().optional(),
       }),
     },
     responses: {
@@ -285,13 +285,13 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     tags: ["Public metrics"],
     summary: "Report SDK runtime metrics",
     description:
-      "Canonical SDK metrics ingest endpoint. Clients send a throttled launch/install ping with a stable per-install X-Quiver-Device-Id and build/runtime metadata. This powers active-device and version-distribution analytics; it is not an unthrottled online heartbeat.",
+      "Canonical SDK metrics ingest endpoint. Clients send a throttled launch/install ping with a stable per-install X-Hands-Device-Id and build/runtime metadata. This powers active-device and version-distribution analytics; it is not an unthrottled online heartbeat.",
     request: {
       params: SlugParam,
       query: z.object({ client_key: z.string().optional(), device_id: z.string().optional() }),
       headers: z.object({
-        "X-Quiver-Client-Key": z.string().optional(),
-        "X-Quiver-Device-Id": z.string().optional(),
+        "X-Hands-Client-Key": z.string().optional(),
+        "X-Hands-Device-Id": z.string().optional(),
       }),
       body: { content: json(MetricsIngestRequest), required: false },
     },
@@ -314,8 +314,8 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
       params: SlugParam,
       query: z.object({ client_key: z.string().optional(), device_id: z.string().optional() }),
       headers: z.object({
-        "X-Quiver-Client-Key": z.string().optional(),
-        "X-Quiver-Device-Id": z.string().optional(),
+        "X-Hands-Client-Key": z.string().optional(),
+        "X-Hands-Device-Id": z.string().optional(),
       }),
       body: { content: json(MetricsIngestRequest), required: false },
     },
@@ -333,11 +333,11 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     tags: ["Public feedback"],
     summary: "Submit feedback or crash report",
     description:
-      "Accepts SDK/client feedback, bug reports, and crash reports. Requires the app client key in X-Quiver-Client-Key or client_key.",
+      "Accepts SDK/client feedback, bug reports, and crash reports. Requires the app client key in X-Hands-Client-Key or client_key.",
     request: {
       params: SlugParam,
       query: z.object({ client_key: z.string().optional() }),
-      headers: z.object({ "X-Quiver-Client-Key": z.string().optional() }),
+      headers: z.object({ "X-Hands-Client-Key": z.string().optional() }),
       body: {
         content: multipart(),
         required: true,

--- a/worker/src/routes/analytics.ts
+++ b/worker/src/routes/analytics.ts
@@ -27,13 +27,13 @@ export async function handleDeviceRegister(c: Context<{ Bindings: Env }>) {
 
   // Same DSN-model client-key gate as feedback.
   const presented =
-    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
   if (!app.client_key || presented !== app.client_key) {
     return c.json({ error: "invalid or missing client key" }, 401);
   }
 
   const deviceId =
-    c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? "";
+    c.req.header("X-Hands-Device-Id") ?? c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? "";
   if (!deviceId || deviceId.length > 200) {
     return c.json({ error: "device id required" }, 400);
   }

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -41,7 +41,7 @@ export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: En
     .first<{ id: string; client_key: string | null }>();
   if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
   const presented =
-    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
   if (!app.client_key || presented !== app.client_key) {
     return c.json({ error: "invalid or missing client key" }, 401);
   }
@@ -106,7 +106,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   // key column have none until an admin generates one — their submissions
   // are rejected rather than silently open.
   const presented =
-    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
   if (!app.client_key || presented !== app.client_key) {
     return c.json({ error: "invalid or missing client key" }, 401);
   }
@@ -456,7 +456,7 @@ export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) 
   if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
 
   const presented =
-    c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
   if (!app.client_key || presented !== app.client_key) {
     return c.json({ error: "invalid or missing client key" }, 401);
   }

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -77,9 +77,9 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   const slug = c.req.param("slug");
   const channel = c.req.query("channel") ?? "main";
   const productType = c.req.query("product_type"); // optional; if null, picks most recent across all
-  const cohort = c.req.header("X-Quiver-Cohort") ?? null;
+  const cohort = c.req.header("X-Hands-Cohort") ?? c.req.header("X-Quiver-Cohort") ?? null;
   const deviceId =
-    c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
+    c.req.header("X-Hands-Device-Id") ?? c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
   const clientPlatform = effectiveClientPlatform(c);
   // cf.clientIp is server-only (we never trust X-Forwarded-For here).
   const clientIp =
@@ -367,7 +367,7 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
   const currentVersionCodeRaw =
     c.req.query("current_version_code") ??
     c.req.query("currentVersionCode") ??
-    c.req.header("X-Quiver-Current-Version-Code");
+    c.req.header("X-Hands-Current-Version-Code") ?? c.req.header("X-Quiver-Current-Version-Code");
   const currentVersionCode = Number(currentVersionCodeRaw);
   if (
     !currentVersionCodeRaw ||
@@ -402,11 +402,11 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
   const requestedPlatform =
     c.req.query("platform") ??
     c.req.query("client_platform") ??
-    c.req.header("X-Quiver-Client-Platform") ??
+    c.req.header("X-Hands-Client-Platform") ?? c.req.header("X-Quiver-Client-Platform") ??
     latest.app.platform;
   const requestedArch =
     c.req.query("arch") ??
-    c.req.header("X-Quiver-Client-Arch") ??
+    c.req.header("X-Hands-Client-Arch") ?? c.req.header("X-Quiver-Client-Arch") ??
     splitPlatformArch(requestedPlatform).arch;
   const requestedFiletype = c.req.query("filetype") ?? "apk";
   const asset = selectBestAsset(latest.assets, {
@@ -564,7 +564,7 @@ export function resolveChangelog(raw: string | null, lang: string | null): strin
 }
 
 function requestedLang(c: Context<{ Bindings: Env }>): string | null {
-  const explicit = c.req.query("lang") ?? c.req.header("X-Quiver-Lang");
+  const explicit = c.req.query("lang") ?? c.req.header("X-Hands-Lang") ?? c.req.header("X-Quiver-Lang");
   if (explicit) return explicit;
   const accept = c.req.header("accept-language");
   if (!accept) return null;
@@ -589,11 +589,11 @@ function splitPlatformArch(value: string | null): {
 
 function effectiveClientPlatform(c: Context<{ Bindings: Env }>): string | null {
   const explicit =
-    c.req.header("X-Quiver-Client-Platform") ??
+    c.req.header("X-Hands-Client-Platform") ?? c.req.header("X-Quiver-Client-Platform") ??
     c.req.query("client_platform");
   if (explicit) return explicit;
   const platform = c.req.query("platform");
-  const arch = c.req.query("arch") ?? c.req.header("X-Quiver-Client-Arch");
+  const arch = c.req.query("arch") ?? c.req.header("X-Hands-Client-Arch") ?? c.req.header("X-Quiver-Client-Arch");
   if (platform && arch) return `${platform}-${arch}`;
   return platform ?? null;
 }

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -363,14 +363,19 @@ async function postOnce(
 ): Promise<{ ok: boolean; status: number; body?: string; error?: string }> {
   try {
     const sig = await hmacSha256Hex(secret, body);
+    const event = (() => {
+      try { return JSON.parse(body).event ?? ""; } catch { return ""; }
+    })();
     const r = await fetch(url, {
       method: "POST",
       headers: {
         "content-type": "application/json",
+        // New canonical headers; legacy X-Quiver-* sent too so existing
+        // webhook consumers keep verifying without a change.
+        "X-Hands-Signature": `sha256=${sig}`,
+        "X-Hands-Event": event,
         "X-Quiver-Signature": `sha256=${sig}`,
-        "X-Quiver-Event": (() => {
-          try { return JSON.parse(body).event ?? ""; } catch { return ""; }
-        })(),
+        "X-Quiver-Event": event,
       },
       body,
     });


### PR DESCRIPTION
Rebrand protocol headers to `X-Hands-*`, server accepts both (shipped apps keep working). Inbound: reads `X-Hands-<name> ?? X-Quiver-<name>` (client key/device id/cohort/platform/arch/lang/version-code). Outbound webhooks: emits both `X-Hands-*` and `X-Quiver-*` signature/event. OpenAPI → `X-Hands-*`. 91 worker tests pass. (SDKs will send `X-Hands-*` on the SDK rename branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)