### PR TITLE
fix(worker): shim proxies to hands.build + split shim/business typecheck

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -51,7 +51,11 @@ jobs:
 
       - name: Generate Worker types
         working-directory: worker
-        run: pnpm exec wrangler types
+        # Generate the business worker's Env from the hands config. The default
+        # wrangler.jsonc is now the legacy proxy shim (shim-only vars), so
+        # without --config the generated Env would lack DB/APK_BUCKET/ASSETS and
+        # the src/index.ts typecheck below would fail.
+        run: pnpm exec wrangler types --config wrangler.hands.jsonc
 
       - name: Run checks
         if: ${{ inputs.run_checks }}

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -3,17 +3,8 @@ name: Deploy Quiver Server
 on:
   workflow_dispatch:
     inputs:
-      containers_rollout:
-        description: "Cloudflare Containers rollout strategy. Use none when only Worker/API/admin assets changed."
-        required: true
-        type: choice
-        options:
-          - none
-          - immediate
-          - gradual
-        default: none
       run_checks:
-        description: "Run Worker tests/build and admin build before deploy."
+        description: "Type-check the proxy shim before deploy."
         required: true
         type: boolean
         default: true
@@ -46,40 +37,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Worker types
-        working-directory: worker
-        run: pnpm exec wrangler types
-
-      - name: Run checks
+      - name: Check shim
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_checks }}
-        run: |
-          pnpm --filter @botiverse/hands-worker test
-          pnpm --filter @botiverse/hands-worker build
-          pnpm --filter @botiverse/hands-cli build
-          pnpm --filter @botiverse/hands-admin build
+        # quiver-worker now deploys ONLY the legacy proxy shim. Type-check it in
+        # isolation (its own tsconfig + ShimEnv) — no `wrangler types` needed,
+        # and NOT the business worker (that lives in deploy-hands-server.yml).
+        run: pnpm --filter @botiverse/hands-worker build:shim
 
