### PR TITLE
ci(deploy): build hands-cli workspace deps in checks

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -62,7 +62,8 @@ jobs:
         run: |
           pnpm --filter @botiverse/hands-worker test
           pnpm --filter @botiverse/hands-worker build
-          pnpm --filter @botiverse/hands-cli build
+          # "..." builds workspace deps first (hands-cli depends on hands-node).
+          pnpm --filter @botiverse/hands-cli... build
           pnpm --filter @botiverse/hands-admin build
 
       - name: Build deploy assets


### PR DESCRIPTION
Deploy run 'Run checks' broke after the CLI gained the `@botiverse/hands-node` workspace dependency (HandsLog Phase 1): `pnpm --filter @botiverse/hands-cli build` doesn't build workspace deps, so tsc failed with TS2307. Switch to `--filter @botiverse/hands-cli... build` (topological, deps first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)