### PR TITLE
ci: build Hands deploy assets when skipping checks

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -61,6 +61,10 @@ jobs:
           pnpm --filter @botiverse/hands-cli build
           pnpm --filter @botiverse/hands-admin build
 
+      - name: Build deploy assets
+        if: ${{ !inputs.run_checks }}
+        run: pnpm --filter @botiverse/hands-admin build
+
       - name: Bootstrap Hands Cloudflare resources
         working-directory: worker
         env:


### PR DESCRIPTION
## Summary
- keep `run_checks=false` as a test/build shortcut
- still build the Hands admin bundle so Wrangler has `admin/dist` during deploy

## Validation
- `pnpm --filter @botiverse/hands-admin build`
- `pnpm exec wrangler types` from `worker/`
- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-worker test` (91 passed)
- `git diff --check`

## Context
The previous Hands deploy reached secret configuration successfully, then failed because `admin/dist` was missing when checks were skipped.
