### PR TITLE
chore: prepare branded Hands SDK releases

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.1.0"
+        default: "0.10.0"
   push:
     tags:
       - "android-sdk-v*"

--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "SDK version to publish. Must match clients/ohos/hands/oh-package.json5."
         required: true
-        default: "0.1.0"
+        default: "0.2.0"
       dry_run:
         description: "Build and prepublish only; skip ohpm publish."
         required: true

--- a/Hands.podspec
+++ b/Hands.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Hands'
-  s.version          = '0.1.4'
+  s.version          = '0.2.0'
   s.summary          = 'Hands feedback + crash reporting for iOS.'
   s.description      = <<-DESC
     Native iOS reporting layer for Hands: in-app feedback tickets
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
     runtime — base URL, app slug, channel, and client key are init
     parameters, never compiled into the SDK.
   DESC
-  s.homepage         = 'https://github.com/oranix-io/quiver'
+  s.homepage         = 'https://github.com/oranix-io/hands'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Oranix' => 'artin@cat.ms' }
-  s.source           = { :git => 'https://github.com/oranix-io/quiver.git', :tag => "ios-v#{s.version}" }
+  s.source           = { :git => 'https://github.com/oranix-io/hands.git', :tag => "ios-v#{s.version}" }
 
   s.ios.deployment_target = '14.1'
   s.source_files     = 'clients/ios/Sources/Hands/**/*.{h,m}'

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -7,7 +7,7 @@ Android SDK for Hands server-side update checks and APK installation.
 ```kotlin
 repositories {
     maven {
-        url = uri("https://maven.pkg.github.com/oranix-io/quiver")
+        url = uri("https://maven.pkg.github.com/oranix-io/hands")
         credentials {
             username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
             password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.4.0")
+    implementation("build.hands:hands-android-sdk:0.10.0")
 }
 ```
 
@@ -25,7 +25,7 @@ dependencies {
 ```kotlin
 val checker = UpdateChecker(
     context = applicationContext,
-    baseUrl = "https://quiver.oranix.io",
+    baseUrl = "https://hands.build",
     appSlug = "myapp-android",
     installedVersionCode = BuildConfig.VERSION_CODE.toLong(),
     channel = "main",
@@ -53,7 +53,7 @@ Publish to GitHub Packages:
 ```bash
 cd clients/android
 GITHUB_ACTOR=<github-user> GITHUB_TOKEN=<token-with-packages-write> \
-  gradle publish -PVERSION_NAME=0.1.0
+  gradle publish -PVERSION_NAME=0.10.0
 ```
 
-In CI, use the `Publish Android SDK` workflow and a version such as `0.1.0`.
+In CI, use the `Publish Android SDK` workflow and a version such as `0.10.0`.

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
                 pom {
                     name.set("Hands Android SDK")
                     description.set("Android SDK for server-side Hands update checks and APK installation.")
-                    url.set("https://github.com/oranix-io/quiver")
+                    url.set("https://github.com/oranix-io/hands")
                     licenses {
                         license {
                             name.set("MIT License")
@@ -72,9 +72,9 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        connection.set("scm:git:https://github.com/oranix-io/quiver.git")
-                        developerConnection.set("scm:git:ssh://git@github.com/oranix-io/quiver.git")
-                        url.set("https://github.com/oranix-io/quiver")
+                        connection.set("scm:git:https://github.com/oranix-io/hands.git")
+                        developerConnection.set("scm:git:ssh://git@github.com/oranix-io/hands.git")
+                        url.set("https://github.com/oranix-io/hands")
                     }
                 }
             }

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -6,7 +6,7 @@ crash reporting. Objective-C, no dependencies, iOS 14.1+.
 ## Install (CocoaPods, via git)
 
 ```ruby
-pod 'Hands', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.3'
+pod 'Hands', :git => 'https://github.com/oranix-io/hands.git', :tag => 'ios-v0.2.0'
 ```
 
 ## Configure & start
@@ -18,7 +18,7 @@ from the console if it leaks).
 
 ```swift
 Hands.install(with: HandsConfig(
-    baseUrl: "https://quiver.example.com",
+    baseUrl: "https://hands.build",
     appSlug: "my-app",
     channel: "main",
     clientKey: "qk_…"

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -5,8 +5,8 @@
   "main": "Index.ets",
   "author": "Oranix",
   "license": "MIT",
-  "homepage": "https://github.com/oranix-io/quiver",
-  "repository": "https://github.com/oranix-io/quiver",
+  "homepage": "https://github.com/oranix-io/hands",
+  "repository": "https://github.com/oranix-io/hands",
   "keywords": ["hands", "crash", "feedback", "harmonyos"],
   "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- prepare Hands iOS 0.2.0 Podspec and repository metadata
- prepare Hands Android 0.10.0 GitHub Packages publication
- prepare Hands OHOS 0.2.0 OHPM publication
- update SDK install examples and default Hands endpoint

## Validation
- `ruby -c Hands.podspec`
- `pod ipc spec Hands.podspec`
- `git diff --check`

Android local build was attempted but the host NDK 26.3.11579264 installation is incomplete (`source.properties` missing); the publish workflow remains the authoritative build.