### PR TITLE
ci: configure Hands Raft login secret

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -93,6 +93,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
           SIGNED_URL_SECRET: ${{ secrets.HANDS_SIGNED_URL_SECRET }}
+          RAFT_CLIENT_SECRET: ${{ secrets.HANDS_RAFT_CLIENT_SECRET }}
         shell: bash
         run: |
           set -euo pipefail
@@ -100,7 +101,12 @@ jobs:
             echo "Missing GitHub secret HANDS_SIGNED_URL_SECRET." >&2
             exit 1
           fi
+          if [[ -z "${RAFT_CLIENT_SECRET:-}" ]]; then
+            echo "Missing GitHub secret HANDS_RAFT_CLIENT_SECRET." >&2
+            exit 1
+          fi
           printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config wrangler.hands.jsonc
+          printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config wrangler.hands.jsonc
 
       - name: Deploy Hands Worker and admin assets
         working-directory: worker

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Required repository secrets:
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
 - `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
+- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands` connected app. The app registration return URL must be `https://hands.build/login/raft/callback`.
 
 Workflows:
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Required repository secrets:
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
 - `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
-- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands` connected app. The app registration return URL must be `https://hands.build/login/raft/callback`.
+- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the existing `quiver` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the return URL `https://hands.build/login/raft/callback`.
 
 Workflows:
 

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -61,7 +61,7 @@
     "CORS_ALLOWED_ORIGINS": "https://hands.build,http://localhost:5173",
     "RAFT_ORIGIN": "https://app.raft.build",
     "RAFT_API_ORIGIN": "https://api.raft.build",
-    "RAFT_CLIENT_ID": "quiver"
+    "RAFT_CLIENT_ID": "hands"
   },
 
   "assets": {

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -61,7 +61,7 @@
     "CORS_ALLOWED_ORIGINS": "https://hands.build,http://localhost:5173",
     "RAFT_ORIGIN": "https://app.raft.build",
     "RAFT_API_ORIGIN": "https://api.raft.build",
-    "RAFT_CLIENT_ID": "hands"
+    "RAFT_CLIENT_ID": "quiver"
   },
 
   "assets": {


### PR DESCRIPTION
## Summary
- switch the Hands deployment config to the dedicated Raft client id `hands`
- have the Hands deploy workflow write `RAFT_CLIENT_SECRET` from `HANDS_RAFT_CLIENT_SECRET`
- document the Hands Raft client secret and callback URL requirement

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-hands-server.yml"); puts "yaml ok"'\n- pnpm --filter @botiverse/hands-worker build\n- git diff --check\n- pnpm exec wrangler deploy --config wrangler.hands.jsonc --dry-run --containers-rollout none --domain hands.build\n\n## Notes\nThis keeps the original Quiver deploy path and `quiver` Raft client unchanged. `hands.build` still needs a registered Raft connected app with return URL `https://hands.build/login/raft/callback`, and the resulting secret must be stored as GitHub secret `HANDS_RAFT_CLIENT_SECRET` before deploy can make browser login work.