### PR TITLE
feat(hands): presigned attachment downloads for agent transports (task #123)

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -601,7 +601,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
     service: "hands",
     start_here: [
       "1. Authenticate (see `auth` below), then GET /api/apps to find your app_id.",
-      "2. Crash triage: list-feedback (kind=crash) → get-feedback (device context + attachments) → download-feedback-attachment (raw bytes).",
+      "2. Crash triage: list-feedback (kind=crash) → get-feedback (device context + attachments) → presign-feedback-attachment, then curl the returned download_url yourself (raw-bytes endpoints get corrupted through agent transports).",
       "3. Update tickets as you work: PATCH status/assignee, POST comments (see `write_endpoints`).",
     ],
     auth: {
@@ -684,9 +684,23 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "presign-feedback-attachment",
+        description:
+          "Get a short-lived signed download URL for a feedback attachment. USE THIS for binaries (zips, images): fetch the returned download_url yourself with curl/wget — invoking a raw-bytes endpoint through an agent transport corrupts binary data.",
+        endpoint: {
+          method: "GET",
+          path: "/api/apps/{app_id}/feedback/{ticket_id}/attachments/{attachment_id}?presign=1",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          ticket_id: { type: "string", in: "path", required: true, description: "Ticket UUID or unique short-id prefix." },
+          attachment_id: { type: "string", in: "path", required: true, description: "Attachment UUID from the ticket detail." },
+        },
+      },
+      {
         name: "download-feedback-attachment",
         description:
-          "Download a raw feedback attachment (bytes as-is; Hands does not unzip or interpret it).",
+          "Download raw attachment bytes directly. NOT for agent transports (bytes get UTF-8-mangled) — use presign-feedback-attachment instead and fetch the URL yourself.",
         endpoint: {
           method: "GET",
           path: "/api/apps/{app_id}/feedback/{ticket_id}/attachments/{attachment_id}",

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -11,6 +11,8 @@ import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { emitWebhookEvent } from "./webhooks";
 import { presignR2UploadUrl } from "../lib/r2_presign";
+import { generateSignedR2Url } from "./public_v2";
+import { requestOrigin } from "../lib/origin";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -1363,14 +1365,37 @@ export async function handleDownloadFeedbackAttachment(c: AdminContext) {
   const ticketId = resolved.id;
   const attachmentId = c.req.param("attachmentId");
   const row = await c.env.DB.prepare(
-    `SELECT fa.r2_key, fa.filename, fa.content_type
+    `SELECT fa.r2_key, fa.filename, fa.content_type, fa.size_bytes
      FROM feedback_attachments fa
      JOIN feedback_tickets t ON t.id = fa.ticket_id
      WHERE t.app_id = ?1 AND t.id = ?2 AND fa.id = ?3`,
   )
     .bind(appId, ticketId, attachmentId)
-    .first<{ r2_key: string; filename: string; content_type: string | null }>();
+    .first<{ r2_key: string; filename: string; content_type: string | null; size_bytes: number | null }>();
   if (!row) return c.json({ error: "attachment not found" }, 404);
+  // ?presign=1 — return a short-lived signed URL instead of streaming bytes.
+  // Agent transports (e.g. `raft integration invoke`) UTF-8-decode response
+  // bodies and corrupt binaries; a URL survives any JSON channel and the
+  // agent downloads the raw bytes itself.
+  if (c.req.query("presign") === "1") {
+    const ttl = Math.max(
+      60,
+      Math.min(Number(c.env.R2_PRESIGNED_DOWNLOAD_TTL_SECONDS ?? "3600"), 24 * 3600),
+    );
+    const downloadUrl = await generateSignedR2Url(
+      c.env,
+      row.r2_key,
+      ttl,
+      requestOrigin(c),
+    );
+    return c.json({
+      download_url: downloadUrl,
+      expires_in: ttl,
+      filename: row.filename,
+      content_type: row.content_type ?? "application/octet-stream",
+      size_bytes: row.size_bytes,
+    });
+  }
   const object = await c.env.APK_BUCKET.get(row.r2_key);
   if (!object) return c.json({ error: "attachment blob missing" }, 404);
   const contentType = row.content_type ?? "application/octet-stream";


### PR DESCRIPTION
artin in #Hands (task #123): "hands api 为何要把附件转成 utf8？应该转成让 agent 自己去下载的，比如说附件给个让 api 带token去请求的下载" — the corruption actually happens in the agent invoke transport (it UTF-8-decodes bodies), but the right fix is exactly what he describes: hand agents a tokenized URL instead of bytes.

- `GET /api/apps/:appId/feedback/:ticketId/attachments/:attachmentId?presign=1` → `{download_url, expires_in, filename, content_type, size_bytes}` using the existing signed-download machinery (same as share downloads; TTL from R2_PRESIGNED_DOWNLOAD_TTL_SECONDS, clamped 60s–24h). Default (no presign) behavior unchanged for the admin UI.
- New `presign-feedback-attachment` manifest action; `download-feedback-attachment`'s description now warns it's not for agent transports; `/api/agent/help` crash-triage flow updated.

Verification: tsc clean, 108/108 worker tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)