### PR TITLE
feat(hands): verify endpoint for stored ASC credentials

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -86,6 +86,7 @@ import {
   handleGetAscCredentials,
   handleSetAscCredentials,
   handleDeleteAscCredentials,
+  handleVerifyAscCredentials,
 } from "./routes/asc_credentials";
 import { handleUploadApk } from "./routes/upload";
 import {
@@ -772,6 +773,7 @@ admin.delete("/api/apps/:appId/deploy-tokens/:tokenId", requireAppRole("admin"),
 
 // App Store Connect API credentials (for Hands-orchestrated TestFlight uploads).
 admin.get("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleGetAscCredentials);
+admin.post("/api/apps/:appId/asc-credentials/verify", requireAppRole("admin"), handleVerifyAscCredentials);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
 

--- a/worker/src/routes/asc_credentials.ts
+++ b/worker/src/routes/asc_credentials.ts
@@ -4,8 +4,10 @@ import { insertAuditLog } from "../lib/permissions";
 import {
   storeAscCredentials,
   getAscCredentialsMeta,
+  getAscCredentials,
   deleteAscCredentials,
 } from "../lib/asc_credentials";
+import { resolveAscAppId, AscApiError } from "../lib/asc_api";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -78,4 +80,45 @@ export async function handleDeleteAscCredentials(c: AdminContext) {
     payload: {},
   });
   return c.json({ ok: true });
+}
+
+/**
+ * POST /verify — prove the stored credentials work end-to-end: decrypt the
+ * .p8, sign a JWT, and ask App Store Connect for the app record matching
+ * the given bundle id. Read-only against Apple; never returns the key.
+ * Body: { bundle_id: string }.
+ */
+export async function handleVerifyAscCredentials(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const encKey = c.env.ASC_CRED_ENC_KEY;
+  if (!encKey) {
+    return c.json({ error: "server is missing ASC_CRED_ENC_KEY" }, 500);
+  }
+  const body = (await c.req.json().catch(() => ({}))) as { bundle_id?: unknown };
+  const bundleId = typeof body.bundle_id === "string" ? body.bundle_id.trim() : "";
+  if (!bundleId) return c.json({ error: "bundle_id is required" }, 400);
+
+  const creds = await getAscCredentials(c.env.DB, encKey, appId);
+  if (!creds) return c.json({ error: "no ASC credentials configured for this app" }, 404);
+
+  try {
+    const ascAppId = await resolveAscAppId(creds, bundleId);
+    return c.json({
+      ok: ascAppId !== null,
+      key_id: creds.key_id,
+      bundle_id: bundleId,
+      asc_app_id: ascAppId,
+      detail: ascAppId
+        ? "Credentials valid; App Store Connect app record found."
+        : "Credentials valid, but no App Store Connect app record matches this bundle id — create it under My Apps first.",
+    });
+  } catch (e) {
+    if (e instanceof AscApiError) {
+      return c.json(
+        { ok: false, key_id: creds.key_id, status: e.status, error: e.message, detail: e.detail },
+        502,
+      );
+    }
+    throw e;
+  }
 }


### PR DESCRIPTION
Pre-flight for TestFlight Part 2b: with artin's ASC key now saved and the app record created, `POST /api/apps/:appId/asc-credentials/verify {bundle_id}` proves the whole chain — decrypt stored .p8 → sign ES256 JWT → `GET /v1/apps?filter[bundleId]` — in one read-only Apple call. Returns `{ok, asc_app_id, detail}`; Apple errors surface with status/title/detail; key material never returned. Will back the panel's future "Test connection" button.

Verification: tsc clean, 108/108 tests; live verification against the real stored key follows post-deploy (results in #Hands:af2a9827).

🤖 Generated with [Claude Code](https://claude.com/claude-code)