### PR TITLE
feat(hands): store per-app App Store Connect credentials (TestFlight, part 1)

### DIFF
--- a/docs/handslog-spec.md
+++ b/docs/handslog-spec.md
@@ -1,7 +1,7 @@
 # HandsLog — design spec
 
-Status: **draft for review** (2026-07-09)
-Owner: CC-Hands-Owner · Requested by: artin
+Status: **Node/desktop track approved — Phase 1 in progress** (2026-07-09)
+Owner: CC-Quiver-Owner · Requested by: artin
 
 ## Why
 
@@ -23,16 +23,49 @@ Hands.log.*  →  rotating JSONL on disk + in-memory ring
 
 ## Scope
 
-- **In**: a Log capability **inside** the existing packages — `@oranix/quiver`
-  (iOS pod), `@oranix/quiver-android`, `@oranix/quiver` (ohpm), and
-  `@oranix/quiver-electron`. No new standalone package.
+Two delivery surfaces for the **same** generic capability:
+
+- **Mobile** — a Log capability **inside** the existing mobile SDKs (`Hands`
+  iOS pod, `hands-android-sdk`, ohpm `@botiverse/hands`). No new standalone
+  package there; it feeds the crash-diagnostics attach that already exists.
+- **Node / desktop** — a **new pure-Node core package `@botiverse/hands-node`**
+  (there was no Node SDK before), consumed directly by the `hands` CLI and any
+  Node service, and wrapped by an **`@botiverse/hands-electron`** adapter for the
+  desktop app. This is the track artin greenlit first (see Architecture below).
 - **Generic only** (see the "Hands stays generic" principle): HandsLog is a
   logging *primitive* — levels, structured fields, tags, rotation, ring buffer,
   redaction. It does **not** encode any consumer's log semantics; Slock and
   others layer meaning on top.
