### PR TITLE
ci(deploy): push ASC_CRED_ENC_KEY Worker secret on Hands deploy

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -102,6 +102,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
           SIGNED_URL_SECRET: ${{ secrets.HANDS_SIGNED_URL_SECRET }}
           RAFT_CLIENT_SECRET: ${{ secrets.HANDS_RAFT_CLIENT_SECRET }}
+          ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -113,8 +114,13 @@ jobs:
             echo "Missing GitHub secret HANDS_RAFT_CLIENT_SECRET." >&2
             exit 1
           fi
+          if [[ -z "${ASC_CRED_ENC_KEY:-}" ]]; then
+            echo "Missing GitHub secret HANDS_ASC_CRED_ENC_KEY." >&2
+            exit 1
+          fi
           printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config wrangler.hands.jsonc
           printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config wrangler.hands.jsonc
+          printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config wrangler.hands.jsonc
 
       - name: Deploy Hands Worker and admin assets
         working-directory: worker


### PR DESCRIPTION
Wires `HANDS_ASC_CRED_ENC_KEY` (GitHub repo secret, already created) into the Hands Worker as `ASC_CRED_ENC_KEY` during deploy, alongside the existing secrets. Needed by the per-app App Store Connect credential endpoints (#178) for AES-GCM encryption of stored .p8 keys. Fails fast if the GitHub secret is missing, matching the existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)