### PR TITLE
ci: add hands build deployment workflow

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -1,0 +1,130 @@
+name: Deploy Hands Server
+
+on:
+  workflow_dispatch:
+    inputs:
+      containers_rollout:
+        description: "Cloudflare Containers rollout strategy. Use none when only Worker/API/admin assets changed."
+        required: true
+        type: choice
+        options:
+          - none
+          - immediate
+          - gradual
+        default: none
+      run_checks:
+        description: "Run Worker tests/build, CLI build, and admin build before deploy."
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hands-server-production
+  cancel-in-progress: false
+
+env:
+  CLOUDFLARE_ACCOUNT_ID: a084c4564dfdce5a7775b08ece638a79
+  HANDS_D1_DATABASE_NAME: hands-db
+  HANDS_R2_BUCKET_NAME: hands-artifacts
+  HANDS_WORKER_DOMAIN: hands.build
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.12.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Worker types
+        working-directory: worker
+        run: pnpm exec wrangler types
+
+      - name: Run checks
+        if: ${{ inputs.run_checks }}
+        run: |
+          pnpm --filter @oranix/quiver-worker test
+          pnpm --filter @oranix/quiver-worker build
+          pnpm --filter @oranix/quiver-cli build
+          pnpm --filter @oranix/quiver-admin build
+
+      - name: Bootstrap Hands Cloudflare resources
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_HANDS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+            echo "Missing GitHub secret CLOUDFLARE_API_TOKEN_HANDS." >&2
+            exit 1
+          fi
+
+          pnpm exec wrangler d1 list --json > /tmp/hands-d1-before.json
+          D1_ID="$(node -e 'const fs=require("fs"); const name=process.env.HANDS_D1_DATABASE_NAME; const rows=JSON.parse(fs.readFileSync("/tmp/hands-d1-before.json","utf8")); const db=rows.find((row)=>row.name===name); if (db) process.stdout.write(db.uuid || db.id || db.database_id || "");')"
+          if [[ -z "${D1_ID}" ]]; then
+            pnpm exec wrangler d1 create "${HANDS_D1_DATABASE_NAME}"
+            pnpm exec wrangler d1 list --json > /tmp/hands-d1-after.json
+            D1_ID="$(node -e 'const fs=require("fs"); const name=process.env.HANDS_D1_DATABASE_NAME; const rows=JSON.parse(fs.readFileSync("/tmp/hands-d1-after.json","utf8")); const db=rows.find((row)=>row.name===name); if (!db) process.exit(1); process.stdout.write(db.uuid || db.id || db.database_id || "");')"
+          fi
+          if [[ -z "${D1_ID}" ]]; then
+            echo "Could not resolve D1 database id for ${HANDS_D1_DATABASE_NAME}." >&2
+            exit 1
+          fi
+
+          if ! pnpm exec wrangler r2 bucket info "${HANDS_R2_BUCKET_NAME}" >/dev/null 2>&1; then
+            pnpm exec wrangler r2 bucket create "${HANDS_R2_BUCKET_NAME}"
+          fi
+
+          D1_ID="${D1_ID}" node -e 'const fs=require("fs"); const id=process.env.D1_ID; const src=fs.readFileSync("wrangler.hands.jsonc","utf8"); fs.writeFileSync("wrangler.hands.generated.jsonc", src.replace("__HANDS_D1_DATABASE_ID__", id));'
+
+      - name: Apply Hands D1 migrations
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_HANDS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec wrangler d1 migrations apply "${HANDS_D1_DATABASE_NAME}" --remote --config wrangler.hands.generated.jsonc
+
+      - name: Deploy Hands Worker and admin assets
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_HANDS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec wrangler deploy \
+            --config wrangler.hands.generated.jsonc \
+            --containers-rollout "${{ inputs.containers_rollout }}" \
+            --domain "${HANDS_WORKER_DOMAIN}"
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "### Hands server deploy"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Ref | \`${GITHUB_REF_NAME}\` |"
+            echo "| SHA | \`${GITHUB_SHA}\` |"
+            echo "| Account | \`${CLOUDFLARE_ACCOUNT_ID}\` |"
+            echo "| Domain | \`${HANDS_WORKER_DOMAIN}\` |"
+            echo "| D1 | \`${HANDS_D1_DATABASE_NAME}\` |"
+            echo "| R2 | \`${HANDS_R2_BUCKET_NAME}\` |"
+            echo "| Containers rollout | \`${{ inputs.containers_rollout }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -64,12 +64,12 @@ jobs:
       - name: Bootstrap Hands Cloudflare resources
         working-directory: worker
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_HANDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
-            echo "Missing GitHub secret CLOUDFLARE_API_TOKEN_HANDS." >&2
+            echo "Missing GitHub secret CLOUDFLARE_BOTIVERSE_API_TOKEN." >&2
             exit 1
           fi
 
@@ -94,7 +94,7 @@ jobs:
       - name: Apply Hands D1 migrations
         working-directory: worker
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_HANDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -103,7 +103,7 @@ jobs:
       - name: Deploy Hands Worker and admin assets
         working-directory: worker
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_HANDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -121,11 +121,13 @@ Required repository secrets:
 
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token allowed to deploy the Quiver Worker and its assets.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
+- `CLOUDFLARE_API_TOKEN_HANDS` — Cloudflare API token for the Hands account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
 
 Workflows:
 
 - `Publish CLI` publishes `@oranix/quiver-cli` to npm through npm Trusted Publishing / GitHub OIDC. Configure the npm package trusted publisher for this repository and workflow, then trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.1.2`.
 - `Deploy Quiver Server` deploys the Worker plus bundled admin/docs assets. Trigger it manually, or push a tag like `server-v2026.07.04`. The default container rollout is `none`; choose `immediate` or `gradual` only when the APK parser container image changed.
