### PR TITLE
ci: publish npm packages with repository token

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with trusted publishing support
         run: |
@@ -90,10 +91,14 @@ jobs:
       - name: Publish dry run
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: npm publish "${{ steps.pack.outputs.path }}" --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         run: npm publish "${{ steps.pack.outputs.path }}" --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
         shell: bash

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with trusted publishing support
         run: |
@@ -75,11 +76,15 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         working-directory: packages/node
         run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         working-directory: packages/node
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
         shell: bash

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ GitHub Actions owns production publishing so local machines do not need long-liv
 
 Required repository secrets:
 
+- `NPM_TOKEN` — npm automation token with publish access to the `@botiverse` scope, used by the Node SDK and CLI publishing workflows.
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token allowed to deploy the Hands Worker and its assets.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
@@ -127,8 +128,8 @@ Required repository secrets:
 
 Workflows:
 
-- `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm through npm Trusted Publishing / GitHub OIDC. Configure the npm package trusted publisher for `.github/workflows/publish-node.yml`, then trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
-- `Publish CLI` publishes `@botiverse/hands-cli` to npm through npm Trusted Publishing / GitHub OIDC. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Configure the npm package trusted publisher for this repository and workflow, then trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.0`.
+- `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm with the repository `NPM_TOKEN`. Trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
+- `Publish CLI` publishes `@botiverse/hands-cli` with the repository `NPM_TOKEN`. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.1`.
 - `Deploy Quiver Server` deploys the Worker plus bundled admin/docs assets. Trigger it manually, or push a tag like `server-v2026.07.04`. The default container rollout is `none`; choose `immediate` or `gradual` only when the APK parser container image changed.
 - `Deploy Hands Server` deploys the same Worker/admin bundle to `hands.build` in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
 


### PR DESCRIPTION
## Summary
- configure `actions/setup-node` with the official npm registry for Node SDK and CLI publishing
- provide `secrets.NPM_TOKEN` as `NODE_AUTH_TOKEN` to dry-run and real publish steps
- document the repository npm secret and token-backed publish flow

## Context
`@botiverse/hands-cli@0.5.1` is merged but its existing publish run failed with `ENEEDAUTH`. The repository secret is now configured; after this PR merges, rerun Publish CLI for 0.5.1.

## Validation
- workflow YAML parse passed for `publish-cli.yml` and `publish-node.yml`
- `git diff --check`
- repository secret list confirms `NPM_TOKEN` is configured (value not exposed)
