### PR TITLE
fix: align Hands SDK version metadata

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.10.0"
+        default: "0.10.1"
   push:
     tags:
       - "android-sdk-v*"

--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "SDK version to publish. Must match clients/ohos/hands/oh-package.json5."
         required: true
-        default: "0.2.0"
+        default: "0.2.1"
       dry_run:
         description: "Build and prepublish only; skip ohpm publish."
         required: true

--- a/Hands.podspec
+++ b/Hands.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Hands'
-  s.version          = '0.2.0'
+  s.version          = '0.2.1'
   s.summary          = 'Hands feedback + crash reporting for iOS.'
   s.description      = <<-DESC
     Native iOS reporting layer for Hands: in-app feedback tickets

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.0")
+    implementation("build.hands:hands-android-sdk:0.10.1")
 }
 ```
 
@@ -53,7 +53,7 @@ Publish to GitHub Packages:
 ```bash
 cd clients/android
 GITHUB_ACTOR=<github-user> GITHUB_TOKEN=<token-with-packages-write> \
-  gradle publish -PVERSION_NAME=0.10.0
+  gradle publish -PVERSION_NAME=0.10.1
 ```
 
-In CI, use the `Publish Android SDK` workflow and a version such as `0.10.0`.
+In CI, use the `Publish Android SDK` workflow and a version such as `0.10.1`.

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -88,7 +88,7 @@ class HandsFeedback(
             versionCode?.let { put("version_code", it) }
             put("platform", "android")
             put("bundle_id", context.packageName)
-            put("quiver_sdk", SDK_VERSION)
+            put("hands_sdk", SDK_VERSION)
             channel?.let { put("channel", it) }
             buildCommit(context)?.let { put("commit", it) }
 
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.9.0"
+        const val SDK_VERSION = "0.10.1"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -6,7 +6,7 @@ crash reporting. Objective-C, no dependencies, iOS 14.1+.
 ## Install (CocoaPods, via git)
 
 ```ruby
-pod 'Hands', :git => 'https://github.com/oranix-io/hands.git', :tag => 'ios-v0.2.0'
+pod 'Hands', :git => 'https://github.com/oranix-io/hands.git', :tag => 'ios-v0.2.1'
 ```
 
 ## Configure & start

--- a/clients/ios/Sources/Hands/Hands.h
+++ b/clients/ios/Sources/Hands/Hands.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// iOS, posting to a Hands server's public feedback endpoint.
 ///
 ///   [Hands installWithConfig:
-///       [HandsConfig configWithBaseUrl:@"https://quiver.example.com"
+///       [HandsConfig configWithBaseUrl:@"https://hands.build"
 ///                                     appSlug:@"my-app"
 ///                                     channel:@"main"
 ///                                   clientKey:@"qk_…"]];

--- a/clients/ios/Sources/Hands/HandsFeedbackClient.m
+++ b/clients/ios/Sources/Hands/HandsFeedbackClient.m
@@ -14,7 +14,7 @@ static NSTimeInterval const HandsUploadTimeout = 120.0;
 
 // Hands iOS SDK version — reported in feedback/crash environment metadata.
 // Keep in sync with Hands.podspec on release.
-static NSString *const kHandsSDKVersion = @"0.1.5";
+static NSString *const kHandsSDKVersion = @"0.2.1";
 
 // Server-enforced: at most 9 attachments per ticket.
 static NSUInteger const HandsMaxAttachments = 9;
@@ -130,7 +130,7 @@ static NSError *HandsErrorWithMessage(NSInteger code, NSString *detail) {
     NSString *commit = HandsBuildCommit(info);
     if (commit) metadata[@"commit"] = commit;
     metadata[@"channel"] = (Hands.config.channel ?: @"");
-    metadata[@"quiver_sdk"] = kHandsSDKVersion;
+    metadata[@"hands_sdk"] = kHandsSDKVersion;
 
     // Platform / OS
     metadata[@"platform"] = @"ios";

--- a/clients/ohos/hands/README.md
+++ b/clients/ohos/hands/README.md
@@ -11,7 +11,7 @@ Hands feedback + crash reporting SDK for HarmonyOS (ArkTS).
 
 Configured at runtime (base URL, app slug, channel, client key are init
 parameters, never compiled in). See the Hands docs at
-<https://quiver.oranix.io/docs> for integration details.
+<https://hands.build/docs> for integration details.
 
 ## Install
 

--- a/clients/ohos/hands/changelog.md
+++ b/clients/ohos/hands/changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.1.0
+## 0.2.1
 
-- Initial release of the HarmonyOS Hands SDK.
+- First branded release of the HarmonyOS Hands SDK.
 - Feedback tickets with attachments and automatic device metadata; large
   attachments upload via presigned direct-to-storage URLs (up to the configured
   cap), smaller ones inline.

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "Oranix",

--- a/clients/ohos/hands/src/main/ets/Hands.ets
+++ b/clients/ohos/hands/src/main/ets/Hands.ets
@@ -10,7 +10,7 @@ import { HandsCrashReporter } from './HandsCrashReporter';
  * from the Hands console).
  */
 export interface HandsConfig {
-  /** Hands server origin, e.g. https://quiver.example.com (no trailing /). */
+  /** Hands server origin, e.g. https://hands.build (no trailing /). */
   baseUrl: string;
   /** App slug in the Hands console. */
   appSlug: string;

--- a/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
@@ -14,7 +14,7 @@ const TAG: string = 'HandsFeedbackClient';
 
 // Hands OHOS SDK version — reported in feedback/crash environment metadata.
 // Keep in sync with oh-package.json5 on release.
-const QUIVER_SDK_VERSION: string = '0.1.0';
+const HANDS_SDK_VERSION: string = '0.2.1';
 
 // @ohos.batteryInfo BatteryChargeState: NONE=0, ENABLE=1, DISABLE=2, FULL=3.
 function ohBatteryStateName(status: number): string {
@@ -132,7 +132,7 @@ export class HandsFeedbackClient {
       'version_code': bundleInfo.versionCode,
       'bundle_id': bundleInfo.name,
       'platform': 'ohos',
-      'quiver_sdk': QUIVER_SDK_VERSION,
+      'hands_sdk': HANDS_SDK_VERSION,
       'channel': Hands.config.channel,
       // Device
       'device_id': HandsDeviceId.get(context),


### PR DESCRIPTION
## Summary
- align Android, iOS, and OHOS runtime SDK version metadata with the package version
- report the branded `hands_sdk` metadata field
- publish patch versions: Android 0.10.1, iOS/OHOS 0.2.1
- update SDK examples and OHOS branded docs

## Validation
- `ruby -c Hands.podspec`
- `pod ipc spec Hands.podspec`
- `git diff --check`