### PR TITLE
feat(ohos-sdk): system-level fault capture via hiAppEvent (0.3.0)

### DIFF
--- a/clients/ohos/hands/Index.ets
+++ b/clients/ohos/hands/Index.ets
@@ -4,3 +4,4 @@ export { HandsCrashUploader, CrashMeta } from './src/main/ets/HandsCrashUploader
 export { HandsDeviceId } from './src/main/ets/HandsDeviceId';
 export { HandsAnalytics } from './src/main/ets/HandsAnalytics';
 export { HandsCrashReporter } from './src/main/ets/HandsCrashReporter';
+export { HandsFaultWatcher } from './src/main/ets/HandsFaultWatcher';

--- a/clients/ohos/hands/changelog.md
+++ b/clients/ohos/hands/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.0
+
+- System-level fault capture via hiAppEvent (`APP_CRASH` + `APP_FREEZE`):
+  native crashes and app freezes that never reach the in-process ArkTS
+  errorManager now become Hands crash tickets, delivered by the OS —
+  including on the launch after a crash. JsError crashes stay with the
+  existing in-process reporter (no duplicate tickets).
+- Reported SDK version now matches the package version.
+
 ## 0.2.1
 
 - First branded release of the HarmonyOS Hands SDK.

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "Oranix",

--- a/clients/ohos/hands/src/main/ets/Hands.ets
+++ b/clients/ohos/hands/src/main/ets/Hands.ets
@@ -2,6 +2,7 @@ import { common } from '@kit.AbilityKit';
 import { HandsAnalytics } from './HandsAnalytics';
 import { HandsCrashUploader } from './HandsCrashUploader';
 import { HandsCrashReporter } from './HandsCrashReporter';
