### PR TITLE
fix(worker): delete-class migration so the shim can deploy over quiver-worker

### DIFF
--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -27,5 +27,17 @@
     "PROXY_TARGET": "https://hands.build",
     // Canonical domain humans are 302-redirected to. No trailing slash.
     "REDIRECT_TARGET": "https://hands.build"
-  }
+  },
+
+  // The business quiver-worker previously bound the ApkParserContainer Durable
+  // Object (Cloudflare Container for APK parsing). The shim drops it, but
+  // Cloudflare refuses to deploy a script that no longer exports a class still
+  // referenced by existing Durable Objects (error 10064) without an explicit
+  // delete-class migration. v1 is the already-applied original; v2 deletes the
+  // class. APK parsing now happens on hands-worker (its own ApkParserContainer),
+  // so removing this one is safe.
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["ApkParserContainer"] },
+    { "tag": "v2", "deleted_classes": ["ApkParserContainer"] }
+  ]
 }


### PR DESCRIPTION
Hotfix — the shim deploy (follow-up to #165/#166) **failed** at `wrangler deploy` with Cloudflare error 10064:

```
New version of script does not export class 'ApkParserContainer' which is
depended on by existing Durable Objects... try a delete-class migration
```

The live quiver-worker still had the `ApkParserContainer` Durable Object (Container for APK parsing) bound. The shim drops it, and Cloudflare won't publish a script that no longer exports a class referenced by existing DOs without an explicit delete-class migration.

**No outage** — Cloudflare kept the previous (business) version live, so quiver.oranix.io kept serving existing apps. Smoke caught it: cache-busted `/apps/raft-android`, `/docs.md`, `/favicon.ico` still returned old-worker 200s instead of the shim's 302.

## Fix

Add a migrations chain to the shim's `wrangler.jsonc`:
```jsonc
"migrations": [
  { "tag": "v1", "new_sqlite_classes": ["ApkParserContainer"] }, // already applied
  { "tag": "v2", "deleted_classes": ["ApkParserContainer"] }     // delete it
]
```
APK parsing now runs on hands-worker (its own `ApkParserContainer`), so removing the legacy one is safe.

## After merge
Redeploy `deploy-server.yml`, then smoke (per me + @Codex-Android-DevOPS): API paths proxied (not 302) + writes land in hands DB; human pages **and** `/docs.md` / `/favicon.ico` / `/apps/*` → 302 to hands.build; `Origin: https://quiver.oranix.io` preflight allowed.

cc @artin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
