### PR TITLE
fix: update Hands Raft login branding

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Quiver</title>
+    <title>Hands</title>
   </head>
   <body class="bg-slate-50 text-slate-900 antialiased">
     <div id="root"></div>

--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -8,7 +8,7 @@ const docsRoot = path.join(repoRoot, "docs/public");
 const outRoot = path.join(repoRoot, "admin/public/docs");
 
 // Docs are grouped by audience; CATEGORY_ORDER controls section order in the
-// sidebar and on the index. Quiver is agent-native, so "For agents" leads.
+// sidebar and on the index. Hands is agent-native, so "For agents" leads.
 const CATEGORY_ORDER = ["For agents", "Console", "SDKs & API"];
 
 // Lucide "external-link" (24x24), used for the OpenAPI explorer nav entry.
@@ -33,7 +33,7 @@ const pages = [
     slug: "admin-user-guide",
     title: "Admin User Guide",
     category: "Console",
-    description: "Using the Quiver admin console: apps, releases, builds, access, and troubleshooting.",
+    description: "Using the Hands admin console: apps, releases, builds, access, and troubleshooting.",
     source: "admin-user-guide.md",
   },
   {
@@ -54,7 +54,7 @@ const pages = [
     slug: "ios-sdk",
     title: "iOS SDK",
     category: "SDKs & API",
-    description: "Feedback tickets and store-then-send crash reporting for iOS (the Quiver CocoaPod).",
+    description: "Feedback tickets and store-then-send crash reporting for iOS (the Hands CocoaPod).",
     source: "ios-sdk.md",
   },
   {
@@ -357,7 +357,7 @@ function indexPage() {
     .join("");
   return layout({
     title: "Documentation",
-    description: "Product, admin, CLI, and API documentation for Quiver.",
+    description: "Product, admin, CLI, and API documentation for Hands.",
     body,
     activeSlug: "",
   });
@@ -368,7 +368,7 @@ function indexPage() {
 // same pages[] as the HTML, so it never drifts.
 function markdownIndex() {
   const lines = [
-    "# Quiver Documentation",
+    "# Hands Documentation",
     "",
     "Machine-readable index. Every page below has a raw-markdown twin at",
     "`/docs/<slug>.md` (this index is `/docs.md`). Fetch those for clean,",

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -25,7 +25,7 @@ export const openApiDocument = docs.getOpenAPI31Document({
     title: "Hands API",
     version: "0.1.0",
     description:
-      "Interactive API reference for Quiver. Generated from modular Hono/Zod route definitions.",
+      "Interactive API reference for Hands. Generated from modular Hono/Zod route definitions.",
   },
   servers: [
     {
@@ -130,7 +130,7 @@ openApiDocument.components.securitySchemes = {
   bearerAuth: {
     type: "http",
     scheme: "bearer",
-    description: "Quiver bearer token. Use app deploy tokens for CI and agents.",
+    description: "Hands bearer token. Use app deploy tokens for CI and agents.",
   },
   cookieAuth: {
     type: "apiKey",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -2,7 +2,7 @@
  * Login with Raft routes.
  *
  * The Raft OAuth code and access token never leave the Worker. The browser
- * only receives Quiver's own HttpOnly session cookie.
+ * only receives Hands's own HttpOnly session cookie.
  */
 
 import type { Context } from "hono";
@@ -391,7 +391,7 @@ async function finalizeRaftLogin(
     token.access_token,
   );
   if (!isUserAllowed(c.env, userinfo)) {
-    return c.text("This Raft server is not allowed for this Quiver admin.", 403);
+    return c.text("This Raft server is not allowed for this Hands admin.", 403);
   }
 
   const account = await upsertRaftAccount(c.env.DB, userinfo);
@@ -504,7 +504,7 @@ export async function handleAuthLogin(c: Context<{ Bindings: Env }>) {
     maxAge: 10 * 60,
   });
 
-  const setup = new URL("/login-with-slock/setup", config.raftOrigin);
+  const setup = new URL("/login-with-raft/setup", config.raftOrigin);
   setup.searchParams.set("client_id", config.clientId);
   setup.searchParams.set("return_to", callbackUrl(c));
   setup.searchParams.set("scope", "openid profile");
@@ -602,7 +602,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
     },
     // HTTP API actions an agent can self-serve via `raft integration invoke`.
     // Paths are relative to execution.base_url (`${origin}/api`). Focused on the
-    // feedback-read/log-retrieval flow; Quiver serves raw attachments and does
+    // feedback-read/log-retrieval flow; Hands serves raw attachments and does
     // not interpret their contents.
     actions: [
       {
@@ -634,7 +634,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "download-feedback-attachment",
         description:
-          "Download a raw feedback attachment (bytes as-is; Quiver does not unzip or interpret it).",
+          "Download a raw feedback attachment (bytes as-is; Hands does not unzip or interpret it).",
         endpoint: {
           method: "GET",
           path: "/api/apps/{app_id}/feedback/{ticket_id}/attachments/{attachment_id}",

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -24,6 +24,7 @@ import { requireCurrentOrgRole } from "../src/lib/permissions";
 import { httpsRedirectUrl, isSecureRequest, requestOrigin } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
 import { handleCreateApp } from "../src/routes/apps";
+import { handleAuthLogin } from "../src/routes/auth";
 
 // ---------- Test harness ----------
 
@@ -1197,6 +1198,28 @@ describe("quiver route handlers — SQL smoke", () => {
 });
 
 describe("auth origin handling", () => {
+  it("redirects Login with Raft through the current Raft setup route", async () => {
+    const env = makeMockEnv();
+    env.RAFT_CLIENT_ID = "hands-4cc7a2";
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/login", handleAuthLogin);
+
+    const res = await app.request(
+      "https://hands.build/api/auth/login?return=%2F",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.origin).toBe("https://app.raft.build");
+    expect(location.pathname).toBe("/login-with-raft/setup");
+    expect(location.searchParams.get("client_id")).toBe("hands-4cc7a2");
+    expect(location.searchParams.get("return_to")).toBe(
+      "https://hands.build/login/raft/callback",
+    );
+  });
+
   it("canonicalizes public http custom-domain requests to https", () => {
     const ctx = {
       req: {


### PR DESCRIPTION
## Summary
- switch Login with Raft setup redirect from legacy `/login-with-slock/setup` to `/login-with-raft/setup`
- change admin HTML title from Quiver to Hands
- update generated docs/API branding strings that still surfaced Quiver labels
- add a regression test covering the Raft setup redirect path and Hands client id

## Validation
- `pnpm --filter @botiverse/hands-worker test` (92 passed)
- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-admin build`
- `git diff --check`
- scan for `login-with-slock`, `<title>Quiver</title>`, `Quiver Documentation`, and old API description labels
