### PR TITLE
fix(admin): sweep remaining user-visible Quiver residuals (Settings, Shares)

### DIFF
--- a/admin/src/pages/Settings.tsx
+++ b/admin/src/pages/Settings.tsx
@@ -65,15 +65,15 @@ export function Settings() {
         </div>
         <div>
           <div className="text-slate-500">Cloudflare Account</div>
-          <div className="font-mono">cfb85626a067371c6e9a75191b5fb09d</div>
+          <div className="font-mono">a084c4564dfdce5a7775b08ece638a79</div>
         </div>
         <div>
           <div className="text-slate-500">D1 Database</div>
-          <div className="font-mono">quiver-db (fdc960cc-d1c5-41ae-96f3-c74df4b97d6b)</div>
+          <div className="font-mono">hands-db (13d02825-af01-40f8-8f3d-a4356649628f)</div>
         </div>
         <div>
           <div className="text-slate-500">R2 Bucket</div>
-          <div className="font-mono">quiver-apks</div>
+          <div className="font-mono">hands-artifacts</div>
         </div>
         <div>
           <div className="text-slate-500">Container</div>

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -132,7 +132,7 @@ export function AppShares({ appId }: { appId: string }) {
         {!shares.isLoading && rows.length === 0 && (
           <p className="text-sm text-slate-500">
             No shares yet. Create one here, from the CLI
-            (<code>quiver releases share</code>), or from the release workflow.
+            (<code>hands releases share</code>), or from the release workflow.
           </p>
         )}
         {rows.length > 0 && (


### PR DESCRIPTION
Follow-up to the landing fix (#170), clearing the other user-visible pre-rename residuals in one pass so we stop playing whack-a-mole.

- **Settings "System" panel** showed the migration's OLD infra: Cloudflare account `cfb85626…`, D1 `quiver-db (fdc960cc…)`, R2 `quiver-apks`. Updated to the current Hands env — new account `a084c456…`, `hands-db (13d02825…)`, `hands-artifacts` (values from `wrangler.hands.jsonc`).
- **Shares** empty-state CLI hint `quiver releases share` → `hands releases share`.

Deliberately left code-only identifiers that aren't user-visible text: `QuiverMark` (logo component), `quiver:last-app-id` (localStorage key — renaming would reset users' last-app selection), `quiver-retrace`/`quiver-symbolicate` (server-set actor names the UI matches on), and `X-Quiver-*` legacy headers.

Verified: `typecheck` clean.

Ships on the next admin/worker deploy (SPA bundle).

cc @artin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
