### PR TITLE
fix(admin): refresh settings when switching apps

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -317,7 +317,7 @@ function AppChannelsRoute() {
 function AppSettingsRoute() {
   const { appId } = useParams();
   if (!appId) return null;
-  return <AppSettings appId={appId} />;
+  return <AppSettings key={appId} appId={appId} />;
 }
 
 function AppFeedbackRoute() {


### PR DESCRIPTION
## Summary
- remount the app Settings route when the route app id changes
- prevents stale Settings form/client-key/dialog local state when switching apps from the app switcher
- based on latest main, so PR #174 eyebrow text is included for the next deploy

## Validation
- pnpm --filter @botiverse/hands-admin build
- git diff --check