### PR TITLE
feat(cli): post-login next-steps + root help recipes (0.5.1)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -115,6 +115,14 @@ export function registerLoginCommands(program: Command): void {
         try {
           await apiRequest("/api/auth/me");
           console.log(`✔ Token verified — you're logged in.`);
+          console.log("");
+          console.log("Next steps:");
+          console.log("  hands whoami                            confirm who you are");
+          console.log("  hands apps list                         see your apps");
+          console.log("  hands feedback list <app> --kind crash  newest crash tickets");
+          console.log("  hands --help                            all commands + recipes");
+          console.log("");
+          console.log("Docs: https://hands.build/docs/cli-reference");
         } catch (e) {
           if (e instanceof QuiverApiError && e.status === 401) {
             console.error(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,13 +36,29 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.0")
+  .version("0.5.1")
   .option(
     "--api <url>",
     "Quiver Worker base URL (default: https://quiver.oranix.io or $QUIVER_API)",
   )
   .option("--json", "Output machine-readable JSON (suppresses human output)", false)
-  .option("--verbose", "Print HTTP request details for debugging", false);
+  .option("--verbose", "Print HTTP request details for debugging", false)
+  .addHelpText(
+    "after",
+    `
+Common recipes:
+  hands whoami                                        Who am I / is my auth valid?
+  hands apps list                                     Apps I can access
+  hands feedback list <app> --kind crash              Newest crash tickets
+  hands feedback show <app> <ticketId>                One ticket: device context + attachments
+  hands feedback download-attachment <app> <t> <a>    Pull a crash log / screenshot
+  hands releases list <app>                           Release history
+  hands logs collect                                  Bundle local CLI logs for a bug report
+
+Every command supports --json for scripts/agents. Full docs:
+  https://hands.build/docs/cli-reference
+  https://hands.build/docs/agent-cli-feedback   (crash/feedback triage guide)`,
+  );
 
 // Re-read global options after parse to wire into the API client.
 program.hook("preAction", (_rootCommand, actionCommand) => {


### PR DESCRIPTION
artin in #首页专修:743491b0: "raft login 后没有什么help之类的吗？要不你提供一个help action？"

- `hands login` success now ends with a **Next steps** block: `whoami`, `apps list`, `feedback list <app> --kind crash`, `--help`, plus the docs URL — so a fresh login lands you somewhere instead of silence.
- Root `hands --help` gains a **Common recipes** epilogue (crash triage flow, releases, logs collect) with links to /docs/cli-reference and /docs/agent-cli-feedback.
- Version 0.5.1.

Verified locally: `pnpm --filter @botiverse/hands-node build` + CLI `tsc` clean; `node dist/index.js --help` renders the recipes block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)