### PR TITLE
ci: pin hands d1 config

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -73,23 +73,11 @@ jobs:
             exit 1
           fi
 
-          pnpm exec wrangler d1 list --json > /tmp/hands-d1-before.txt
-          D1_ID="$(node -e 'const fs=require("fs"); const name=process.env.HANDS_D1_DATABASE_NAME; const raw=fs.readFileSync("/tmp/hands-d1-before.txt","utf8"); let rows=[]; for (const m of raw.matchAll(/\\[[\\s\\S]*?\\]/g)) { try { const parsed=JSON.parse(m[0]); if (Array.isArray(parsed)) { rows=parsed; break; } } catch {} } const db=rows.find((row)=>row.name===name); if (db) process.stdout.write(db.uuid || db.id || db.database_id || "");')"
-          if [[ -z "${D1_ID}" ]]; then
-            pnpm exec wrangler d1 create "${HANDS_D1_DATABASE_NAME}"
-            pnpm exec wrangler d1 list --json > /tmp/hands-d1-after.txt
-            D1_ID="$(node -e 'const fs=require("fs"); const name=process.env.HANDS_D1_DATABASE_NAME; const raw=fs.readFileSync("/tmp/hands-d1-after.txt","utf8"); let rows=[]; for (const m of raw.matchAll(/\\[[\\s\\S]*?\\]/g)) { try { const parsed=JSON.parse(m[0]); if (Array.isArray(parsed)) { rows=parsed; break; } } catch {} } const db=rows.find((row)=>row.name===name); if (!db) process.exit(1); process.stdout.write(db.uuid || db.id || db.database_id || "");')"
-          fi
-          if [[ -z "${D1_ID}" ]]; then
-            echo "Could not resolve D1 database id for ${HANDS_D1_DATABASE_NAME}." >&2
-            exit 1
-          fi
+          pnpm exec wrangler d1 info "${HANDS_D1_DATABASE_NAME}" --config wrangler.hands.jsonc >/dev/null
 
           if ! pnpm exec wrangler r2 bucket info "${HANDS_R2_BUCKET_NAME}" >/dev/null 2>&1; then
             pnpm exec wrangler r2 bucket create "${HANDS_R2_BUCKET_NAME}"
           fi
-
-          D1_ID="${D1_ID}" node -e 'const fs=require("fs"); const id=process.env.D1_ID; const src=fs.readFileSync("wrangler.hands.jsonc","utf8"); fs.writeFileSync("wrangler.hands.generated.jsonc", src.replace("__HANDS_D1_DATABASE_ID__", id));'
 
       - name: Apply Hands D1 migrations
         working-directory: worker
@@ -98,7 +86,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pnpm exec wrangler d1 migrations apply "${HANDS_D1_DATABASE_NAME}" --remote --config wrangler.hands.generated.jsonc
+          pnpm exec wrangler d1 migrations apply "${HANDS_D1_DATABASE_NAME}" --remote --config wrangler.hands.jsonc
 
       - name: Deploy Hands Worker and admin assets
         working-directory: worker
@@ -108,7 +96,7 @@ jobs:
         run: |
           set -euo pipefail
           pnpm exec wrangler deploy \
-            --config wrangler.hands.generated.jsonc \
+            --config wrangler.hands.jsonc \
             --containers-rollout "${{ inputs.containers_rollout }}" \
             --domain "${HANDS_WORKER_DOMAIN}"
 

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -18,7 +18,7 @@
     {
       "binding": "DB",
       "database_name": "hands-db",
-      "database_id": "__HANDS_D1_DATABASE_ID__",
+      "database_id": "13d02825-af01-40f8-8f3d-a4356649628f",
       "migrations_dir": "../migrations/sql"
     }
   ],
@@ -47,12 +47,9 @@
     }
   ],
 
-  "triggers": [
-    {
-      "type": "scheduled",
-      "cron": "*/5 * * * *"
-    }
-  ],
+  "triggers": {
+    "crons": ["*/5 * * * *"]
+  },
 
   "vars": {
     "ENVIRONMENT": "production",


### PR DESCRIPTION
## Summary
- pin the newly-created Hands D1 database id in worker/wrangler.hands.jsonc
- remove fragile wrangler d1 list JSON parsing and generated config from the Hands deploy workflow
- update the Hands cron trigger shape to the current Wrangler JSON schema

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-hands-server.yml")'
- pnpm exec wrangler deploy --config worker/wrangler.hands.jsonc --dry-run --containers-rollout none --domain hands.build
- pnpm --filter @botiverse/hands-worker test
- pnpm --filter @botiverse/hands-worker build
- pnpm --filter @botiverse/hands-cli build
- pnpm --filter @botiverse/hands-admin build
- git diff --check