+import { HandsFaultWatcher } from './HandsFaultWatcher';
 
 /**
  * Hands SDK entry point for HarmonyOS. All configuration is runtime
@@ -43,6 +44,9 @@ export class Hands {
       // Register the crash observer synchronously so a crash during startup
       // is still captured.
       HandsCrashReporter.install(context);
+      // System-level fault watcher: native crashes + app freezes that never
+      // reach errorManager (delivered by the OS, including on next launch).
+      HandsFaultWatcher.install(context);
       // Device ping + pending-crash upload off the launch critical path.
       setTimeout(() => {
         HandsAnalytics.reportDevice(context).catch((): void => {});

--- a/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
@@ -1,0 +1,184 @@
+import { common } from '@kit.AbilityKit';
+import { hiAppEvent } from '@kit.PerformanceAnalysisKit';
+import fs from '@ohos.file.fs';
+import hilog from '@ohos.hilog';
+import { HandsCrashUploader } from './HandsCrashUploader';
+
+const TAG: string = 'HandsFaultWatcher';
+const FAULT_LOG_MAX_CHARS: number = 180000;
+
+/**
+ * System-level fault capture via hiAppEvent (the same channel Bugly-class
+ * SDKs use on HarmonyOS): subscribes to the OS domain's APP_CRASH and
+ * APP_FREEZE events. The SYSTEM records these — native cppcrash included —
+ * and delivers them to the watcher on the next launch, so faults that never
+ * reach the in-process ArkTS errorManager (which HandsCrashReporter owns)
+ * still become Hands crash tickets.
+ *
+ * Scope split: JsError APP_CRASH events are skipped here because
+ * HandsCrashReporter already captured them at crash time — this watcher only
+ * reports what errorManager cannot see (NativeCrash, CppCrash, AppFreeze).
+ * Hands.install() calls this — apps do not use it directly.
+ */
+export class HandsFaultWatcher {
+  private static installed: boolean = false;
+
+  static install(context: common.UIAbilityContext): void {
+    if (HandsFaultWatcher.installed) {
+      return;
+    }
+    HandsFaultWatcher.installed = true;
+    try {
+      hiAppEvent.addWatcher({
+        name: 'hands_fault_watcher',
+        appEventFilters: [
+          {
+            domain: hiAppEvent.domain.OS,
+            names: [hiAppEvent.event.APP_CRASH, hiAppEvent.event.APP_FREEZE],
+          },
+        ],
+        onReceive: (domain: string, appEventGroups: Array<hiAppEvent.AppEventGroup>): void => {
+          HandsFaultWatcher.onFaultEvents(context, domain, appEventGroups);
+        },
+      });
+      hilog.info(0x0000, TAG, 'fault watcher installed (APP_CRASH + APP_FREEZE)');
+    } catch (error) {
+      hilog.error(0x0000, TAG, 'failed to install fault watcher: %{public}s', String(error));
+    }
+  }
+
+  private static onFaultEvents(
+    context: common.UIAbilityContext,
+    domain: string,
+    appEventGroups: Array<hiAppEvent.AppEventGroup>,
+  ): void {
+    try {
+      for (const group of appEventGroups) {
+        for (const eventInfo of group.appEventInfos) {
+          HandsFaultWatcher.captureFault(context, group.name, eventInfo);
+        }
+      }
+      // Fault events arrive while the app is alive (freeze) or on the launch
+      // after a crash — either way an immediate upload attempt is safe.
+      HandsCrashUploader.enforceRetention(context);
+      HandsCrashUploader.uploadPending(context).catch((): void => {});
+    } catch (error) {
+      hilog.error(0x0000, TAG, 'failed handling fault events: %{public}s', String(error));
+    }
+  }
+
+  private static captureFault(
+    context: common.UIAbilityContext,
+    eventName: string,
+    eventInfo: hiAppEvent.AppEventInfo,
+  ): void {
+    const params = eventInfo.params as Record<string, Object>;
+    const crashType = String(params['crash_type'] ?? '');
+    // JsError crashes are already captured in-process by HandsCrashReporter;
+    // re-reporting them here would duplicate tickets.
+    if (eventName === hiAppEvent.event.APP_CRASH && crashType === 'JsError') {
+      hilog.info(0x0000, TAG, 'skipping JsError APP_CRASH (errorManager already captured it)');
+      return;
+    }
+
+    const kind = eventName === hiAppEvent.event.APP_FREEZE ? 'AppFreeze' : (crashType || 'NativeCrash');
+    const exception = params['exception'];
+    const exceptionText =
+      typeof exception === 'string' ? exception : JSON.stringify(exception ?? {}, null, 2);
+    const hilogTail = HandsFaultWatcher.joinLines(params['hilog']);
+    const threads = params['threads'];
+    const threadsText = threads === undefined ? '' : JSON.stringify(threads, null, 2);
+    const externalLogs = HandsFaultWatcher.joinLines(params['external_log']);
+
+    const lines: string[] = [
+      'Hands OHOS fault log (hiAppEvent)',
+      `Event: ${eventName}`,
+      `Fault kind: ${kind}`,
+      `Fault time: ${new Date(Number(params['time'] ?? Date.now())).toString()}`,
+      `Foreground: ${String(params['foreground'] ?? 'unknown')}`,
+      `Bundle version: ${String(params['bundle_version'] ?? '')}`,
+      `Pid/Uid: ${String(params['pid'] ?? '')}/${String(params['uid'] ?? '')}`,
+      '',
+      '--- exception ---',
+      exceptionText,
+    ];
+    if (threadsText.length > 0) {
+      lines.push('', '--- threads ---', threadsText);
+    }
+    if (hilogTail.length > 0) {
+      lines.push('', '--- hilog ---', hilogTail);
+    }
+    if (externalLogs.length > 0) {
+      lines.push('', '--- system fault log files (on device) ---', externalLogs);
+    }
+    const crashLog = lines.join('\n').slice(0, FAULT_LOG_MAX_CHARS);
+
+    const crashPath = HandsFaultWatcher.writeFaultLog(context, crashLog);
+    const summary = HandsFaultWatcher.exceptionSummary(exception, kind);
+    HandsCrashUploader.writeMeta(crashPath, {
+      exception_class: summary.cls,
+      exception_message: summary.message,
+      top_frame: summary.topFrame,
+      reason: eventName === hiAppEvent.event.APP_FREEZE ? 'appFreeze' : 'nativeCrash',
+      crash_at: Number(params['time'] ?? Date.now()),
+    });
+    hilog.info(0x0000, TAG, 'captured %{public}s fault', kind);
+  }
+
+  private static exceptionSummary(
+    exception: Object | undefined,
+    kind: string,
+  ): SummaryParts {
+    const result: SummaryParts = { cls: kind, message: '', topFrame: '' };
+    if (exception !== undefined && typeof exception === 'object') {
+      const ex = exception as Record<string, Object>;
+      const name = String(ex['name'] ?? '');
+      const message = String(ex['message'] ?? '');
+      const signal = String(ex['signal'] ?? '');
+      if (name.length > 0) {
+        result.cls = name;
+      } else if (signal.length > 0) {
+        result.cls = `${kind}(signal ${signal})`;
+      }
+      result.message = message;
+      const frames = ex['frames'];
+      if (Array.isArray(frames) && frames.length > 0) {
+        const top = frames[0] as Record<string, Object>;
+        const file = String(top['file'] ?? top['symbol'] ?? '');
+        const offset = String(top['offset'] ?? '');
+        result.topFrame = offset.length > 0 ? `${file}+${offset}` : file;
+      }
+    }
+    return result;
+  }
+
+  private static joinLines(value: Object | undefined): string {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    if (Array.isArray(value)) {
+      return (value as Array<Object>).map((entry: Object): string => String(entry)).join('\n');
+    }
+    return String(value);
+  }
+
+  private static writeFaultLog(context: common.UIAbilityContext, crashLog: string): string {
+    const crashDir = `${context.filesDir}/crashes`;
+    fs.mkdirSync(crashDir, true);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const crashPath = `${crashDir}/crash-${timestamp}-fault.txt`;
+    const file = fs.openSync(crashPath, fs.OpenMode.CREATE | fs.OpenMode.TRUNC | fs.OpenMode.WRITE_ONLY);
+    try {
+      fs.writeSync(file.fd, crashLog);
+    } finally {
+      fs.closeSync(file);
+    }
+    return crashPath;
+  }
+}
+
+interface SummaryParts {
+  cls: string;
+  message: string;
+  topFrame: string;
+}

