### PR TITLE
feat(worker): quiver-worker becomes a legacy proxy shim

### DIFF
--- a/worker/src/proxy-shim.ts
+++ b/worker/src/proxy-shim.ts
@@ -1,0 +1,133 @@
+/**
+ * Legacy proxy shim for `quiver-worker`.
+ *
+ * After the Hands migration, `quiver.oranix.io` no longer runs the business
+ * worker — all business logic, D1, and R2 live on `hands-worker`
+ * (`hands.build`). This shim is the ONLY thing `quiver-worker` deploys going
+ * forward. It exists purely to keep the legacy domain working for two very
+ * different classes of traffic:
+ *
+ *   1. Machine / API paths (installed apps + CI): transparently
+ *      reverse-proxied to the Hands worker, preserving method, body, query,
+ *      and headers. Existing shipped apps POST feedback / crash / metrics and
+ *      GET update-checks against `quiver.oranix.io/public/*`; a 302 here would
+ *      drop the POST body/headers (multipart), so these MUST be proxied, never
+ *      redirected. Writes land in the Hands DB via the proxy — single source
+ *      of truth, no divergence.
+ *
+ *   2. Human pages (browsers): 302-redirected to `hands.build` so people land
+ *      on the canonical new domain.
+ *
+ * The shim holds NO D1 / R2 / Container bindings and never touches the legacy
+ * database. See `wrangler.jsonc` (name `quiver-worker`) for the stripped-down
+ * config that deploys this file.
+ */
+
+export interface ShimEnv {
+  /**
+   * Origin serving the Hands business worker, no trailing slash. Points at the
+   * worker's direct `workers.dev` route (NOT `hands.build`) to skip the edge
+   * cache and avoid any custom-domain loop, e.g.
+   * `https://hands-worker.botiverse.workers.dev`.
+   */
+  PROXY_TARGET: string;
+  /**
+   * Origin humans are 302-redirected to, no trailing slash, e.g.
+   * `https://hands.build`.
+   */
+  REDIRECT_TARGET: string;
+}
+
+/**
+ * Machine / API paths that must be reverse-proxied (never redirected) because
+ * they carry POST bodies, machine downloads, or the admin/auth API. Mirrors the
+ * real route table in `src/index.ts`.
+ */
+function isMachinePath(pathname: string): boolean {
+  if (
+    pathname.startsWith("/public/") || // update-check, feedback/minidump/metrics POST, r2, icon
+    pathname.startsWith("/api/") || // auth + admin API
+    pathname.startsWith("/electron/") || // electron-updater asset fetches
+    pathname.startsWith("/.well-known/") // agent manifests
+  ) {
+    return true;
+  }
+  if (
+    pathname === "/health" ||
+    pathname === "/openapi.json" ||
+    pathname === "/login/raft/callback"
+  ) {
+    return true;
+  }
+  // `/apps/:slug/history` and `/apps/:slug/history/:releaseId/download` are
+  // JSON / machine downloads. The bare `/apps/:slug` client-side admin route is
+  // a human page (falls through to redirect).
+  if (pathname.startsWith("/apps/") && pathname.includes("/history")) {
+    return true;
+  }
+  // `/share/:token` is a human page (redirect). Its sub-resources
+  // `/share/:token/{download,unlock,icon}` are machine endpoints (proxy).
+  if (pathname.startsWith("/share/")) {
+    return pathname.slice("/share/".length).includes("/");
+  }
+  return false;
+}
+
+/**
+ * Reverse-proxy the request to PROXY_TARGET, preserving method, body (streamed,
+ * not buffered — feedback attachments / dSYM uploads can reach 200MB), query,
+ * and headers. `redirect: "manual"` passes the origin's own 3xx (e.g. presigned
+ * R2 download redirects) straight through instead of following them.
+ */
+async function proxy(request: Request, url: URL, env: ShimEnv): Promise<Response> {
+  const target = new URL(env.PROXY_TARGET);
+  const proxied = new URL(url.pathname + url.search, target);
+
+  const headers = new Headers(request.headers);
+  // Let fetch derive Host from the target URL; the Hands worker routes by path,
+  // not Host, so rewriting it is safe and correct for workers.dev routing.
+  headers.delete("host");
+  // Record the original edge hostname for the origin's logs / audit trail.
+  headers.set("x-forwarded-host", url.host);
+  headers.set("x-forwarded-proto", url.protocol.replace(/:$/, ""));
+
+  const init: RequestInit & { duplex?: "half" } = {
+    method: request.method,
+    headers,
+    body: request.body,
+    redirect: "manual",
+  };
+  // Streaming a request body requires duplex: "half" (undici / Workers runtime).
+  // GET/HEAD have a null body, so this is only set for POST/PUT/PATCH.
+  if (request.body) {
+    init.duplex = "half";
+  }
+
+  const resp = await fetch(proxied, init);
+
+  // Return the origin response as-is — status, headers, streamed body.
+  return new Response(resp.body, {
+    status: resp.status,
+    statusText: resp.statusText,
+    headers: resp.headers,
+  });
+}
+
+export default {
+  async fetch(request: Request, env: ShimEnv): Promise<Response> {
+    const url = new URL(request.url);
+    const isGetOrHead = request.method === "GET" || request.method === "HEAD";
+
+    // Machine/API paths — and any non-GET (a 302 would drop the body) — proxy.
+    if (isMachinePath(url.pathname) || !isGetOrHead) {
+      return proxy(request, url, env);
+    }
+
+    // Human page — 302 to the canonical new domain, preserving path + query.
+    const location = env.REDIRECT_TARGET + url.pathname + url.search;
+    return new Response(null, { status: 302, headers: { Location: location } });
+  },
+};
+
+// Exported for unit tests.
+export { isMachinePath };

