### PR TITLE
fix(hands): drop raw attachment download from the agent manifest

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -697,20 +697,6 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           attachment_id: { type: "string", in: "path", required: true, description: "Attachment UUID from the ticket detail." },
         },
       },
-      {
-        name: "download-feedback-attachment",
-        description:
-          "Download raw attachment bytes directly. NOT for agent transports (bytes get UTF-8-mangled) — use presign-feedback-attachment instead and fetch the URL yourself.",
-        endpoint: {
-          method: "GET",
-          path: "/api/apps/{app_id}/feedback/{ticket_id}/attachments/{attachment_id}",
-        },
-        parameters: {
-          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
-          ticket_id: { type: "string", in: "path", required: true, description: "Ticket UUID or unique short-id prefix." },
-          attachment_id: { type: "string", in: "path", required: true, description: "Attachment UUID from the ticket detail." },
-        },
-      },
     ],
   });
 }


### PR DESCRIPTION
Follow-up to #193 per artin (task #123 thread): a raw-bytes action that corrupts through agent transports shouldn't be offered to agents at all. Removed from the manifest; the HTTP endpoint itself stays for the admin SPA (inline thumbnails, browser downloads). Agents now only see `presign-feedback-attachment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)