### PR TITLE
feat: add Hands Node logging core

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -1,10 +1,10 @@
-name: Publish CLI
+name: Publish Hands Node SDK
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "CLI package version to publish. Defaults to packages/cli/package.json."
+        description: "Node SDK version to publish. Defaults to packages/node/package.json."
         required: false
         type: string
       dry_run:
@@ -14,7 +14,7 @@ on:
         default: false
   push:
     tags:
-      - "cli-v*"
+      - "node-v*"
 
 permissions:
   contents: read
@@ -48,62 +48,48 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          package_version="$(node -p "require('./packages/cli/package.json').version")"
+          package_version="$(node -p "require('./packages/node/package.json').version")"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            requested="${GITHUB_REF_NAME#cli-v}"
+            requested="${GITHUB_REF_NAME#node-v}"
           elif [[ -n "${{ inputs.version }}" ]]; then
             requested="${{ inputs.version }}"
           else
             requested="${package_version}"
           fi
           if [[ "${requested}" != "${package_version}" ]]; then
-            echo "Requested version ${requested} does not match packages/cli/package.json ${package_version}" >&2
+            echo "Requested version ${requested} does not match packages/node/package.json ${package_version}" >&2
             exit 1
           fi
           echo "value=${package_version}" >> "$GITHUB_OUTPUT"
 
-      - name: Verify Hands Node SDK dependency is published
-        shell: bash
+      - name: Test and build Node SDK
         run: |
-          set -euo pipefail
-          dependency="$(node -p "require('./packages/cli/package.json').dependencies['@botiverse/hands-node']")"
-          version="${dependency#workspace:^}"
-          npm view "@botiverse/hands-node@${version}" version
-
-      - name: Build Node SDK and CLI
-        run: |
+          pnpm --filter @botiverse/hands-node test
           pnpm --filter @botiverse/hands-node build
-          pnpm --filter @botiverse/hands-cli build
 