+- `Deploy Hands Server` deploys the same Worker/admin bundle to `hands.build` in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Required repository secrets:
 
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token allowed to deploy the Quiver Worker and its assets.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
-- `CLOUDFLARE_API_TOKEN_HANDS` — Cloudflare API token for the Hands account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
+- `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
 
 Workflows:
 

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -1,0 +1,76 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "hands-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-10-08",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": { "enabled": true },
+  "upload_source_maps": true,
+
+  "r2_buckets": [
+    {
+      "binding": "APK_BUCKET",
+      "bucket_name": "hands-artifacts"
+    }
+  ],
+
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "hands-db",
+      "database_id": "__HANDS_D1_DATABASE_ID__",
+      "migrations_dir": "../migrations/sql"
+    }
+  ],
+
+  "containers": [
+    {
+      "class_name": "ApkParserContainer",
+      "image": "../container/Dockerfile",
+      "max_instances": 3
+    }
+  ],
+
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "ApkParserContainer",
+        "name": "APK_PARSER"
+      }
+    ]
+  },
+
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ApkParserContainer"]
+    }
+  ],
+
+  "triggers": [
+    {
+      "type": "scheduled",
+      "cron": "*/5 * * * *"
+    }
+  ],
+
+  "vars": {
+    "ENVIRONMENT": "production",
+    "MAX_APK_SIZE_MB": "200",
+    "SIGNED_URL_TTL_SECONDS": "3600",
+    "R2_ACCOUNT_ID": "a084c4564dfdce5a7775b08ece638a79",
+    "R2_BUCKET_NAME": "hands-artifacts",
+    "R2_PRESIGNED_DOWNLOAD_TTL_SECONDS": "3600",
+    "CORS_ALLOWED_ORIGINS": "https://hands.build,http://localhost:5173",
+    "RAFT_ORIGIN": "https://app.raft.build",
+    "RAFT_API_ORIGIN": "https://api.raft.build",
+    "RAFT_CLIENT_ID": "quiver"
+  },
+
+  "assets": {
+    "directory": "../admin/dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a separate manual `Deploy Hands Server` workflow targeting `hands.build`
- add `worker/wrangler.hands.jsonc` for the Hands/Botiverse Cloudflare account `a084c4564dfdce5a7775b08ece638a79`
- bootstrap `hands-db` and `hands-artifacts` in the target account without changing the existing Quiver deploy workflow
- document the new `CLOUDFLARE_BOTIVERSE_API_TOKEN` secret and workflow

## Notes
- Existing `Deploy Quiver Server` remains untouched and continues to deploy `quiver.oranix.io`.
- The new workflow is manual-only.
- The workflow uses `CLOUDFLARE_BOTIVERSE_API_TOKEN`, which has been configured in repo secrets.
- `hands.build` must exist in the Hands/Botiverse Cloudflare account before the custom-domain deploy step can succeed.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-hands-server.yml")'`
- `node -e 'const fs=require("fs"); const src=fs.readFileSync("worker/wrangler.hands.jsonc","utf8"); if(!src.includes("hands.build")||!src.includes("a084c4564dfdce5a7775b08ece638a79")||!src.includes("__HANDS_D1_DATABASE_ID__")) process.exit(1);'`
- `pnpm exec wrangler deploy --config wrangler.hands.generated.jsonc --dry-run --containers-rollout none --domain hands.build` with a temporary generated config
- `git diff --check`
