### PR TITLE
feat(hands): session events + release-health rollup (sdk-parity P0.1, server)

### DIFF
--- a/migrations/sql/0036_app_sessions.sql
+++ b/migrations/sql/0036_app_sessions.sql
@@ -1,0 +1,23 @@
+-- Session events for release health (crash-free rate) — sdk-parity P0.1.
+-- One row per client session. `start` inserts; `end` (or a next-launch
+-- crash marker) updates the same row. device_id is the same random
+-- per-install UUID device_pings uses — no PII.
+CREATE TABLE app_sessions (
+  app_id TEXT NOT NULL REFERENCES apps(id),
+  session_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  version_name TEXT,
+  version_code INTEGER,
+  channel TEXT,
+  platform TEXT,
+  os_version TEXT,
+  device_model TEXT,
+  started_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  duration_ms INTEGER,
+  crashed INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (app_id, session_id)
+);
+
+CREATE INDEX idx_app_sessions_app_started ON app_sessions(app_id, started_at);
+CREATE INDEX idx_app_sessions_app_version ON app_sessions(app_id, version_code, started_at);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -69,6 +69,7 @@ import {
   handlePresignFeedbackAttachments,
 } from "./routes/feedback";
 import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail, handleVersionAnalytics } from "./routes/analytics";
