### PR TITLE
fix: use Hands Raft client

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Required repository secrets:
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
 - `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
-- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the existing `quiver` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the return URL `https://hands.build/login/raft/callback`.
+- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands-4cc7a2` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the return URL `https://hands.build/login/raft/callback`.
 
 Workflows:
 

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -61,7 +61,7 @@
     "CORS_ALLOWED_ORIGINS": "https://hands.build,http://localhost:5173",
     "RAFT_ORIGIN": "https://app.raft.build",
     "RAFT_API_ORIGIN": "https://api.raft.build",
-    "RAFT_CLIENT_ID": "quiver"
+    "RAFT_CLIENT_ID": "hands-4cc7a2"
   },
 
   "assets": {


### PR DESCRIPTION
## Summary
- switch Hands Worker Raft client id to the dedicated `hands-4cc7a2` client
- update deploy README secret wording to match the Hands client

## Validation
- `git diff --check`
- GitHub secret `HANDS_RAFT_CLIENT_SECRET` is present and updated
- Local clean worktree lacks `node_modules`; full worker build/test will run in GitHub deploy workflow after merge
