### PR TITLE
fix(admin): document X-Hands-* headers (legacy X-Quiver note)

### DIFF
--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -284,8 +284,8 @@ function ClientKeyPanel({ appId }: { appId: string }) {
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium">Client key</div>
         <div className="text-xs text-slate-500">
-          Required on feedback/crash submissions (X-Quiver-Client-Key). Embedded in
-          client builds; rotate if leaked.
+          Required on feedback/crash submissions (X-Hands-Client-Key; legacy
+          X-Quiver-Client-Key still accepted). Embedded in client builds; rotate if leaked.
         </div>
         {key && revealed && (
           <div className="mt-1 font-mono text-xs break-all">{key}</div>

--- a/admin/src/pages/OrgSettings.tsx
+++ b/admin/src/pages/OrgSettings.tsx
@@ -820,7 +820,7 @@ function WebhooksTab({
             <p className="text-xs text-slate-500">
               Subscribe external HTTP endpoints to release and build events.
               Deliveries are signed with HMAC SHA-256
-              (<code className="font-mono">X-Quiver-Signature</code>).
+              (<code className="font-mono">X-Hands-Signature</code>).
             </p>
           </div>
           {canManage && (
@@ -886,8 +886,9 @@ function WebhooksTab({
           </li>
           <li>
             Receiver must verify
-            <code className="font-mono"> X-Quiver-Signature: sha256=&lt;hmac&gt;</code>
-            using the webhook&apos;s secret.
+            <code className="font-mono"> X-Hands-Signature: sha256=&lt;hmac&gt;</code>
+            using the webhook&apos;s secret (legacy{" "}
+            <code className="font-mono">X-Quiver-Signature</code> is still sent too).
           </li>
         </ul>
       </div>
@@ -1140,7 +1141,7 @@ function CreateWebhookDialog({
             />
             <p className="text-xs text-slate-500 mt-1">
               Used to sign deliveries via{" "}
-              <code className="font-mono">X-Quiver-Signature</code>. Choose a
+              <code className="font-mono">X-Hands-Signature</code>. Choose a
               strong secret; receivers must verify the signature.
             </p>
           </div>


### PR DESCRIPTION
Admin console still showed X-Quiver-Client-Key / X-Quiver-Signature; canonical is now X-Hands-* (server/webhooks dual). Updated with legacy note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)