### PR TITLE
ci: configure hands signed url secret

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -88,6 +88,20 @@ jobs:
           set -euo pipefail
           pnpm exec wrangler d1 migrations apply "${HANDS_D1_DATABASE_NAME}" --remote --config wrangler.hands.jsonc
 
+      - name: Configure Hands Worker secrets
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+          SIGNED_URL_SECRET: ${{ secrets.HANDS_SIGNED_URL_SECRET }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${SIGNED_URL_SECRET:-}" ]]; then
+            echo "Missing GitHub secret HANDS_SIGNED_URL_SECRET." >&2
+            exit 1
+          fi
+          printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config wrangler.hands.jsonc
+
       - name: Deploy Hands Worker and admin assets
         working-directory: worker
         env:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Required repository secrets:
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token allowed to deploy the Hands Worker and its assets.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
+- `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
 
 Workflows:
 


### PR DESCRIPTION
## Summary
- add a Hands deploy step that writes HANDS_SIGNED_URL_SECRET into the Worker as SIGNED_URL_SECRET
- document the new GitHub secret

## Why
After the Hands deploy and data sync, health/openapi were OK but public update-check returned 500 because signed release download URLs need SIGNED_URL_SECRET, ADMIN_API_TOKEN, or RAFT_CLIENT_SECRET. This configures a Hands-only signing secret without reusing the old Quiver runtime secrets.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-hands-server.yml")'
- git diff --check