### PR TITLE
fix(hands): serve feedback attachments through signed download URLs

### DIFF
--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -774,7 +774,31 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
       version_code: number;
       app_slug: string;
     }>();
-  if (!asset) return c.json({ error: "asset not found" }, 404);
+  if (!asset) {
+    // Not a build asset — the HMAC signature (key + expiry) already proves
+    // this URL came from an authenticated presign call, so also serve
+    // feedback attachments (task #123: agents fetch binaries via signed URL
+    // because agent transports corrupt raw bytes).
+    const attachment = await c.env.DB.prepare(
+      `SELECT filename, content_type, size_bytes FROM feedback_attachments WHERE r2_key = ?1 LIMIT 1`,
+    )
+      .bind(key)
+      .first<{ filename: string; content_type: string | null; size_bytes: number | null }>();
+    if (!attachment) return c.json({ error: "asset not found" }, 404);
+    const object = await c.env.APK_BUCKET.get(key);
+    if (!object) return c.json({ error: "object not found" }, 404);
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    headers.set("etag", object.httpEtag);
+    headers.set("cache-control", "private, max-age=0, no-store");
+    headers.set("content-type", attachment.content_type ?? "application/octet-stream");
+    if (attachment.size_bytes != null) headers.set("content-length", String(attachment.size_bytes));
+    headers.set(
+      "content-disposition",
+      `attachment; filename*=UTF-8''${encodeURIComponent(attachment.filename)}`,
+    );
+    return new Response(object.body, { headers });
+  }
 
   const contentDisposition = contentDispositionForAsset(asset);
   const directUrl = await presignR2DownloadUrl(c.env, {


### PR DESCRIPTION
Follow-up to #193 — the `/public/r2` signed route rejected feedback-attachment keys (build-assets-only lookup), so presigned URLs 404'd. The HMAC over key+expiry already proves the URL came from an authenticated presign call; add a `feedback_attachments` fallback that streams the object with its stored filename/content-type.

Verified after deploy on the real ticket bab64d46 (see thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)