--- a/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
@@ -14,7 +14,7 @@ const TAG: string = 'HandsFeedbackClient';
 
 // Hands OHOS SDK version — reported in feedback/crash environment metadata.
 // Keep in sync with oh-package.json5 on release.
-const HANDS_SDK_VERSION: string = '0.2.1';
+const HANDS_SDK_VERSION: string = '0.3.0';
 
 // @ohos.batteryInfo BatteryChargeState: NONE=0, ENABLE=1, DISABLE=2, FULL=3.
 function ohBatteryStateName(status: number): string {


### PR DESCRIPTION
The OHOS half of task #122 ("鸿蒙那个crash也要接入") — closes the gap diagnosed yesterday: wiring/key/transport were all fine, but the SDK only hooked ArkTS `errorManager`, so native cppcrash and freezes never became tickets.

## What
- **`HandsFaultWatcher`** — `hiAppEvent.addWatcher` on the OS domain's `APP_CRASH` + `APP_FREEZE` (the Bugly-class channel): the system captures JS+native crashes and freezes, and delivers them to the watcher including on the launch after a crash. Events are written through the existing store-then-send pipeline (`crash-<ts>-fault.txt` + meta sidecar → existing uploader), with exception, threads, hilog tail, and on-device fault-log paths in the body.
- **No duplicates**: `JsError` APP_CRASH events are skipped — the in-process reporter already captured those at crash time.
- Wired into `Hands.install` (no app-side API change); exported from Index; version 0.2.1 → **0.3.0** and the reported `hands_sdk` version now matches the package.

## Verification
- PR CI (publish-ohos-sdk.yml pull_request path) builds the HAR.
- Runtime validation lands with the mobile bump (@Codex-Android-DevOPS owns it): install on device → trigger a native crash / freeze → ticket appears in Hands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)