### PR TITLE
docs(sdk-parity): four mechanism-level deep dives vs Sentry (task #120)

### DIFF
--- a/docs/sdk-parity/README.md
+++ b/docs/sdk-parity/README.md
@@ -5,6 +5,22 @@ capability set (task #120, 2026-07-09). Per-platform detail lives in
 [android.md](android.md), [ios.md](ios.md), [ohos.md](ohos.md),
 [electron.md](electron.md); the execution plan is in [roadmap.md](roadmap.md).
 
+Four deep dives compare mechanism-by-mechanism against Sentry's actual docs,
+each rating every gap 关键/重要/可后置/不追 with a top-5 borrow list:
+
+- [deep-sdk-architecture.md](deep-sdk-architecture.md) — scopes/hub, envelope
+  disk queue, beforeSend, rate-limit protocol, client reports, sampling,
+  PII scrubbing, session modes, config surface
+- [deep-issue-pipeline.md](deep-issue-pipeline.md) — grouping/fingerprinting,
+  issue states, debug-ids, gradle/xcode auto symbol upload, sourcemaps,
+  suspect commits, ownership, environments
+- [deep-product-surface.md](deep-product-surface.md) — alert rules/anomaly
+  detection, chat-ops (vs our Raft-native model), VCS integrations,
+  dashboards/query API, quotas/retention, crash-linked feedback, AI/Seer
+- [deep-mobile.md](deep-mobile.md) — ANRv2/tombstones, Mach/App Hangs/
+  watchdog/MetricKit, app start/TTID/frames, 30s session threshold, offline
+  envelope queue, screenshots/view hierarchy, mobile replay
+
 ## Positioning
 
 Hands SDKs are **crash + feedback-ticket + device-stats + update-distribution

--- a/docs/sdk-parity/deep-issue-pipeline.md
+++ b/docs/sdk-parity/deep-issue-pipeline.md
@@ -1,0 +1,401 @@
+# 深挖:Sentry Issue 管线与符号化工具链 vs Hands
+
+任务 #(2026-07-09),对照 docs.sentry.io / develop.sentry.dev 实际文档逐条核实
+(核实日期 2026-07-09)。每个机制按 **Sentry 做法 → Hands 现状 → 差距评级 + 理由**
+展开。评级:**关键**(直接影响核心价值/采用率)、**重要**(明显提升但可排期)、
+**可后置**(有价值但依赖前置项或规模)、**不追**(不符合 Hands 定位或已更强)。
+
+Hands 基线(与 [README.md](README.md) 能力矩阵一致):服务端基于签名的
+crash 分组(产出 `crash:new_group` / `crash:spike` webhook);Android R8
+mapping + native 符号经 CI 手工调用 `hands builds publish-android
+--mapping/--symbols` 上传;Electron breakpad `.sym` 经 `publish-electron`;
+iOS dSYM 经 `publish-ios --dsym` 已入库但**服务端解析器未实现**;OHOS 无;
+无 debug-id、无 source context、无 suspect commits(但 build 带
+`source_commit` 溯源);release/渠道是一等平台对象(强于 Sentry);无
+ownership 规则;issue 工作流仅有反馈工单状态(open/triaged/resolved)+
+指派人。
+
+---
+
+## 1. 分组与指纹(Grouping / Fingerprinting)
+
+### 1.1 默认分组算法
+
+**Sentry 做法**:每个事件算出一个 fingerprint,相同 fingerprint 归入同一
+issue。优先级链:显式 `fingerprint` → 堆栈 → 异常 type/value → message。
+堆栈分组只看 SDK 标记为 in-app 的帧,每帧取模块名、**规范化文件名(剥离
+revision hash)**、**规范化的上下文源码行**;分组算法带版本号,新项目用最新
+版,改版只影响新事件(避免老 issue 重新洗牌)。JS 未上传 sourcemap 时分组
+质量会崩(压缩代码指纹不稳定)。另有内置规则(如 chunk load error 归并)和
+AI 相似度分组(对错误消息 + in-app 帧做 embedding,把语义相同但指纹不同的
+错误合并;自定义 fingerprint 会绕过 AI 分组)。
+
+**Hands 现状**:服务端签名分组已存在,是 webhook(`crash:new_group` /
+`crash:spike`)的基础。但签名规范化的深度(是否剥离地址/行号抖动、hash 后缀、
+递归帧折叠)未对齐 Sentry 的成熟度;混淆后 Android 堆栈若在分组**前**未
+还原,同一崩溃会因 R8 重命名不同而裂成多组。
+
+**差距:重要**。分组是所有下游(计数、spike 检测、webhook、以后的状态机)的
+地基,分裂/误并会直接放大噪音。Hands 已有骨架,要补的是"先符号化再分组"
+的顺序保证 + 规范化规则(剥地址、剥构建随机后缀、限帧数、递归折叠)。算法
+版本化(改规则不重洗旧组)值得直接抄。AI 相似度分组不追(投入产出比低)。
+
+### 1.2 Stack trace rules(grouping enhancements)
+
+**Sentry 做法**:项目级规则 DSL,逐帧匹配(`family:` / `stack.abs_path:` /
+`stack.function:` / `stack.module:` / `stack.package:` / `app:` /
+`category:`,glob 语法,`!` 取反),动作为 `+app/-app`(改 in-app 标记)、
+`+group/-group`(纳入/排除分组)、`^`/`v` 方向修饰(向崩溃方向/反方向传播)、
+`max-frames=N`。典型用法:`stack.abs_path:**/node_modules/** -group`。
+
+**Hands 现状**:无任何用户可配置的分组调节;in-app 判定(如果有)是硬编码。
+
+**差距:可后置**。这是给成熟团队调噪音的 power-user 工具,前提是默认分组
+先做好。但其中一个子集值得提前:**服务端可配置的 in-app 包前缀列表**
+(per-app 一行配置,如 `com.example.*` 为 in-app),成本低、对分组质量和
+堆栈展示都立竿见影。完整 DSL 不急。
+
+### 1.3 自定义 fingerprint(SDK 端 + 服务端规则)
+
+**Sentry 做法**:两层。SDK 端事件可携带 `fingerprint: ["my-key", "{{ default }}"]`,
+`{{ default }}` 表示在默认分组基础上细分;服务端 fingerprint rules 是
+`matcher -> fingerprint` 的规则表(matcher 支持 `error.type` / `error.value` /
+`message` / `logger` / `level` / 堆栈字段 / `tags.*`,值支持
+`{{ transaction }}` `{{ error.type }}` 等变量,还能 `title="..."` 覆盖标题),
+首条命中生效,无需改代码即可修正分组。
+
+**Hands 现状**:无。签名完全由服务端算法决定,用户无法干预。
+
+**差距:重要(SDK 端)/ 可后置(服务端规则)**。SDK 端 fingerprint 字段
+成本极低(事件模型加一个数组字段 + 分组时优先采用),却是逃生舱:任何
+分组 bug 用户都能自救,大幅降低分组算法必须一次做对的压力。服务端规则
+引擎等有租户提出再做。
+
+### 1.4 Merge / Unmerge
+
+**Sentry 做法**:UI 里把多个已存在的 issue 合并,之后落入这些旧指纹的事件
+进合并后的 issue;Merged Issues 标签页可按指纹勾选 unmerge 还原。注意
+文档明确:merge **不影响未来新指纹的产生**,要治本得用 fingerprint/stack
+trace rules。
+
+**Hands 现状**:无,分组结果不可编辑。
+
+**差距:可后置**。本质是"组 → 指纹集合"的一对多映射 + 一次数据迁移,
+模型改动不大,但需要控制台 UI 承载,且在有 1.3 的逃生舱后紧迫性下降。
+建议在 crash 控制台迭代时一并做(至少先做 merge,unmerge 可再后)。
+
+### 1.5 Issue 状态机:resolved / regressed / archive-until
+
+**Sentry 做法**:六态(New ≤7 天 / Ongoing / Escalating / Regressed /
+Archived / Resolved)。核心机制:
+- **Resolve in release**:可标记"在当前 release 解决 / 在下一个 release
+  解决 / 由某 commit 解决"。之后若在**更新的版本**再次出现,自动转
+  `Regressed` 并回到收件箱(semver 项目按版本比较,非 semver 按 release
+  创建时间比较)。
+- **Archive until**:归档可设条件——永久 / 一段时间 / 累计次数达到 N /
+  影响用户数达到 N / **until escalating**(事件量超出算法预测的水位时
+  自动升级回来)。Escalating 由事件量预测算法驱动,同样用于 1.6 的优先级。
+
+**Hands 现状**:crash 组没有任何状态;工作流只存在于反馈工单
+(open/triaged/resolved + assignee),与 crash 组不通。
+
+**差距:关键**。这是 Hands 最值得投入的一块:**Hands 的 release/渠道是一等
+对象,做"resolved in release X → 在 Y 复发自动 regressed"比 Sentry 更顺**
+(Sentry 的 release 是事件上报出来的弱实体,Hands 的 release 是发布平台
+权威数据,版本序、渠道、灰度比例全都已知)。没有状态机,crash 列表只会
+单调增长,`crash:new_group` webhook 也没有"复发"这个最有行动价值的信号。
+最小版本:组级 open/resolved(可绑 release)/regressed 三态 + 复发自动
+翻转 + webhook 加 `crash:regressed` 事件。archive-until(按次数/用户数)
+第二步跟上,escalating 预测算法可用简单的"对比近 7 天基线的倍数阈值"
+起步(Hands 已有 spike 检测,是同一块肌肉)。
+
+### 1.6 优先级评分
+
+**Sentry 做法**:error 类按 log level 定初始档(ERROR/FATAL→high,
+WARNING→medium,DEBUG/INFO→low);付费档对 Python/JS 额外看错误消息、
+是否 handled、历史处理行为。事件量升高时自动升档(escalating 算法),
+回落自动降档;手动改过优先级后永久停用自动调整。
+
+**Hands 现状**:无优先级概念。
+
+**差距:可后置**。Hands 事件几乎全是 crash(天然都是 FATAL 档),按
+level 分层的信息量小;真正有用的排序维度是"影响设备数 × 是否新增 ×
+所在渠道/灰度阶段",这更接近排序列而不是状态字段。等控制台列表有了
+排序需求再做,不必照抄。
+
+---
+
+## 2. 符号化工具链(Symbolication)
+
+### 2.1 Debug IDs
+
+**Sentry 做法**:构建期为每个产物生成确定性的全局唯一 ID(由内容派生),
+注入压缩 JS(`//# debugId=...` 注释)和 sourcemap(顶层字段),SDK 上报
+事件时带上所有已加载产物的 debug ID,服务端据此精确匹配符号文件——
+彻底取代按 release+dist+URL 路径猜配的旧模式,**上传符号不再要求先建
+release**(可选"弱关联"到 release)。native 侧等价物本来就存在:ELF
+build-id、Mach-O UUID、PDB GUID、ProGuard 的 UUID(写进
+`AndroidManifest.xml` / `sentry-debug-meta.properties`);sentry-cli
+`debug-files check` 能直接读出这些 ID。
+
+**Hands 现状**:无 debug-id 概念。符号与事件按 build(app + 版本)关联;
+`publish-android --mapping` 把 mapping 挂到某个 build 上。风险:同一版本
+号重打包(CI 重跑、热修)、多 flavor/多 ABI、事件里的库不属于本 app
+(系统库、共享 SDK)时,按 build 匹配会拿错或拿不到符号。
+
+**差距:重要**。不需要发明新东西——**native 平台的 ID 已经免费存在**
+(dSYM UUID、ELF build-id、R8 从 AGP 7.2 起也在 mapping 里带
+`pg_map_id`)。要做的是:上传时提取并按 ID 索引符号文件;SDK 崩溃记录里
+带上每个映像的 build-id/UUID(Android native 与 Electron minidump 其实
+已含此信息,JVM 侧要把 mapping UUID 写进事件);解析时**先按 ID 精确
+匹配、build 关联仅作回退**。这同时解决 iOS 解析器(2.4)的正确性地基,
+建议与其一起做。
+
+### 2.2 sentry-cli debug-files(统一符号上传 CLI)
+
+**Sentry 做法**:`sentry-cli debug-files upload` 一个入口递归扫描目录/ZIP,
+自动识别格式(dSYM/ELF/PE/PDB/Breakpad sym/ProGuard/source bundle),
+跳过已上传文件,`--wait` 等待服务端解析完成,`debug-files check` 本地
+校验文件可用性并打印 debug ID。文档明确提示 Breakpad sym 丢信息,能传
+原生格式就传原生格式。
+
+**Hands 现状**:按平台分命令:`publish-android --mapping/--symbols`、
+`publish-electron`(breakpad .sym)、`publish-ios --dsym`。上传与"发布
+build"耦合在一起。
+
+**差距:可后置**。按平台分命令对 Hands 的"发布即上传"模型其实是合理的,
+不必追求单一入口。值得吸收的两个点:(a) `hands symbols check <file>`
+本地校验 + 打印 ID(排查"为什么没解析出来"的第一工具,配合 2.1);
+(b) 把符号上传从 publish 中解耦出一个独立子命令,允许"符号晚于发布补传"
+(热修/重传场景)。
+
+### 2.3 Android Gradle 插件自动上传
+
+**Sentry 做法**:`io.sentry.android.gradle` 插件挂进
+`assemble{Variant}`:自动生成 UUID、注入 manifest、上传 R8/ProGuard
+mapping(`autoUploadProguardMapping` 默认开)、发现并上传 NDK 符号
+(`uploadNativeSymbols` / `includeNativeSources`)、打包 JVM source
+bundle(`includeSourceContext`)、外加字节码插桩和 SDK 依赖自动安装。
+凭证走 `sentry.properties` 或 `SENTRY_AUTH_TOKEN` 环境变量。开发者
+**零 CI 脚本**即可获得完整符号化。
+
+**Hands 现状**:纯手工——用户要在 CI 里自己找到 mapping 路径和
+`merged_native_libs` 目录,拼 `hands builds publish-android
+--mapping ... --symbols ...` 命令。路径写错、variant 弄混、忘传其中
+一样,都是静默失败。
+
+**差距:关键**。符号化链路的最大流失点不在服务端,在接入摩擦:Sentry 的
+经验证明"插件默认开"是 mapping 覆盖率接近 100% 的原因。Hands 已有
+Android SDK 的 Gradle 生态位,插件只需做三件事:定位 variant 的 mapping
+文件、定位 native `.so`(unstripped)、在 `assembleRelease` 后调用与
+`hands builds publish-android` 相同的 API(或直接内嵌上传逻辑)。凭证
+沿用 `HANDS_TOKEN` 环境变量。这是 top-1 借鉴项。
+
+### 2.4 iOS:Xcode build phase / fastlane dSYM 上传
+
+**Sentry 做法**:三条路——Xcode Run Script build phase(调
+`sentry-cli debug-files upload`,要求 `DEBUG_INFORMATION_FORMAT =
+DWARF with dSYM`,新 Xcode 需关 `ENABLE_USER_SCRIPT_SANDBOXING`);
+fastlane 插件 `sentry_debug_files_upload`;或 CI 手动 sentry-cli。均可
+`--include-sources` 顺带打源码包。
+
+**Hands 现状**:上传端已通(`publish-ios --dsym` 入库),但**服务端 iOS
+解析器没有实现**——dSYM 收了不用,iOS 崩溃堆栈仍是裸地址。客户端已上报
+binary images(见 [ios.md](ios.md)),原材料齐全。
+
+**差距:关键(服务端解析器)/ 重要(Xcode 集成)**。先后顺序明确:先把
+服务端 dSYM 解析器做完(按 UUID 匹配 dSYM → symbolicate,与 2.1 同一批
+工作;Electron minidump 解析器已趟过 breakpad 这条路,可复用大量代码),
+否则任何上传端优化都是空转。解析器落地后,补一个可复制粘贴的 Xcode Run
+Script 模板 + fastlane action(fastlane 插件是 Ruby 一小片,包装
+`hands builds publish-ios`),接入成本才降到 Sentry 水平。
+
+### 2.5 Source context / source bundles
+
+**Sentry 做法**:把源码片段(每帧上下若干行)随符号一起展示。JVM 侧:
+构建期生成 UUID 写入 `sentry-debug-meta.properties`,gradle 插件
+(`includeSourceContext = true`)或 `sentry-cli debug-files bundle-jvm`
+把 `.java/.kt/...` 打成 source bundle 上传,事件携带 UUID 反查。native
+侧:`--include-sources` 扫描调试文件里引用的源码路径打包。UI 里堆栈帧
+直接展开源码。
+
+**Hands 现状**:无。符号化(如果成功)只给出 类名/文件/行号。
+
+**差距:可后置**。锦上添花:有文件+行号后,开发者在 IDE 里跳转的成本
+很低;而且 Hands 的 build 带 `source_commit`,将来更优雅的形态是
+**链接到 forge 的 commit 快照上的那一行**(零上传、零存储),而不是
+复刻 source bundle。建议不做 bundle,做"堆栈帧 → 源码托管深链"。
+
+### 2.6 JS sourcemaps 管线
+
+**Sentry 做法**:bundler 插件(webpack/Vite/Rollup/esbuild)在生产构建时
+生成+注入 debug ID 并上传 artifact bundle;不支持的构建工具用
+`sentry-cli sourcemaps inject` + `sourcemaps upload`;debug ID 模式下
+无需 release、无需 URL 匹配。`npx @sentry/wizard -i sourcemaps` 一键
+接线。
+
+**Hands 现状**:无 JS sourcemap 管线。而且根据 [electron.md](electron.md),
+Electron SDK 目前**根本不捕获 JS 错误**(只有 Crashpad 原生崩溃),OHOS
+的 ArkTS 错误有捕获但无 sourcemap 还原。
+
+**差距:可后置(Electron)/ 重要(OHOS)**。Electron 侧 sourcemap 依赖
+"先有 JS 错误捕获"(roadmap 里的前置项),没有事件就没有可还原的东西。
+OHOS 相反:ArkTS `errorManager` 已经在产出混淆堆栈,DevEco 的
+release 构建有 sourcemap/nameCache 产物,这是四端里"已有事件但零符号化"
+的唯一平台,补一个 `publish-ohos --sourcemap` + 服务端还原,边际收益
+最高。做的时候直接按 debug-id 思路设计,不要走 Sentry 已淘汰的
+release+URL 匹配老路。
+
+---
+
+## 3. Release 追踪
+
+### 3.1 Release 创建
+
+**Sentry 做法**:release 是弱实体——SDK 事件带 `release` 字段即自动创建;
+正式流程用 `sentry-cli releases new/finalize` 或 bundler 插件。semver
+版本可比较大小(用于 regression 判定),非 semver 按创建时间比。
+
+**Hands 现状**:release/渠道是一等平台对象,由发布流程权威创建,带
+artifact、灰度比例、强更策略、`source_commit`。
+
+**差距:不追(Hands 更强)**。Sentry 的 release 是"观测出来的影子",
+Hands 的是"发布系统的事实"。唯一要补的是把这个优势**接进 issue 管线**:
+崩溃事件必须可靠携带 build/release 标识(四端 SDK 已做),使 1.5 的
+regression 判定和 3.3 的 suspect commits 能直接吃到权威版本序。
+
+### 3.2 关联提交(associate commits)
+
+**Sentry 做法**:`sentry-cli releases set-commits --auto VERSION`(自动取
+上一个 release 的 HEAD 到当前 HEAD 的 commit 区间,需要 repo 集成;无
+集成可 `--local` 读本地 git)或显式 `--commit "repo@from..to"`。解锁:
+suspect commits、commit message 里 `Fixes SENTRY-123` 自动关单、release
+间 diff 视图。
+
+**Hands 现状**:build 携带单个 `source_commit`(HEAD 指针),没有
+commit 区间、没有 repo 集成、没有 patch 数据。
+
+**差距:可后置**。有两个相邻 release 的 `source_commit`,commit 区间就是
+`from..to`,**不需要用户再跑任何命令**——这是 Hands 优于 Sentry 接入
+体验的机会点。但消费端(3.3)不存在之前,先把区间算出来没有用户价值,
+跟 3.3 绑定排期。
+
+### 3.3 Suspect commits(定位肇事提交)
+
+**Sentry 做法**:取 issue 堆栈的 in-app 帧,经 code mapping 把堆栈路径映射
+到仓库路径,查这些 文件+行 的 git blame,一年内且落在 release commit
+区间里的提交列为 suspect,展示在 issue 详情页(作者 + PR);开启
+"Auto-assign to suspect commits"后自动把 issue 指派给肇事作者(需作者
+是组织成员,手动指派过则不覆盖)。
+
+**Hands 现状**:无。但原材料链条几乎完整:crash 组有符号化后的
+文件+行号(Android/Electron)、build 有 `source_commit`、相邻 release
+可推区间;缺仓库访问(blame/diff)和路径映射。
+
+**差距:重要**。这是 crash 平台从"报警器"升级为"给出行动建议"的分水岭
+功能,也是 agent 场景的富矿(Hands 的 CLI/agent 定位:`hands crashes
+inspect` 直接给出 suspect commit,agent 可以顺着去开修复 PR)。最小
+实现:新组产生时,对 crash 帧文件在 `prev_release.source_commit..
+this_release.source_commit` 区间内跑 `git log -L`/diff 匹配,命中即在
+API/webhook 里附 `suspect_commits`。可以让用户在 CI 里用一条 CLI 子命令
+(能访问 git 的地方)完成计算再回传,避免服务端先做 repo 集成。
+
+### 3.4 Ownership rules / CODEOWNERS
+
+**Sentry 做法**:项目级规则 `type:pattern owners`(path/module/url/tags
+四类 matcher,owner 为邮箱或 `#team`),自底向上最后命中的规则生效;
+Business 档可导入 GitHub/GitLab CODEOWNERS(需 code mapping + 外部账号
+到 Sentry 用户/团队的映射,手写规则优先于 CODEOWNERS);命中者收告警、
+成为 suggested assignee,可开自动指派(一旦被指派过即不再自动改)。
+
+**Hands 现状**:无 ownership 概念;反馈工单有手动 assignee。
+
+**差距:可后置**。价值随团队规模增长,小团队全员看板即可。若做,Hands
+的形态应该更轻:crash webhook payload 里带命中规则的 owner 提示,由
+下游(飞书/agent)路由,而不是先建一套组织成员/团队体系。排在状态机
+(1.5)和 suspect commits(3.3)之后,后者到位时"指派给肇事作者"已经
+覆盖了 ownership 最常见的用途。
+
+### 3.5 Release adoption stages(采用度阶段)
+
+**Sentry 做法**:基于 session(用户态 session:前台启动到退后台 30s)算
+adoption = 该 release 的 session/用户 占近 24h 全部 release 的百分比;
+移动端单环境下每小时按 6 小时窗口重算阶段:**Adopted**(≥10% session)/
+**Low Adoption**(<10%)/ **Replaced**(曾 Adopted 后跌破 10%)。配套
+crash-free sessions / crash-free users 指标与阈值告警。
+
+**Hands 现状**:分发侧有权威数据(渠道、灰度比例、`hands` 更新器的下载/
+安装事实),但**无 session 上报**,crash-free rate 不可计算(见 README
+矩阵);24h 设备 ping 只能给出粗粒度活跃。
+
+**差距:重要(依赖 sessions)**。注意 Hands 的独特位置:Sentry 只能
+**观测**采用度,Hands **控制**采用度(灰度百分比是自己设的)。真正的
+杀手组合是"灰度 10% → 观测该 release 的 crash-free 指标 → 达标自动/
+建议放量"——这要求 session 数据,而 session 上报已是 roadmap 中四端
+共同的缺口。adoption stage 标签本身(Adopted/Replaced)对 Hands 意义
+不大(渠道状态已表达),要追的是 **crash-free rate per release**,并把
+它接进放量决策。
+
+---
+
+## 4. Environments(环境维度)
+
+**Sentry 做法**:SDK init 时设 `environment`(如 production/staging),
+事件带上后服务端自动建环境;环境是**全局切片维度**——issue 流、单个
+issue 的计数与趋势图、release(一个 release 可部署到多个环境,按环境看
+health)、告警规则、看板全部可按环境过滤。命名约束(≤64 字符、无空格/
+斜杠、不可叫 "None"),环境不可删只可隐藏(隐藏仍计配额)。
+
+**Hands 现状**:无环境维度。最接近的概念是渠道(channel),但渠道是
+**分发**维度(stable/beta 面向不同人群),不等于**部署**维度(同一个
+beta 包也分内部测试机和真实用户)。
+
+**差距:可后置**。理由:Hands 的客群以移动/桌面客户端为主,"环境"在
+客户端场景大部分被 渠道 + debug/release 构建类型覆盖,不像服务端
+(dev/staging/prod)那样是刚需。低成本版本:事件模型预留 `environment`
+字符串字段(SDK 可选设置,默认 production),crash 组计数按其可过滤——
+现在加字段便宜,以后补维度贵。完整的"全产品按环境切片"不追。
+
+---
+
+## Top-5 借鉴清单(按优先级)
+
+1. **Android Gradle 插件自动上传 mapping/native 符号**(2.3,关键)——
+   把 `publish-android --mapping/--symbols` 从"CI 手工拼路径"变成
+   `assembleRelease` 后自动执行,凭证走环境变量。符号覆盖率决定其余一切
+   的上限,Sentry 证明了"插件默认开"是唯一能到 ~100% 覆盖的路径。
+2. **iOS 服务端 dSYM 解析器 + 按 UUID/build-id 索引符号**(2.4 + 2.1,
+   关键)——dSYM 已在收、binary images 已在报,只差解析器;实现时直接按
+   debug-id 思路(UUID 精确匹配,build 关联作回退)建索引,一次把
+   Android/Electron 的符号匹配正确性也夯实。
+3. **组级状态机:resolved-in-release + 自动 regressed**(1.5,关键)——
+   利用 Hands 一等 release 对象的权威版本序做复发判定(比 Sentry 的
+   影子 release 更可靠),webhook 增加 `crash:regressed`;第二步补
+   archive-until(次数/用户数/escalating)。
+4. **Suspect commits(基于 `source_commit` 区间)**(3.3 + 3.2,重要)——
+   相邻 release 的 `source_commit` 天然给出 commit 区间,对 crash 帧文件
+   跑 blame/diff 匹配,结果进 `crashes inspect` 输出和 webhook payload;
+   这是 agent 自动修复闭环的关键输入。
+5. **SDK 端自定义 fingerprint + in-app 前缀配置**(1.3 + 1.2 子集,
+   重要)——事件模型加 `fingerprint` 数组(支持 `{{ default }}` 语义)+
+   per-app 的 in-app 包前缀配置,作为分组质量问题的逃生舱,让默认算法
+   不必一次做到完美。
+
+不追清单:release 创建/管理(Hands 已更强)、AI 相似度分组、完整
+ownership/CODEOWNERS 体系、source bundle(用 forge 深链替代)、issue
+优先级 ML、全产品环境切片。
+
+## 来源
+
+- 分组:docs.sentry.io/concepts/data-management/event-grouping/(含
+  fingerprint-rules、stack-trace-rules 子页)
+- 合并:docs.sentry.io/product/issues/grouping-and-fingerprints/
+- 状态/优先级:docs.sentry.io/product/issues/states-triage/、
+  /product/issues/issue-priority/
+- Debug ID:docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/debug-ids/
+- 符号工具链:docs.sentry.io/cli/dif/、/platforms/android/configuration/gradle/、
+  /platforms/apple/guides/ios/dsym/、/platforms/javascript/sourcemaps/、
+  /platforms/android/enhance-errors/source-context/
+- Release:docs.sentry.io/product/releases/(含 associate-commits、health)、
+  /product/issues/suspect-commits/、/product/issues/ownership-rules/
+- 环境:docs.sentry.io/concepts/key-terms/environments/

--- a/docs/sdk-parity/deep-mobile.md
+++ b/docs/sdk-parity/deep-mobile.md
@@ -1,0 +1,347 @@
+# 移动端深度监控对比：Sentry 机制 vs Hands SDK 现状
+
+任务 #120 追加深挖（2026-07-09）。逐机制对比 Sentry Android / Apple SDK 的实现深度
+与 Hands Android / iOS / OHOS SDK 的现状，给出差距分级：
+
+- **关键** — 不做就无法回答"这个版本崩不崩/卡不卡"这类核心问题
+- **重要** — 明显提升定位效率或数据可信度，应排入近期路线
+- **可后置** — 有价值但依赖前置能力（sessions/tracing），先欠着
+- **不追** — 与 Hands 定位（崩溃 + 反馈 + 分发）不匹配，或投入产出不成立
+
+Sentry 侧结论均已对照 docs.sentry.io / develop.sentry.dev 核实（见文末来源）。
+Hands 侧结论来自同日源码审计（[android.md](android.md) / [ios.md](ios.md) /
+[ohos.md](ohos.md)）。
+
+---
+
+## 1. Android
+
+### 1.1 ANR 检测
+
+**Sentry 机制**：双轨。
+- **v1（watchdog，Android < 11）**：SDK 内起看门狗线程，主线程阻塞超过
+  `anrTimeoutIntervalMillis`（默认 5s）即上报 `mechanism:ANR`。官方自述"基于启发式、
+  误报较多"，但能在 ANR 现场拿到截图/事务上下文。
+- **v2（ApplicationExitInfo，Android 11+，现为默认）**：下次启动时读系统
+  `ApplicationExitInfo`，异步上报 `mechanism:AppExitInfo`；只有
+  `getTraceInputStream()` 非空（即系统真实生成了线程转储）才上报，天然只统计
+  **致命 ANR**（导致进程被杀的），误报极低。最近一条会补挂 breadcrumbs/tags 等
+  scope 数据；`setReportHistoricalAnrs` 可回捞历史 ANR
+  （`mechanism:HistoricalAppExitInfo`）；`isAttachAnrThreadDump` 把系统线程转储
+  作为附件上传。前后台 ANR 分开统计；8.35+ 对"纯系统帧堆栈"的 ANR 做静态指纹
+  归并降噪。
+
+**Hands 现状**：完全没有 ANR 检测。有 JVM 崩溃时的全线程转储能力（说明拿主线程
+堆栈的基础设施已在），但没有 watchdog，也没读 `ApplicationExitInfo`。
+
+**差距：关键**。ANR 是 Android 上仅次于崩溃的稳定性信号，且 Google Play 以 ANR 率
+作为上架质量红线。ANRv2 路线对 Hands 极其友好：minSdk 24 但主力设备基本都是
+Android 11+，"下次启动读 `ApplicationExitInfo` + 上传系统 trace 文件"与 Hands 现有
+store-then-send 架构（写盘、下次启动上传）完全同构，不需要任何常驻监控线程。
+建议直接抄 v2、跳过 v1 watchdog。
+
+### 1.2 Native 崩溃（NDK / tombstone）
+
+**Sentry 机制**：`sentry-android-ndk` 打包 `sentry-native`，底层可选
+breakpad/crashpad 后端生成 **minidump**，信号处理链可配
+（`ndkHandlerStrategy` 决定与宿主已有 handler 的先后）；scope（breadcrumbs、
+tags、user）会同步到 native 层，崩溃报告里带上。符号化依赖 Gradle 插件自动上传
+`.so` 调试符号。8.32+ 新增 **Tombstone Integration**：直接经
+`ApplicationExitInfo` 读系统墓碑文件，作为 NDK 集成的替代或补充。
+
+**Hands 现状**：自研 `handscrash`（信号 ILL/TRAP/ABRT/BUS/FPE/SEGV），
+async-signal-safe 写 `.qnc`：信号、故障地址、**原始 PC 帧 + /proc/self/maps**，
+非 minidump。服务端凭 maps + so 符号可以解，但只有崩溃线程的 PC 链，没有寄存器
+全景/所有线程/内存片段。
+
+**差距：重要（非关键）**。Hands 已能捕获并解出主干堆栈，缺的是深度而不是有无。
+两条低成本增量：(a) 学 Sentry 8.32 的 tombstone 路线——Android 11+ 用
+`ApplicationExitInfo.getTraceInputStream()`（REASON_CRASH_NATIVE）把系统墓碑
+整文件带回，系统墓碑天然含全线程/寄存器/fd 表，比自己扩 `.qnc` 便宜得多；
+(b) 崩溃时把 JVM 侧 scope（设备上下文已有）合并进 native 报告。上 crashpad/
+minidump 属于大重构，可后置。
+
+### 1.3 App Start（冷/热启动插桩）
+
+**Sentry 机制**：冷启动 = 进程新建；热启动 = 其余（含后台返回、Activity 重建）。
+起点取进程 fork 时间（API 24+）或 `SentryPerformanceProvider` 创建，终点为首帧；
+产出 `app.start.cold` / `app.start.warm` span，挂在首个 `ui.load` 事务上；只统计
+前台启动。配套 TTID（`ui.load.initial-display`，自动）与 TTFD
+（`ui.load.full-display`，需 `reportFullyDisplayed()` 手动收口，25s 超时判
+DEADLINE_EXCEEDED）。
+
+**Hands 现状**：无任何性能插桩，也无事务/Span 模型。
+
+**差距：可后置**。价值真实（启动耗时是移动端第一性能指标），但它依赖 trace/span
+数据模型与后端聚合，Hands 当前连 sessions 都未闭环。若想先给个粗指标：在 SDK init
+时记进程启动到首帧的单个标量，随 24h ping 或 session 上报，不建 span 体系——
+够画启动耗时分布，成本 1/10。
+
+### 1.4 慢帧 / 冻结帧 / Frame Delay
+
+**Sentry 机制**：慢帧 = 渲染超过帧预算（60fps 即 16ms）；冻结帧 = 渲染 > 700ms；
+Frames Delay = 用户感知的总延迟时长（例：60fps 下两帧各花 20ms → delay =
+2×(20-16) = 8ms）。指标挂在 Activity 事务上（Android 7+），在 Mobile Vitals 面板
+按屏幕聚合。
+
+**Hands 现状**：无。
+
+**差距：可后置**。同 1.3，依赖事务体系；且帧指标离"崩溃 + 反馈"主线最远。
+在 sessions 与 ANR 落地前不动。
+
+### 1.5 用户交互事务 + Activity/Fragment 自动插桩
+
+**Sentry 机制**：Activity 生命周期自动开 `ui.load` 事务（onCreate 前开始、首帧后
+结束）；Fragment 作为子 span；用户交互（点击/滚动/滑动）开 `ui.action.*` 事务，
+命名 `Activity.view_id`，idle 3s / deadline 30s 自动收口；Compose 需
+`Modifier.sentryTag()` 或编译器插件。另有 OkHttp / Room / File I/O 的字节码级
+span 插桩。
+
+**Hands 现状**：无。
+
+**差距：不追（作为事务）/ 可后置（作为面包屑）**。完整 UI 事务体系是 Sentry
+tracing 产品的一部分，Hands 不做 APM，不值得追。但其中一个子集非常值得借：
+把 Activity 生命周期与点击事件记成**面包屑**（breadcrumbs 本身已是 Hands P1 项），
+崩溃/ANR 报告里"用户最后点了什么、在哪个页面"是排障第一问。
+
+### 1.6 出错截图 + 视图层级附件
+
+**Sentry 机制**：`attachScreenshot`（opt-in，明确因 PII 风险）：错误/崩溃事件
+best-effort 抓屏，2 秒去抖，`BeforeCaptureCallback` 可按事件级别过滤；运行时若
+没有 replay 的 masking 模块则**整体跳过**以防泄敏。`attachViewHierarchy`
+（opt-in）：view 树 JSON（alpha/visible/x/y/w/h/type/id），同样 2 秒去抖，
+服务端有树状 + 线框交互查看器。
+
+**Hands 现状**：无截图、无视图层级。但反馈工单链路已有 ≤200MB 附件通道。
+
+**差距：重要**。对 Hands 是顺势能力：附件管道现成，服务端只需存展。优先做在
+**反馈工单**上（用户主动提交，无 PII 顾虑，价值最高），其次才是 crash 事件的
+自动抓屏（需要 masking 方案，谨慎）。view hierarchy JSON 成本极低，可与截图同批。
+
+---
+
+## 2. iOS / Apple
+
+### 2.1 崩溃捕获内核（Mach 异常 + 信号 + KSCrash 血统）
+
+**Sentry 机制**：内核是 **SentryCrash**——KSCrash 的源内 fork。同时挂
+**Mach 异常端口**、BSD 信号处理器、C++ terminate handler、NSException
+uncaughtExceptionHandler 四层；崩溃路径全程 async-signal-safe（不 malloc、
+不发 ObjC 消息），报告写盘、**下次启动**反序列化后补 scope 再发送。Mach 层能接住
+纯信号处理器接不住的场景（如栈溢出时信号处理器自身没栈可用——Mach 异常在独立
+线程处理）。
+
+**Hands 现状**：仅 NSException handler + BSD 信号处理器；只抓**崩溃线程**且
+≤64 帧；带 binary images 供服务端 dSYM 符号化（解析器未建成）。无 Mach、无
+C++ terminate、无全线程转储。
+
+**差距：关键**。两点实质缺口：(a) 无 Mach 异常层意味着一类崩溃（栈溢出、部分
+EXC_BAD_ACCESS 形态）整体漏采；(b) 只有崩溃线程堆栈，主线程死锁类问题看不到
+全景。自研补齐 Mach + async-signal-safe 全线程回溯的工程量非常大（这正是 KSCrash
+存在的理由）；务实路线是评估直接引入/裁剪 KSCrash（MIT），Hands 只做报告格式
+与上传层。同时优先把服务端 dSYM 解析器建起来——现在客户端已上报 binary images
+却无人消费。
+
+### 2.2 Watchdog Termination（0x8badf00d 类）
+
+**Sentry 机制**：纯启发式，8.0 前叫 "Out of Memory tracking"。原理是下次启动时
+**排除法**：上次运行不是崩溃、没接调试器、非模拟器、系统/应用没升级、不是用户
+手动杀、不是 App Hang——全部排除后判定为 watchdog 终止（含 OOM 与
+0x8badf00d 超时被杀，SDK 无法区分二者，故改名）。因为系统杀进程不给任何通知，
+**拿不到堆栈**；breadcrumbs 靠平时追加写盘的文件在下次启动时恢复。
+`enableWatchdogTerminationTracking` 控制开关。
+
+**Hands 现状**：无。iOS SDK 不做任何"上次为何退出"的推断。
+
+**差距：重要**。OOM/看门狗被杀在重 App 上占非崩溃退出的大头，且用户感知等同
+闪退。实现成本低（一个启动状态机 + 几个持久化标记位），不需要新采集面；难点只在
+排除法的每个分支都要做对，否则误报（Sentry 也承认这是启发式）。建议在 sessions
+落地时一并做——session 的 abnormal 终态与 watchdog 判定共享同一套"上次运行
+状态"存储。
+
+### 2.3 App Hangs（v1 / v2）
+
+**Sentry 机制**：`io.sentry.AppHangTracker` 线程周期性向主线程投递工作项，超时
+（`appHangTimeoutInterval` 默认 2s，判定窗口 7.24 起为 1.2×）未执行即为 hang。
+**v2（9.0 起默认）**区分 **Fully Blocked**（一帧都渲染不出）与 **Non Fully
+Blocked**（还能渲染少量帧），并报告**实际卡顿时长**；hang 期间被用户/看门狗杀掉
+则下次启动报 **Fatal App Hang**。已知限制：主线程忙于多处代码时堆栈可能采偏。
+
+**Hands 现状**：无。
+
+**差距：关键**。与 Android ANR 同一优先级——卡死是移动端第二大稳定性信号，
+且 Fatal App Hang 与 2.2 的 watchdog 判定互为兄弟（Sentry 明确把 hang 从
+watchdog 排除法中拆出来单报）。最小实现：单看门狗线程 + 主线程 ping + 采样
+全线程堆栈，先做 v1 语义（有/无 hang），时长与 blocked 细分后补。
+
+### 2.4 MetricKit 集成
+
+**Sentry 机制**：`enableMetricKit` 接入 MXMetricManager，消费
+**MXHangDiagnostic / MXCPUExceptionDiagnostic / MXDiskWriteExceptionDiagnostic**
+三类系统诊断（iOS 15+ 才即时投递，故设此下限），转成 Sentry 事件
+（mechanism `mx_hang_diagnostic` 等）；`enableMetricKitRawPayload` 可附原始
+JSON。堆栈完整度参差，官方建议不满意就 beforeSend 过滤。
+
+**Hands 现状**：无。但已有 diagnostics-provider 文件附件钩子——宿主可塞任意
+诊断文件。
+
+**差距：重要，且是性价比最高的一项**。MetricKit 是苹果官方免费数据源：不用自己
+起任何监控线程就能拿到系统视角的 hang / CPU 异常 / 磁盘写异常（含系统采的调用
+树）。对 Hands 尤其合适：在 2.3 自研 hang 检测成熟前，MetricKit 可以先把 hang
+可见性从 0 拉起来。实现是薄适配层（订阅 + payload 转发），甚至可先走现有
+diagnostics-provider 通道原样上传 JSON、服务端解析。
+
+### 2.5 App Start / TTID / TTFD / 帧指标 / 预热启动
+
+**Sentry 机制**：把启动切成五个 span（Pre Runtime Init → Runtime Init →
+UIKit Init → Application Init → Initial Frame Render），挂到首个 `ui.load` 事务
+（>5s 则丢弃防污染）。iOS 15+ 系统**预热**（`ActivePrewarm`）会使"进程创建时间"
+失真，SDK 检测到预热则裁掉前两个 span、改从用户点图标起算，并打
+`cold.prewarmed` / `warm.prewarmed` 标。TTID 自动、TTFD 手动
+（`reportFullyDisplayed()`，30s 超时）。慢帧/冻结帧同 Android 定义，经
+CADisplayLink 统计。UIViewController 自动开 `ui.load` 事务。
+
+**Hands 现状**：无。
+
+**差距：可后置**。同 1.3/1.4：依赖事务模型。唯一值得现在记下的教训是
+**prewarming 陷阱**——将来做启动耗时哪怕是标量版，也必须检查
+`ActivePrewarm` 环境变量，否则冷启动数据整体虚高到不可用。
+
+### 2.6 截图 + 视图层级（iOS）
+
+**Sentry 机制**：与 Android 对称（`attachScreenshot` / `attachViewHierarchy`，
+opt-in，去抖）。崩溃事件本身抓不了（进程正在死），主要覆盖错误/hang 类事件。
+
+**Hands 现状**：无。
+
+**差距：重要**。同 1.6，随反馈工单先行。
+
+---
+
+## 3. 双端共性
+
+### 3.1 离线缓存（envelope 落盘重发）
+
+**Sentry 机制**：所有遥测统一打包为 envelope，先写 `cacheDirPath` 再发；
+`maxCacheItems`（默认 30）超限删最旧，且删除前会把其中的 session 迁移到下一个
+envelope 以保 release health 统计完整；离线时下次启动补发。
+
+**Hands 现状**：崩溃链路本就是 store-then-send（这点方向正确且与 Sentry 同构），
+但**保留数 5**且仅覆盖崩溃；反馈/统计不走此通道；没有"删除时保护会话统计"之类
+的完整性语义。
+
+**差距：重要**。不是从 0 到 1，而是把崩溃专用的落盘队列泛化成 SDK 统一出口
+（崩溃、ANR、session、未来的 hang 全走一个盘上队列），保留数提到 ~30，并在
+session 数据加入后实现"驱逐不丢会话计数"。这是 3.2 的地基。
+
+### 3.2 会话跟踪（30s 前后台阈值）
+
+**Sentry 机制**：`enableAutoSessionTracking` 默认开。进前台开 session，退后台
+超过 `sessionTrackingIntervalMillis`（默认 **30s**）判定 session 结束；30s 内
+回前台算同一 session。终态四种：healthy / errored（有 handled error 但正常退出）/
+crashed（未处理崩溃）/ abnormal（SDK 无法判断是否体面退出——OOM、被杀等落
+此桶）。session 随 envelope 上报。
+
+**Hands 现状**：SDK 无 session 概念（只有 24h 设备 ping）。服务端 sessions
+端点**刚上线**，SDK 挂钩未做。
+
+**差距：关键（当前第一优先级）**。没有 session 分母，crash-free rate 无法计算，
+所有稳定性指标都是绝对数而非比率，跨版本不可比。服务端已就绪，SDK 侧就是
+生命周期钩子 + 30s 计时器 + 崩溃标记回写（下次启动把上个 session 改判
+crashed/abnormal）。注意 abnormal 桶要与 2.2 watchdog / 1.1 ANRv2 的"上次退出
+原因"共享判定，否则口径打架。
+
+### 3.3 Release Health 指标（服务端/UI）
+
+**Sentry 机制**：crash-free sessions %（区间内未以崩溃结束的 session 占比）、
+crash-free users %（未遇崩溃的独立用户占比）、adoption 阶段（Adopted ≥10%
+session 量 / Low Adoption / Replaced，6 小时滚动窗口每小时更新）、活跃用户
+（24h 内启动过）、session 时长分布。
+
+**Hands 现状**：服务端 sessions 端点已通，聚合指标与 UI 未建。
+
+**差距：关键（随 3.2 联动）**。Hands 的差异化是"发布平台自带质量门禁"：
+crash-free rate × 现有**灰度放量**（hash bucketing）= "崩溃率超阈值自动停止
+放量"，这是 Sentry 做不到的组合（Sentry 无分发能力）。指标口径直接抄 Sentry
+定义即可，别自创。
+
+### 3.4 OOM / 异常退出全景
+
+**Sentry 机制**：iOS 走 2.2 的 watchdog 启发式（OOM 与超时被杀合并上报）；
+Android 走 `ApplicationExitInfo`，exit reason 天然区分 ANR / CRASH /
+CRASH_NATIVE / LOW_MEMORY 等。
+
+**Hands 现状**：两端均无"上次为何退出"的任何推断。
+
+**差距：重要**。Android 侧做 1.1 时顺手就有（同一个 API 的不同 reason 分支）；
+iOS 侧即 2.2。
+
+---
+
+## 4. 移动端 Session Replay
+
+**Sentry 机制**：Android / iOS 原生 + React Native + Flutter 均已 GA。实现是
+**每秒一次的视图层级快照 + 同帧截图**（非录像；屏幕无变化不抓），Android 提供
+PixelCopy（默认，开销低、遮罩可能错位）与 Canvas（实验，遮罩可靠、开销略高、
+不支持细粒度遮罩配置）两种策略。隐私默认极激进：**所有文本、图片、输入默认
+遮罩**，"敏感数据不出设备"。采样双旋钮 `sessionSampleRate` /
+`onErrorSampleRate`（错误触发型回溯缓冲 1 分钟）。性能口径为"对多数应用终端
+用户无感知"，但官方自己标注测试"并不彻底"、复杂应用可能受影响。
+
+**Hands 现状**：无，三端皆无。
+
+**差距：不追（本阶段）**。理由：(a) 工程量是本清单里最大的（逐帧抓取、端上
+遮罩引擎、录像回放服务端）；(b) 强 PII 敏感，Hands 的 To B 分发场景（含华为
+生态客户）对"抓用户屏幕"极其保守；(c) 其 80% 排障价值可用 1.6/2.6 的
+"错误时单张截图 + view hierarchy"以 5% 成本获得。保留观察，等崩溃/会话/卡顿
+三大件闭环后重估。
+
+---
+
+## 5. OHOS 快评
+
+OHOS SDK 仅 ArkTS `errorManager`（JS 未捕获异常），上表所有机制均缺。但鸿蒙
+系统侧有现成对应物，追赶路径与 Android ANRv2 同构（读系统数据而非自建监控）：
+`hiAppEvent` 订阅系统 APP_CRASH / APP_FREEZE（≈ANR）/ RESOURCE_OVERLIMIT
+（≈OOM）事件，`faultLogger` 拉取 native 崩溃与冻结日志。优先级：hiAppEvent
+订阅（关键，等效于一次拿到崩溃+卡死+OOM 三件套）> session 钩子（关键，随 3.2
+三端同做）> 其余可后置。
+
+---
+
+## Top-5 借鉴清单（按投入产出排序）
+
+1. **会话跟踪 SDK 钩子（三端）** —— 前后台 + 30s 阈值 + 崩溃回写，照抄 Sentry
+   四终态口径；服务端已就绪，这是解锁 crash-free rate 和"灰度自动熔断"的唯一
+   阻塞项。（对应 3.2/3.3）
+2. **Android ANRv2：`ApplicationExitInfo` 消费器** —— 下次启动读 exit reasons +
+   `getTraceInputStream()` 附系统 trace；一个 API 同时拿到 ANR、native 崩溃
+   墓碑（1.2 的 tombstone 路线）和 LOW_MEMORY，零常驻开销，与 Hands
+   store-then-send 架构天然契合。（对应 1.1/1.2/3.4）
+3. **iOS MetricKit 薄适配** —— `MXMetricManager` 订阅 hang / CPU / 磁盘写诊断，
+   先经现有 diagnostics-provider 通道上传原始 JSON；以最小成本把 iOS 卡顿
+   可见性从 0 拉起，为自研 App Hangs 争取时间。（对应 2.4/2.3）
+4. **iOS 崩溃内核补强** —— 评估引入 KSCrash（或裁剪版）补 Mach 异常层 + 全线程
+   async-signal-safe 转储；同期把服务端 dSYM 解析器建成（客户端 binary images
+   已在白白上报）。（对应 2.1）
+5. **错误/反馈截图 + view hierarchy 附件** —— 复用现有 200MB 附件管道，抄
+   Sentry 的 opt-in + 2s 去抖 + before-capture 过滤模型；先反馈工单后崩溃事件。
+   这是对 Hands"反馈强于 Sentry"这一护城河的直接加固。（对应 1.6/2.6）
+
+---
+
+## 来源（均于 2026-07-09 核实）
+
+- Sentry Android ANR: <https://docs.sentry.io/platforms/android/configuration/app-not-respond/>
+- Sentry Android 自动插桩（App Start/TTID/TTFD/交互/Activity/Fragment）: <https://docs.sentry.io/platforms/android/tracing/instrumentation/automatic-instrumentation/>
+- Sentry Android NDK / Tombstone: <https://docs.sentry.io/platforms/android/configuration/using-ndk/>
+- Sentry Android 截图 / 视图层级: <https://docs.sentry.io/platforms/android/enriching-events/screenshots/> · <https://docs.sentry.io/platforms/android/enriching-events/viewhierarchy/>
+- 慢帧/冻结帧/Frames Delay 定义: <https://develop.sentry.dev/sdk/telemetry/traces/frames-delay/> · <https://docs.sentry.io/product/insights/mobile/mobile-vitals/>
+- Sentry iOS App Hangs (v1/v2/Fatal): <https://docs.sentry.io/platforms/apple/guides/ios/configuration/app-hangs/>
+- Sentry iOS Watchdog Terminations: <https://docs.sentry.io/platforms/apple/guides/ios/configuration/watchdog-terminations/>
+- Sentry iOS MetricKit: <https://docs.sentry.io/platforms/apple/guides/ios/configuration/metric-kit/>
+- Sentry iOS 自动插桩（启动 span/预热/TTID/TTFD/帧）: <https://docs.sentry.io/platforms/apple/guides/ios/tracing/instrumentation/automatic-instrumentation/>
+- SentryCrash/KSCrash 与信号处理: <https://develop.sentry.dev/sdk/platform-specifics/native-sdks/signal-handlers/> · <https://github.com/getsentry/sentry-cocoa>
+- 会话跟踪 / Release Health: <https://docs.sentry.io/platforms/android/configuration/releases/> · <https://docs.sentry.io/product/releases/health/>
+- 离线缓存: <https://docs.sentry.io/platforms/android/configuration/options/>
+- 移动端 Session Replay: <https://docs.sentry.io/product/explore/session-replay/mobile/> · <https://docs.sentry.io/platforms/android/session-replay/>

--- a/docs/sdk-parity/deep-product-surface.md
+++ b/docs/sdk-parity/deep-product-surface.md
@@ -1,0 +1,321 @@
+# Sentry 产品面深度对比：告警 / 集成 / 仪表盘 / 配额 / 反馈 / AI
+
+对 Sentry 2025–26 产品面(以 docs.sentry.io 为准逐项核实,2026-07-09)与
+Hands 服务端现状的逐域对比。SDK 层对比见 [README.md](README.md) 及各平台
+文件;本文只覆盖**服务端产品面**:告警、集成、仪表盘/查询、配额、用户反馈、
+AI 能力。
+
+评级:**关键**(不做会流失核心场景)/ **重要**(明显差距,应排期)/
+**可后置**(有价值但不紧急)/ **不追**(与我们的模型不符,或我们的路线更优)。
+
+**总立场**:Sentry 的告警/集成体系本质是"把信号推给人,再让人去各个工具里
+操作"。Hands 的差异化是 **agent-native**:信号直接进到 AI agent 的工作环境
+(CLI/API,Raft/Slock 聊天即席),由 agent 完成分诊甚至修复。所以很多领域
+我们不该抄 Sentry 的"人肉 UI",而是补齐**信号生成层**(规则、阈值、聚合),
+把"消费层"留给 agent。
+
+---
+
+## 1. 告警(Alerting)
+
+### Sentry 机制
+
+Sentry 2025 年底把告警重构为 **Alerts + Monitors** 双层模型
+(<https://docs.sentry.io/product/alerts/>,
+<https://docs.sentry.io/product/monitors-and-alerts/monitors/>):
+
+- **Alerts(原 issue alerts)**——基于 issue 状态的规则引擎:
+  - **触发器(when)**:全部基于 issue 状态变化——新 issue 创建、被指派、
+    升级(escalates)、resolved→unresolved 回归等;多触发器为 ANY 逻辑。
+  - **过滤器(if)**:severity、指派团队、来源项目/monitor 等,支持
+    ANY/ALL 分组。
+  - **动作(then)**:聊天通知(Slack/Teams/Discord)、邮件、on-call
+    (PagerDuty/Opsgenie)、建单(Jira/Azure DevOps/Linear)、webhook、
+    自定义集成。经典配置里还有"动作频率上限"(同一 issue 最多每 N 分钟
+    执行一次动作),这是防噪的核心旋钮。
+  - 规则按项目配置,可限定 environment,默认跨全部环境。
+- **Monitors(原 metric alerts + crons + uptime)**——周期评估数据流并
+  **生成 issue**(再由 Alerts 层通知):
+  - **Metric Monitors**:对 errors、spans、logs、releases、应用指标设阈值
+    (如 crash rate > 1%),可配检查间隔、优先级、auto-resolve、按
+    ownership 规则自动指派。
+  - **检测方式三种**:固定阈值、百分比变化(相对历史基线)、
+    **动态/异常检测**——用 Matrix Profile + Prophet 两个开源算法学习
+    季节性(昼夜/工作日)与长期趋势,阈值由 Sentry 托管不可手调,只暴露
+    低/中/高三档"响应度";仅 Business/Enterprise/Trial 可用
+    (<https://blog.sentry.io/anomaly-alerts-open-beta-smarter-monitoring-fewer-false-alarms/>)。
+  - **Cron Monitors**(check-in 宽限、最大时长、失败容忍)与
+    **Uptime Monitors**(HTTP 探测)。
+  - 内置默认 monitor(Issue Stream / Error Monitor)开箱即用。
+- 注意:计费侧的 **spike protection 不是告警功能**,是配额保护(见 §4);
+  但"事件量异常上涨"这个用户诉求,Sentry 靠 anomaly-detection monitor 覆盖。
+
+### Hands 现状
+
+- 只有 **webhooks**:`crash:new_group`、`crash:spike` 两个事件类型 +
+  投递记录/清理(reaping)管理端。没有规则 UI、没有 environment/严重度
+  过滤、没有频率上限旋钮、没有指标阈值(crash-free rate 目前因 SDK 无
+  session 采集而算不出,见 README)。
+- `crash:spike` 说明我们已有最朴素的量突增检测,但无基线学习、无季节性。
+
+### 差距:**关键**(信号生成层)/ **可后置**(规则 UI)
+
+- **关键**的是"可配置的信号生成":哪怕消费端全是 agent,agent 也需要
+  服务端先产出**语义化事件**——新组、回归(resolved→unresolved)、量级
+  升级、阈值越界。这层不做,agent 只能轮询原始数据自己算,浪费且不实时。
+  最小集:① 回归检测(resolve 后再现即触发,Sentry 触发器里最有价值的
+  一个);② 阈值规则(表驱动即可:指标 + 窗口 + 阈值 → webhook);
+  ③ 每规则频率上限(防噪,Sentry 经验证明这是必需品)。
+- **可后置**:告警规则的图形化 UI。我们的消费者是 agent 和 CLI 用户,
+  规则用 CLI/API/配置文件表达反而更顺(版本可控、可 review),这正是
+  agent-native 优于 Sentry 表单式规则编辑器的地方。
+- **可后置**:Prophet 级异常检测。自托管、单租户、数据量小,先做
+  "7 天同时段均值 × 系数"的轻量基线即可覆盖 80% 场景;Sentry 也是先有
+  固定阈值多年后才补异常检测。
+- **不追**:Uptime/Cron monitors——不是崩溃平台的本职,Slock 生态另有位置。
+
+---
+
+## 2. 集成(Integrations)
+
+### Sentry 机制
+
+- **聊天(notify + act)**(<https://docs.sentry.io/organization/integrations/notification-incidents/slack/>):
+  Slack 通知卡片上可直接 **Resolve / Archive / Assign**,`/sentry link`
+  绑定个人账号收工作流通知,团队频道订阅,metric issue 带历史图表并在
+  thread 里更新状态,链接自动 unfurl;2025–26 新增 **@sentry 唤起 Seer
+  Agent 在 Slack 里直接调试**、Seer 开启时可从 Slack 触发"Fix"。
+  Discord/Teams 同类但略弱。
+- **issue 同步**(<https://docs.sentry.io/organization/integrations/issue-tracking/>):
+  Jira/Linear/GitHub/GitLab/Azure DevOps/Bitbucket + 十余家小厂;以
+  GitHub/Jira 为例是**双向同步**:指派、评论、状态(对端关单 → Sentry
+  resolve),支持用户映射;可手动关联或由告警动作自动建单。
+- **on-call**:PagerDuty/Opsgenie 作为告警动作,分级(critical/warning)
+  路由。
+- **VCS(GitHub 为例)**(<https://docs.sentry.io/organization/integrations/source-code-mgmt/github/>):
+  - **commit 追踪 → suspect commits**:分析 stack trace 中文件的最近改动,
+    commit 作者自动成为建议指派人;
+  - commit/PR message 写 `fixes <SHORT-ID>`,随 release 发布即自动 resolve;
+  - **stack trace linking**:code mapping 把栈帧文件链到仓库对应行
+    (出错时的精确版本或默认分支);
+  - **CODEOWNERS 导入**自动指派与路由(Business+);
+  - **PR comments**:Sentry 主动在 PR 上评论——疑似引入 issue 的已合并
+    PR、以及开放 PR 所触碰文件上的未解决 issue。
+
+### Hands 现状
+
+- 无任何 chat-ops 集成;无 issue tracker 同步;无 VCS 集成(无 commit
+  追踪、无 suspect commit、无栈帧链接)。
+- 但:**Raft/Slock 聊天平台是我们的原生栖息地**。Sentry 花大力气把自己
+  "嵌进" Slack;我们的 agent 本来就活在 Raft 对话里,通过 CLI/API 直接
+  读写 crash 组和 feedback 工单——"在聊天里 resolve" 对我们不是集成,
+  是本体。
+
+### 差距:**关键**(Raft 集成 + suspect commit)/ **重要**(issue 同步)
+
+- **关键:Raft 原生集成**。把 webhook 事件接入 Raft 频道(新组/回归/
+  尖峰卡片,附 agent 可执行的动作清单),等价于 Sentry 的 Slack 集成但
+  **更进一步**:Sentry 在 Slack 里只有固定按钮 + 刚起步的 Seer Agent,
+  我们频道里坐着的是全功能 agent,能查符号化栈、翻设备分布、改状态、
+  开工单、甚至提修复 PR——这是我们**领先而非追赶**的一域,应最优先做实。
+  (参照 slock-agent-manifest 的 actions[] 模式暴露可调用动作。)
+- **关键:suspect commit(轻量版)**。这是 Sentry VCS 集成里对分诊增益
+  最大的一项,而且对 agent 消费尤其有价值:agent 拿到"疑似引入提交 +
+  作者"后可以直接去读 diff。最小实现:上传 release 时带 commit SHA
+  (CLI 已在发布链路上,顺手),服务端对栈帧文件做 `git log` 归因。
+- **重要:GitHub/Gitea issue 单向建单 + 状态回写**(从 crash 组/feedback
+  工单建 issue,对端关闭时回写)。双向评论同步可后置。
+- **重要:stack trace → 仓库行链接**(release 带 SHA 后近乎免费,agent
+  与人都受益)。
+- **可后置**:PR comments(需要 GitHub App 常驻,收益在团队规模大时才
+  显现);CODEOWNERS 自动指派。
+- **不追**:PagerDuty/Opsgenie、Slack/Teams/Discord 官方集成矩阵。webhook
+  已是通用逃生门,on-call 编排交给下游;我们的重心是 Raft。
+
+---
+
+## 3. 仪表盘 / Discover 查询
+
+### Sentry 机制
+
+- **Discover**(<https://docs.sentry.io/product/explore/discover-queries/>):
+  跨项目的事件查询引擎——自选列 + 聚合、搜索语法、图表/表格/tag 汇总,
+  预置查询(All Events / Errors by Title / Errors by URL),**保存查询**
+  为组织级、可分享 URL、可嵌入 dashboard;正逐步被新的 Explore/Trace
+  Explorer 取代。issue 流另有**saved searches**。
+- **Dashboards**(<https://docs.sentry.io/product/dashboards/>):
+  widget 化(表格/时序图/大数字),可画错误、性能、Web Vitals、session
+  健康;全局过滤(项目/环境/时间/release);预置模板(前端/后端/移动/AI)
+  + 自定义;2025–26 起支持**自然语言 AI 生成 dashboard**、编辑历史与回滚;
+  widget 可下钻回 Discover/Issues。
+
+### Hands 现状
+
+- 管理端有**设备/版本分析仪表盘**(固定视图),无自定义查询、无保存
+  搜索、无 widget 化 dashboard。
+- 但 agent 通过 CLI/API 可以拿到原始数据自行聚合——Sentry 用户要靠
+  Discover UI 回答的问题("这个错误集中在哪个版本/机型?"),我们的
+  用户直接**问 agent**,agent 现查现答并给出解释。
+
+### 差距:**重要**(查询 API)/ **不追**(dashboard builder)
+
+- **重要:结构化查询/聚合 API**。agent 替代的是 Discover 的 *UI*,替代
+  不了 *查询引擎*——目前 agent 只能拉列表自己数,数据量一大就不可行。
+  需要一个 `group by X, filter Y, count/uniq over 时间窗` 的服务端聚合
+  端点(D1 上做物化或直接 SQL)。这同时是未来一切告警阈值、分析视图的
+  地基。**Sentry 的 AI 生成 dashboard 恰好佐证了我们的判断:连 Sentry
+  都承认自然语言才是查询的正确入口——而我们全平台本来就是这个入口。**
+- **可后置**:保存查询(agent 侧记在 memory/脚本里即可;等有 Web 端
+  多人共享需求再做服务端保存)。
+- **不追**:widget/dashboard builder、拖拽编辑器。固定管理端视图 +
+  agent 即席查询覆盖需求;做 builder 是给自己造 Sentry 的包袱。
+
+---
+
+## 4. 配额 / 尖峰保护 / 保留期
+
+### Sentry 机制
+
+- **配额**(<https://docs.sentry.io/pricing/quotas/>):按类别计量
+  (errors/spans/replays/logs/attachments),预留量 + **pay-as-you-go
+  预算**;管理手段分层:spike protection → 配额调整 → rate limit /
+  inbound filter → SDK 采样(`beforeSend`、sample rate)。
+- **Spike protection**(<https://docs.sentry.io/pricing/quotas/spike-protection/>):
+  动态算法按项目建阈值——取"配额推导的最小事件数"与"过去 168 小时
+  加权投影(含日/时季节性)"中较高者,尖峰期间每小时重算;触发后对
+  项目动态限流丢弃事件,24–48h 衰减回落;通知默认关闭,可发
+  email/Slack/PagerDuty。
+- **Per-key rate limit**(<https://docs.sentry.io/pricing/quotas/manage-event-stream-guide/>):
+  每项目多把 DSN key,各配独立限流(分/时/天粒度),超限回 429 +
+  `Retry-After`,客户端应丢弃不重试;Business+ 才有。
+- **Inbound filters**:限流与计量之前的服务端过滤(浏览器扩展、
+  localhost、老浏览器、爬虫;IP/release/错误消息过滤要 Business+)。
+- **保留期**(<https://docs.sentry.io/security-legal-pii/security/data-retention-periods/>):
+  事件 **90 天**(免费计划 30 天),到期删除事件,组内事件全删则 issue
+  一并删除;附件 30/90 天,debug 文件 90 天 TTI。**90 天是硬顶,不可
+  付费延长**——这是用户对 Sentry 的长期抱怨点。
+
+### Hands 现状
+
+- 自托管、自有基础设施,**无配额、无计费**;保留期无上限(D1/R2)。
+- 无 ingest 侧限流、无 inbound filter;`crash:spike` webhook 提供告知
+  但不限流。
+
+### 差距:**重要**(ingest 自保护)/ **不追**(计费配额)
+
+- **不追**:计费配额、pay-as-you-go、spike protection 的"省钱"语义——
+  那是 SaaS 多租户计费的产物,与自托管模型无关。
+- **重要:ingest 自保护限流**。动机不同但机制要有:一个 SDK bug 或
+  崩溃风暴可以打爆 D1/Workers 或刷满 R2。最小集:每 app(或每 key)
+  的滑动窗口限流 + 429,以及服务端丢弃计数(可观测被丢了多少)。
+  Sentry 的经验(429 + 不重试、限流在计量之前)可直接抄。
+- **可后置**:inbound filter(按版本/消息/设备过滤噪声源)——量大后
+  再做;分级存储/归档(热 D1 冷 R2)——真到规模再说。
+- **领先项**:**保留期无限**是我们相对 Sentry 90 天硬顶的直接卖点,
+  文档和营销里应明说。
+
+---
+
+## 5. 用户反馈(User Feedback)
+
+### Sentry 机制
+
+(<https://docs.sentry.io/product/user-feedback/>)
+
+- **常驻 widget**:网页任意处嵌入,收文字 + 截图 + email,自动关联
+  session replay(前 60 秒)与页面 URL。
+- **Crash-report modal**:报错后自动弹出,反馈**直接挂在错误事件上**,
+  面板里可预览并跳转对应 issue。
+- 反馈可一键建/关联外部 issue(GitHub/Jira,自动填标题描述)。
+- **AI 汇总**:归纳共性情绪、自动打分类标签供过滤。
+- **ML 反垃圾**:疑似 spam 移入单独文件夹并抑制其告警。
+- 可对新反馈配告警(通知或自动建单)。
+
+### Hands 现状
+
+- 反馈工单是**一等公民**且强于 Sentry:状态流转、指派、评论、≤200 MB
+  附件(截图/日志),CLI/agent 直接分诊——Sentry 的 feedback 只是挂在
+  issue 侧的轻量列表,没有工单生命周期。README 已将其列为护城河。
+- 缺:反馈与 crash 组的**自动关联**(crash 后引导提交、提交时带上
+  最近 crash/事件 ID);无 AI 汇总/去重;无反垃圾(自托管场景暂不痛)。
+
+### 差距:**重要**(crash↔feedback 关联)/ **可后置**(其余)
+
+- **重要:crash-linked feedback**。Sentry 这招把"用户说的"和"机器
+  看到的"接在一起,是 crash 分诊质量的倍增器。我们 SDK 已同时有 crash
+  与 feedback 两条通道,补一个"crash 后提示反馈 + 工单携带 crash 组
+  引用"的闭环成本低、收益高;工单 ↔ crash 组的双向引用也让 agent 分诊
+  时能一次拿全上下文。
+- **可后置**:AI 汇总/自动分类——我们的 agent 分诊本来就在做这件事,
+  且是即席、带追问的,比 Sentry 的静态标签强;只在工单量大到 agent
+  逐条看不过来时,才值得做服务端预聚合。
+- **不追**:ML 反垃圾(自托管 + 实名分发渠道,垃圾反馈不是威胁模型)。
+
+---
+
+## 6. Seer / AI 能力(2025–26 现状)
+
+### Sentry 机制
+
+(<https://docs.sentry.io/product/ai-in-sentry/seer/>)
+
+- **Autofix + 根因分析**:issue 进入时自动判断可否分析,结合代码上下文
+  与遥测在 issue 页给出初步判断;可继续生成修复 PR/MR(GitHub/GitLab
+  云版),支持自然语言补充上下文。
+- **外部 coding agent 委托**:Seer 做完根因与方案后,可把落地实现交给
+  Claude Code、Cursor Cloud Agents、GitHub Copilot。
+- **Seer Agent(open beta)**:跨错误/span/日志/trace/代码的交互式问答,
+  可在 Slack 里 @sentry 唤起,对话线程可分享。
+- **AI Code Review**:在 PR 上预测缺陷。
+- issue summaries、AI 生成 dashboard、feedback AI 汇总散布各产品面。
+- 商业化:付费 add-on,按"活跃贡献者"计费(当月在启用项目建 ≥2 个
+  PR 即计费);默认不用客户数据训练模型。
+
+### Hands 现状
+
+- 平台自身无内置 AI,但**架构即 AI**:agent 经 CLI/API 对 crash 组、
+  符号化栈、设备/版本分布、feedback 工单有全量读写权,在 Slock/Raft
+  里即席完成 Seer 的全部用例(总结、根因、修复 PR、问答)——且用户
+  自带模型和 agent,无 add-on 计费、无数据出域。
+
+### 差距:**不追**(内置 AI)/ **关键**(把 agent 通路做顺)
+
+- **不追**:自研 Seer 式内置 AI。Sentry 的方向恰恰在向我们收敛——
+  Seer 最新的卖点是"委托给 Claude Code 等外部 agent"和"在 Slack 里
+  对话",即承认**通用 agent 是终局形态**。Sentry 是从封闭产品向 agent
+  开口子;我们生来就是开的。复制 Seer 等于放弃身位。
+- **关键**(承接 §1–3):让 agent 用得顺的三块地基——语义化事件推送
+  (告警信号直达 Raft)、聚合查询 API(不用拉全量)、suspect commit /
+  栈-仓库链接(根因分析的原料)。Seer 强是因为 Sentry 给它喂了这些
+  结构化输入;我们要喂给用户自己的 agent。
+- **可后置**:文档层面的 agent 引导(MCP 清单 / actions[] 声明已有
+  方向,见 slock-agent-manifest 备忘)。
+
+---
+
+## 结论:优先借鉴 Top-5
+
+1. **回归检测 + 阈值规则引擎(§1,关键)**——resolved→unresolved 触发、
+   表驱动指标阈值、每规则频率上限;这是所有下游信号的源头。
+2. **Raft 原生告警卡片 + 可执行动作(§2,关键)**——对标并超越 Sentry
+   Slack 集成:事件卡片进频道,全功能 agent 就地分诊;我们唯一该
+   "重仓"的集成。
+3. **Suspect commit + 栈帧→仓库行链接(§2,关键)**——release 携带
+   commit SHA,服务端做栈帧文件归因;对 agent 根因分析是杠杆最大的
+   单项输入。
+4. **聚合查询 API(§3,重要)**——group/filter/count 的服务端聚合端点,
+   替代 Discover 引擎(不抄其 UI),兼作告警阈值与分析视图的地基。
+5. **Crash-linked feedback + ingest 自保护限流(§5/§4,重要)**——
+   crash 组 ↔ 反馈工单互相引用;per-app 滑动窗口限流 + 429 防崩溃风暴
+   打爆自有基础设施。
+
+不追清单(明确止损):dashboard builder、PagerDuty/Teams/Discord 集成
+矩阵、计费配额与 spike protection、ML 反垃圾、内置 Seer 式 AI、
+Uptime/Cron monitors。
+
+*来源:docs.sentry.io(alerts、monitors-and-alerts/monitors、
+organization/integrations/{notification-incidents/slack, issue-tracking,
+source-code-mgmt/github}、product/{dashboards, explore/discover-queries,
+user-feedback, ai-in-sentry/seer}、pricing/quotas{,/spike-protection,
+/manage-event-stream-guide}、security-legal-pii/security/data-retention-periods)、
+blog.sentry.io(anomaly alerts open beta),核实日期 2026-07-09。*

--- a/docs/sdk-parity/deep-sdk-architecture.md
+++ b/docs/sdk-parity/deep-sdk-architecture.md
@@ -1,0 +1,119 @@
+# Sentry SDK 架构深度对比：数据管线与 Hands SDK 差距分析
+
+> 依据 docs.sentry.io 与 develop.sentry.dev 官方文档核实（2026-07）。
+> Hands 现状来自四端（Android / iOS / OHOS / Electron）源码审计：无 scope/hub、无 beforeSend、除崩溃文件（保留 5 份、下次启动上传）外无信封/离线队列、无 client reports、无采样、无限流处理、配置极简（baseUrl / appSlug / channel / clientKey）、feedback 与 metrics 发后即忘、24h 节流设备 ping。Electron 额外有 setUser / setTag / setExtra / addBreadcrumb（仅写入 Crashpad 崩溃注解）。
+>
+> 严重度标尺：**关键** = 影响数据可靠性/合规，应尽快补；**重要** = 明显提升质量或为后续能力铺路；**可后置** = 有价值但依赖前置能力或量级；**不追** = Sentry 场景特有，Hands 不需要。
+
+---
+
+## 1. Scope 模型（Hub → 三层 Scope）
+
+**Sentry 怎么做**：v8+ 用三层 scope 取代旧 Hub：Global Scope（进程级单例，存 release/environment 等全局数据）、Isolation Scope（一次执行单元——服务端一个请求、移动端一次用户会话，靠 thread-local/async-local 自动隔离）、Current Scope（绑定当前 span 或 `withScope` 块，fork 时写时复制）。捕获事件时按 global → isolation → current 合并，越具体优先级越高。废弃 Hub 是因为异步隔离需手动 clone，三层模型让 fork 全自动，并与 OpenTelemetry Context 对齐。
+
+**Hands 现状**：四端均无 scope/hub 概念。Electron 有 setUser/setTag/setExtra，但只落到 Crashpad 注解（只对崩溃生效），feedback/metrics 上报不带这些上下文；其余三端连全局上下文都没有。
+
+**差距：可后置** — Hands 是低频、封闭场景，一个跨四端统一的"单层全局 context"（setUser/setTag 对所有上报生效）就够了；三层 scope 是为高并发服务端与异步 tracing 设计的，不必照搬。
+
+## 2. 事件生命周期钩子（beforeSend / beforeBreadcrumb / Event Processors）
+
+**Sentry 怎么做**：事件产生后依次经过 scope 数据合并 → event processors（scope 级 `scope.addEventProcessor` 只在该 scope 生效，全局 `Sentry.addEventProcessor` 全部生效，顺序不保证）→ `beforeSend` / `beforeSendTransaction`（保证最后执行，拿到最终事件）→ 传输层。任一环节返回 `null` 即丢弃事件；hint 参数携带 originalException 等原始对象。另有声明式过滤 `ignoreErrors`（字符串/正则匹配消息）与 `denyUrls`/`allowUrls`（按栈帧来源过滤）。beforeBreadcrumb 对每条面包屑同样可改可丢。
+
+**Hands 现状**：四端均无任何发送前钩子。数据一旦采集直接出网，宿主 App 无法脱敏、无法降噪、无法按业务规则丢弃。
+
+**差距：关键** — 这是隐私合规（脱敏）与降噪的最低门槛，实现成本极低（一个回调 + 判空），却是宿主 App 唯一的"最后拦截点"。
+
+## 3. Integrations 插件架构
+
+**Sentry 怎么做**：SDK 功能以 integration 为单元组装。默认集成自动启用（JS 端如 InboundFilters、Breadcrumbs、GlobalHandlers、HttpContext、Dedupe、LinkedErrors、FunctionToString、BrowserApiErrors），通过 `integrations` 数组增删改配置、传函数过滤默认集成、`defaultIntegrations: false` 全关，还支持 `lazyLoadIntegration` 按需从 CDN 加载以控制包体积。
+
+**Hands 现状**：无插件机制，各端功能硬编码在 SDK 内部。
+
+**差距：不追** — 插件架构服务于"通用 SDK 适配无数第三方库"的目标；Hands 场景封闭、功能面小，内部模块化即可，对外暴露插件 API 只会增加维护面。
+
+## 4. Envelope 信封格式
+
+**Sentry 怎么做**：所有上报统一为 envelope：换行分隔的格式，第一行是信封头（JSON，可含完整 DSN 实现自认证），其后交替出现 item 头（必含 `type`，建议含 `length`）与 payload。item 类型覆盖 event、transaction、session、attachment、client_report、profile、replay 等。一次 HTTP 请求可批量携带多类型数据 + 二进制附件，且信封本身就是磁盘落盘/多跳转发（SDK → Relay）的序列化单元。
+
+**Hands 现状**：无统一封装。feedback、metrics、ping 各自独立 JSON 接口直发；崩溃文件是唯一落盘物，格式与在线上报完全不同。
+
+**差距：重要** — 不必照抄 Sentry 信封，但"统一的上报封装 = 同一份序列化既能出网又能落盘重发"是做离线队列（见 §5）的前置设计；现在每种数据一个格式，队列和补发逻辑要写 N 遍。
+
+## 5. 磁盘队列 / 离线缓存
+
+**Sentry 怎么做**：移动端 SDK 把信封先写入磁盘缓存目录（Android `cacheDirPath`，`maxCacheItems` 默认 30 个信封），发送成功才删除；断网/进程被杀时数据保留，下次启动或网络恢复后补发。缓存满时删最旧信封，但会把其中的 session 迁移到下一个信封以保住 release health 数据；`shutdownTimeoutMillis`（默认 2000ms）控制退出前排空队列的等待时间。
+
+**Hands 现状**：只有崩溃文件落盘（保留 5 份、下次启动上传）。feedback、metrics 全部发后即忘——请求失败即数据永久丢失，无重试、无落盘。
+
+**差距：关键** — 移动端弱网是常态，fire-and-forget 意味着最需要反馈的场景（网络差、刚崩溃完）恰恰丢数据最多；这是 Hands 数据可信度的最大窟窿。
+
+## 6. 限流处理（429 / X-Sentry-Rate-Limits）
+
+**Sentry 怎么做**：SDK 检查每个响应的 `X-Sentry-Rate-Limits` 头，格式 `retry_after:categories:scope:reason_code`，可按数据类别（error/transaction/session/…）分别限流，空类别 = 全部；429 时回退到标准 `Retry-After`，两者都没有则默认退避 60 秒。被限流期间 SDK 停发对应类别并直接丢弃（同时记入 client report），限流状态按 DSN 在 transport 内维护，同类别取更长的限期。
+
+**Hands 现状**：无任何限流响应处理。当前 fire-and-forget 且无重试，客户端不会形成重试风暴；但 24h ping 之外的 feedback/metrics 峰值对服务端毫无客户端侧保护。
+
+**差距：重要** — 一旦补上磁盘队列 + 重试（§5），没有服务端限流协议就会把"补发"变成"打爆自己后端"的放大器；应与离线队列同期设计（一个 Retry-After + 按类别退避即可起步）。
+
+## 7. Client Reports（SDK 自报丢弃）
+
+**Sentry 怎么做**：SDK 把自己丢弃的数据以 `client_report` 信封项上报：`discarded_events` 数组，每项含 `reason`（ratelimit_backoff / queue_overflow / cache_overflow / sample_rate / before_send / event_processor / network_error / send_error / internal_sdk_error）、`category`、`quantity`。规范要求"谁丢弃谁记录上报"，通常搭车在其他信封里发送以省请求。这让服务端能回答"SDK 到底丢了多少数据、为什么"。
+
+**Hands 现状**：无。丢了就是丢了，服务端与开发者都无从知晓丢弃量。
+
+**差距：可后置** — 先有"会丢弃数据的机制"（采样、限流、队列上限）才有丢弃统计的意义；在 §5/§6/§9 落地后作为观测补充再做。
+
+## 8. 背压管理（Backpressure）
+
+**Sentry 怎么做**：服务端 SDK 内置背压监控：每 ~10 秒异步健康检查（队列是否将满、是否被限流），不健康时把 transaction 的有效采样率对半砍，`downsample_factor` 每 10 秒翻倍、最多 10 次（指数退避），恢复健康后回到用户设定的采样率；由 `enable_backpressure_handling` 开关控制。
+
+**Hands 现状**：无，也没有高吞吐管线需要保护。
+
+**差距：不追** — 这是为服务端高吞吐 tracing 设计的自保护；Hands 无 tracing、上报频率低（且 ping 已有 24h 节流），不存在该问题域。
+
+## 9. 采样体系
+
+**Sentry 怎么做**：三层客户端采样——`sampleRate`（错误事件，默认 1.0）、`tracesSampleRate` 或 `tracesSampler`（函数式，拿到 samplingContext 含事务名与 `parentSampled`，可按路由差异化采样，优先级 tracesSampler > 父决策继承 > tracesSampleRate，采样决策沿分布式链路传播）、profiles/replay 各有独立采样率。此外服务端还有 Dynamic Sampling：入站后按目标存储率对 span/transaction 二次智能采样（优先新版本、低量项目），UI 实时调整无需发版，但不作用于 error。
+
+**Hands 现状**：无任何采样。所有端全量上报，唯一的量控是 24h 节流的设备 ping。
+
+**差距：重要** — metrics 是 Hands 里唯一会随 DAU 线性膨胀的数据流，客户端采样率（哪怕只有一个全局 `sampleRate`，最好可由服务端下发）是量级增长后唯一不发版就能拉的成本阀门；服务端 Dynamic Sampling 不追。
+
+## 10. 数据清洗与 PII
+
+**Sentry 怎么做**：分层防御。客户端：`sendDefaultPii` 默认关闭——SDK 有意不采集 IP、cookie、请求体等 PII，开启需显式授权；beforeSend/beforeBreadcrumb 做定制脱敏。服务端：默认 scrubbing 自动打码 password/secret/信用卡等模式，Advanced Data Scrubbing 规则在持久化前二次脱敏，支持 sensitive fields / safe fields 配置，附件也有专门的 attachment scrubbing。
+
+**Hands 现状**：无 PII 开关、无客户端脱敏钩子、无服务端清洗。设备 ping 与崩溃附件采什么就传什么、存什么。
+
+**差距：关键** — 个保法/GDPR 语境下"默认不采 PII + 至少一层脱敏"是底线而非增强；崩溃日志和 breadcrumb 是最常见的 PII 泄露面，与 §2 的 beforeSend 一起做成本最低。
+
+## 11. 会话与发布健康度（Sessions）
+
+**Sentry 怎么做**：两种模式——application-mode（移动/桌面/浏览器，一次会话覆盖应用一次运行，逐条发送完整会话状态更新）与 request-mode（服务端每请求一会话，按分钟预聚合成计数再发）。生命周期 init → ok → exited/crashed/abnormal/unhandled，到达终态后不得再更新；自动会话跟踪在应用启动开始、退出结束，移动端后台超 30 秒可判定会话结束。由此得出 crash-free sessions/users 等发布健康度指标。
+
+**Hands 现状**：无会话概念。24h 节流的设备 ping 只能当粗粒度 DAU 代理，无法回答"这个版本 crash-free 率多少"。
+
+**差距：重要** — crash-free rate 是崩溃监控产品的头牌指标，而客户端实现很轻（启动发 init、退出/崩溃发终态，复用 §5 的队列保投递）；application-mode 一种就够，request-mode 不追。
+
+## 12. 配置面与版本维度（release / environment / dist）
+
+**Sentry 怎么做**：JS/Android 端 init 选项各约 60+，按核心 / 错误 / tracing / 会话 / 传输分组。三个版本维度贯穿全链路：`release` 建议 `project-name@version`（如 `my-app@2.3.12`），用于回归判定、suspect commit 与 source map/符号解析；`environment` 默认 `production` 区分部署环境；`dist` 进一步区分同一 release 的不同构建（如构建号），移动端用于精确匹配符号文件。
+
+**Hands 现状**：4 个配置项（baseUrl / appSlug / channel / clientKey）。channel 勉强对应 environment 的一部分职责，无 release、无 dist，崩溃无法按版本聚合归因。
+
+**差距：关键** — 没有 release/dist，崩溃去重、"哪个版本引入的回归"、符号表匹配都做不了；这是三个字段的成本，却决定后端一切聚合分析的粒度。配置总量不必追 60+，但 release/environment/dist + sampleRate + beforeSend 这一档必须有。
+
+---
+
+## 值得借鉴的前 5 个机制（按优先级）
+
+1. **磁盘信封队列 + 启动/联网补发**（§5 + §4）— 统一上报封装先落盘、成功才删、崩溃与弱网不丢数，直接决定 Hands 数据可信度；崩溃文件已有的"下次启动上传"逻辑可推广为全数据类型通道。
+2. **release / environment / dist 版本维度**（§12）— 三个字段解锁版本聚合、回归定位与符号匹配，是后端分析能力的地基，改动最小收益最大。
+3. **beforeSend 钩子 + sendDefaultPii 默认关闭**（§2 + §10）— 一个回调加一个布尔开关，同时解决合规底线与宿主降噪，四端 API 形状统一即可。
+4. **限流协议（429 / Retry-After / 按类别退避）**（§6）— 与队列重试同期设计，避免补发机制反噬后端；服务端只需会下发 Retry-After，客户端只需会尊重它。
+5. **application-mode 自动会话跟踪**（§11）— 启动/退出/崩溃三个信号 + 后台 30s 超时判定，换来 crash-free rate 这一发布健康度头牌指标，复用 1 的队列即可保投递。
+
+### 主要参考
+
+- develop.sentry.dev：Hub & Scope Refactoring、Envelopes、Rate Limiting、Client Reports、Sessions、Backpressure（sdk/telemetry/traces/backpressure）
+- docs.sentry.io：JavaScript Options / Filtering / Sampling / Integrations / Event Processors、Android Options、Data Scrubbing、Dynamic Sampling、Releases


### PR DESCRIPTION
Response to artin's "是不是你分析的太少了" — ~1200 lines of mechanism-level comparison, every claim verified against docs.sentry.io / develop.sentry.dev (not memory), each gap rated 关键/重要/可后置/不追 with rationale and a top-5 borrow list per doc.

- **deep-sdk-architecture.md** — v8 three-scope model, envelope format + disk queue (maxCacheItems), X-Sentry-Rate-Limits protocol, client reports, backpressure, sampling stack, PII scrubbing layers, session modes, 60+ init options vs our 4.
- **deep-issue-pipeline.md** — grouping algorithms + fingerprint escape hatches, issue state machine (resolved-in-release/regressed), debug-ids, Gradle/Xcode/fastlane auto symbol upload, sourcemaps pipeline, suspect commits, ownership rules; notes where Hands releases are already stronger.
- **deep-product-surface.md** — alert rules + anomaly detection, Slack notify+act vs our Raft-native agent model (Seer's pivot to delegating validates our positioning), VCS integrations, Discover/dashboards, quotas/spike protection vs our unbounded retention.
- **deep-mobile.md** — ANRv2/ApplicationExitInfo, tombstones, Mach exceptions, App Hangs v1/v2, watchdog heuristics, MetricKit, prewarmed starts, TTID/TTFD/frames, 30s session threshold, mobile replay economics (80% of value via error screenshot + view tree at ~5% cost).

README updated with the index. Findings feed the existing roadmap.md P0–P3 (which the ROI-ordered borrow lists broadly confirm: sessions hooks first, then ApplicationExitInfo consumer, MetricKit adapter, dSYM resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)