-      - name: Resolve rollout strategy
-        id: rollout
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            echo "value=none" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${{ inputs.containers_rollout }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Apply D1 migrations
-        working-directory: worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          pnpm exec wrangler d1 migrations apply quiver-db --remote
-
-      - name: Deploy Worker and admin assets
+      - name: Deploy proxy shim
         working-directory: worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -91,17 +56,18 @@ jobs:
             echo "Missing GitHub secret CLOUDFLARE_API_TOKEN." >&2
             exit 1
           fi
-          pnpm exec wrangler deploy --containers-rollout "${{ steps.rollout.outputs.value }}"
+          # Default wrangler.jsonc is the shim: no D1 migrations, no containers.
+          pnpm exec wrangler deploy
 
       - name: Summary
         shell: bash
         run: |
           {
-            echo "### Quiver server deploy"
+            echo "### Quiver proxy shim deploy"
             echo
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Ref | \`${GITHUB_REF_NAME}\` |"
             echo "| SHA | \`${GITHUB_SHA}\` |"
-            echo "| Containers rollout | \`${{ steps.rollout.outputs.value }}\` |"
+            echo "| Role | \`legacy proxy shim -> hands.build\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/worker/package.json
+++ b/worker/package.json
@@ -8,6 +8,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "build": "tsc --noEmit",
+    "build:shim": "tsc -p tsconfig.shim.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/",

--- a/worker/tsconfig.shim.json
+++ b/worker/tsconfig.shim.json
@@ -1,0 +1,14 @@
+{
+  // Type-checks ONLY the legacy proxy shim (src/proxy-shim.ts), in isolation
+  // from the business worker (src/index.ts). The shim uses its own ShimEnv
+  // interface — not the Cloudflare-generated global Env — so it must NOT depend
+  // on `wrangler types` output (worker-configuration.d.ts), which is generated
+  // per wrangler config. This lets the shim deploy validate independently of
+  // whichever Env the business worker's config would produce.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/proxy-shim.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -58,7 +58,11 @@
     "R2_ACCOUNT_ID": "a084c4564dfdce5a7775b08ece638a79",
     "R2_BUCKET_NAME": "hands-artifacts",
     "R2_PRESIGNED_DOWNLOAD_TTL_SECONDS": "3600",
-    "CORS_ALLOWED_ORIGINS": "https://hands.build,http://localhost:5173",
+    // quiver.oranix.io is included as a cutover/cache safety net: a browser
+    // still running a cached admin SPA from the legacy domain may fire /api/*
+    // (proxied through the shim) with Origin: https://quiver.oranix.io before it
+    // follows the 302 to hands.build. Native SDKs don't use CORS.
+    "CORS_ALLOWED_ORIGINS": "https://hands.build,https://quiver.oranix.io,http://localhost:5173",
     "RAFT_ORIGIN": "https://app.raft.build",
     "RAFT_API_ORIGIN": "https://api.raft.build",
     "RAFT_CLIENT_ID": "hands-4cc7a2"

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -19,9 +19,12 @@
 
   // Non-secret config for the shim.
   "vars": {
-    // Direct workers.dev origin of the Hands business worker — NOT hands.build,
-    // to skip the edge cache and avoid a custom-domain loop. No trailing slash.
-    "PROXY_TARGET": "https://hands-worker.botiverse.workers.dev",
+    // Origin serving the Hands business worker. hands.build routes to
+    // hands-worker; quiver never appears in that path, so there is no loop.
+    // (The direct hands-worker.botiverse.workers.dev route is not enabled, so
+    // we proxy via the custom domain; GET edge-caching there is benign, POSTs
+    // are not cached.) No trailing slash.
+    "PROXY_TARGET": "https://hands.build",
     // Canonical domain humans are 302-redirected to. No trailing slash.
     "REDIRECT_TARGET": "https://hands.build"
   }


### PR DESCRIPTION
Follow-up to #165, closing the pre-deploy gates raised by @QA-Tester and @Codex-Android-DevOPS.

## 1. PROXY_TARGET → `https://hands.build`

The intended direct route `hands-worker.botiverse.workers.dev` is **not enabled** — I and Codex both curl-verified it returns 404 / CF error 1042, while `hands.build` serves the business worker correctly (200 + real 1.1.0 data). Deploying the shim against the dead route would 404 every installed app.

`hands.build` routes only to `hands-worker` (quiver never appears in that path → no loop). GET edge-caching there is benign; POSTs are not cached. The direct workers.dev route can be enabled + swapped back later, off the cutover critical path.

## 2. Split shim vs business typecheck (#165 broke both deploy workflows)

#165 made the **default** `wrangler.jsonc` the shim (shim-only vars). Both deploy workflows ran `wrangler types` with **no `--config`**, so the generated `Env` now lacks `DB`/`APK_BUCKET`/`ASSETS` and the `src/index.ts` build fails — in `deploy-hands-server.yml` too (not just the shim workflow).

- **`deploy-hands-server.yml`**: `wrangler types --config wrangler.hands.jsonc` → business worker type-checks against its real Env.
- **`worker/tsconfig.shim.json`** (new) + `build:shim` script: type-check **only** `src/proxy-shim.ts`, which uses its own `ShimEnv` and is independent of generated types. Verified it passes even with `worker-configuration.d.ts` absent.
- **`deploy-server.yml`** becomes a real shim deploy: type-check the shim only, drop the business build/test, drop the `quiver-db` D1 migration and `--containers-rollout` (the shim has neither D1 nor containers), remove the now-unused `containers_rollout` dispatch input.

## 3. CORS safety net

Add `https://quiver.oranix.io` to the hands worker `CORS_ALLOWED_ORIGINS`. A browser running a **cached** admin SPA on the legacy domain may fire `/api/*` (proxied via the shim) with `Origin: https://quiver.oranix.io` before it follows the 302 to hands.build. Native SDKs don't use CORS. `client-key` headers are intentionally **not** added to `allowHeaders` — the admin UI authenticates by cookie, and SDKs are native (no preflight).

## Verification
- `build:shim` passes with `worker-configuration.d.ts` moved aside (proves independence from generated Env).
- Full worker suite: **97 passing**.
- Both wrangler configs + both workflow YAMLs parse.

## Deploy sequencing (per Codex)
1. Merge this → `PROXY_TARGET=hands.build`, typecheck fixed, CORS set.
2. Deploy hands-worker (picks up CORS) and the shim (`deploy-server.yml`).
3. Repoint the `quiver.oranix.io` CF route to `quiver-worker` (the shim).
4. Smoke: API paths not 302 + writes land in hands DB; human pages 302 to hands.build; `Origin: https://quiver.oranix.io` preflight allowed.

cc @artin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
