### PR TITLE
fix(admin): revert landing eyebrow to the original tagline

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -521,7 +521,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
           <div className="mx-auto grid max-w-6xl gap-10 px-4 py-14 md:grid-cols-[1.1fr_0.9fr] md:items-center md:py-20">
             <div className="max-w-2xl">
               <div className="mb-4 inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
-                Agent-native release operations for client apps
+                The release platform for Raft-built client apps
               </div>
               <h1 className="text-4xl font-bold leading-tight sm:text-5xl">
                 Ship it, roll it out, hear it break, fix it.


### PR DESCRIPTION
Per @artin — revert the landing hero eyebrow from "Agent-native release operations for client apps" (sourced from #169) back to the original **"The release platform for Raft-built client apps"**.

Only the eyebrow tagline changes; the switchable terminal tabs (Release / iOS+dSYM / Feedback / Metrics), the Metrics tab, and all residual fixes from #170/#171 stay.

Merging fast so it bundles into the in-flight Hands deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