--- a/worker/test/proxy-shim.test.ts
+++ b/worker/test/proxy-shim.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the legacy proxy shim's path classifier.
+ *
+ * The shim reverse-proxies machine/API paths (never redirects — POST bodies
+ * would be dropped) and 302-redirects human pages. The subtle cases are the
+ * `/share/:token` page (redirect) vs its `/download|/unlock|/icon` sub-resources
+ * (proxy), and `/apps/:slug/history*` (proxy) vs the bare `/apps/:slug` admin
+ * SPA route (redirect).
+ */
+
+import { describe, it, expect } from "vitest";
+import { isMachinePath } from "../src/proxy-shim";
+
+describe("proxy-shim isMachinePath", () => {
+  it("proxies public API paths (update-check + POST endpoints)", () => {
+    for (const p of [
+      "/public/v2/apps/raft-android/latest",
+      "/public/v2/apps/raft-android/updates/check",
+      "/public/v2/apps/raft-android/feedback",
+      "/public/v2/apps/raft-android/minidump",
+      "/public/v2/apps/raft-android/devices",
+      "/public/v2/apps/raft-android/metrics",
+      "/public/v2/apps/raft-android/feedback/presign",
+      "/public/apps/raft-android/icon",
+      "/public/r2/some-key",
+    ]) {
+      expect(isMachinePath(p), p).toBe(true);
+    }
+  });
+
+  it("proxies admin/auth API, electron assets, manifests, health", () => {
+    for (const p of [
+      "/api/auth/me",
+      "/api/orgs",
+      "/api/invites/abc",
+      "/electron/raft-desktop/main/latest.yml",
+      "/.well-known/raft-agent-manifest.json",
+      "/health",
+      "/openapi.json",
+      "/login/raft/callback",
+    ]) {
+      expect(isMachinePath(p), p).toBe(true);
+    }
+  });
+
+  it("proxies /share sub-resources but redirects the /share page", () => {
+    expect(isMachinePath("/share/TOKEN123/download")).toBe(true);
+    expect(isMachinePath("/share/TOKEN123/unlock")).toBe(true);
+    expect(isMachinePath("/share/TOKEN123/icon")).toBe(true);
+    // bare share page -> human -> redirect
+    expect(isMachinePath("/share/TOKEN123")).toBe(false);
+  });
+
+  it("proxies /apps history JSON + download, redirects bare SPA route", () => {
+    expect(isMachinePath("/apps/raft-android/history")).toBe(true);
+    expect(isMachinePath("/apps/raft-android/history/rel-id/download")).toBe(true);
+    // bare admin SPA route -> human -> redirect
+    expect(isMachinePath("/apps/raft-android")).toBe(false);
+  });
+
+  it("redirects human pages", () => {
+    for (const p of [
+      "/",
+      "/docs",
+      "/docs.md",
+      "/docs/android-sdk/",
+      "/notes/raft-android",
+      "/api-docs",
+      "/assets/index-abc123.js",
+      "/favicon.ico",
+    ]) {
+      expect(isMachinePath(p), p).toBe(false);
+    }
+  });
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,82 +1,28 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "quiver-worker",
-  "main": "src/index.ts",
+
+  // quiver-worker is now a LEGACY PROXY SHIM, not the business worker.
+  // See src/proxy-shim.ts for the full rationale. It keeps quiver.oranix.io
+  // working after the Hands migration:
+  //   - machine/API paths  -> reverse-proxied to the Hands worker (writes land
+  //                           in the Hands DB; POST bodies preserved)
+  //   - human pages        -> 302 to hands.build
+  // It holds NO D1 / R2 / Container / cron bindings and never touches the
+  // legacy database. The business worker + its bindings + the webhook-reaper
+  // cron all live in wrangler.hands.jsonc (name "hands-worker").
+  "main": "src/proxy-shim.ts",
   "compatibility_date": "2025-10-08",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "upload_source_maps": true,
 
-  // R2 bucket — APK binaries + parsed icons
-  "r2_buckets": [
-    {
-      "binding": "APK_BUCKET",
-      "bucket_name": "quiver-apks"
-    }
-  ],
-
-  // D1 database — apps / versions / channels / audit_logs
-  "d1_databases": [
-    {
-      "binding": "DB",
-      "database_name": "quiver-db",
-      "database_id": "fdc960cc-d1c5-41ae-96f3-c74df4b97d6b",
-      "migrations_dir": "../migrations/sql"
-    }
-  ],
-
-  // Cloudflare Container — APK metadata parser
-  "containers": [
-    {
-      "class_name": "ApkParserContainer",
-      "image": "../container/Dockerfile",
-      "max_instances": 3
-    }
-  ],
-
-  // Durable Object binding for the container (per containers-template pattern)
-  "durable_objects": {
-    "bindings": [
-      {
-        "class_name": "ApkParserContainer",
-        "name": "APK_PARSER"
-      }
-    ]
-  },
-
-  "migrations": [
-    {
-      "tag": "v1",
-      "new_sqlite_classes": ["ApkParserContainer"]
-    }
-  ],
-
-  // Cron trigger — reaps pending webhook deliveries every 5 minutes.
-  // Invokes handleReapDeliveries via the "scheduled" handler in src/index.ts.
-  "triggers": {
-    "crons": ["*/5 * * * *"]
-  },
-
-  // Non-secret config
+  // Non-secret config for the shim.
   "vars": {
-    "ENVIRONMENT": "production",
-    "MAX_APK_SIZE_MB": "200",
-    "SIGNED_URL_TTL_SECONDS": "3600",
-    "R2_ACCOUNT_ID": "cfb85626a067371c6e9a75191b5fb09d",
-    "R2_BUCKET_NAME": "quiver-apks",
-    "R2_PRESIGNED_DOWNLOAD_TTL_SECONDS": "3600",
-    "CORS_ALLOWED_ORIGINS": "https://quiver.oranix.io,http://localhost:5173,https://quiver-admin.pages.dev,https://*.quiver-admin.pages.dev",
-    "RAFT_ORIGIN": "https://app.raft.build",
-    "RAFT_API_ORIGIN": "https://api.raft.build",
-    "RAFT_CLIENT_ID": "quiver"
-  },
-
-  // Serve admin SPA static assets from this Worker (no separate Pages project).
-  // Hono routes take precedence; unmatched paths fall through to /index.html.
-  "assets": {
-    "directory": "../admin/dist",
-    "binding": "ASSETS",
-    "not_found_handling": "single-page-application",
-    "run_worker_first": true
+    // Direct workers.dev origin of the Hands business worker — NOT hands.build,
+    // to skip the edge cache and avoid a custom-domain loop. No trailing slash.
+    "PROXY_TARGET": "https://hands-worker.botiverse.workers.dev",
+    // Canonical domain humans are 302-redirected to. No trailing slash.
+    "REDIRECT_TARGET": "https://hands.build"
   }
 }


### PR DESCRIPTION
## What

Turns `quiver-worker` into a **legacy proxy shim**. After the Hands migration, all business logic, D1, R2, container, and the webhook-reaper cron live on `hands-worker` (`hands.build`). `quiver-worker` no longer runs any business code — it deploys only `src/proxy-shim.ts`.

Its sole job is to keep `quiver.oranix.io` working for **already-installed apps** (which POST feedback/crash/metrics and GET update-checks there) and to move **humans** to the new domain.

## Behavior

| Path class | Examples | Action |
|---|---|---|
| Machine / API | `/public/*`, `/api/*`, `/electron/*`, `/.well-known/*`, `/apps/*/history*`, `/share/:token/{download,unlock,icon}`, `/health`, `/openapi.json`, `/login/raft/callback` | **reverse-proxy** to `hands-worker.botiverse.workers.dev`, preserving method, body (streamed), query, headers |
| Human page | `/`, `/docs*`, `/notes/:slug`, `/share/:token` (page), `/api-docs`, SPA assets | **302** to `https://hands.build<same path+query>` |
| Any non-GET | (all POSTs are machine paths) | proxied (never 302 — would drop the body) |

## Why proxy, not 302, for the API

A 302 on a POST drops the request body and headers — existing apps' multipart feedback/crash/metrics submissions would silently break. The proxy preserves method/body/headers/query and streams the body (feedback attachments / dSYM uploads reach 200MB, so it must not buffer). `redirect: "manual"` passes the origin's own 3xx (e.g. presigned R2 download redirects) straight through.

**Writes land in the Hands DB** via the proxy → single source of truth, no divergence between the old and new environments.

## Config

`wrangler.jsonc` (name `quiver-worker`) is stripped of **all** D1/R2/Container/cron/assets bindings — the shim needs none and must never touch the legacy DB. Proxy target is the direct `workers.dev` origin (not `hands.build`) to skip the edge cache and avoid a custom-domain loop. Two vars: `PROXY_TARGET`, `REDIRECT_TARGET`.

The webhook-reaper cron + all bindings remain on `hands-worker` (`wrangler.hands.jsonc`), unchanged.

## Tests

- New `test/proxy-shim.test.ts` covers the classifier, including the subtle `/share/:token` page (redirect) vs `/share/:token/download|unlock|icon` (proxy) and `/apps/:slug/history*` (proxy) vs bare `/apps/:slug` SPA route (redirect).
- Full suite: 97 passing. `tsc --noEmit` clean.

## Reviewer smoke (per QA-Tester)

After deploy, on `quiver.oranix.io`:
- `latest`, `updates/check`, `feedback`, `metrics`, crash/minidump, `share/:token/download` → **not 302**, POST body/headers preserved, writes land in Hands DB
- `/`, `/docs`, `/notes/:slug`, `/share/:token`, `/api-docs` → **302** to `hands.build`

cc @artin — do not deploy until the CF route for `quiver.oranix.io` is repointed to `quiver-worker` (this shim) and `hands.build`/`hands-worker.botiverse.workers.dev` are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