+import { handleSessionEvent, handleReleaseHealth } from "./routes/sessions";
 import {
   handlePublicAppHistory,
   handlePublicAppHistoryDownload,
@@ -487,6 +488,7 @@ app.post("/public/v2/apps/:slug/feedback", handlePublicFeedbackSubmit);
 app.post("/public/v2/apps/:slug/minidump", handlePublicMinidumpSubmit);
 app.post("/public/v2/apps/:slug/devices", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/metrics", handleDeviceRegister);
+app.post("/public/v2/apps/:slug/sessions", handleSessionEvent);
 app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/apps/:slug/history", handlePublicAppHistory);
@@ -611,6 +613,7 @@ admin.get("/api/apps/:appId/feedback/stats", requireAppRole("viewer"), handleFee
 admin.get("/api/apps/:appId/analytics/devices", requireAppRole("viewer"), handleDeviceAnalytics);
 admin.get("/api/apps/:appId/analytics/versions", requireAppRole("viewer"), handleVersionAnalytics);
 admin.get("/api/apps/:appId/analytics/devices/:deviceId", requireAppRole("viewer"), handleDeviceDetail);
+admin.get("/api/apps/:appId/release-health", requireAppRole("viewer"), handleReleaseHealth);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);

--- a/worker/src/routes/sessions.ts
+++ b/worker/src/routes/sessions.ts
@@ -1,0 +1,194 @@
+/**
+ * Session events → release health (sdk-parity P0.1).
+ *
+ * SDKs post `start` when the app comes to the foreground and `end` when it
+ * backgrounds; a crash found on next launch is reported as `end` with
+ * crashed=true (or a bare `crash` marker when the end never made it out).
+ * Sessions are the denominator that makes crash-free rate computable —
+ * device pings alone can't provide it.
+ */
+import type { Context } from "hono";
+import type { AdminEnv } from "../middleware/auth";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+const WINDOW_DEFAULT_DAYS = 30;
+const WINDOW_MAX_DAYS = 365;
+
+export async function handleSessionEvent(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await c.env.DB.prepare(
+    "SELECT id, client_key FROM apps WHERE slug = ?1 AND archived = 0",
+  )
+    .bind(slug)
+    .first<{ id: string; client_key: string | null }>();
+  if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
+
+  // Same DSN-model client-key gate as feedback/metrics.
+  const presented =
+    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? "";
+  if (!app.client_key || presented !== app.client_key) {
+    return c.json({ error: "invalid or missing client key" }, 401);
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    const raw = await c.req.json();
+    if (raw && typeof raw === "object") body = raw as Record<string, unknown>;
+  } catch {
+    return c.json({ error: "JSON body required" }, 400);
+  }
+
+  const str = (key: string, max = 200): string | null => {
+    const v = body[key];
+    if (v === undefined || v === null) return null;
+    return String(v).slice(0, max) || null;
+  };
+  const num = (key: string): number | null => {
+    const v = body[key];
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  };
+
+  const sessionId = str("session_id", 100);
+  const deviceId = str("device_id", 200);
+  const event = str("event", 20);
+  if (!sessionId) return c.json({ error: "session_id required" }, 400);
+  if (!deviceId) return c.json({ error: "device_id required" }, 400);
+  if (event !== "start" && event !== "end" && event !== "crash") {
+    return c.json({ error: "event must be start, end, or crash" }, 400);
+  }
+
+  const now = Date.now();
+  const crashed = event === "crash" || body["crashed"] === true ? 1 : 0;
+
+  if (event === "start") {
+    await c.env.DB.prepare(
+      `INSERT INTO app_sessions
+         (app_id, session_id, device_id, version_name, version_code, channel,
+          platform, os_version, device_model, started_at, crashed)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0)
+       ON CONFLICT(app_id, session_id) DO NOTHING`,
+    )
+      .bind(
+        app.id,
+        sessionId,
+        deviceId,
+        str("version_name"),
+        num("version_code"),
+        str("channel"),
+        str("platform"),
+        str("os_version"),
+        str("device_model"),
+        num("started_at") ?? now,
+      )
+      .run();
+    return c.json({ ok: true }, 202);
+  }
+
+  // end / crash: update the existing row, or insert a stub when the start
+  // event was lost (offline, crash before flush) so the session still counts.
+  await c.env.DB.prepare(
+    `INSERT INTO app_sessions
+       (app_id, session_id, device_id, version_name, version_code, channel,
+        platform, os_version, device_model, started_at, ended_at, duration_ms, crashed)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+     ON CONFLICT(app_id, session_id) DO UPDATE SET
+       ended_at = excluded.ended_at,
+       duration_ms = COALESCE(excluded.duration_ms, app_sessions.duration_ms),
+       crashed = MAX(app_sessions.crashed, excluded.crashed)`,
+  )
+    .bind(
+      app.id,
+      sessionId,
+      deviceId,
+      str("version_name"),
+      num("version_code"),
+      str("channel"),
+      str("platform"),
+      str("os_version"),
+      str("device_model"),
+      num("started_at") ?? now,
+      now,
+      num("duration_ms"),
+      crashed,
+    )
+    .run();
+  return c.json({ ok: true }, 202);
+}
+
+/**
+ * Admin release-health rollup: per version, session/device counts and
+ * crash-free percentages over a window (?window_days=, default 30, max 365).
+ */
+export async function handleReleaseHealth(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const daysRaw = Number(c.req.query("window_days"));
+  const windowDays =
+    Number.isFinite(daysRaw) && daysRaw > 0
+      ? Math.min(Math.ceil(daysRaw), WINDOW_MAX_DAYS)
+      : WINDOW_DEFAULT_DAYS;
+  const since = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+
+  const { results } = await c.env.DB.prepare(
+    `SELECT version_code, version_name,
+            COUNT(*) AS sessions,
+            SUM(crashed) AS crashed_sessions,
+            COUNT(DISTINCT device_id) AS devices,
+            COUNT(DISTINCT CASE WHEN crashed = 1 THEN device_id END) AS crashed_devices
+     FROM app_sessions
+     WHERE app_id = ?1 AND started_at >= ?2
+     GROUP BY version_code, version_name
+     ORDER BY version_code DESC`,
+  )
+    .bind(appId, since)
+    .all<{
+      version_code: number | null;
+      version_name: string | null;
+      sessions: number;
+      crashed_sessions: number | null;
+      devices: number;
+      crashed_devices: number | null;
+    }>();
+
+  const versions = (results ?? []).map((r) => {
+    const crashedSessions = r.crashed_sessions ?? 0;
+    const crashedDevices = r.crashed_devices ?? 0;
+    return {
+      version_code: r.version_code,
+      version_name: r.version_name,
+      sessions: r.sessions,
+      crashed_sessions: crashedSessions,
+      crash_free_sessions_pct:
+        r.sessions > 0 ? Math.round((1 - crashedSessions / r.sessions) * 10000) / 100 : null,
+      devices: r.devices,
+      crashed_devices: crashedDevices,
+      crash_free_devices_pct:
+        r.devices > 0 ? Math.round((1 - crashedDevices / r.devices) * 10000) / 100 : null,
+    };
+  });
+
+  const totals = versions.reduce(
+    (acc, v) => {
+      acc.sessions += v.sessions;
+      acc.crashed_sessions += v.crashed_sessions;
+      return acc;
+    },
+    { sessions: 0, crashed_sessions: 0 },
+  );
+
+  return c.json({
+    window_days: windowDays,
+    since,
+    totals: {
+      sessions: totals.sessions,
+      crashed_sessions: totals.crashed_sessions,
+      crash_free_sessions_pct:
+        totals.sessions > 0
+          ? Math.round((1 - totals.crashed_sessions / totals.sessions) * 10000) / 100
+          : null,
+    },
+    versions,
+  });
+}

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -296,6 +296,22 @@ function makeMockDb() {
       ping_count INTEGER NOT NULL DEFAULT 1,
       PRIMARY KEY (app_id, device_id)
     );
+    CREATE TABLE app_sessions (
+      app_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      device_id TEXT NOT NULL,
+      version_name TEXT,
+      version_code INTEGER,
+      channel TEXT,
+      platform TEXT,
+      os_version TEXT,
+      device_model TEXT,
+      started_at INTEGER NOT NULL,
+      ended_at INTEGER,
+      duration_ms INTEGER,
+      crashed INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (app_id, session_id)
+    );
     CREATE TABLE feedback_attachments (
       id TEXT PRIMARY KEY,
       ticket_id TEXT NOT NULL,
@@ -3955,6 +3971,61 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(v102.devices).toBe(2);
     expect(body.by_platform[0].platform).toBe("android");
     expect(body.by_platform[0].devices).toBe(4);
+  });
+
+  it("sessions: start/end/crash events roll up into crash-free release health", async () => {
+    const env = makeEnv();
+    const { handleSessionEvent, handleReleaseHealth } = await import("../src/routes/sessions");
+    const post = (body: Record<string, unknown>, key = "qk_test") =>
+      handleSessionEvent({
+        env,
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: (n: string) => (n === "X-Hands-Client-Key" ? key : undefined),
+          json: async () => body,
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+
+    // wrong key -> 401; bad event -> 400
+    expect((await post({ session_id: "s1", device_id: "d1", event: "start" }, "wrong")).status).toBe(401);
+    expect((await post({ session_id: "s1", device_id: "d1", event: "nope" })).status).toBe(400);
+
+    const base = { version_name: "1.2.0", version_code: 1020000, platform: "android" };
+    // devA: one clean session (start+end), one crashed session
+    expect((await post({ ...base, session_id: "s1", device_id: "devA", event: "start" })).status).toBe(202);
+    expect((await post({ ...base, session_id: "s1", device_id: "devA", event: "end", duration_ms: 60000 })).status).toBe(202);
+    expect((await post({ ...base, session_id: "s2", device_id: "devA", event: "start" })).status).toBe(202);
+    expect((await post({ ...base, session_id: "s2", device_id: "devA", event: "crash" })).status).toBe(202);
+    // devB: clean session; duplicate start is idempotent
+    expect((await post({ ...base, session_id: "s3", device_id: "devB", event: "start" })).status).toBe(202);
+    expect((await post({ ...base, session_id: "s3", device_id: "devB", event: "start" })).status).toBe(202);
+    // devC: end arrives with no start (lost offline) — still counts as a session
+    expect((await post({ ...base, session_id: "s4", device_id: "devC", event: "end" })).status).toBe(202);
+    // older version, crashed
+    expect((await post({ session_id: "s5", device_id: "devD", event: "crash", version_name: "1.1.0", version_code: 1010000 })).status).toBe(202);
+
+    const res = await handleReleaseHealth({
+      env,
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: () => undefined },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    const body = await responseJson<any>(res);
+
+    expect(body.totals.sessions).toBe(5);
+    expect(body.totals.crashed_sessions).toBe(2);
+    expect(body.totals.crash_free_sessions_pct).toBe(60);
+
+    const v12 = body.versions.find((v: any) => v.version_code === 1020000);
+    expect(v12.sessions).toBe(4); // s1, s2, s3 (deduped start), s4
+    expect(v12.crashed_sessions).toBe(1);
+    expect(v12.crash_free_sessions_pct).toBe(75);
+    expect(v12.devices).toBe(3); // devA, devB, devC
+    expect(v12.crashed_devices).toBe(1); // devA
+    expect(v12.crash_free_devices_pct).toBeCloseTo(66.67, 1);
+
+    const v11 = body.versions.find((v: any) => v.version_code === 1010000);
+    expect(v11.crash_free_sessions_pct).toBe(0);
   });
 
   it("analytics: versions aggregates release metrics, devices, feedback, and downloads", async () => {


### PR DESCRIPTION
First execution slice of `docs/sdk-parity/roadmap.md` P0.1 (task #120) — the highest-value Sentry gap: without session events, crash-free rate (release health) is uncomputable.

## What
- **Migration 0036**: `app_sessions` (PK app_id+session_id, indexed by app+started_at and app+version_code; same anonymous per-install device_id as device_pings — no PII).
- **`POST /public/v2/apps/:slug/sessions`** — client-key gated (same DSN model as feedback/metrics). Events: `start` (INSERT, idempotent), `end` (upsert: an end whose start was lost offline still creates the row so the session counts), `crash` (crashed sticky via MAX; SDKs send it on next-launch crash upload).
- **`GET /api/apps/:appId/release-health`** (viewer role) — per-version sessions/devices, crashed counts, crash-free-sessions % and crash-free-devices %, plus totals; `?window_days=` (default 30, max 365).

## Verification
- tsc clean; 108/108 worker tests. New test drives the full lifecycle: 401/400 gates, idempotent double-start, end-without-start, crash marking, and asserts the exact rollup percentages per version and in totals.

## Next slices
SDK lifecycle hooks (Android ProcessLifecycleOwner / iOS UIApplication notifications / OHOS ability lifecycle / Electron app events) + admin Release Health panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)