### PR TITLE
feat(cli): HANDS_* env vars with QUIVER_* fallback

### DIFF
--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -5,6 +5,7 @@
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import { apiRequest } from "../lib/api.js";
+import { readEnv } from "../lib/env.js";
 
 interface AppRow {
   id: string;
@@ -166,7 +167,7 @@ export function registerReleaseCommands(program: Command): void {
         } else {
           body.ttl_seconds = parsePositiveNumber(opts.ttlSeconds ?? DEFAULT_SHARE_TTL_SECONDS, "--ttl-seconds");
         }
-        const password = opts.password ?? process.env.QUIVER_SHARE_PASSWORD;
+        const password = opts.password ?? readEnv("SHARE_PASSWORD");
         if (password) body.password = password;
         const share = await apiRequest<ReleaseShare>(
           `/api/apps/${appId}/releases/${releaseId}/shares`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import { registerFeedbackCommands } from "./commands/feedback.js";
 import { registerDeployTokenCommands } from "./commands/deploy_tokens.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { getConfig } from "./lib/config.js";
+import { readEnv } from "./lib/env.js";
 import { setApiBase } from "./lib/api.js";
 
 const program = new Command();
@@ -45,9 +46,9 @@ program
 program.hook("preAction", (thisCommand) => {
   const opts = thisCommand.opts<{ api?: string; json?: boolean; verbose?: boolean }>();
   const cfg = getConfig();
-  const apiBase = opts.api ?? process.env.QUIVER_API ?? cfg.apiBase;
+  const apiBase = opts.api ?? readEnv("API") ?? cfg.apiBase;
   if (apiBase) setApiBase(apiBase);
-  if (opts.verbose) process.env.QUIVER_VERBOSE = "1";
+  if (opts.verbose) process.env.HANDS_VERBOSE = "1";
 });
 
 // --- Subcommand groups ---
@@ -81,7 +82,7 @@ program.parseAsync(process.argv).catch((err) => {
     } else if (typeof info.manage_url === "string") {
       console.error(`Next action: see ${info.manage_url}`);
     }
-    if (process.env.QUIVER_VERBOSE === "1" && err.stack) {
+    if (readEnv("VERBOSE") === "1" && err.stack) {
       console.error(err.stack);
     }
     process.exit(1);

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -10,6 +10,7 @@
  */
 
 import { resolveApiBase, resolveSessionCookie } from "./config.js";
+import { readEnv } from "./env.js";
 import { Blob } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
@@ -56,7 +57,7 @@ export async function apiRequest<T = unknown>(
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  const bearer = process.env.QUIVER_AUTH_TOKEN ?? process.env.QUIVER_BEARER_TOKEN;
+  const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
   if (bearer) headers.authorization = `Bearer ${bearer}`;
   const cookie = resolveSessionCookie();
   if (!bearer && cookie) headers["cookie"] = cookie;
@@ -70,7 +71,7 @@ export async function apiRequest<T = unknown>(
     headers,
     ...(body !== undefined ? { body } : {}),
   });
-  if (process.env.QUIVER_VERBOSE === "1") {
+  if (readEnv("VERBOSE") === "1") {
     console.error(`> ${opts.method ?? "GET"} ${url}`);
     console.error(`< ${res.status}`);
   }
@@ -108,7 +109,7 @@ export async function apiUploadFile<T = unknown>(
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  const bearer = process.env.QUIVER_AUTH_TOKEN ?? process.env.QUIVER_BEARER_TOKEN;
+  const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
   if (bearer) headers.authorization = `Bearer ${bearer}`;
   if (!bearer && cookie) headers.cookie = cookie;
 
@@ -117,7 +118,7 @@ export async function apiUploadFile<T = unknown>(
     headers,
     body: form,
   });
-  if (process.env.QUIVER_VERBOSE === "1") {
+  if (readEnv("VERBOSE") === "1") {
     console.error(`> POST ${url}`);
     console.error(`< ${res.status}`);
   }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -13,6 +13,7 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readEnv } from "./env.js";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
@@ -59,9 +60,9 @@ export function clearConfig(): void {
 }
 
 export function resolveApiBase(): string {
-  const cliFlag = process.env.QUIVER_CLI_API;
+  const cliFlag = readEnv("CLI_API");
   if (cliFlag) return cliFlag;
-  const env = process.env.QUIVER_API;
+  const env = readEnv("API");
   if (env) return env;
   const cfg = getConfig();
   if (cfg.apiBase) return cfg.apiBase;
@@ -70,7 +71,7 @@ export function resolveApiBase(): string {
 
 export function resolveSessionCookie(): string | undefined {
   // CI mode wins over file config (env vars are explicit).
-  const env = process.env.QUIVER_SESSION_COOKIE;
+  const env = readEnv("SESSION_COOKIE");
   if (env) return env;
   return getConfig().sessionCookie;
 }

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -1,0 +1,9 @@
+/**
+ * Environment variables during the Quiver → Hands rebrand: prefer the new
+ * `HANDS_<name>` and fall back to the legacy `QUIVER_<name>` so existing CI
+ * (which sets e.g. `QUIVER_BEARER_TOKEN`) keeps working unchanged. Same
+ * backward-compat approach as the X-Hands / X-Quiver request headers.
+ */
+export function readEnv(suffix: string): string | undefined {
+  return process.env[`HANDS_${suffix}`] ?? process.env[`QUIVER_${suffix}`];
+}


### PR DESCRIPTION
Rebrand CLI env vars to HANDS_* with QUIVER_* backward-compat (artin follow-up, same approach as X-Hands headers). readEnv() = HANDS_<name> ?? QUIVER_<name>, wired into API base/bearer/cookie/share-password/verbose. Existing QUIVER_BEARER_TOKEN CI keeps working. tsc + 7 CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)