### PR TITLE
docs(sdk-parity): Hands SDK vs Sentry analysis + P0-P3 roadmap (task #120)

### DIFF
--- a/docs/sdk-parity/README.md
+++ b/docs/sdk-parity/README.md
@@ -1,0 +1,53 @@
+# Hands SDK ↔ Sentry parity analysis & roadmap
+
+Source-level audit of all four Hands client SDKs against Sentry's 2025–26
+capability set (task #120, 2026-07-09). Per-platform detail lives in
+[android.md](android.md), [ios.md](ios.md), [ohos.md](ohos.md),
+[electron.md](electron.md); the execution plan is in [roadmap.md](roadmap.md).
+
+## Positioning
+
+Hands SDKs are **crash + feedback-ticket + device-stats + update-distribution
+clients** attached to a release platform. Sentry is **full-stack
+observability** (error monitoring, distributed tracing, continuous profiling,
+session replay, logs, release health, alerting). The gap is therefore not
+uniform lag — it is a different coverage shape, with several capabilities
+Sentry does not have at all (see "Moats").
+
+## Capability matrix
+
+| Capability | Android | iOS | OHOS | Electron | Sentry |
+|---|---|---|---|---|---|
+| Crash capture | ✅ JVM + NDK signals | ✅ NSException + signals | ⚠️ ArkTS `errorManager` only | ✅ Crashpad minidumps, all processes | ✅ deeper |
+| Crash-capture depth | ❌ no ANR | ❌ no Mach / watchdog / all-threads dump | ❌ no native (faultLogger) | ❌ no JS errors (main + renderer) | ✅ ANR / hangs / MetricKit |
+| Symbolication | ⚠️ server-side (mapping via CLI) | ⚠️ client emits binary images; server resolver not rolled out | ❌ none | ✅ minidump + breakpad .sym; ❌ no JS sourcemaps | ✅ automatic end-to-end |
+| Breadcrumbs | ❌ (logcat tail as stand-in) | ❌ (app's own JSONL log as stand-in) | ❌ | ⚠️ API exists, crash-scope only | ✅ |
+| Handled errors (`captureException`) | ❌ | ❌ | ❌ | ❌ | ✅ core API |
+| Sessions / release health | ❌ 24h device ping only → **crash-free rate uncomputable** | same | same | same | ✅ signature feature |
+| Performance (transactions/spans/startup/frames) | ❌ | ❌ | ❌ | ❌ | ✅ |
+| User feedback + attachments | ✅ ≤200 MB presigned | ✅ | ✅ (50 MB) | ❌ in SDK (tickets exist server-side) | ⚠️ weaker than ours |
+| Log capture | crash-time logcat tail | host-provided via diagnostics provider | ❌ | ❌ | ✅ Logs GA |
+| Session replay / profiling / crons / uptime | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **In-app update distribution + staged rollout** | ✅ full (hash bucketing, force-update, installer) | ❌ | ❌ | ⚠️ CLI publishes electron-updater artifacts | ❌ **Sentry has none** |
+
+## Moats to keep (Sentry can't follow)
+
+1. **Update distribution + staged rollout** — device-hash bucketing,
+   force-update, channels; integrated with the release platform. This is the
+   core differentiation.
+2. **Feedback tickets** — attachments to 200 MB (screenshots/logs), status
+   flow, comments, CLI/agent triage. Stronger than Sentry User Feedback.
+3. **Agent-native** — CLI + API let AI agents triage crashes/feedback
+   directly (Sentry only started AI/MCP work in 2025).
+4. **Self-hosted, Cloudflare-native**, crash ↔ build ↔ release in one
+   database — correlation is free.
+
+## Strategy
+
+Deepen our own closed loop — **crash → symbolication → release health →
+feedback → update** — rather than chasing Sentry's APM breadth. Priorities are
+defined in [roadmap.md](roadmap.md): P0 = sessions/crash-free rate, unified
+`captureException`, unified breadcrumbs; P1 = crash-capture depth +
+symbolication completion + SDK hygiene; P2 = selective (logs via HandsLog,
+app-start + hang-rate only); P3 = explicitly not pursued (replay, continuous
+profiling, crons/uptime).

--- a/docs/sdk-parity/android.md
+++ b/docs/sdk-parity/android.md
@@ -1,0 +1,50 @@
+# Android SDK inventory (`build.hands:hands-android-sdk`)
+
+Source: `clients/android` (all Kotlin read 2026-07-09). minSdk 24, hand-rolled
+(okhttp 4.12, kotlinx-serialization/coroutines) — no third-party crash SDK.
+Native lib `handscrash` (CMake, arm64-v8a/armeabi-v7a/x86_64).
+
+**Version drift (P1.6):** Gradle `0.1.0-SNAPSHOT` default vs README `0.4.0`
+vs `HandsFeedback.SDK_VERSION = 0.9.0` (the value actually reported in
+ticket metadata).
+
+## Present
+
+- **JVM crashes** — `HandsCrash.install()` chains the prior default handler;
+  writes structured log + `.meta.json` to `<externalFilesDir>/crashes/`;
+  no network in the dying process; uploaded on next launch; retention 5.
+- **Native crashes** — signal handlers (ILL/TRAP/ABRT/BUS/FPE/SEGV) write an
+  async-signal-safe `.qnc` record (signal, fault addr, raw PC frames,
+  `/proc/self/maps`); PC→module-offset resolution Kotlin-side next launch.
+  Custom minimal format, not minidump/breakpad.
+- **Crash context (rich)** — device/OS/app version, per-install device id,
+  all-threads stack dump, JVM heap + PSS, RAM/low-memory, FD count/targets,
+  process uptime, logcat tail (200 lines/20 KB), optional `extraContext`
+  lambda + `extras` map. Feedback adds locale/timezone/arch/emulator/screen/
+  disk/battery/thermal/commit.
+- **Feedback** — `HandsFeedback.submit()` multipart; ≤9 attachments; ≤10 MB
+  inline, ≤200 MB via presigned R2 PUT. No built-in UI/auto-screenshot.
+- **Device analytics** — `HandsAnalytics.reportDevice()`, 24h-throttled ping
+  to `/public/v2/apps/{slug}/metrics`.
+- **Update checking (flagship)** — `UpdateChecker.checkAndInstall()`:
+  staged-rollout hash bucketing, force_update, changelog, DownloadManager +
+  installer intent (`REQUEST_INSTALL_PACKAGES`).
+- **Offline durability** — crashes disk-buffered, retried next launch.
+
+## Absent (→ roadmap)
+
+- ANR detection (P1.1); coroutine-exception integration
+- Breadcrumbs (P0.3) — logcat tail is the only stand-in
+- `captureException` handled errors (P0.2)
+- Session start/end → crash-free rate (P0.1)
+- All performance monitoring (P2.2: app-start + ANR rate only)
+- Sampling / client rate limits; first-class user-id/tags API
+- Mapping upload is CLI-side (`hands builds publish-android --mapping`), not
+  SDK-side — acceptable, document it.
+
+## Config surface
+
+`Hands.install(context, baseUrl, appSlug, versionName?, versionCode?,
+channel?, clientKey?, copyToClipboard, uploadOnLaunch, captureNativeCrashes,
+reportDeviceAnalytics, extraContext?)`; `UpdateChecker` and `HandsFeedback`
+constructed separately.

--- a/docs/sdk-parity/electron.md
+++ b/docs/sdk-parity/electron.md
@@ -1,0 +1,54 @@
+# Electron SDK inventory (`@botiverse/hands-electron` v0.2.0)
+
+Source: `clients/electron/src/{main,renderer,preload,common}.ts`. Peer dep
+`electron >= 22`, zero runtime deps. Model: thin wrapper over Electron's
+built-in Crashpad reporter with Hands as the minidump endpoint.
+
+## Present
+
+- **Native crashes (all processes)** — `crashReporter.start()` → Crashpad
+  minidumps for main + renderer + GPU/child, auto-uploaded to
+  `/public/v2/apps/:slug/minidump`; Crashpad's own queue gives
+  restart-surviving offline buffering. `render-process-gone`/
+  `child-process-gone` listeners annotate reason and fire the `onCrash`
+  callback (covers dump-less OOM/killed cases).
+- **Symbolication** — server-side against Breakpad `.sym` sets uploaded via
+  `hands builds publish-electron --symbols` (keyed by versionCode).
+- **Crash context** — product_type, version/version_code, environment/
+  channel, platform/arch, process_type, electron/chrome/node versions +
+  runtime scope APIs `setUser`/`setTag`/`setExtra` (Crashpad annotations,
+  2 KB slices).
+- **Breadcrumbs (crash-scope)** — `addBreadcrumb` in main, renderer, and
+  `window.hands` (preload); ring buffer 100; attached to the next crash
+  annotation only (8 KB cap).
+- **Device analytics** — 24h-throttled metrics ping, device id persisted in
+  `userData/quiver-metrics.json`.
+
+## Absent (→ roadmap)
+
+- **JS error capture — none**: no main-process `uncaughtException`/
+  `unhandledRejection` handler, and `renderer.init()` is an explicit no-op
+  (P1.4)
+- Renderer JS sourcemaps (P1.4)
+- `captureException` (P0.2); sessions/crash-free rate (P0.1)
+- **Feedback submit API — none in this SDK** (tickets exist server-side;
+  CLI can triage them) (P1.4)
+- Update-check client — electron-updater artifacts (latest*.yml, blockmap,
+  installer) are published via CLI; no client wiring here
+- Log capture/shipping (P2.1: HandsLog electron adapter is the plan);
+  sampling controls
+- Standalone breadcrumb delivery (today they die with the process unless a
+  crash happens)
+
+## Config surface
+
+`HandsElectronOptions`: appSlug, clientKey, endpoint, productName, release,
+versionCode, environment, uploadToServer, extra, onCrash. Scope APIs:
+setUser/setTag/setExtra/addBreadcrumb.
+
+## Related: `@botiverse/hands-cli` v0.4.0
+
+Publish + triage only, no runtime telemetry: `builds publish-electron
+--symbols/--metadata/--installer/--blockmap`, `publish-android --mapping/
+--symbols`, `publish-ios --dsym`; `feedback list/show/update/comment/
+download-attachment`.

--- a/docs/sdk-parity/ios.md
+++ b/docs/sdk-parity/ios.md
@@ -1,0 +1,45 @@
+# iOS SDK inventory (`Hands` pod)
+
+Source: `clients/ios/Sources/Hands` (Objective-C — no Swift files, which is
+why naive `*.swift` searches miss it). Podspec v0.1.4, iOS 14.1+, zero deps.
+
+**Version drift (P1.6):** podspec `0.1.4` vs `kHandsSDKVersion = 0.1.5`.
+**Rename in flight (P1.6):** the Slock mobile app still consumes the old
+`Quiver` pod name pinned to an old git commit (Podfile.lock `Quiver (0.1.4)`)
+and calls `Quiver`-prefixed symbols via reflection.
+
+## Present
+
+- **NSException crashes** — `NSSetUncaughtExceptionHandler`, chains prior
+  handler; `callStackSymbols` + return addresses; store-then-send
+  (`Application Support/quiver/crashes`, retention 5, upload ~3 s after next
+  launch, retried until success).
+- **Fatal signals** — ABRT/SEGV/BUS/ILL/FPE/TRAP with an async-signal-safe
+  writer (sidecar first, best-effort `backtrace()` last).
+- **Symbolication prep** — emits `crash_binary_images` (Mach-O UUID, load/
+  base/end, slide, path from `_dyld_register_func_for_add_image`) + raw
+  `crash_frames`. dSYMs reach the server via
+  `hands builds publish-ios --dsym`; **the server-side resolver is not yet
+  rolled out** (P1.5).
+- **Feedback** — `submitFeedback:kind:attachmentPaths:extras:` with auto
+  device metadata; same 10 MB inline / 200 MB presigned model; ≤9 files.
+- **Device analytics** — 24h-throttled `reportDevice` ping.
+- **Diagnostics provider** — `setDiagnosticsProvider:` lets the host attach
+  log files at crash-upload time. The mobile app feeds its own
+  `slock-diagnostics.jsonl` (512 KB × 4 rotation) — a self-built substitute
+  for the missing breadcrumb layer.
+
+## Absent (→ roadmap)
+
+- Mach exception handling, watchdog/hang detection, all-threads dump —
+  documented v1 gaps (P1.2); no MetricKit
+- Breadcrumbs (P0.3); `captureException` (P0.2); sessions (P0.1)
+- Performance monitoring (P2.2)
+- **Update checking — none at all on iOS**; the TestFlight-on-Hands lane is
+  the current distribution answer
+- Feedback/metrics are fire-and-forget (only crashes are disk-buffered)
+
+## Config surface
+
+`HandsConfig`: `baseUrl`, `appSlug`, `channel`, `clientKey` (all runtime).
+Plus `setDiagnosticsProvider:`, `reportDevice`, `deviceId`.

--- a/docs/sdk-parity/ohos.md
+++ b/docs/sdk-parity/ohos.md
@@ -1,0 +1,39 @@
+# OHOS SDK inventory (`@botiverse/hands`)
+
+Source: `clients/ohos/hands` (all ArkTS read 2026-07-09).
+
+**Version drift (P1.6):** `oh-package.json5` `0.2.0` vs reported
+`QUIVER_SDK_VERSION = 0.1.0` — tickets claim 0.1.0 regardless of package
+bump.
+
+Positioning note: this SDK is a feedback + crash-ticket client mirroring the
+Android classes; crashes are delivered as feedback tickets (`kind=crash`).
+
+## Present
+
+- **ArkTS/JS crashes** — `errorManager.on('error')` uncaught-error capture;
+  store-then-send (`filesDir/crashes`, retention 5, upload next launch,
+  deferred 3 s).
+- **Crash/feedback context** — device (manufacturer/model/brand/marketName/
+  deviceType), OS/API, bundle version, arch, locale, timezone, screen, disk,
+  battery, per-install device id.
+- **Feedback** — multipart tickets, ≤9 attachments; ≤10 MB inline; presigned
+  R2 PUT above that, **hard cap 50 MB** (whole file read into ArrayBuffer —
+  OOM risk, lower than the 200 MB Android/iOS support).
+- **Device analytics** — 24h-throttled `/metrics` ping.
+
+## Absent (→ roadmap)
+
+- **Native crash capture — none** (no `faultLogger`/`hiAppEvent`) (P1.3)
+- Symbolication entirely — raw ArkTS stack text only, no sourcemaps
+- Breadcrumbs (P0.3); `captureException` (P0.2); sessions (P0.1)
+- Performance monitoring (P2.2)
+- **Update checking — none** (prefs store is even named `quiver_update`,
+  but no check API exists)
+- Log capture; retry/backoff (failed feedback submit just throws); sampling
+- Streaming attachment upload (fix the 50 MB / OOM limitation)
+
+## Config surface
+
+`Hands.install(config, context?)` — `HandsConfig = { baseUrl, appSlug,
+channel, clientKey }`. Everything else hardcoded (no hooks, no toggles).

--- a/docs/sdk-parity/roadmap.md
+++ b/docs/sdk-parity/roadmap.md
@@ -1,0 +1,79 @@
+# SDK parity roadmap (P0–P3)
+
+Work items from the [parity analysis](README.md), ordered by
+value-per-effort. Each P0/P1 item lists the concrete change per layer
+(server / SDKs / admin) so it can be picked up directly.
+
+## P0 — small effort, large value
+
+### P0.1 Session events → crash-free rate (release health)
+The single most persuasive Sentry metric. Today all four SDKs send only a
+24-hour-throttled device ping, so there is no session denominator and
+crash-free rate cannot be computed.
+
+- **Server**: `POST /public/v2/apps/:slug/sessions` accepting
+  `{device_id, session_id, event: "start"|"end", version_code, version_name,
+  channel, os, model, duration_ms?, crashed?}`; D1 table `app_sessions`
+  (rollup-friendly: daily aggregates per version). Crash reports carry
+  `session_id` so a session is marked crashed even when `end` never arrives.
+- **SDKs**: emit `start` on install/foreground, `end` on background (Android
+  `ProcessLifecycleOwner` / iOS `UIApplication` notifications / OHOS ability
+  lifecycle / Electron `app` events). Store-and-forward like crashes; batch
+  on next launch if offline.
+- **Admin**: Release Health panel — crash-free sessions %, crash-free
+  devices %, per release/channel; adoption curve already exists via device
+  pings.
+
+### P0.2 Unified `captureException` (handled errors)
+No SDK can report a caught exception today; a whole event class is missing.
+
+- **Server**: reuse the crash ingest path with `fatal: false` grouping into
+  crash groups (group key = exception type + top app frame).
+- **SDKs**: `Hands.captureException(throwable/error, extras?)` on all four
+  platforms, sharing the crash context builders that already exist.
+  Fire-and-forget with the same store-then-send durability as crashes.
+
+### P0.3 Unified breadcrumbs
+Electron already has `addBreadcrumb` (crash-scope only); the iOS app built
+its own rolling JSONL log to fill this hole — demand is proven.
+
+- **SDKs**: `Hands.addBreadcrumb(category, message, data?)`, ring buffer
+  (~100), serialized into crash/captureException/feedback payloads. Android/
+  iOS/OHOS new; Electron extend to feedback (once P1.4 adds feedback there).
+- **Server**: render breadcrumb trail on ticket/crash detail.
+
+## P1 — crash-capture depth + symbolication completion + hygiene
+
+1. **Android ANR detection** — main-thread watchdog (5s heartbeat) +
+   `ApplicationExitInfo` (REASON_ANR) harvest on next launch.
+2. **iOS depth** — Mach exception handler, watchdog/hang detection,
+   all-threads dump (documented v1 gaps in `HandsCrashReporter`).
+3. **OHOS native crashes** — wire `hiAppEvent`/`faultLogger` so native
+   faults are captured, not just ArkTS errors.
+4. **Electron JS layer** — main-process `uncaughtException`/
+   `unhandledRejection` + renderer error capture (renderer.init is currently
+   a no-op); renderer sourcemap support; feedback submit API.
+5. **iOS dSYM server resolver** — client already ships
+   `crash_binary_images` (UUID/slide/ranges); implement the server-side
+   dSYM lookup + frame resolution (dSYMs already uploaded via
+   `hands builds publish-ios --dsym`).
+6. **SDK hygiene** — single source of truth for versions (Android reports
+   0.1.0-SNAPSHOT/0.4.0/0.9.0 depending on where you look; OHOS package
+   0.2.0 reports 0.1.0; iOS podspec 0.1.4 vs constant 0.1.5); finish the
+   Quiver→Hands rename (mobile iOS app still consumes the old `Quiver` pod
+   pinned to an old commit). Overlaps the "upgrade repos to latest hands
+   SDK" task.
+
+## P2 — selective follow
+
+1. **Logs** — HandsLog (`@botiverse/hands-node` core + electron adapter) is
+   already specced and in build (docs/handslog-spec.md); mobile aligns to
+   the same schema later.
+2. **Performance** — only the two highest-signal metrics: app-start time and
+   ANR/hang rate. No general tracing/span product.
+
+## P3 — explicitly not pursued
+
+Session replay, continuous profiling, crons/uptime monitoring. Huge
+investment, off-positioning; apps that need them can run Sentry alongside
+Hands without conflict.


### PR DESCRIPTION
artin's directive in #Hands:420b9e35: "建一个文件夹，详细分析我们和 sentry 的差距，你可以按 p0~p3 定，然后去做".

New `docs/sdk-parity/` folder:
- **README.md** — positioning, full capability matrix (4 platforms × Sentry), moats Sentry lacks (update distribution/staged rollout, feedback tickets, agent-native, crash↔build↔release one DB).
- **roadmap.md** — P0–P3 with concrete per-layer work items: P0.1 session events → crash-free rate (server endpoint + D1 rollups + SDK lifecycle hooks + admin Release Health panel), P0.2 unified captureException, P0.3 unified breadcrumbs; P1 crash-depth (Android ANR, iOS Mach/watchdog/all-threads, OHOS faultLogger, Electron JS errors/sourcemaps/feedback), iOS dSYM server resolver, SDK version-drift + Quiver→Hands rename cleanup; P2 HandsLog + minimal perf; P3 explicitly not pursued.
- **android.md / ios.md / ohos.md / electron.md** — source-level inventories (present/absent per capability, exact mechanisms and limits, version drift findings).

Method: all four SDKs read at source level (not docs) on 2026-07-09; Sentry baseline verified against 2025–26 feature set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)