### PR TITLE
feat(admin): TestFlight upload UI + status + Test connection (part 3)

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -650,6 +650,60 @@ export const deleteAscCredentials = (appId: string) =>
     admin: true,
   });
 
+export const verifyAscCredentials = (appId: string, bundleId: string) =>
+  request<{
+    ok: boolean;
+    key_id?: string;
+    bundle_id?: string;
+    asc_app_id?: string | null;
+    detail?: string;
+    error?: string;
+    status?: number;
+  }>(`/api/apps/${appId}/asc-credentials/verify`, {
+    method: "POST",
+    admin: true,
+    body: JSON.stringify({ bundle_id: bundleId }),
+  });
+
+// ---------- TestFlight upload (Hands → Apple) ----------
+
+/** Apple's build-upload state is an object, not a bare string. */
+export interface AscUploadState {
+  state: "AWAITING_UPLOAD" | "PROCESSING" | "FAILED" | "COMPLETE" | string;
+  errors?: Array<{ code?: string; description?: string }>;
+  warnings?: Array<{ code?: string; description?: string }>;
+  infos?: Array<{ code?: string; description?: string }>;
+}
+
+export const uploadBuildToTestflight = (
+  appId: string,
+  buildId: string,
+  bundleId?: string,
+) =>
+  request<{
+    operation_id: string;
+    ok: boolean;
+    asc_app_id?: string;
+    build_upload_id?: string;
+    parts_uploaded?: number;
+    state?: AscUploadState;
+    error?: string;
+    detail?: string | null;
+  }>(`/api/apps/${appId}/builds/${buildId}/testflight-upload`, {
+    method: "POST",
+    admin: true,
+    body: JSON.stringify(bundleId ? { bundle_id: bundleId } : {}),
+  });
+
+export const getTestflightUploadStatus = (appId: string, buildUploadId: string) =>
+  request<{
+    build_upload_id: string;
+    state: AscUploadState | null;
+    version: string | null;
+    build_number: string | null;
+    uploaded_at: string | null;
+  }>(`/api/apps/${appId}/testflight-uploads/${buildUploadId}`, { admin: true });
+
 export const listAppDeployTokens = (appId: string) =>
   request<{ deploy_tokens: AppDeployToken[] }>(
     `/api/apps/${appId}/deploy-tokens`,

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -22,6 +22,7 @@ import {
   getAscCredentials,
   setAscCredentials,
   deleteAscCredentials,
+  verifyAscCredentials,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
@@ -374,6 +375,38 @@ function TestFlightPanel({ appId }: { appId: string }) {
       toast.show({ kind: "error", title: "Remove failed", description: (e as Error).message }),
   });
 
+  const test = useMutation({
+    mutationFn: () => {
+      const bundleId = window.prompt(
+        "Bundle ID to verify against App Store Connect (e.g. build.raft.app):",
+        "",
+      );
+      if (!bundleId || !bundleId.trim()) throw new Error("cancelled");
+      return verifyAscCredentials(appId, bundleId.trim());
+    },
+    onSuccess: (res) => {
+      if (res.ok) {
+        toast.show({
+          kind: "success",
+          title: "Connection OK",
+          description: res.asc_app_id
+            ? `App Store Connect app ${res.asc_app_id} found.`
+            : res.detail ?? "",
+        });
+      } else {
+        toast.show({
+          kind: "error",
+          title: "Verification failed",
+          description: res.detail ?? res.error ?? "unknown",
+        });
+      }
+    },
+    onError: (e) => {
+      if ((e as Error).message === "cancelled") return;
+      toast.show({ kind: "error", title: "Test failed", description: (e as Error).message });
+    },
+  });
+
   const readP8File = (file: File | undefined) => {
     if (!file) return;
     file.text().then(
@@ -410,6 +443,14 @@ function TestFlightPanel({ appId }: { appId: string }) {
         </div>
         {meta && !editing && (
           <>
+            <button
+              className="btn-secondary !py-1 !px-2 !text-xs"
+              disabled={test.isPending}
+              onClick={() => test.mutate()}
+              title="Verify the stored key against App Store Connect for this app's bundle id"
+            >
+              {test.isPending ? "Testing…" : "Test connection"}
+            </button>
             <button
               className="btn-secondary !py-1 !px-2 !text-xs"
               onClick={() => setEditing(true)}

--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -15,6 +15,8 @@ import {
   listBuilds,
   listChannels,
   listProductTypes,
+  uploadBuildToTestflight,
+  getTestflightUploadStatus,
   type Build,
   type BuildAsset,
 } from "../lib/api";
@@ -125,6 +127,9 @@ export function Builds({ appId }: { appId: string }) {
                   </button>
                 )}
               </div>
+              {b.product_type === "ios-ipa" && (
+                <TestflightUploadPanel appId={appId} build={b} />
+              )}
               {isExpanded && <BuildAssetList appId={appId} buildId={b.id} />}
             </div>
           );
@@ -141,6 +146,98 @@ export function Builds({ appId }: { appId: string }) {
             qc.invalidateQueries({ queryKey: ["builds", appId] });
           }}
         />
+      )}
+    </div>
+  );
+}
+
+function TestflightUploadPanel({ appId, build }: { appId: string; build: Build }) {
+  const toast = useToast();
+  const [buildUploadId, setBuildUploadId] = useState<string | null>(null);
+
+  const upload = useMutation({
+    mutationFn: () => uploadBuildToTestflight(appId, build.id),
+    onSuccess: (res) => {
+      if (res.ok && res.build_upload_id) {
+        setBuildUploadId(res.build_upload_id);
+        toast.show({ kind: "success", title: "Uploaded to Apple — processing" });
+      } else {
+        toast.show({
+          kind: "error",
+          title: "Upload rejected",
+          description: res.error ?? res.detail ?? "unknown error",
+        });
+      }
+    },
+    onError: (e) =>
+      toast.show({ kind: "error", title: "Upload failed", description: (e as Error).message }),
+  });
+
+  const status = useQuery({
+    queryKey: ["testflight-status", appId, buildUploadId],
+    queryFn: () => getTestflightUploadStatus(appId, buildUploadId!),
+    enabled: buildUploadId != null,
+    refetchInterval: (q) => {
+      const s = q.state.data?.state?.state;
+      return s === "COMPLETE" || s === "FAILED" ? false : 5000;
+    },
+  });
+
+  const state = status.data?.state;
+  const stateName = state?.state;
+  const stateColor =
+    stateName === "COMPLETE"
+      ? "text-green-700"
+      : stateName === "FAILED"
+        ? "text-red-700"
+        : "text-blue-700";
+
+  return (
+    <div className="mt-2 pt-2 border-t border-slate-100">
+      <div className="flex items-center gap-2 flex-wrap text-xs">
+        <span className="badge-gray"> TestFlight</span>
+        <button
+          className="btn-secondary !py-1 !px-2 !text-xs"
+          disabled={upload.isPending || build.status !== "succeeded"}
+          onClick={() => upload.mutate()}
+          title={
+            build.status !== "succeeded"
+              ? "Build must be succeeded"
+              : "Upload this IPA to App Store Connect / TestFlight"
+          }
+        >
+          {upload.isPending ? "Uploading…" : "Upload to TestFlight"}
+        </button>
+        <a
+          className="btn-secondary !py-1 !px-2 !text-xs no-underline"
+          href="https://appstoreconnect.apple.com/apps"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Open App Store Connect ↗
+        </a>
+        {stateName && (
+          <span className={`font-medium ${stateColor}`}>
+            {stateName === "PROCESSING" || stateName === "AWAITING_UPLOAD"
+              ? "Apple processing…"
+              : stateName}
+          </span>
+        )}
+      </div>
+      {state?.errors && state.errors.length > 0 && (
+        <ul className="mt-1 text-xs text-red-700 list-disc pl-5">
+          {state.errors.map((e, i) => (
+            <li key={i}>
+              {e.code ? `[${e.code}] ` : ""}
+              {e.description}
+            </li>
+          ))}
+        </ul>
+      )}
+      {stateName === "COMPLETE" && (
+        <p className="mt-1 text-xs text-green-700">
+          Processed — add it to a tester group in App Store Connect → TestFlight.
+        </p>
       )}
     </div>
   );


### PR DESCRIPTION
The console UI artin asked for ("后台 ui 要加一个直跳的，然后还要能展示 testflight 状态"):

- **Builds tab, iOS builds**: a TestFlight row with **Upload to TestFlight** (drives the part-2b lane), **live Apple status** (polls `/testflight-uploads/:id` every 5s until COMPLETE/FAILED; renders Apple's error `code`/`description` inline — e.g. the SDK-version 90725 we just hit), and an **Open App Store Connect ↗** deep link.
- **Settings → TestFlight panel**: a **Test connection** button backed by `/asc-credentials/verify` (prompts for the bundle id, reports the found ASC app id).
- api.ts: `verifyAscCredentials`, `uploadBuildToTestflight`, `getTestflightUploadStatus`, and an `AscUploadState` type (Apple's state is an object with errors/warnings, not a string).

Verified: admin tsc + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)