-- **Out (P1)**: remote distribution/collection and tag "染色" selective capture
-  are **P2**. This spec designs the P1 surface so P2 slots in without breaking
-  changes.
+- **Out (P1)**: server-assisted distribution/collection and tag "染色" selective
+  capture are later phases. This spec designs the P1 surface + the collection
+  **contract** so they slot in without breaking changes.
+
+## Architecture (Node / desktop two-layer)
+
+Decided 2026-07-09 (artin + KMP + QA + Codex, thread #Hands:c526b5e1):
+
+- **`@botiverse/hands-node`** — the pure-Node core. Logger (JSONL / size+daily
+  rotation / ring buffer / retention / redaction), plus compression, upload, and
+  the collect-policy executor. Depends only on Node `fs/http/crypto/timers` —
+  **no Electron or browser deps** — so the `hands` CLI, any Node service, CI, and
+  the Electron main process all import it directly.
+  - **Schema is a stable sub-export**, `@botiverse/hands-node/logs/schema`:
+    the `types + validators` for the **collect policy**, the **log bundle**, and
+    the **redaction contract**. Client SDK, CLI, and the Hands backend all agree
+    on this one definition (no per-consumer reinterpretation). Kept as a
+    sub-export rather than a separate `@botiverse/hands-log-schema` package —
+    split it out only if a cross-language / separate-backend-repo / contract-only
+    consumer appears.
+- **`@botiverse/hands-electron`** — the desktop adapter. Depends on
+  `@botiverse/hands-node`; adds only Electron-runtime context: main/renderer
+  **preload + IPC** (the renderer cannot write files, so it logs via IPC to the
+  main-process node logger), `windowId` / `process`, `app.getPath('userData')`
+  default log dir, crashpad/minidump association, and autoUpdater events. All
+  write/rotate/redact/collect/upload logic is reused from the core.
+
+So CLI uses the core, Electron uses the wrapped package, and future Node backends
+reuse the same core — one log format, one rotation/redaction, one collection
+contract everywhere.
 
 ## Non-goals
 
@@ -139,23 +172,75 @@ Verify end-to-end (trigger a crash → confirm the ticket's diagnostics zip
 contains the HandsLog files and the backend/UI still renders them) before
 removing the bespoke writer/rotation.
 
+## Server-assisted collection — contract & governance
+
+Backend-driven collection ("下发日志采集") is **pull-based**, reusing the poll the
+client already does (update-check / metrics): the server includes a **collect
+policy** in the poll response; the client matches locally, packages a **log
+bundle**, and uploads it to a **log-ingest endpoint** decoupled from the business
+API. Both `collect policy` and `log bundle` are defined by
+`@botiverse/hands-node/logs/schema`. Governance constraints (must be enforced in
+the core, so every consumer inherits them):
+
+- **Signed + versioned + expiring policy.** The client verifies the policy's
+  signature, schema version, and expiry; expired / downgraded / bad-signature
+  policies **fail closed** and write an audit entry — never collect on a stale or
+  tampered policy.
+- **Hard budgets.** Per-collection max bytes, per-day max bytes, upload
+  concurrency cap, and weak-network backoff. Hitting a limit must not affect the
+  host app / CLI main flow.
+- **Redaction is mandatory and re-applied at upload.** Secrets / tokens / JWTs /
+  API keys / env / `Authorization` / cookies are redacted by default; the bundle
+  is scrubbed again just before upload. No plaintext secret may appear in a
+  bundle.
+- **Decoupled + non-blocking.** The log-ingest endpoint is separate from the
+  business API; ingest failure must not affect the app.
+- **Opt-out.** Org- and user-level switches; enterprise environments can disable
+  remote collection entirely.
+
 ## Phasing
 
-- **P1** — core capture: levels, tags, structured JSONL, size+daily rotation,
-  ring buffer, redaction, retention; wire into the existing crash-diagnostics
-  attach; migrate `slock-diagnostics` via the adapter above. Platforms: **iOS +
-  Android are must-do**; OHOS ships the same batch if its SDK writes to disk
-  reliably, otherwise interface-placeholder now + wire attach right after.
-  (Electron: P2, unless the website/Electron story is wanted immediately.)
-- **P2** — server-assisted **distribution/collection** (on-demand log pull,
-  remote minimum level per device/cohort) and **染色 / tag-based selective
-  capture** (mark a tag/session for verbose capture + eager upload). Needs new
-  server endpoints; designed to layer on P1's tag + level model.
+Node / desktop track (artin greenlit, thread #Hands:c526b5e1):
+
+- **Phase 1** — `@botiverse/hands-node` core: logger (levels, tags, structured
+  JSONL, size+daily rotation, ring buffer, redaction, retention) +
+  `logs/schema` sub-export (policy/bundle/redaction types + validators) + **CLI
+  integration** (the `hands` CLI writes structured logs via the core; a
+  `hands logs collect` scaffold that packages locally against a policy).
+- **Phase 2** — server: log-ingest endpoint + a `collect` policy in the poll
+  response + admin UI (start a collection / view returned bundles / opt-out
+  switches). Enforces the governance contract above.
+- **Phase 3** — `@botiverse/hands-electron` adapter over the core (IPC/window/
+  crashpad/autoUpdater/userData context).
+
+Mobile track (original P1/P2, unchanged):
+
+- **Mobile P1** — core capture inside the mobile SDKs + wire into the existing
+  crash-diagnostics attach; migrate `slock-diagnostics` via the adapter above.
+  **iOS + Android must-do**; OHOS same batch if its SDK writes to disk reliably,
+  else interface-placeholder + wire attach right after.
+- **Mobile P2** — the same server-assisted distribution/collection + 染色, built
+  on the contract above.
+
+### Phase 1 acceptance criteria (QA)
+
+- CLI writes JSONL rolling logs via `@botiverse/hands-node`; append/rotate resume
+  correctly after a restart.
+- `policy` / `bundle` / `redaction` schemas are exported from
+  `@botiverse/hands-node/logs/schema`; CLI fixtures validate against them.
+- Redaction by default covers token / JWT / API key / env / `Authorization` /
+  cookies; no plaintext secret appears in an upload bundle.
+- A collect policy is verified for signature / version / expiry; expired,
+  downgraded, and bad-signature policies all **fail closed** and write an audit
+  log.
+- Budget hard-limits (per-collection size, per-day size, concurrency, weak-net
+  backoff) are testable and, when hit, do not affect the CLI main flow.
 
 ## Open questions for review
 
 1. Default rotation — `daily`+size-cap as proposed, or size-only to match today?
 2. Ring buffer default size (500?) and default retention (7 days / 4 MB?).
-3. Electron in P1 or P2?
+3. ~~Electron in P1 or P2?~~ **Resolved**: Node core (`@botiverse/hands-node`) +
+   CLI is Phase 1; Electron adapter is Phase 3, built over the core.
 4. P2 remote-level control: per-device vs per-cohort, and does it reuse the
    `/metrics` device identity or a new channel?

--- a/migrations/sql/0035_app_asc_credentials.sql
+++ b/migrations/sql/0035_app_asc_credentials.sql
@@ -1,0 +1,23 @@
+-- Migration 0035: per-app App Store Connect API credentials for Hands-orchestrated
+-- TestFlight uploads.
+--
+-- Hands (not the app's CI) holds the ASC API key so the "Upload to TestFlight"
+-- action can run server-side (via the Container + iTMSTransporter). The .p8
+-- private key is stored ENCRYPTED (AES-GCM) — unlike deploy tokens (hashed),
+-- this must be reversible because iTMSTransporter needs the real key to
+-- authenticate. Key id / issuer id are non-secret identifiers, stored plain.
+--
+-- One credential set per app (UNIQUE app_id). Rotating = overwrite.
+
+CREATE TABLE IF NOT EXISTS app_asc_credentials (
+  id                TEXT PRIMARY KEY,
+  app_id            TEXT NOT NULL UNIQUE REFERENCES apps(id) ON DELETE CASCADE,
+  key_id            TEXT NOT NULL,
+  issuer_id         TEXT NOT NULL,
+  -- AES-GCM encrypted .p8 private key + its random IV, both base64.
+  p8_ciphertext_b64 TEXT NOT NULL,
+  p8_iv_b64         TEXT NOT NULL,
+  created_by_actor  TEXT NOT NULL,
+  created_at        INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL
+);

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -21,6 +21,9 @@ declare global {
     R2_S3_SECRET_ACCESS_KEY?: string;
     R2_PRESIGNED_DOWNLOAD_TTL_SECONDS?: string;
     SHARE_STATS_SALT?: string;
+    // AES-GCM key material for encrypting per-app App Store Connect .p8 keys
+    // (see lib/asc_credentials.ts). Set via `wrangler secret put ASC_CRED_ENC_KEY`.
+    ASC_CRED_ENC_KEY?: string;
     RAFT_ALLOWED_SERVER_IDS?: string;
     RAFT_ALLOWED_SERVER_SLUGS?: string;
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -80,6 +80,11 @@ import {
   handleListAppDeployTokens,
   handleRevokeAppDeployToken,
 } from "./routes/deploy_tokens";
+import {
+  handleGetAscCredentials,
+  handleSetAscCredentials,
+  handleDeleteAscCredentials,
+} from "./routes/asc_credentials";
 import { handleUploadApk } from "./routes/upload";
 import {
   handleListOperations,
@@ -759,6 +764,11 @@ admin.delete("/api/apps/:appId/server-grants/:serverId", requireAppRole("admin")
 admin.get("/api/apps/:appId/deploy-tokens", requireAppRole("admin"), handleListAppDeployTokens);
 admin.post("/api/apps/:appId/deploy-tokens", requireAppRole("admin"), handleCreateAppDeployToken);
 admin.delete("/api/apps/:appId/deploy-tokens/:tokenId", requireAppRole("admin"), handleRevokeAppDeployToken);
+
+// App Store Connect API credentials (for Hands-orchestrated TestFlight uploads).
+admin.get("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleGetAscCredentials);
+admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
+admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
 
 app.route("/", admin);
 

--- a/worker/src/lib/asc_credentials.ts
+++ b/worker/src/lib/asc_credentials.ts
@@ -1,0 +1,185 @@
+/**
+ * Per-app App Store Connect (ASC) API credentials, stored in Hands so the
+ * "Upload to TestFlight" action runs server-side (Container + iTMSTransporter)
+ * instead of the app's CI holding the ASC key.
+ *
+ * The .p8 private key is stored ENCRYPTED with AES-GCM (unlike deploy tokens,
+ * which are hashed — this must be reversible because iTMSTransporter needs the
+ * real key). The AES key is derived from the ASC_CRED_ENC_KEY worker secret;
+ * key_id / issuer_id are non-secret identifiers stored in plaintext.
+ */
+
+export type AscCredentialsMeta = {
+  id: string;
+  app_id: string;
+  key_id: string;
+  issuer_id: string;
+  created_by_actor: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export type AscCredentials = AscCredentialsMeta & {
+  /** The decrypted .p8 private key (PEM). Only returned to the upload path. */
+  p8: string;
+};
+
+function b64Encode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function b64Decode(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** Derive a stable AES-GCM key from the encryption secret (SHA-256 → 256-bit key). */
+async function deriveAesKey(secret: string): Promise<CryptoKey> {
+  if (!secret || secret.length === 0) {
+    throw new Error("ASC_CRED_ENC_KEY is not configured");
+  }
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(secret),
+  );
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export async function encryptP8(
+  p8: string,
+  secret: string,
+): Promise<{ ciphertext_b64: string; iv_b64: string }> {
+  const key = await deriveAesKey(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(p8),
+  );
+  return {
+    ciphertext_b64: b64Encode(new Uint8Array(ciphertext)),
+    iv_b64: b64Encode(iv),
+  };
+}
+
+export async function decryptP8(
+  ciphertext_b64: string,
+  iv_b64: string,
+  secret: string,
+): Promise<string> {
+  const key = await deriveAesKey(secret);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: b64Decode(iv_b64) },
+    key,
+    b64Decode(ciphertext_b64),
+  );
+  return new TextDecoder().decode(plaintext);
+}
+
+/**
+ * Store (or overwrite — rotate) an app's ASC credentials. Returns metadata only.
+ */
+export async function storeAscCredentials(
+  db: D1Database,
+  encKey: string,
+  args: {
+    app_id: string;
+    key_id: string;
+    issuer_id: string;
+    p8: string;
+    actor: string;
+  },
+): Promise<AscCredentialsMeta> {
+  const { ciphertext_b64, iv_b64 } = await encryptP8(args.p8, encKey);
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  // Upsert on app_id (one credential set per app; rotating overwrites).
+  await db
+    .prepare(
+      `INSERT INTO app_asc_credentials
+         (id, app_id, key_id, issuer_id, p8_ciphertext_b64, p8_iv_b64,
+          created_by_actor, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)
+       ON CONFLICT(app_id) DO UPDATE SET
+         key_id = excluded.key_id,
+         issuer_id = excluded.issuer_id,
+         p8_ciphertext_b64 = excluded.p8_ciphertext_b64,
+         p8_iv_b64 = excluded.p8_iv_b64,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(
+      id,
+      args.app_id,
+      args.key_id,
+      args.issuer_id,
+      ciphertext_b64,
+      iv_b64,
+      args.actor,
+      now,
+    )
+    .run();
+  const meta = await getAscCredentialsMeta(db, args.app_id);
+  if (!meta) throw new Error("failed to persist ASC credentials");
+  return meta;
+}
+
+export async function getAscCredentialsMeta(
+  db: D1Database,
+  appId: string,
+): Promise<AscCredentialsMeta | null> {
+  const row = await db
+    .prepare(
+      `SELECT id, app_id, key_id, issuer_id, created_by_actor, created_at, updated_at
+       FROM app_asc_credentials WHERE app_id = ?1`,
+    )
+    .bind(appId)
+    .first<AscCredentialsMeta>();
+  return row ?? null;
+}
+
+/** Full credentials incl. the decrypted .p8 — only for the upload path. */
+export async function getAscCredentials(
+  db: D1Database,
+  encKey: string,
+  appId: string,
+): Promise<AscCredentials | null> {
+  const row = await db
+    .prepare(
+      `SELECT id, app_id, key_id, issuer_id, p8_ciphertext_b64, p8_iv_b64,
+              created_by_actor, created_at, updated_at
+       FROM app_asc_credentials WHERE app_id = ?1`,
+    )
+    .bind(appId)
+    .first<
+      AscCredentialsMeta & { p8_ciphertext_b64: string; p8_iv_b64: string }
+    >();
+  if (!row) return null;
+  const p8 = await decryptP8(row.p8_ciphertext_b64, row.p8_iv_b64, encKey);
+  return {
+    id: row.id,
+    app_id: row.app_id,
+    key_id: row.key_id,
+    issuer_id: row.issuer_id,
+    created_by_actor: row.created_by_actor,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    p8,
+  };
+}
+
+export async function deleteAscCredentials(
+  db: D1Database,
+  appId: string,
+): Promise<void> {
+  await db
+    .prepare(`DELETE FROM app_asc_credentials WHERE app_id = ?1`)
+    .bind(appId)
+    .run();
+}

--- a/worker/src/routes/asc_credentials.ts
+++ b/worker/src/routes/asc_credentials.ts
@@ -1,0 +1,81 @@
+import type { Context } from "hono";
+import { currentActor, type AdminEnv } from "../middleware/auth";
+import { insertAuditLog } from "../lib/permissions";
+import {
+  storeAscCredentials,
+  getAscCredentialsMeta,
+  deleteAscCredentials,
+} from "../lib/asc_credentials";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+/** GET — returns credential metadata only (never the .p8). */
+export async function handleGetAscCredentials(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const meta = await getAscCredentialsMeta(c.env.DB, appId);
+  return c.json({ asc_credentials: meta });
+}
+
+/**
+ * PUT — set (or rotate) the app's ASC API credentials. Body:
+ * { key_id, issuer_id, p8 }. The .p8 is the raw PEM contents of the
+ * downloaded AuthKey_XXXX.p8. Stored encrypted; response is metadata only.
+ */
+export async function handleSetAscCredentials(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const encKey = c.env.ASC_CRED_ENC_KEY;
+  if (!encKey) {
+    return c.json(
+      { error: "server is missing ASC_CRED_ENC_KEY; cannot store credentials" },
+      500,
+    );
+  }
+  const body = (await c.req.json().catch(() => ({}))) as {
+    key_id?: unknown;
+    issuer_id?: unknown;
+    p8?: unknown;
+  };
+  const key_id = typeof body.key_id === "string" ? body.key_id.trim() : "";
+  const issuer_id =
+    typeof body.issuer_id === "string" ? body.issuer_id.trim() : "";
+  const p8 = typeof body.p8 === "string" ? body.p8.trim() : "";
+  if (!key_id) return c.json({ error: "key_id is required" }, 400);
+  if (!issuer_id) return c.json({ error: "issuer_id is required" }, 400);
+  if (!p8) return c.json({ error: "p8 is required" }, 400);
+  if (!p8.includes("BEGIN PRIVATE KEY")) {
+    return c.json(
+      { error: "p8 must be the PEM contents of the AuthKey_XXXX.p8 file" },
+      400,
+    );
+  }
+
+  const actor = currentActor(c);
+  const meta = await storeAscCredentials(c.env.DB, encKey, {
+    app_id: appId,
+    key_id,
+    issuer_id,
+    p8,
+    actor,
+  });
+
+  await insertAuditLog(c.env.DB, c, {
+    app_id: appId,
+    action: "asc_credentials.set",
+    // never log the p8 or its ciphertext
+    payload: { key_id, issuer_id },
+    created_at: meta.updated_at,
+  });
+
+  return c.json({ asc_credentials: meta });
+}
+
+export async function handleDeleteAscCredentials(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  await deleteAscCredentials(c.env.DB, appId);
+  await insertAuditLog(c.env.DB, c, {
+    app_id: appId,
+    action: "asc_credentials.delete",
+    payload: {},
+  });
+  return c.json({ ok: true });
+}

--- a/worker/test/asc_credentials.test.ts
+++ b/worker/test/asc_credentials.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for the ASC .p8 encryption helpers. The .p8 must round-trip
+ * exactly (iTMSTransporter needs the byte-identical key), a wrong secret must
+ * fail to decrypt, and each encryption must use a fresh IV.
+ */
+
+import { describe, it, expect } from "vitest";
+import { encryptP8, decryptP8 } from "../src/lib/asc_credentials";
+
+const SAMPLE_P8 = `-----BEGIN PRIVATE KEY-----
+MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg+sample+key+bytes+
+here+and+more+base64+data==\n-----END PRIVATE KEY-----`;
+
+describe("asc_credentials encryption", () => {
+  it("round-trips the .p8 exactly", async () => {
+    const secret = "test-enc-secret";
+    const { ciphertext_b64, iv_b64 } = await encryptP8(SAMPLE_P8, secret);
+    const back = await decryptP8(ciphertext_b64, iv_b64, secret);
+    expect(back).toBe(SAMPLE_P8);
+  });
+
+  it("fails to decrypt with the wrong secret", async () => {
+    const { ciphertext_b64, iv_b64 } = await encryptP8(SAMPLE_P8, "secret-a");
+    await expect(decryptP8(ciphertext_b64, iv_b64, "secret-b")).rejects.toThrow();
+  });
+
+  it("uses a fresh IV per encryption (ciphertext differs)", async () => {
+    const secret = "same-secret";
+    const a = await encryptP8(SAMPLE_P8, secret);
+    const b = await encryptP8(SAMPLE_P8, secret);
+    expect(a.iv_b64).not.toBe(b.iv_b64);
+    expect(a.ciphertext_b64).not.toBe(b.ciphertext_b64);
+    // both still decrypt back to the same plaintext
+    expect(await decryptP8(a.ciphertext_b64, a.iv_b64, secret)).toBe(SAMPLE_P8);
+    expect(await decryptP8(b.ciphertext_b64, b.iv_b64, secret)).toBe(SAMPLE_P8);
+  });
+
+  it("throws when the encryption key is empty", async () => {
+    await expect(encryptP8(SAMPLE_P8, "")).rejects.toThrow(/ASC_CRED_ENC_KEY/);
+  });
+});


### PR DESCRIPTION
First piece of the **"ASC configured on hands.build, Hands orchestrates the TestFlight upload"** design (per @artin, #iOS适配 thread). Lands credential storage so the ASC API key lives in Hands, not the app's CI. Follow-up PRs add the Container + iTMSTransporter upload and the admin "Upload to TestFlight" button.

- **Migration 0035** `app_asc_credentials` (one set per app). The .p8 is stored **AES-GCM encrypted** (reversible — iTMSTransporter needs the real key), unlike deploy tokens (hashed). `key_id`/`issuer_id` are non-secret.
- **lib/asc_credentials.ts**: AES-GCM encrypt/decrypt (key derived from new `ASC_CRED_ENC_KEY` secret) + store/get-meta/get-full/delete; get-meta never returns the .p8.
- **routes** (app-admin only): `GET/PUT/DELETE /api/apps/:appId/asc-credentials`. PUT validates the PEM; audit logs never include key material.
- **Tests**: .p8 round-trips exactly, wrong secret fails, fresh IV per encryption, empty key throws. Full suite 101 passing, tsc clean.

**Deploy prereq**: `wrangler secret put ASC_CRED_ENC_KEY` on hands-worker.

cc @artin

🤖 Generated with [Claude Code](https://claude.com/claude-code)