### PR TITLE
feat(hands): App Store Connect API client for TestFlight upload (part 2a)

### DIFF
--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -1,0 +1,277 @@
+/**
+ * App Store Connect API client — JWT auth + the Build Upload flow
+ * (WWDC25 API; replaces Transporter/altool for TestFlight delivery).
+ *
+ * Flow: resolve app by bundle id → POST /v1/buildUploads →
+ * POST /v1/buildUploadFiles (returns per-part uploadOperations) →
+ * PUT each part → PATCH the file uploaded:true → poll the buildUpload
+ * state (AWAITING_UPLOAD → PROCESSING → COMPLETE | FAILED).
+ */
+
+export interface AscApiCredentials {
+  key_id: string;
+  issuer_id: string;
+  /** PEM contents of the AuthKey_XXXX.p8 file. */
+  p8: string;
+}
+
+export const ASC_API_BASE = "https://api.appstoreconnect.apple.com";
+
+/** Max token lifetime Apple accepts is 20 minutes; stay under it. */
+const JWT_TTL_SECONDS = 15 * 60;
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function pemToPkcs8(pem: string): Uint8Array {
+  const body = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\s+/g, "");
+  const bin = atob(body);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Sign an App Store Connect API JWT (ES256). WebCrypto's ECDSA output is
+ * already the raw r||s form JWTs use, so no DER re-encoding is needed.
+ */
+export async function createAscJwt(
+  creds: AscApiCredentials,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToPkcs8(creds.p8),
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+  const encoder = new TextEncoder();
+  const header = base64UrlEncode(
+    encoder.encode(
+      JSON.stringify({ alg: "ES256", kid: creds.key_id, typ: "JWT" }),
+    ),
+  );
+  const payload = base64UrlEncode(
+    encoder.encode(
+      JSON.stringify({
+        iss: creds.issuer_id,
+        iat: nowSeconds,
+        exp: nowSeconds + JWT_TTL_SECONDS,
+        aud: "appstoreconnect-v1",
+      }),
+    ),
+  );
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    key,
+    encoder.encode(`${header}.${payload}`),
+  );
+  return `${header}.${payload}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+export class AscApiError extends Error {
+  status: number;
+  detail: string | null;
+  constructor(status: number, message: string, detail: string | null = null) {
+    super(message);
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+/**
+ * Authenticated JSON request against the ASC API. Throws AscApiError with
+ * Apple's error detail (their errors array carries title/detail per item).
+ */
+export async function ascRequest<T>(
+  creds: AscApiCredentials,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const jwt = await createAscJwt(creds);
+  const res = await fetch(`${ASC_API_BASE}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${jwt}`,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    // non-JSON error body; keep raw text as detail below
+  }
+  if (!res.ok) {
+    const errors = (parsed as { errors?: Array<{ title?: string; detail?: string }> })
+      ?.errors;
+    const first = errors?.[0];
+    throw new AscApiError(
+      res.status,
+      first?.title ?? `App Store Connect API ${method} ${path} failed (${res.status})`,
+      first?.detail ?? (parsed ? null : text.slice(0, 500) || null),
+    );
+  }
+  return parsed as T;
+}
+
+// ---------- Build Upload resources ----------
+
+export interface UploadOperationHeader {
+  name: string;
+  value: string;
+}
+
+export interface UploadOperation {
+  url: string;
+  method: string;
+  offset: number;
+  length: number;
+  requestHeaders: UploadOperationHeader[];
+}
+
+export type BuildUploadState =
+  | "AWAITING_UPLOAD"
+  | "PROCESSING"
+  | "FAILED"
+  | "COMPLETE";
+
+export interface BuildUploadResource {
+  id: string;
+  attributes: {
+    cfBundleShortVersionString: string | null;
+    cfBundleVersion: string | null;
+    platform: string | null;
+    state: BuildUploadState | null;
+    createdDate: string | null;
+    uploadedDate: string | null;
+  };
+}
+
+export interface BuildUploadFileResource {
+  id: string;
+  attributes: {
+    fileName: string | null;
+    fileSize: number | null;
+    uploadOperations: UploadOperation[] | null;
+    assetDeliveryState: unknown;
+  };
+}
+
+/** Look up the ASC app id for a bundle id (e.g. "build.raft.app"). */
+export async function resolveAscAppId(
+  creds: AscApiCredentials,
+  bundleId: string,
+): Promise<string | null> {
+  const res = await ascRequest<{ data: Array<{ id: string }> }>(
+    creds,
+    "GET",
+    `/v1/apps?filter[bundleId]=${encodeURIComponent(bundleId)}&limit=1`,
+  );
+  return res.data[0]?.id ?? null;
+}
+
+export async function createBuildUpload(
+  creds: AscApiCredentials,
+  args: {
+    ascAppId: string;
+    /** Marketing version, e.g. "1.2.0". */
+    version: string;
+    /** Build number, e.g. "1020000". */
+    buildNumber: string;
+    platform?: "IOS" | "MAC_OS" | "TV_OS" | "VISION_OS";
+  },
+): Promise<BuildUploadResource> {
+  const res = await ascRequest<{ data: BuildUploadResource }>(
+    creds,
+    "POST",
+    "/v1/buildUploads",
+    {
+      data: {
+        type: "buildUploads",
+        attributes: {
+          cfBundleShortVersionString: args.version,
+          cfBundleVersion: args.buildNumber,
+          platform: args.platform ?? "IOS",
+        },
+        relationships: {
+          app: { data: { type: "apps", id: args.ascAppId } },
+        },
+      },
+    },
+  );
+  return res.data;
+}
+
+export async function createBuildUploadFile(
+  creds: AscApiCredentials,
+  args: { buildUploadId: string; fileName: string; fileSize: number },
+): Promise<BuildUploadFileResource> {
+  const res = await ascRequest<{ data: BuildUploadFileResource }>(
+    creds,
+    "POST",
+    "/v1/buildUploadFiles",
+    {
+      data: {
+        type: "buildUploadFiles",
+        attributes: {
+          assetType: "ASSET",
+          fileName: args.fileName,
+          fileSize: args.fileSize,
+          uti: "com.apple.ipa",
+        },
+        relationships: {
+          buildUpload: {
+            data: { type: "buildUploads", id: args.buildUploadId },
+          },
+        },
+      },
+    },
+  );
+  return res.data;
+}
+
+/** Tell Apple every part is uploaded so processing can start. */
+export async function commitBuildUploadFile(
+  creds: AscApiCredentials,
+  args: { fileId: string; sha256?: string },
+): Promise<void> {
+  await ascRequest(creds, "PATCH", `/v1/buildUploadFiles/${args.fileId}`, {
+    data: {
+      type: "buildUploadFiles",
+      id: args.fileId,
+      attributes: {
+        uploaded: true,
+        ...(args.sha256
+          ? {
+              sourceFileChecksums: {
+                file: { algorithm: "SHA_256", hash: args.sha256 },
+              },
+            }
+          : {}),
+      },
+    },
+  });
+}
+
+export async function getBuildUpload(
+  creds: AscApiCredentials,
+  buildUploadId: string,
+): Promise<BuildUploadResource> {
+  const res = await ascRequest<{ data: BuildUploadResource }>(
+    creds,
+    "GET",
+    `/v1/buildUploads/${buildUploadId}`,
+  );
+  return res.data;
+}

--- a/worker/test/asc_api.test.ts
+++ b/worker/test/asc_api.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the App Store Connect API client: the ES256 JWT must
+ * verify against the corresponding public key and carry the claims Apple
+ * requires, and the Build Upload calls must send the exact resource shapes
+ * from the buildUploads schema.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createAscJwt,
+  ascRequest,
+  createBuildUpload,
+  createBuildUploadFile,
+  commitBuildUploadFile,
+  resolveAscAppId,
+  AscApiError,
+  type AscApiCredentials,
+} from "../src/lib/asc_api";
+
+async function generateTestCreds(): Promise<{
+  creds: AscApiCredentials;
+  publicKey: CryptoKey;
+}> {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(
+    (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer,
+  );
+  let bin = "";
+  for (const b of pkcs8) bin += String.fromCharCode(b);
+  const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(bin)}\n-----END PRIVATE KEY-----`;
+  return {
+    creds: { key_id: "TESTKEY123", issuer_id: "issuer-uuid-1234", p8: pem },
+    publicKey: pair.publicKey,
+  };
+}
+
+function decodeSegment(seg: string): Record<string, unknown> {
+  const b64 = seg.replace(/-/g, "+").replace(/_/g, "/");
+  return JSON.parse(atob(b64));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createAscJwt", () => {
+  it("produces a verifiable ES256 JWT with Apple's required claims", async () => {
+    const { creds, publicKey } = await generateTestCreds();
+    const now = 1_752_000_000;
+    const jwt = await createAscJwt(creds, now);
+    const [h, p, s] = jwt.split(".");
+    expect(h && p && s).toBeTruthy();
+
+    const header = decodeSegment(h!);
+    expect(header).toEqual({ alg: "ES256", kid: "TESTKEY123", typ: "JWT" });
+
+    const payload = decodeSegment(p!);
+    expect(payload.iss).toBe("issuer-uuid-1234");
+    expect(payload.aud).toBe("appstoreconnect-v1");
+    expect(payload.iat).toBe(now);
+    // Apple rejects tokens valid longer than 20 minutes
+    expect((payload.exp as number) - now).toBeLessThanOrEqual(20 * 60);
+
+    const sigB64 = s!.replace(/-/g, "+").replace(/_/g, "/");
+    const sigBin = atob(sigB64);
+    const sig = new Uint8Array(sigBin.length);
+    for (let i = 0; i < sigBin.length; i++) sig[i] = sigBin.charCodeAt(i);
+    const ok = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      publicKey,
+      sig,
+      new TextEncoder().encode(`${h}.${p}`),
+    );
+    expect(ok).toBe(true);
+  });
+});
+
+describe("ascRequest", () => {
+  it("sends a bearer JWT and parses JSON", async () => {
+    const { creds } = await generateTestCreds();
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const auth = new Headers(init?.headers).get("authorization") ?? "";
+      expect(auth.startsWith("Bearer ")).toBe(true);
+      expect(auth.split(".").length).toBe(3 - 1 + 1); // header.payload.sig
+      return new Response(JSON.stringify({ data: [{ id: "app-1" }] }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const id = await resolveAscAppId(creds, "build.raft.app");
+    expect(id).toBe("app-1");
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toContain("/v1/apps?filter[bundleId]=build.raft.app");
+  });
+
+  it("throws AscApiError with Apple's error detail on failure", async () => {
+    const { creds } = await generateTestCreds();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            errors: [{ title: "NOT_AUTHORIZED", detail: "Key lacks access" }],
+          }),
+          { status: 403 },
+        ),
+      ),
+    );
+    await expect(ascRequest(creds, "GET", "/v1/apps")).rejects.toMatchObject({
+      status: 403,
+      message: "NOT_AUTHORIZED",
+      detail: "Key lacks access",
+    } satisfies Partial<AscApiError>);
+  });
+});
+
+describe("build upload resource shapes", () => {
+  it("createBuildUpload sends the buildUploads create schema", async () => {
+    const { creds } = await generateTestCreds();
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({
+        data: {
+          type: "buildUploads",
+          attributes: {
+            cfBundleShortVersionString: "1.2.0",
+            cfBundleVersion: "1020000",
+            platform: "IOS",
+          },
+          relationships: {
+            app: { data: { type: "apps", id: "app-1" } },
+          },
+        },
+      });
+      return new Response(
+        JSON.stringify({
+          data: { id: "bu-1", attributes: { state: "AWAITING_UPLOAD" } },
+        }),
+        { status: 201 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const bu = await createBuildUpload(creds, {
+      ascAppId: "app-1",
+      version: "1.2.0",
+      buildNumber: "1020000",
+    });
+    expect(bu.id).toBe("bu-1");
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("/v1/buildUploads");
+  });
+
+  it("createBuildUploadFile sends the ipa file schema and returns uploadOperations", async () => {
+    const { creds } = await generateTestCreds();
+    const ops = [
+      {
+        url: "https://upload.example/part1",
+        method: "PUT",
+        offset: 0,
+        length: 5,
+        requestHeaders: [{ name: "x-part", value: "1" }],
+      },
+    ];
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.data.type).toBe("buildUploadFiles");
+      expect(body.data.attributes).toEqual({
+        assetType: "ASSET",
+        fileName: "app.ipa",
+        fileSize: 5,
+        uti: "com.apple.ipa",
+      });
+      expect(body.data.relationships.buildUpload.data).toEqual({
+        type: "buildUploads",
+        id: "bu-1",
+      });
+      return new Response(
+        JSON.stringify({
+          data: { id: "file-1", attributes: { uploadOperations: ops } },
+        }),
+        { status: 201 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const file = await createBuildUploadFile(creds, {
+      buildUploadId: "bu-1",
+      fileName: "app.ipa",
+      fileSize: 5,
+    });
+    expect(file.attributes.uploadOperations).toEqual(ops);
+  });
+
+  it("commitBuildUploadFile PATCHes uploaded:true with an optional sha256", async () => {
+    const { creds } = await generateTestCreds();
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      expect(String(url)).toContain("/v1/buildUploadFiles/file-1");
+      expect(init?.method).toBe("PATCH");
+      const body = JSON.parse(String(init?.body));
+      expect(body.data.id).toBe("file-1");
+      expect(body.data.attributes.uploaded).toBe(true);
+      expect(body.data.attributes.sourceFileChecksums.file).toEqual({
+        algorithm: "SHA_256",
+        hash: "abc123",
+      });
+      return new Response(JSON.stringify({ data: {} }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await commitBuildUploadFile(creds, { fileId: "file-1", sha256: "abc123" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What
The ASC API client that Part 2's upload lane runs on — using Apple's **official Build Upload API** (WWDC25, GA) instead of fastlane/iTMSTransporter.

- `worker/src/lib/asc_api.ts`:
  - `createAscJwt` — ES256 via WebCrypto (P-256 pkcs8 import; WebCrypto emits P1363 r||s, exactly what JWT wants), claims per Apple: `kid`/`iss`/`aud: appstoreconnect-v1`/`exp ≤ 20min`.
  - `ascRequest` — bearer-authed JSON with Apple error extraction (`AscApiError` carries status/title/detail).
  - Build Upload flow: `resolveAscAppId` (bundle-id filter) → `createBuildUpload` (version/buildNumber/platform) → `createBuildUploadFile` (ipa uti, returns per-part `uploadOperations`) → `commitBuildUploadFile` (uploaded:true + optional SHA_256) → `getBuildUpload` (state: AWAITING_UPLOAD/PROCESSING/FAILED/COMPLETE).
- Schemas verified against Apple's docs JSON (buildUploadCreateRequest, buildUploadFileCreateRequest, uploadOperation, checksums.file).

## Why not fastlane
Transporter's Linux installer is Apple-auth-gated (anonymous → /unauthorized), the fastlane docker image ships without it, and Transporter 3.0 has the issuerId regression (fastlane#20741). The official REST flow needs none of that and runs Worker-native.

## Verification
- `tsc --noEmit` clean; 107/107 worker tests (6 new: JWT verifies against its public key + claim checks; request shapes asserted byte-for-byte against the Apple schema; error propagation).

Next (part 2b): upload orchestration route — R2 ranged reads → per-part PUTs → commit → status polling into the operations stream; then the status page (part 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)