-      - name: Pack CLI
-        id: pack
-        working-directory: packages/cli
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "$GITHUB_WORKSPACE/dist-packages"
-          pnpm pack --pack-destination "$GITHUB_WORKSPACE/dist-packages"
-          package_path="$(find "$GITHUB_WORKSPACE/dist-packages" -maxdepth 1 -name 'botiverse-hands-cli-*.tgz' -print -quit)"
-          test -n "${package_path}"
-          echo "path=${package_path}" >> "$GITHUB_OUTPUT"
+      - name: Pack check
+        working-directory: packages/node
+        run: npm pack --dry-run
 
       - name: Publish dry run
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
-        run: npm publish "${{ steps.pack.outputs.path }}" --access public --dry-run
+        working-directory: packages/node
+        run: npm publish --access public --dry-run
 
       - name: Publish to npm
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
-        run: npm publish "${{ steps.pack.outputs.path }}" --access public
+        working-directory: packages/node
+        run: npm publish --access public
 
       - name: Summary
         shell: bash
         run: |
           {
-            echo "### CLI publish"
+            echo "### Hands Node SDK publish"
             echo
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Package | \`@botiverse/hands-cli\` |"
+            echo "| Package | \`@botiverse/hands-node\` |"
             echo "| Version | \`${{ steps.version.outputs.value }}\` |"
             echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Required repository secrets:
 
 Workflows:
 
-- `Publish CLI` publishes `@botiverse/hands-cli` to npm through npm Trusted Publishing / GitHub OIDC. Configure the npm package trusted publisher for this repository and workflow, then trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.1.2`.
+- `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm through npm Trusted Publishing / GitHub OIDC. Configure the npm package trusted publisher for `.github/workflows/publish-node.yml`, then trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
+- `Publish CLI` publishes `@botiverse/hands-cli` to npm through npm Trusted Publishing / GitHub OIDC. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Configure the npm package trusted publisher for this repository and workflow, then trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.0`.
 - `Deploy Quiver Server` deploys the Worker plus bundled admin/docs assets. Trigger it manually, or push a tag like `server-v2026.07.04`. The default container rollout is `none`; choose `immediate` or `gradual` only when the APK parser container image changed.
 - `Deploy Hands Server` deploys the same Worker/admin bundle to `hands.build` in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
 

--- a/docs/handslog-spec.md
+++ b/docs/handslog-spec.md
@@ -102,9 +102,9 @@ contract everywhere.
 
 Support **both** schemes, configurable, because the tradeoff is real:
 
-- `rotate: "size"` — `quiver-<name>.jsonl`, `.1`, `.2`, … (fixed file count,
+- `rotate: "size"` — `hands-<name>.jsonl`, `.1`, `.2`, … (fixed file count,
   simple). This is what `slock-diagnostics` does today.
-- `rotate: "daily"` — `quiver-<name>-YYYY-MM-DD.jsonl` (one file per calendar
+- `rotate: "daily"` — `hands-<name>-YYYY-MM-DD.jsonl` (one file per calendar
   day). Trivially correlates to a crash timestamp and to age-based retention;
   costs more files if the app launches many times a day.
 
@@ -156,7 +156,7 @@ crash/feedback evidence chain during migration:
    thread/seq/dropped/truncated`). `event` stays a distinct field — do not fold
    it into `tag` — or `event=…` grep/filters regress.
 2. **Filename-agnostic attach.** Do not assume the server keys off filenames.
-   P1 may default to `quiver-<name>-YYYY-MM-DD.jsonl`, but the crash/feedback
+   P1 defaults to `hands-<name>-YYYY-MM-DD.jsonl`, but the crash/feedback
    attach must keep a compatibility entry: **either** `currentFiles()` also
    returns a legacy `slock-diagnostics*.jsonl` alias/manifest, **or** the server
    is confirmed to parse by JSONL *content*, not filename. Pin this in the spec —

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,7 +14,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.3.2 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.0 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build
@@ -69,3 +69,25 @@ For CI, pass it via `QUIVER_SESSION_COOKIE` instead.
 
 v2 will swap this for a true headless flow (Raft Device Flow or a
 `--token-stdin` service-user mode). See `publish-tasks.md` P3.4.x.
+
+## Local logs
+
+The CLI writes best-effort, redacted JSONL logs under
+`$XDG_STATE_HOME/hands/logs` (or `~/.local/state/hands/logs`). Logging failures
+never change command output or exit status. Override the directory with
+`HANDS_LOG_DIR`.
+
+Create a gzip bundle only when you have a signed, unexpired collect policy and
+its Ed25519 public key:
+
+```bash
+hands logs collect \
+  --policy ./collect-policy.json \
+  --public-key ./hands-log-policy-public.pem \
+  --output ./hands-logs.json.gz
+```
+
+Policy signature, version, expiry, downgrade state, redaction, daily size,
+per-collection size, concurrency, and network budgets are enforced locally.
+Rejected collection stays fail-closed and writes an audit log without changing
+the CLI process exit behavior.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {
@@ -26,6 +26,7 @@
     "lint:fix": "eslint --fix src/"
   },
   "dependencies": {
+    "@botiverse/hands-node": "workspace:^0.1.0",
     "commander": "^12.1.0"
   },
   "devDependencies": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
+import fixturePolicy from "./fixtures/collect-policy.json";
 
 describe("config round-trip", () => {
   let dir: string;
@@ -168,6 +169,31 @@ describe("build publish changelog options", () => {
         }),
       ).toBe(JSON.stringify({ "zh-CN": "中文更新", en: "English update" }));
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Hands logging integration", () => {
+  it("validates the CLI collect-policy fixture against hands-node schema", async () => {
+    const { validateCollectPolicy } = await import("@botiverse/hands-node/logs/schema");
+    expect(validateCollectPolicy(fixturePolicy)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("never throws when the configured log directory cannot be created", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hands-cli-logging-"));
+    const blocked = join(dir, "not-a-directory");
+    writeFileSync(blocked, "file");
+    const original = process.env.HANDS_LOG_DIR;
+    process.env.HANDS_LOG_DIR = blocked;
+    try {
+      const { recordCliEvent, resetCliLoggerForTests } = await import("./lib/logging.js");
+      resetCliLoggerForTests();
+      expect(() => recordCliEvent("info", "test", "test event")).not.toThrow();
+      resetCliLoggerForTests();
+    } finally {
+      if (original === undefined) delete process.env.HANDS_LOG_DIR;
+      else process.env.HANDS_LOG_DIR = original;
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Command } from "commander";
+import {
+  collectLogs,
+  defaultCollectionStateFile,
+  type CollectionNetwork,
+} from "@botiverse/hands-node";
+import type { SignedCollectPolicy } from "@botiverse/hands-node/logs/schema";
+import { tryGetCliLogger } from "../lib/logging.js";
+
+interface CollectOptions {
+  policy: string;
+  publicKey: string;
+  output?: string;
+  network?: string;
+  json?: boolean;
+}
+
+function timestampForFile(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+export function registerLogsCommands(program: Command): void {
+  const logs = program.command("logs").description("Inspect and collect local Hands logs.");
+
+  logs
+    .command("collect")
+    .description("Create a redacted local log bundle against a signed collect policy.")
+    .requiredOption("--policy <path>", "Signed collect-policy JSON file.")
+    .requiredOption("--public-key <path>", "Ed25519 public key in PEM format.")
+    .option("--output <path>", "Output .json.gz bundle path.")
+    .option("--network <quality>", "Network quality: strong, weak, or offline.", "strong")
+    .option("--json", "Output machine-readable JSON.", false)
+    .action((opts: CollectOptions, command: Command) => {
+      const logger = tryGetCliLogger();
+      if (!logger) {
+        const result = {
+          ok: false as const,
+          code: "LOG_DIRECTORY_UNAVAILABLE",
+          message: "the Hands log directory is unavailable",
+        };
+        if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+          console.log(JSON.stringify(result));
+        } else {
+          console.error(`Hands log collection skipped: ${result.message}`);
+          console.error(`Code: ${result.code}`);
+        }
+        return;
+      }
+      const output = resolve(opts.output ?? `hands-logs-${timestampForFile()}.json.gz`);
+      let policy: SignedCollectPolicy;
+      try {
+        policy = JSON.parse(readFileSync(resolve(opts.policy), "utf8")) as SignedCollectPolicy;
+      } catch (cause) {
+        const result = {
+          ok: false as const,
+          code: "POLICY_READ_FAILED",
+          message: cause instanceof Error ? cause.message : String(cause),
+        };
+        if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+          console.log(JSON.stringify(result));
+        } else {
+          console.error(`Hands log collection skipped: ${result.message}`);
+          console.error(`Code: ${result.code}`);
+        }
+        return;
+      }
+      const network = opts.network as CollectionNetwork;
+      if (!(["strong", "weak", "offline"] as const).includes(network)) {
+        const result = {
+          ok: false as const,
+          code: "NETWORK_QUALITY_INVALID",
+          message: "network must be strong, weak, or offline",
+        };
+        if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+          console.log(JSON.stringify(result));
+        } else {
+          console.error(`Hands log collection skipped: ${result.message}`);
+          console.error(`Code: ${result.code}`);
+        }
+        return;
+      }
+      let publicKey: string;
+      try {
+        publicKey = readFileSync(resolve(opts.publicKey), "utf8");
+      } catch (cause) {
+        const result = {
+          ok: false as const,
+          code: "PUBLIC_KEY_READ_FAILED",
+          message: cause instanceof Error ? cause.message : String(cause),
+        };
+        if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+          console.log(JSON.stringify(result));
+        } else {
+          console.error(`Hands log collection skipped: ${result.message}`);
+          console.error(`Code: ${result.code}`);
+        }
+        return;
+      }
+
+      const result = collectLogs({
+        policy,
+        publicKeys: {
+          [policy?.payload?.key_id ?? "unknown"]: publicKey,
+        },
+        files: logger.currentFiles(),
+        outputFile: output,
+        stateFile: defaultCollectionStateFile(logger.options.dir),
+        source: "hands-cli",
+        network,
+        auditLogger: logger,
+      });
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(result));
+        return;
+      }
+      if (!result.ok) {
+        console.error(`Hands log collection skipped: ${result.message}`);
+        console.error(`Code: ${result.code}`);
+        return;
+      }
+      console.log(`Created ${result.output_file}`);
+      console.log(
+        `Collected ${result.bundle.manifest.entries_count} entries (${result.bundle.manifest.uncompressed_bytes} bytes, ${result.compressed_bytes} compressed).`,
+      );
+    });
+}

--- a/packages/cli/src/fixtures/collect-policy.json
+++ b/packages/cli/src/fixtures/collect-policy.json
@@ -1,0 +1,22 @@
+{
+  "signature_algorithm": "ed25519",
+  "signature": "fixture-signature",
+  "payload": {
+    "schema_version": 1,
+    "policy_id": "fixture-policy",
+    "revision": 1,
+    "key_id": "fixture-key",
+    "issued_at": "2026-07-10T00:00:00.000Z",
+    "expires_at": "2026-07-11T00:00:00.000Z",
+    "selection": {
+      "levels": ["info", "warn", "error"],
+      "tags": ["cli"]
+    },
+    "budgets": {
+      "max_collection_bytes": 1048576,
+      "max_daily_bytes": 4194304,
+      "max_concurrency": 1,
+      "weak_network_backoff_ms": 30000
+    }
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,16 +25,18 @@ import { registerReleaseCommands } from "./commands/releases.js";
 import { registerFeedbackCommands } from "./commands/feedback.js";
 import { registerDeployTokenCommands } from "./commands/deploy_tokens.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
+import { registerLogsCommands } from "./commands/logs.js";
 import { getConfig } from "./lib/config.js";
 import { readEnv } from "./lib/env.js";
 import { setApiBase } from "./lib/api.js";
+import { recordCliEvent } from "./lib/logging.js";
 
 const program = new Command();
 
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.4.0")
+  .version("0.5.0")
   .option(
     "--api <url>",
     "Quiver Worker base URL (default: https://quiver.oranix.io or $QUIVER_API)",
@@ -43,12 +45,21 @@ program
   .option("--verbose", "Print HTTP request details for debugging", false);
 
 // Re-read global options after parse to wire into the API client.
-program.hook("preAction", (thisCommand) => {
-  const opts = thisCommand.opts<{ api?: string; json?: boolean; verbose?: boolean }>();
+program.hook("preAction", (_rootCommand, actionCommand) => {
+  const opts = program.opts<{ api?: string; json?: boolean; verbose?: boolean }>();
   const cfg = getConfig();
   const apiBase = opts.api ?? readEnv("API") ?? cfg.apiBase;
   if (apiBase) setApiBase(apiBase);
   if (opts.verbose) process.env.HANDS_VERBOSE = "1";
+  recordCliEvent("info", "command_start", "CLI command started", {
+    command: actionCommand.name(),
+  });
+});
+
+program.hook("postAction", (_rootCommand, actionCommand) => {
+  recordCliEvent("info", "command_success", "CLI command completed", {
+    command: actionCommand.name(),
+  });
 });
 
 // --- Subcommand groups ---
@@ -59,6 +70,7 @@ registerBuildCommands(program);
 registerReleaseCommands(program);
 registerFeedbackCommands(program);
 registerDeployTokenCommands(program);
+registerLogsCommands(program);
 
 program
   .command("version")
@@ -68,6 +80,10 @@ program
   });
 
 program.parseAsync(process.argv).catch((err) => {
+  recordCliEvent("error", "command_error", "CLI command failed", {
+    command: program.args[0] ?? "unknown",
+    error_name: err instanceof Error ? err.name : "unknown",
+  });
   if (err instanceof Error && err.name === "QuiverApiError") {
     // Admin-native, actionable error print (mirrors the Raft CLI discipline):
     // surface the server's stable Code and Next action so an agent knows what

--- a/packages/cli/src/lib/logging.ts
+++ b/packages/cli/src/lib/logging.ts
@@ -1,0 +1,41 @@
+import {
+  HandsLogger,
+  defaultLogDirectory,
+  type LogFields,
+  type LogLevel,
+} from "@botiverse/hands-node";
+
+let cliLogger: HandsLogger | undefined;
+
+export function getCliLogger(): HandsLogger {
+  if (!cliLogger) {
+    cliLogger = new HandsLogger({
+      name: "cli",
+      dir: process.env.HANDS_LOG_DIR ?? defaultLogDirectory("hands"),
+      minLevel: process.env.HANDS_VERBOSE === "1" ? "debug" : "info",
+      thread: "cli",
+    });
+  }
+  return cliLogger;
+}
+
+export function tryGetCliLogger(): HandsLogger | undefined {
+  try {
+    return getCliLogger();
+  } catch {
+    return undefined;
+  }
+}
+
+export function recordCliEvent(
+  level: LogLevel,
+  event: string,
+  message: string,
+  fields?: LogFields,
+): void {
+  tryGetCliLogger()?.write(level, "cli", message, fields, event);
+}
+
+export function resetCliLoggerForTests(): void {
+  cliLogger = undefined;
+}

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,13 @@
+# `@botiverse/hands-node`
+
+Pure-Node Hands logging and policy-governed log collection.
+
+```ts
+import { HandsLogger } from "@botiverse/hands-node";
+
+const logger = new HandsLogger({ name: "worker" });
+logger.info("auth", "login completed", { provider: "raft" }, "login_ok");
+```
+
+The signed collect-policy, bundle, and redaction contracts are exported from
+`@botiverse/hands-node/logs/schema`.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@botiverse/hands-node",
+  "version": "0.1.0",
+  "description": "Hands logging, redaction, and policy-governed log collection for Node.js.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oranix-io/hands.git"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./logs/schema": {
+      "types": "./dist/logs/schema.d.ts",
+      "import": "./dist/logs/schema.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/node/src/collect.test.ts
+++ b/packages/node/src/collect.test.ts
@@ -1,0 +1,265 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CollectionBudgetManager,
+  CollectPolicyError,
+  collectLogs,
+  verifyCollectPolicy,
+} from "./collect.js";
+import {
+  HANDS_LOG_SCHEMA_VERSION,
+  HANDS_LOG_SIGNATURE_ALGORITHM,
+  canonicalize,
+  validateCollectPolicy,
+  validateLogBundle,
+  validateRedactionContract,
+  type CollectPolicyPayload,
+  type SignedCollectPolicy,
+} from "./logs/schema.js";
+import { DEFAULT_REDACTION_CONTRACT } from "./redaction.js";
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function temporaryDirectory(): string {
+  const path = mkdtempSync(join(tmpdir(), "hands-node-collect-"));
+  cleanup.push(path);
+  return path;
+}
+
+function fixture(
+  overrides: Partial<CollectPolicyPayload> = {},
+): { policy: SignedCollectPolicy; publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"] } {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const payload: CollectPolicyPayload = {
+    schema_version: HANDS_LOG_SCHEMA_VERSION,
+    policy_id: "policy-1",
+    revision: 2,
+    key_id: "test-key",
+    issued_at: "2026-07-10T00:00:00.000Z",
+    expires_at: "2026-07-11T00:00:00.000Z",
+    budgets: {
+      max_collection_bytes: 64 * 1024,
+      max_daily_bytes: 128 * 1024,
+      max_concurrency: 1,
+      weak_network_backoff_ms: 10_000,
+    },
+    ...overrides,
+  };
+  const signature = sign(null, Buffer.from(canonicalize(payload)), privateKey).toString("base64url");
+  return {
+    policy: {
+      signature_algorithm: HANDS_LOG_SIGNATURE_ALGORITHM,
+      signature,
+      payload,
+    },
+    publicKey,
+  };
+}
+
+describe("logs/schema", () => {
+  it("validates policy and redaction contracts", () => {
+    const { policy } = fixture();
+    expect(validateCollectPolicy(policy)).toEqual({ valid: true, errors: [] });
+    expect(validateRedactionContract(DEFAULT_REDACTION_CONTRACT)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+});
+
+describe("signed collect policy", () => {
+  it("accepts a valid Ed25519 policy", () => {
+    const { policy, publicKey } = fixture();
+    expect(
+      verifyCollectPolicy(policy, {
+        publicKeys: { "test-key": publicKey },
+        now: new Date("2026-07-10T01:00:00.000Z"),
+      }).revision,
+    ).toBe(2);
+  });
+
+  it("fails closed for expired and bad-signature policies", () => {
+    const expired = fixture({
+      issued_at: "2026-07-08T00:00:00.000Z",
+      expires_at: "2026-07-09T00:00:00.000Z",
+    });
+    expect(() =>
+      verifyCollectPolicy(expired.policy, {
+        publicKeys: { "test-key": expired.publicKey },
+        now: new Date("2026-07-10T01:00:00.000Z"),
+      }),
+    ).toThrowError(expect.objectContaining({ code: "POLICY_EXPIRED" }));
+
+    const bad = fixture();
+    bad.policy.signature = Buffer.from("not-the-signature").toString("base64url");
+    expect(() =>
+      verifyCollectPolicy(bad.policy, {
+        publicKeys: { "test-key": bad.publicKey },
+        now: new Date("2026-07-10T01:00:00.000Z"),
+      }),
+    ).toThrowError(expect.objectContaining({ code: "POLICY_SIGNATURE_INVALID" }));
+  });
+
+  it("rejects policy downgrades and enforces concurrency/network budgets", () => {
+    const dir = temporaryDirectory();
+    const manager = new CollectionBudgetManager(join(dir, "state.json"), () =>
+      new Date("2026-07-10T01:00:00.000Z"),
+    );
+    const current = fixture().policy.payload;
+    manager.acceptRevision(current);
+    expect(() => manager.acceptRevision({ ...current, revision: 1 })).toThrowError(
+      expect.objectContaining({ code: "POLICY_DOWNGRADE_REJECTED" }),
+    );
+    const lease = manager.acquire(current, "strong");
+    expect(() => manager.acquire(current, "strong")).toThrowError(
+      expect.objectContaining({ code: "COLLECTION_CONCURRENCY_EXCEEDED" }),
+    );
+    lease.release();
+    expect(() => manager.acquire(current, "weak")).toThrowError(
+      expect.objectContaining({ code: "WEAK_NETWORK_BACKOFF" }),
+    );
+  });
+
+  it("enforces the persistent daily byte budget", () => {
+    const dir = temporaryDirectory();
+    const manager = new CollectionBudgetManager(join(dir, "state.json"), () =>
+      new Date("2026-07-10T01:00:00.000Z"),
+    );
+    const payload = fixture({
+      budgets: {
+        max_collection_bytes: 100,
+        max_daily_bytes: 100,
+        max_concurrency: 1,
+        weak_network_backoff_ms: 0,
+      },
+    }).policy.payload;
+    manager.acceptRevision(payload);
+    const first = manager.acquire(payload, "strong");
+    first.commit(90);
+    first.release();
+    const second = manager.acquire(payload, "strong");
+    expect(() => second.commit(20)).toThrowError(
+      expect.objectContaining({ code: "DAILY_BUDGET_EXCEEDED" }),
+    );
+    second.release();
+  });
+});
+
+describe("collectLogs", () => {
+  it("re-redacts secrets, validates the bundle, and writes gzip output", () => {
+    const dir = temporaryDirectory();
+    const log = join(dir, "hands-cli.jsonl");
+    writeFileSync(
+      log,
+      `${JSON.stringify({
+        ts: "2026-07-10T01:00:00.000Z",
+        level: "info",
+        event: "request",
+        tag: "http",
+        message: "Bearer raw-access-token",
+        fields: { cookie: "session-secret", safe: "kept" },
+        seq: 1,
+        dropped: 0,
+        truncated: false,
+      })}\n`,
+    );
+    const output = join(dir, "bundle.json.gz");
+    const signed = fixture();
+    const result = collectLogs({
+      policy: signed.policy,
+      publicKeys: { "test-key": signed.publicKey },
+      files: [log],
+      outputFile: output,
+      stateFile: join(dir, "state.json"),
+      source: "hands-cli",
+      now: new Date("2026-07-10T01:30:00.000Z"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.message);
+    expect(validateLogBundle(result.bundle)).toEqual({ valid: true, errors: [] });
+    const unpacked = JSON.parse(gunzipSync(readFileSync(output)).toString("utf8")) as {
+      files: Array<{ content_base64: string }>;
+    };
+    const collectedLog = Buffer.from(unpacked.files[0]!.content_base64, "base64").toString("utf8");
+    expect(collectedLog).not.toContain("raw-access-token");
+    expect(collectedLog).not.toContain("session-secret");
+    expect(collectedLog).toContain("[REDACTED]");
+    expect(collectedLog).toContain("kept");
+  });
+
+  it("returns a failure and audit event instead of throwing", () => {
+    const dir = temporaryDirectory();
+    const signed = fixture({
+      issued_at: "2026-07-08T00:00:00.000Z",
+      expires_at: "2026-07-09T00:00:00.000Z",
+    });
+    const audit: string[] = [];
+    const invoke = () =>
+      collectLogs({
+        policy: signed.policy,
+        publicKeys: { "test-key": signed.publicKey },
+        files: [],
+        outputFile: join(dir, "bundle.json.gz"),
+        stateFile: join(dir, "state.json"),
+        now: new Date("2026-07-10T01:30:00.000Z"),
+        audit: (event) => audit.push(event.code),
+      });
+
+    expect(invoke).not.toThrow();
+    expect(invoke()).toEqual(
+      expect.objectContaining({ ok: false, code: "POLICY_EXPIRED" }),
+    );
+    expect(audit).toContain("POLICY_EXPIRED");
+  });
+
+  it("enforces the per-collection byte budget without throwing", () => {
+    const dir = temporaryDirectory();
+    const log = join(dir, "large.jsonl");
+    writeFileSync(
+      log,
+      `${JSON.stringify({
+        ts: "2026-07-10T01:00:00.000Z",
+        level: "info",
+        event: "large",
+        tag: "test",
+        message: "x".repeat(512),
+      })}\n`,
+    );
+    const signed = fixture({
+      budgets: {
+        max_collection_bytes: 100,
+        max_daily_bytes: 1000,
+        max_concurrency: 1,
+        weak_network_backoff_ms: 0,
+      },
+    });
+    const result = collectLogs({
+      policy: signed.policy,
+      publicKeys: { "test-key": signed.publicKey },
+      files: [log],
+      outputFile: join(dir, "bundle.json.gz"),
+      stateFile: join(dir, "state.json"),
+      now: new Date("2026-07-10T01:30:00.000Z"),
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ ok: false, code: "COLLECTION_BUDGET_EXCEEDED" }),
+    );
+  });
+});
+
+describe("CollectPolicyError", () => {
+  it("carries a stable machine code", () => {
+    expect(new CollectPolicyError("TEST", "message")).toEqual(
+      expect.objectContaining({ name: "CollectPolicyError", code: "TEST" }),
+    );
+  });
+});

--- a/packages/node/src/collect.ts
+++ b/packages/node/src/collect.ts
@@ -1,0 +1,437 @@
+import { createHash, randomUUID, verify as verifySignature, type KeyLike } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { gzipSync } from "node:zlib";
+import type { HandsLogger } from "./logger.js";
+import { redactValue } from "./redaction.js";
+import {
+  HANDS_LOG_SCHEMA_VERSION,
+  canonicalize,
+  validateCollectPolicy,
+  validateLogBundle,
+  type CollectPolicyPayload,
+  type LogBundle,
+  type LogBundleFile,
+  type LogLevel,
+  type SignedCollectPolicy,
+} from "./logs/schema.js";
+
+export type CollectionNetwork = "strong" | "weak" | "offline";
+
+export interface CollectionAuditEvent {
+  event: string;
+  code: string;
+  message: string;
+  policy_id?: string;
+  policy_revision?: number;
+}
+
+export type CollectionAuditSink = (event: CollectionAuditEvent) => void;
+
+export class CollectPolicyError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "CollectPolicyError";
+    this.code = code;
+  }
+}
+
+export interface VerifyPolicyOptions {
+  publicKeys: Record<string, KeyLike>;
+  now?: Date;
+  maximumClockSkewMs?: number;
+}
+
+export function verifyCollectPolicy(
+  policy: SignedCollectPolicy,
+  options: VerifyPolicyOptions,
+): CollectPolicyPayload {
+  const validation = validateCollectPolicy(policy);
+  if (!validation.valid) {
+    throw new CollectPolicyError("POLICY_SCHEMA_INVALID", validation.errors.join("; "));
+  }
+  const now = options.now ?? new Date();
+  const skew = options.maximumClockSkewMs ?? 5 * 60_000;
+  const issuedAt = Date.parse(policy.payload.issued_at);
+  const expiresAt = Date.parse(policy.payload.expires_at);
+  if (issuedAt > now.getTime() + skew) {
+    throw new CollectPolicyError("POLICY_NOT_YET_VALID", "collect policy was issued in the future");
+  }
+  if (expiresAt <= now.getTime()) {
+    throw new CollectPolicyError("POLICY_EXPIRED", "collect policy has expired");
+  }
+  const key = options.publicKeys[policy.payload.key_id];
+  if (!key) {
+    throw new CollectPolicyError("POLICY_KEY_UNKNOWN", "collect policy signing key is unknown");
+  }
+  let signature: Buffer;
+  try {
+    signature = Buffer.from(policy.signature, "base64url");
+  } catch {
+    throw new CollectPolicyError("POLICY_SIGNATURE_INVALID", "collect policy signature is malformed");
+  }
+  const valid = verifySignature(
+    null,
+    Buffer.from(canonicalize(policy.payload), "utf8"),
+    key,
+    signature,
+  );
+  if (!valid) {
+    throw new CollectPolicyError("POLICY_SIGNATURE_INVALID", "collect policy signature is invalid");
+  }
+  return policy.payload;
+}
+
+interface BudgetState {
+  date: string;
+  daily_bytes: number;
+  highest_revisions: Record<string, number>;
+}
+
+const ACTIVE_COLLECTIONS = new Map<string, number>();
+
+function utcDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function emptyState(date: Date): BudgetState {
+  return { date: utcDay(date), daily_bytes: 0, highest_revisions: {} };
+}
+
+export interface CollectionLease {
+  commit(bytes: number): void;
+  release(): void;
+}
+
+export class CollectionBudgetManager {
+  readonly stateFile: string;
+  private readonly now: () => Date;
+
+  constructor(stateFile: string, now: () => Date = () => new Date()) {
+    this.stateFile = stateFile;
+    this.now = now;
+  }
+
+  acceptRevision(payload: CollectPolicyPayload): void {
+    const state = this.loadState();
+    const highest = state.highest_revisions[payload.policy_id] ?? 0;
+    if (payload.revision < highest) {
+      throw new CollectPolicyError(
+        "POLICY_DOWNGRADE_REJECTED",
+        `collect policy revision ${payload.revision} is older than accepted revision ${highest}`,
+      );
+    }
+    if (payload.revision > highest) {
+      state.highest_revisions[payload.policy_id] = payload.revision;
+      this.saveState(state);
+    }
+  }
+
+  acquire(payload: CollectPolicyPayload, network: CollectionNetwork): CollectionLease {
+    if (network === "offline") {
+      throw new CollectPolicyError("NETWORK_OFFLINE", "log collection is disabled while offline");
+    }
+    if (network === "weak" && payload.budgets.weak_network_backoff_ms > 0) {
+      throw new CollectPolicyError(
+        "WEAK_NETWORK_BACKOFF",
+        `log collection deferred for ${payload.budgets.weak_network_backoff_ms}ms on a weak network`,
+      );
+    }
+    const key = this.stateFile;
+    const active = ACTIVE_COLLECTIONS.get(key) ?? 0;
+    if (active >= payload.budgets.max_concurrency) {
+      throw new CollectPolicyError(
+        "COLLECTION_CONCURRENCY_EXCEEDED",
+        "log collection concurrency budget is exhausted",
+      );
+    }
+    const state = this.loadState();
+    if (state.daily_bytes >= payload.budgets.max_daily_bytes) {
+      throw new CollectPolicyError("DAILY_BUDGET_EXCEEDED", "daily log collection budget is exhausted");
+    }
+    ACTIVE_COLLECTIONS.set(key, active + 1);
+    let released = false;
+    return {
+      commit: (bytes: number) => {
+        const latest = this.loadState();
+        if (latest.daily_bytes + bytes > payload.budgets.max_daily_bytes) {
+          throw new CollectPolicyError(
+            "DAILY_BUDGET_EXCEEDED",
+            "log bundle would exceed the daily collection budget",
+          );
+        }
+        latest.daily_bytes += bytes;
+        this.saveState(latest);
+      },
+      release: () => {
+        if (released) return;
+        released = true;
+        const current = ACTIVE_COLLECTIONS.get(key) ?? 1;
+        if (current <= 1) ACTIVE_COLLECTIONS.delete(key);
+        else ACTIVE_COLLECTIONS.set(key, current - 1);
+      },
+    };
+  }
+
+  private loadState(): BudgetState {
+    const now = this.now();
+    try {
+      const parsed = JSON.parse(readFileSync(this.stateFile, "utf8")) as Partial<BudgetState>;
+      const revisions: Record<string, number> = {};
+      if (parsed.highest_revisions && typeof parsed.highest_revisions === "object") {
+        for (const [policyId, revision] of Object.entries(parsed.highest_revisions)) {
+          if (Number.isSafeInteger(revision) && revision > 0) revisions[policyId] = revision;
+        }
+      }
+      return {
+        date: parsed.date === utcDay(now) ? parsed.date : utcDay(now),
+        daily_bytes:
+          parsed.date === utcDay(now) && typeof parsed.daily_bytes === "number"
+            ? parsed.daily_bytes
+            : 0,
+        highest_revisions: revisions,
+      };
+    } catch {
+      return emptyState(now);
+    }
+  }
+
+  private saveState(state: BudgetState): void {
+    mkdirSync(dirname(this.stateFile), { recursive: true, mode: 0o700 });
+    const temporary = `${this.stateFile}.${process.pid}.tmp`;
+    writeFileSync(temporary, JSON.stringify(state), { encoding: "utf8", mode: 0o600 });
+    renameSync(temporary, this.stateFile);
+  }
+}
+
+export interface CollectLogsOptions {
+  policy: SignedCollectPolicy;
+  publicKeys: Record<string, KeyLike>;
+  files: string[];
+  outputFile: string;
+  stateFile: string;
+  source?: string;
+  network?: CollectionNetwork;
+  now?: Date;
+  budgetManager?: CollectionBudgetManager;
+  audit?: CollectionAuditSink;
+  auditLogger?: HandsLogger;
+}
+
+export interface CollectSuccess {
+  ok: true;
+  output_file: string;
+  bundle: LogBundle;
+  compressed_bytes: number;
+}
+
+export interface CollectFailure {
+  ok: false;
+  code: string;
+  message: string;
+}
+
+export type CollectResult = CollectSuccess | CollectFailure;
+
+function auditFailure(options: CollectLogsOptions, error: CollectPolicyError): void {
+  const payload = options.policy?.payload;
+  const event: CollectionAuditEvent = {
+    event: "handslog_collect_rejected",
+    code: error.code,
+    message: error.message,
+    ...(payload?.policy_id ? { policy_id: payload.policy_id } : {}),
+    ...(payload?.revision ? { policy_revision: payload.revision } : {}),
+  };
+  try {
+    options.audit?.(event);
+  } catch {
+    // Audit callbacks are best-effort and cannot change host behavior.
+  }
+  options.auditLogger?.warn(
+    "handslog",
+    error.message,
+    {
+      code: error.code,
+      policy_id: payload?.policy_id ?? "unknown",
+      policy_revision: payload?.revision ?? 0,
+    },
+    event.event,
+  );
+}
+
+function matchesSelection(entry: Record<string, unknown>, payload: CollectPolicyPayload): boolean {
+  const selection = payload.selection;
+  if (!selection) return true;
+  if (
+    selection.levels &&
+    (typeof entry.level !== "string" || !selection.levels.includes(entry.level as LogLevel))
+  ) {
+    return false;
+  }
+  if (selection.tags && !selection.tags.includes(String(entry.tag ?? ""))) return false;
+  if (selection.events && !selection.events.includes(String(entry.event ?? ""))) return false;
+  if (selection.since) {
+    const timestamp = typeof entry.ts === "string" ? Date.parse(entry.ts) : Number.NaN;
+    if (!Number.isFinite(timestamp) || timestamp < Date.parse(selection.since)) return false;
+  }
+  return true;
+}
+
+function collectFile(
+  path: string,
+  payload: CollectPolicyPayload,
+  remainingBytes: number,
+): { file: LogBundleFile | null; entries: number; bytes: number } {
+  const lines: string[] = [];
+  let entries = 0;
+  let bytes = 0;
+  const redaction = {
+    additionalSensitiveKeys: payload.redaction?.additional_sensitive_keys ?? [],
+    additionalValuePatterns: payload.redaction?.additional_value_patterns ?? [],
+  };
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    if (!matchesSelection(parsed as Record<string, unknown>, payload)) continue;
+    const redacted = redactValue(parsed, redaction);
+    const serialized = `${JSON.stringify(redacted)}\n`;
+    const lineBytes = Buffer.byteLength(serialized);
+    if (bytes + lineBytes > remainingBytes) {
+      throw new CollectPolicyError(
+        "COLLECTION_BUDGET_EXCEEDED",
+        "selected logs exceed the per-collection byte budget",
+      );
+    }
+    lines.push(serialized);
+    entries += 1;
+    bytes += lineBytes;
+  }
+  if (lines.length === 0) return { file: null, entries: 0, bytes: 0 };
+  const content = Buffer.from(lines.join(""), "utf8");
+  return {
+    file: {
+      name: basename(path),
+      size_bytes: content.byteLength,
+      sha256: createHash("sha256").update(content).digest("hex"),
+      content_base64: content.toString("base64"),
+    },
+    entries,
+    bytes,
+  };
+}
+
+export function collectLogs(options: CollectLogsOptions): CollectResult {
+  let lease: CollectionLease | undefined;
+  try {
+    const payload = verifyCollectPolicy(options.policy, {
+      publicKeys: options.publicKeys,
+      ...(options.now === undefined ? {} : { now: options.now }),
+    });
+    const manager =
+      options.budgetManager ??
+      new CollectionBudgetManager(options.stateFile, () => options.now ?? new Date());
+    manager.acceptRevision(payload);
+    lease = manager.acquire(payload, options.network ?? "strong");
+
+    const files: LogBundleFile[] = [];
+    let entries = 0;
+    let bytes = 0;
+    for (const path of options.files) {
+      const result = collectFile(path, payload, payload.budgets.max_collection_bytes - bytes);
+      if (result.file) files.push(result.file);
+      entries += result.entries;
+      bytes += result.bytes;
+    }
+    const createdAt = (options.now ?? new Date()).toISOString();
+    const bundle: LogBundle = {
+      manifest: {
+        schema_version: HANDS_LOG_SCHEMA_VERSION,
+        bundle_id: randomUUID(),
+        policy_id: payload.policy_id,
+        policy_revision: payload.revision,
+        created_at: createdAt,
+        source: options.source ?? "hands-node",
+        entries_count: entries,
+        uncompressed_bytes: bytes,
+        files: files.map(({ name, size_bytes, sha256 }) => ({ name, size_bytes, sha256 })),
+      },
+      files,
+    };
+    const validation = validateLogBundle(bundle);
+    if (!validation.valid) {
+      throw new CollectPolicyError("BUNDLE_SCHEMA_INVALID", validation.errors.join("; "));
+    }
+    const compressed = gzipSync(Buffer.from(JSON.stringify(bundle), "utf8"), { level: 9 });
+    lease.commit(bytes);
+    mkdirSync(dirname(options.outputFile), { recursive: true, mode: 0o700 });
+    writeFileSync(options.outputFile, compressed, { mode: 0o600 });
+    return {
+      ok: true,
+      output_file: options.outputFile,
+      bundle,
+      compressed_bytes: compressed.byteLength,
+    };
+  } catch (cause) {
+    const error =
+      cause instanceof CollectPolicyError
+        ? cause
+        : new CollectPolicyError(
+            "COLLECTION_FAILED",
+            cause instanceof Error ? cause.message : String(cause),
+          );
+    auditFailure(options, error);
+    return { ok: false, code: error.code, message: error.message };
+  } finally {
+    lease?.release();
+  }
+}
+
+export interface UploadLogBundleOptions {
+  endpoint: string;
+  bundleFile: string;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+}
+
+export async function uploadLogBundle(
+  options: UploadLogBundleOptions,
+): Promise<{ ok: true; status: number } | { ok: false; code: string; message: string }> {
+  try {
+    const response = await fetch(options.endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/gzip",
+        ...(options.headers ?? {}),
+      },
+      body: readFileSync(options.bundleFile),
+      signal: AbortSignal.timeout(options.timeoutMs ?? 30_000),
+    });
+    if (!response.ok) {
+      return { ok: false, code: "UPLOAD_REJECTED", message: `log ingest returned HTTP ${response.status}` };
+    }
+    return { ok: true, status: response.status };
+  } catch (cause) {
+    return {
+      ok: false,
+      code: "UPLOAD_FAILED",
+      message: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+}
+
+export function defaultCollectionStateFile(logDirectory: string): string {
+  return join(logDirectory, ".handslog-collection-state.json");
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,0 +1,35 @@
+export {
+  HandsLogger,
+  defaultLogDirectory,
+  logFileName,
+  type HandsLoggerOptions,
+  type LogEntry,
+  type LogFields,
+  type LogRedactor,
+} from "./logger.js";
+export type { LogLevel } from "./logs/schema.js";
+export {
+  DEFAULT_REDACTION_CONTRACT,
+  REDACTED,
+  redactEnvironment,
+  redactValue,
+  type RedactionOptions,
+} from "./redaction.js";
+export {
+  CollectionBudgetManager,
+  CollectPolicyError,
+  collectLogs,
+  defaultCollectionStateFile,
+  uploadLogBundle,
+  verifyCollectPolicy,
+  type CollectFailure,
+  type CollectionAuditEvent,
+  type CollectionAuditSink,
+  type CollectionLease,
+  type CollectionNetwork,
+  type CollectLogsOptions,
+  type CollectResult,
+  type CollectSuccess,
+  type UploadLogBundleOptions,
+  type VerifyPolicyOptions,
+} from "./collect.js";

--- a/packages/node/src/logger.test.ts
+++ b/packages/node/src/logger.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { HandsLogger } from "./logger.js";
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function temporaryDirectory(): string {
+  const path = mkdtempSync(join(tmpdir(), "hands-node-logger-"));
+  cleanup.push(path);
+  return path;
+}
+
+describe("HandsLogger", () => {
+  it("appends JSONL and resumes monotonic sequence numbers after restart", () => {
+    const dir = temporaryDirectory();
+    const first = new HandsLogger({ dir, name: "cli", minLevel: "debug" });
+    first.info("cli", "started", { command: "apps" }, "command_start");
+    first.warn("cli", "slow", undefined, "command_slow");
+
+    const second = new HandsLogger({ dir, name: "cli", minLevel: "debug" });
+    second.info("cli", "completed", { command: "apps" }, "command_success");
+
+    const entries = second
+      .currentFiles()
+      .flatMap((path) => readFileSync(path, "utf8").trim().split("\n"))
+      .map((line) => JSON.parse(line) as { seq: number; event: string });
+    expect(entries.map((entry) => entry.seq).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    expect(entries.some((entry) => entry.event === "command_success")).toBe(true);
+  });
+
+  it("rotates daily files at the size cap and keeps a bounded ring", () => {
+    const dir = temporaryDirectory();
+    const logger = new HandsLogger({
+      dir,
+      name: "rotate",
+      maxFileBytes: 240,
+      maxTotalBytes: 10_000,
+      ringSize: 2,
+      now: () => new Date("2026-07-10T04:00:00+08:00"),
+    });
+    logger.info("test", "a".repeat(100));
+    logger.info("test", "b".repeat(100));
+    logger.info("test", "c".repeat(100));
+
+    expect(logger.currentFiles().length).toBeGreaterThan(1);
+    expect(logger.snapshot()).toHaveLength(2);
+    expect(logger.snapshot().map((entry) => entry.message)).toEqual([
+      "b".repeat(100),
+      "c".repeat(100),
+    ]);
+  });
+
+  it("applies mandatory default redaction before disk and ring output", () => {
+    const dir = temporaryDirectory();
+    const logger = new HandsLogger({ dir, name: "redaction" });
+    logger.info(
+      "auth",
+      "Authorization: Bearer abc.def.ghi token sk_agent_supersecret",
+      { authorization: "Bearer raw-secret", safe: "visible" },
+    );
+
+    const output = readFileSync(logger.currentFiles()[0]!, "utf8");
+    expect(output).not.toContain("raw-secret");
+    expect(output).not.toContain("sk_agent_supersecret");
+    expect(output).toContain("[REDACTED]");
+    expect(logger.snapshot()[0]?.fields?.safe).toBe("visible");
+  });
+
+  it("allows a custom redactor to drop an entry after default redaction", () => {
+    const dir = temporaryDirectory();
+    const logger = new HandsLogger({ dir, name: "drop", redactor: () => null });
+    logger.info("test", "do not persist");
+    expect(logger.currentFiles()).toEqual([]);
+    expect(logger.snapshot()).toEqual([]);
+  });
+});

--- a/packages/node/src/logger.ts
+++ b/packages/node/src/logger.ts
@@ -1,0 +1,330 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import type { JsonScalar, LogLevel } from "./logs/schema.js";
+import { redactValue, type RedactionOptions } from "./redaction.js";
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  verbose: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+export interface LogFields {
+  [key: string]: JsonScalar;
+}
+
+export interface LogEntry {
+  ts: string;
+  level: LogLevel;
+  event: string;
+  tag: string;
+  message: string;
+  fields?: LogFields;
+  thread?: string;
+  seq: number;
+  dropped: number;
+  truncated: boolean;
+}
+
+export type LogRedactor = (entry: LogEntry) => LogEntry | null;
+
+export interface HandsLoggerOptions {
+  name?: string;
+  dir?: string;
+  minLevel?: LogLevel;
+  rotate?: "daily" | "size";
+  maxFileBytes?: number;
+  maxTotalBytes?: number;
+  maxFiles?: number;
+  maxAgeDays?: number;
+  ringSize?: number;
+  maxEntryBytes?: number;
+  thread?: string;
+  redactor?: LogRedactor;
+  redaction?: RedactionOptions;
+  console?: boolean;
+  now?: () => Date;
+}
+
+interface ResolvedLoggerOptions {
+  name: string;
+  dir: string;
+  minLevel: LogLevel;
+  rotate: "daily" | "size";
+  maxFileBytes: number;
+  maxTotalBytes: number;
+  maxFiles: number;
+  maxAgeDays: number;
+  ringSize: number;
+  maxEntryBytes: number;
+  thread?: string;
+  redactor?: LogRedactor;
+  redaction: RedactionOptions;
+  console: boolean;
+  now: () => Date;
+}
+
+export function defaultLogDirectory(appName = "hands"): string {
+  const stateHome = process.env.XDG_STATE_HOME;
+  if (stateHome) return join(stateHome, appName, "logs");
+  if (process.platform === "win32" && process.env.LOCALAPPDATA) {
+    return join(process.env.LOCALAPPDATA, appName, "logs");
+  }
+  return join(homedir(), ".local", "state", appName, "logs");
+}
+
+function safeName(name: string): string {
+  const value = name.trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return value || "app";
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function localDay(date: Date): string {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+function isoWithOffset(date: Date): string {
+  const offset = -date.getTimezoneOffset();
+  const sign = offset >= 0 ? "+" : "-";
+  const hours = pad(Math.floor(Math.abs(offset) / 60));
+  const minutes = pad(Math.abs(offset) % 60);
+  const millis = String(date.getMilliseconds()).padStart(3, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${millis}${sign}${hours}:${minutes}`;
+}
+
+function positive(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export class HandsLogger {
+  readonly options: ResolvedLoggerOptions;
+  private readonly ring: LogEntry[] = [];
+  private sequence = 0;
+
+  constructor(options: HandsLoggerOptions = {}) {
+    const thread = options.thread;
+    const redactor = options.redactor;
+    this.options = {
+      name: safeName(options.name ?? "hands"),
+      dir: options.dir ?? defaultLogDirectory(),
+      minLevel: options.minLevel ?? "info",
+      rotate: options.rotate ?? "daily",
+      maxFileBytes: positive(options.maxFileBytes, 512 * 1024),
+      maxTotalBytes: positive(options.maxTotalBytes, 4 * 1024 * 1024),
+      maxFiles: positive(options.maxFiles, 20),
+      maxAgeDays: positive(options.maxAgeDays, 7),
+      ringSize: positive(options.ringSize, 500),
+      maxEntryBytes: positive(options.maxEntryBytes, 64 * 1024),
+      ...(thread === undefined ? {} : { thread }),
+      ...(redactor === undefined ? {} : { redactor }),
+      redaction: options.redaction ?? {},
+      console: options.console ?? false,
+      now: options.now ?? (() => new Date()),
+    };
+    mkdirSync(this.options.dir, { recursive: true, mode: 0o700 });
+    this.sequence = this.readLastSequence();
+    this.enforceRetention();
+  }
+
+  verbose(tag: string, message: string, fields?: LogFields, event?: string): void {
+    this.write("verbose", tag, message, fields, event);
+  }
+
+  debug(tag: string, message: string, fields?: LogFields, event?: string): void {
+    this.write("debug", tag, message, fields, event);
+  }
+
+  info(tag: string, message: string, fields?: LogFields, event?: string): void {
+    this.write("info", tag, message, fields, event);
+  }
+
+  warn(tag: string, message: string, fields?: LogFields, event?: string): void {
+    this.write("warn", tag, message, fields, event);
+  }
+
+  error(tag: string, message: string, fields?: LogFields, event?: string): void {
+    this.write("error", tag, message, fields, event);
+  }
+
+  write(
+    level: LogLevel,
+    tag: string,
+    message: string,
+    fields?: LogFields,
+    event?: string,
+  ): void {
+    if (LEVEL_PRIORITY[level] < LEVEL_PRIORITY[this.options.minLevel]) return;
+    try {
+      const now = this.options.now();
+      const base: LogEntry = {
+        ts: isoWithOffset(now),
+        level,
+        event: event ?? tag,
+        tag,
+        message,
+        ...(fields === undefined ? {} : { fields }),
+        ...(this.options.thread === undefined ? {} : { thread: this.options.thread }),
+        seq: ++this.sequence,
+        dropped: 0,
+        truncated: false,
+      };
+      const defaultRedacted = redactValue(base, this.options.redaction) as LogEntry;
+      const entry = this.options.redactor
+        ? this.options.redactor(defaultRedacted)
+        : defaultRedacted;
+      if (entry === null) return;
+      const normalized = this.truncateEntry(entry);
+      const line = `${JSON.stringify(normalized)}\n`;
+      const target = this.prepareTarget(Buffer.byteLength(line), now);
+      appendFileSync(target, line, { encoding: "utf8", mode: 0o600, flag: "a" });
+      this.ring.push(normalized);
+      while (this.ring.length > this.options.ringSize) this.ring.shift();
+      if (this.options.console) console.error(line.trimEnd());
+      this.enforceRetention();
+    } catch {
+      // Logging is deliberately best-effort and must never alter host behavior.
+    }
+  }
+
+  flush(): void {
+    // Writes are synchronous so there is no pending queue to flush.
+  }
+
+  snapshot(): LogEntry[] {
+    return this.ring.map((entry) => structuredClone(entry));
+  }
+
+  currentFiles(): string[] {
+    try {
+      return this.logFiles()
+        .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs)
+        .slice(0, this.options.maxFiles);
+    } catch {
+      return [];
+    }
+  }
+
+  private truncateEntry(entry: LogEntry): LogEntry {
+    let serialized = JSON.stringify(entry);
+    if (Buffer.byteLength(serialized) <= this.options.maxEntryBytes) return entry;
+    const copy: LogEntry = { ...entry, truncated: true };
+    delete copy.fields;
+    const overhead = Buffer.byteLength(JSON.stringify({ ...copy, message: "" }));
+    const allowed = Math.max(0, this.options.maxEntryBytes - overhead - 16);
+    copy.message = Buffer.from(copy.message).subarray(0, allowed).toString("utf8");
+    serialized = JSON.stringify(copy);
+    while (Buffer.byteLength(serialized) > this.options.maxEntryBytes && copy.message.length > 0) {
+      copy.message = copy.message.slice(0, Math.floor(copy.message.length * 0.9));
+      serialized = JSON.stringify(copy);
+    }
+    return copy;
+  }
+
+  private prepareTarget(incomingBytes: number, now: Date): string {
+    if (this.options.rotate === "size") return this.prepareSizeTarget(incomingBytes);
+    const base = join(this.options.dir, `hands-${this.options.name}-${localDay(now)}.jsonl`);
+    if (!existsSync(base) || statSync(base).size + incomingBytes <= this.options.maxFileBytes) {
+      return base;
+    }
+    let index = 1;
+    while (true) {
+      const candidate = base.replace(/\.jsonl$/, `.${index}.jsonl`);
+      if (!existsSync(candidate) || statSync(candidate).size + incomingBytes <= this.options.maxFileBytes) {
+        return candidate;
+      }
+      index += 1;
+    }
+  }
+
+  private prepareSizeTarget(incomingBytes: number): string {
+    const base = join(this.options.dir, `hands-${this.options.name}.jsonl`);
+    if (!existsSync(base) || statSync(base).size + incomingBytes <= this.options.maxFileBytes) {
+      return base;
+    }
+    for (let index = this.options.maxFiles - 1; index >= 1; index -= 1) {
+      const source = index === 1 ? base : `${base}.${index - 1}`;
+      const destination = `${base}.${index}`;
+      if (!existsSync(source)) continue;
+      if (existsSync(destination)) rmSync(destination, { force: true });
+      renameSync(source, destination);
+    }
+    return base;
+  }
+
+  private logFiles(): string[] {
+    if (!existsSync(this.options.dir)) return [];
+    const dailyPrefix = `hands-${this.options.name}-`;
+    const sizePrefix = `hands-${this.options.name}.jsonl`;
+    return readdirSync(this.options.dir)
+      .filter(
+        (name) =>
+          (name.startsWith(dailyPrefix) && name.endsWith(".jsonl")) ||
+          name === sizePrefix ||
+          name.startsWith(`${sizePrefix}.`),
+      )
+      .map((name) => join(this.options.dir, name));
+  }
+
+  private readLastSequence(): number {
+    let highest = 0;
+    for (const path of this.logFiles()) {
+      try {
+        for (const line of readFileSync(path, "utf8").split("\n")) {
+          if (!line) continue;
+          const parsed = JSON.parse(line) as { seq?: unknown };
+          if (typeof parsed.seq === "number" && Number.isSafeInteger(parsed.seq)) {
+            highest = Math.max(highest, parsed.seq);
+          }
+        }
+      } catch {
+        // Ignore damaged files and keep the best sequence found elsewhere.
+      }
+    }
+    return highest;
+  }
+
+  private enforceRetention(): void {
+    try {
+      const cutoff = this.options.now().getTime() - this.options.maxAgeDays * 86_400_000;
+      const files = this.logFiles()
+        .map((path) => ({ path, stat: statSync(path) }))
+        .sort((left, right) => right.stat.mtimeMs - left.stat.mtimeMs);
+
+      for (const file of files) {
+        if (file.stat.mtimeMs < cutoff) rmSync(file.path, { force: true });
+      }
+
+      const remaining = this.logFiles()
+        .map((path) => ({ path, stat: statSync(path) }))
+        .sort((left, right) => right.stat.mtimeMs - left.stat.mtimeMs);
+      let total = 0;
+      remaining.forEach((file, index) => {
+        total += file.stat.size;
+        if (index >= this.options.maxFiles || total > this.options.maxTotalBytes) {
+          rmSync(file.path, { force: true });
+        }
+      });
+    } catch {
+      // Retention cleanup is best-effort for the same reason writes are.
+    }
+  }
+}
+
+export function logFileName(path: string): string {
+  return basename(path);
+}

--- a/packages/node/src/logs/schema.ts
+++ b/packages/node/src/logs/schema.ts
@@ -1,0 +1,321 @@
+export const HANDS_LOG_SCHEMA_VERSION = 1 as const;
+export const HANDS_LOG_SIGNATURE_ALGORITHM = "ed25519" as const;
+
+export type LogLevel = "verbose" | "debug" | "info" | "warn" | "error";
+export type JsonScalar = string | number | boolean | null;
+
+export interface RedactionContract {
+  schema_version: typeof HANDS_LOG_SCHEMA_VERSION;
+  replacement: string;
+  sensitive_keys: string[];
+  value_patterns: string[];
+}
+
+export interface CollectSelection {
+  levels?: LogLevel[];
+  tags?: string[];
+  events?: string[];
+  since?: string;
+}
+
+export interface CollectBudgets {
+  max_collection_bytes: number;
+  max_daily_bytes: number;
+  max_concurrency: number;
+  weak_network_backoff_ms: number;
+}
+
+export interface CollectPolicyPayload {
+  schema_version: typeof HANDS_LOG_SCHEMA_VERSION;
+  policy_id: string;
+  revision: number;
+  key_id: string;
+  issued_at: string;
+  expires_at: string;
+  selection?: CollectSelection;
+  budgets: CollectBudgets;
+  redaction?: {
+    additional_sensitive_keys?: string[];
+    additional_value_patterns?: string[];
+  };
+}
+
+export interface SignedCollectPolicy {
+  signature_algorithm: typeof HANDS_LOG_SIGNATURE_ALGORITHM;
+  signature: string;
+  payload: CollectPolicyPayload;
+}
+
+export interface LogBundleFile {
+  name: string;
+  size_bytes: number;
+  sha256: string;
+  content_base64: string;
+}
+
+export interface LogBundleManifest {
+  schema_version: typeof HANDS_LOG_SCHEMA_VERSION;
+  bundle_id: string;
+  policy_id: string;
+  policy_revision: number;
+  created_at: string;
+  source: string;
+  entries_count: number;
+  uncompressed_bytes: number;
+  files: Array<Pick<LogBundleFile, "name" | "size_bytes" | "sha256">>;
+}
+
+export interface LogBundle {
+  manifest: LogBundleManifest;
+  files: LogBundleFile[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+const LEVELS = new Set<LogLevel>(["verbose", "debug", "info", "warn", "error"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && Number.isFinite(Date.parse(value));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function validateStringArray(
+  value: unknown,
+  path: string,
+  errors: string[],
+  predicate: (item: string) => boolean = () => true,
+): void {
+  if (!Array.isArray(value) || !value.every((item) => isNonEmptyString(item) && predicate(item))) {
+    errors.push(`${path} must be an array of supported non-empty strings`);
+  }
+}
+
+function validateRegexArray(value: unknown, path: string, errors: string[]): void {
+  validateStringArray(value, path, errors);
+  if (!Array.isArray(value)) return;
+  value.forEach((pattern, index) => {
+    if (typeof pattern !== "string") return;
+    try {
+      new RegExp(pattern);
+    } catch {
+      errors.push(`${path}[${index}] must be a valid regular expression`);
+    }
+  });
+}
+
+export function validateCollectPolicy(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { valid: false, errors: ["policy must be an object"] };
+  if (value.signature_algorithm !== HANDS_LOG_SIGNATURE_ALGORITHM) {
+    errors.push(`signature_algorithm must be ${HANDS_LOG_SIGNATURE_ALGORITHM}`);
+  }
+  if (!isNonEmptyString(value.signature)) errors.push("signature must be a non-empty string");
+  if (!isRecord(value.payload)) {
+    errors.push("payload must be an object");
+    return { valid: false, errors };
+  }
+
+  const payload = value.payload;
+  if (payload.schema_version !== HANDS_LOG_SCHEMA_VERSION) {
+    errors.push(`payload.schema_version must be ${HANDS_LOG_SCHEMA_VERSION}`);
+  }
+  if (!isNonEmptyString(payload.policy_id)) errors.push("payload.policy_id is required");
+  if (!isPositiveInteger(payload.revision)) errors.push("payload.revision must be a positive integer");
+  if (!isNonEmptyString(payload.key_id)) errors.push("payload.key_id is required");
+  if (!isIsoDate(payload.issued_at)) errors.push("payload.issued_at must be ISO-8601");
+  if (!isIsoDate(payload.expires_at)) errors.push("payload.expires_at must be ISO-8601");
+  if (
+    isIsoDate(payload.issued_at) &&
+    isIsoDate(payload.expires_at) &&
+    Date.parse(payload.expires_at) <= Date.parse(payload.issued_at)
+  ) {
+    errors.push("payload.expires_at must be later than payload.issued_at");
+  }
+
+  if (!isRecord(payload.budgets)) {
+    errors.push("payload.budgets must be an object");
+  } else {
+    if (!isPositiveInteger(payload.budgets.max_collection_bytes)) {
+      errors.push("payload.budgets.max_collection_bytes must be a positive integer");
+    }
+    if (!isPositiveInteger(payload.budgets.max_daily_bytes)) {
+      errors.push("payload.budgets.max_daily_bytes must be a positive integer");
+    }
+    if (!isPositiveInteger(payload.budgets.max_concurrency)) {
+      errors.push("payload.budgets.max_concurrency must be a positive integer");
+    }
+    if (!isNonNegativeInteger(payload.budgets.weak_network_backoff_ms)) {
+      errors.push("payload.budgets.weak_network_backoff_ms must be a non-negative integer");
+    }
+  }
+
+  if (payload.selection !== undefined) {
+    if (!isRecord(payload.selection)) {
+      errors.push("payload.selection must be an object");
+    } else {
+      if (payload.selection.levels !== undefined) {
+        validateStringArray(
+          payload.selection.levels,
+          "payload.selection.levels",
+          errors,
+          (level) => LEVELS.has(level as LogLevel),
+        );
+      }
+      if (payload.selection.tags !== undefined) {
+        validateStringArray(payload.selection.tags, "payload.selection.tags", errors);
+      }
+      if (payload.selection.events !== undefined) {
+        validateStringArray(payload.selection.events, "payload.selection.events", errors);
+      }
+      if (payload.selection.since !== undefined && !isIsoDate(payload.selection.since)) {
+        errors.push("payload.selection.since must be ISO-8601");
+      }
+    }
+  }
+
+  if (payload.redaction !== undefined) {
+    if (!isRecord(payload.redaction)) {
+      errors.push("payload.redaction must be an object");
+    } else {
+      if (payload.redaction.additional_sensitive_keys !== undefined) {
+        validateStringArray(
+          payload.redaction.additional_sensitive_keys,
+          "payload.redaction.additional_sensitive_keys",
+          errors,
+        );
+      }
+      if (payload.redaction.additional_value_patterns !== undefined) {
+        validateRegexArray(
+          payload.redaction.additional_value_patterns,
+          "payload.redaction.additional_value_patterns",
+          errors,
+        );
+      }
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateLogBundle(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  let manifestFiles: unknown[] | undefined;
+  if (!isRecord(value)) return { valid: false, errors: ["bundle must be an object"] };
+  if (!isRecord(value.manifest)) {
+    errors.push("manifest must be an object");
+  } else {
+    const manifest = value.manifest;
+    if (manifest.schema_version !== HANDS_LOG_SCHEMA_VERSION) {
+      errors.push(`manifest.schema_version must be ${HANDS_LOG_SCHEMA_VERSION}`);
+    }
+    if (!isNonEmptyString(manifest.bundle_id)) errors.push("manifest.bundle_id is required");
+    if (!isNonEmptyString(manifest.policy_id)) errors.push("manifest.policy_id is required");
+    if (!isPositiveInteger(manifest.policy_revision)) {
+      errors.push("manifest.policy_revision must be a positive integer");
+    }
+    if (!isIsoDate(manifest.created_at)) errors.push("manifest.created_at must be ISO-8601");
+    if (!isNonEmptyString(manifest.source)) errors.push("manifest.source is required");
+    if (!isNonNegativeInteger(manifest.entries_count)) {
+      errors.push("manifest.entries_count must be a non-negative integer");
+    }
+    if (!isNonNegativeInteger(manifest.uncompressed_bytes)) {
+      errors.push("manifest.uncompressed_bytes must be a non-negative integer");
+    }
+    if (!Array.isArray(manifest.files)) {
+      errors.push("manifest.files must be an array");
+    } else {
+      manifestFiles = manifest.files;
+      manifest.files.forEach((file, index) => {
+        if (!isRecord(file)) {
+          errors.push(`manifest.files[${index}] must be an object`);
+          return;
+        }
+        if (!isNonEmptyString(file.name)) errors.push(`manifest.files[${index}].name is required`);
+        if (!isNonNegativeInteger(file.size_bytes)) {
+          errors.push(`manifest.files[${index}].size_bytes must be a non-negative integer`);
+        }
+        if (typeof file.sha256 !== "string" || !/^[a-f0-9]{64}$/.test(file.sha256)) {
+          errors.push(`manifest.files[${index}].sha256 must be lowercase SHA-256 hex`);
+        }
+      });
+    }
+  }
+  if (!Array.isArray(value.files)) {
+    errors.push("files must be an array");
+  } else {
+    value.files.forEach((file, index) => {
+      if (!isRecord(file)) {
+        errors.push(`files[${index}] must be an object`);
+        return;
+      }
+      if (!isNonEmptyString(file.name)) errors.push(`files[${index}].name is required`);
+      if (!isNonNegativeInteger(file.size_bytes)) {
+        errors.push(`files[${index}].size_bytes must be a non-negative integer`);
+      }
+      if (typeof file.sha256 !== "string" || !/^[a-f0-9]{64}$/.test(file.sha256)) {
+        errors.push(`files[${index}].sha256 must be lowercase SHA-256 hex`);
+      }
+      if (typeof file.content_base64 !== "string") {
+        errors.push(`files[${index}].content_base64 must be a string`);
+      } else if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(file.content_base64)) {
+        errors.push(`files[${index}].content_base64 must be valid base64`);
+      }
+    });
+    if (manifestFiles && manifestFiles.length !== value.files.length) {
+      errors.push("manifest.files and files must have the same length");
+    }
+    if (manifestFiles) {
+      value.files.forEach((file, index) => {
+        const manifestFile = manifestFiles?.[index];
+        if (!isRecord(file) || !isRecord(manifestFile)) return;
+        if (
+          file.name !== manifestFile.name ||
+          file.size_bytes !== manifestFile.size_bytes ||
+          file.sha256 !== manifestFile.sha256
+        ) {
+          errors.push(`manifest.files[${index}] must match files[${index}] metadata`);
+        }
+      });
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateRedactionContract(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(value)) return { valid: false, errors: ["redaction must be an object"] };
+  if (value.schema_version !== HANDS_LOG_SCHEMA_VERSION) {
+    errors.push(`schema_version must be ${HANDS_LOG_SCHEMA_VERSION}`);
+  }
+  if (!isNonEmptyString(value.replacement)) errors.push("replacement is required");
+  validateStringArray(value.sensitive_keys, "sensitive_keys", errors);
+  validateRegexArray(value.value_patterns, "value_patterns", errors);
+  return { valid: errors.length === 0, errors };
+}
+
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  const fields = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`);
+  return `{${fields.join(",")}}`;
+}

--- a/packages/node/src/redaction.ts
+++ b/packages/node/src/redaction.ts
@@ -1,0 +1,100 @@
+import type { RedactionContract } from "./logs/schema.js";
+import { HANDS_LOG_SCHEMA_VERSION } from "./logs/schema.js";
+
+export const REDACTED = "[REDACTED]";
+
+export const DEFAULT_REDACTION_CONTRACT: RedactionContract = {
+  schema_version: HANDS_LOG_SCHEMA_VERSION,
+  replacement: REDACTED,
+  sensitive_keys: [
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "token",
+    "access_token",
+    "refresh_token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "password",
+    "passwd",
+    "session",
+    "credential",
+    "private_key",
+  ],
+  value_patterns: [
+    "\\bBearer\\s+[A-Za-z0-9._~+/=-]+",
+    "\\bBasic\\s+[A-Za-z0-9+/=]+",
+    "\\beyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\b",
+    "\\b(?:sk_agent|sk_machine|qvdt|ghp|github_pat)_[A-Za-z0-9_-]{8,}\\b",
+    "\\b(?:api[_-]?key|token|secret|password|authorization|cookie)\\s*[:=]\\s*[^\\s,;]+",
+  ],
+};
+
+export interface RedactionOptions {
+  replacement?: string;
+  additionalSensitiveKeys?: string[];
+  additionalValuePatterns?: string[];
+}
+
+function normalizeKey(key: string): string {
+  return key.toLowerCase().replaceAll("-", "_");
+}
+
+function keyMatches(key: string, sensitiveKeys: Set<string>): boolean {
+  const normalized = normalizeKey(key);
+  return [...sensitiveKeys].some(
+    (candidate) =>
+      normalized === candidate ||
+      normalized.startsWith(`${candidate}_`) ||
+      normalized.endsWith(`_${candidate}`) ||
+      normalized.includes(`_${candidate}_`),
+  );
+}
+
+function compilePatterns(patterns: string[]): RegExp[] {
+  return patterns.map((pattern) => new RegExp(pattern, "gi"));
+}
+
+function redactString(value: string, patterns: RegExp[], replacement: string): string {
+  let redacted = value;
+  for (const pattern of patterns) redacted = redacted.replace(pattern, replacement);
+  return redacted;
+}
+
+export function redactValue(value: unknown, options: RedactionOptions = {}): unknown {
+  const replacement = options.replacement ?? DEFAULT_REDACTION_CONTRACT.replacement;
+  const sensitiveKeys = new Set(
+    [...DEFAULT_REDACTION_CONTRACT.sensitive_keys, ...(options.additionalSensitiveKeys ?? [])].map(
+      normalizeKey,
+    ),
+  );
+  const patterns = compilePatterns([
+    ...DEFAULT_REDACTION_CONTRACT.value_patterns,
+    ...(options.additionalValuePatterns ?? []),
+  ]);
+  const seen = new WeakSet<object>();
+
+  const visit = (current: unknown): unknown => {
+    if (typeof current === "string") return redactString(current, patterns, replacement);
+    if (current === null || typeof current !== "object") return current;
+    if (seen.has(current)) return "[CIRCULAR]";
+    seen.add(current);
+    if (Array.isArray(current)) return current.map(visit);
+
+    const output: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(current)) {
+      output[key] = keyMatches(key, sensitiveKeys) ? replacement : visit(nested);
+    }
+    return output;
+  };
+
+  return visit(value);
+}
+
+export function redactEnvironment(
+  environment: NodeJS.ProcessEnv,
+  options: RedactionOptions = {},
+): Record<string, string> {
+  return redactValue(environment, options) as Record<string, string>;
+}

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@botiverse/hands-node':
+        specifier: workspace:^0.1.0
+        version: link:../node
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -105,6 +108,18 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.20.0)
+
+  packages/node:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -720,89 +735,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -908,66 +939,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}


### PR DESCRIPTION
## Summary
- add `@botiverse/hands-node@0.1.0` with JSONL logging, daily/size rotation, retention, ring snapshots, mandatory default redaction, gzip bundles, and best-effort upload
- export collect-policy, bundle, and redaction types/validators from `@botiverse/hands-node/logs/schema`
- enforce Ed25519 policy signatures, schema version, expiry, downgrade state, collection/daily/concurrency/network budgets, and fail-closed audit events
- integrate structured logging and `hands logs collect` into `@botiverse/hands-cli@0.5.0` without changing command exit behavior on logging/collection failures
- add trusted-publishing workflow for the Node SDK and pack the CLI with pnpm so its workspace dependency publishes as `@botiverse/hands-node@^0.1.0`

## Validation
- `pnpm --filter @botiverse/hands-node test` (13 passed)
- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli test` (12 passed)
- `pnpm --filter @botiverse/hands-cli build`
- `pnpm install --frozen-lockfile`
- workflow YAML parse for `publish-node.yml` and `publish-cli.yml`
- `git diff --check`
- real CLI smoke: JSONL start/success entries, valid signed-policy gzip bundle, bad signature returns structured failure with exit 0 and writes `handslog_collect_rejected`
- packed `hands-node@0.1.0` + `hands-cli@0.5.0` installed together in an empty prefix; installed CLI and `logs/schema` sub-export resolve successfully

## Note
A full `pnpm -r build` reached the unrelated Worker package and stopped because this fresh worktree does not contain the generated `worker/worker-configuration.d.ts`. Node, CLI, Electron, container, and admin compilation stages completed before that baseline setup failure.

## Publish order
Publish `@botiverse/hands-node@0.1.0` first, then `@botiverse/hands-cli@0.5.0`; the CLI workflow verifies the declared Node SDK version exists before publishing.
