### PR TITLE
feat(admin): deep-link TestFlight rows to the ASC build page

### DIFF
--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -154,12 +154,14 @@ export function Builds({ appId }: { appId: string }) {
 function TestflightUploadPanel({ appId, build }: { appId: string; build: Build }) {
   const toast = useToast();
   const [buildUploadId, setBuildUploadId] = useState<string | null>(null);
+  const [ascAppId, setAscAppId] = useState<string | null>(null);
 
   const upload = useMutation({
     mutationFn: () => uploadBuildToTestflight(appId, build.id),
     onSuccess: (res) => {
       if (res.ok && res.build_upload_id) {
         setBuildUploadId(res.build_upload_id);
+        if (res.asc_app_id) setAscAppId(res.asc_app_id);
         toast.show({ kind: "success", title: "Uploaded to Apple — processing" });
       } else {
         toast.show({
@@ -210,11 +212,15 @@ function TestflightUploadPanel({ appId, build }: { appId: string; build: Build }
         </button>
         <a
           className="btn-secondary !py-1 !px-2 !text-xs no-underline"
-          href="https://appstoreconnect.apple.com/apps"
+          href={
+            ascAppId
+              ? `https://appstoreconnect.apple.com/apps/${ascAppId}/testflight/ios`
+              : "https://appstoreconnect.apple.com/apps"
+          }
           target="_blank"
           rel="noopener noreferrer"
         >
-          Open App Store Connect ↗
+          Open in App Store Connect ↗
         </a>
         {stateName && (
           <span className={`font-medium ${stateColor}`}>

--- a/admin/src/pages/Testflight.tsx
+++ b/admin/src/pages/Testflight.tsx
@@ -21,6 +21,13 @@ interface UploadInput {
 }
 interface UploadOutput {
   build_upload_id?: string;
+  asc_app_id?: string;
+}
+
+function ascTestflightUrl(ascAppId: string | undefined): string {
+  return ascAppId
+    ? `https://appstoreconnect.apple.com/apps/${ascAppId}/testflight/ios`
+    : "https://appstoreconnect.apple.com/apps";
 }
 
 export function Testflight({ appId }: { appId: string }) {
@@ -106,6 +113,16 @@ function UploadRow({ appId, op }: { appId: string; op: Operation }) {
         </span>
         {input.bundle_id && <span className="badge-gray">{input.bundle_id}</span>}
         <StateBadge uploadFailed={uploadFailed} appleState={appleState} />
+        {!uploadFailed && (
+          <a
+            className="text-xs underline text-blue-700"
+            href={ascTestflightUrl(output.asc_app_id)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View in App Store Connect ↗
+          </a>
+        )}
         <span className="text-xs text-slate-500 ml-auto">
           {new Date(op.created_at).toISOString().slice(0, 16)}Z
         </span>
@@ -131,7 +148,7 @@ function UploadRow({ appId, op }: { appId: string; op: Operation }) {
           Processed — add it to a tester group in{" "}
           <a
             className="underline"
-            href="https://appstoreconnect.apple.com/apps"
+            href={ascTestflightUrl(output.asc_app_id)}
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
artin: "ui 上感觉可以直接让我快速跳到对应的页面比较好". Uses `asc_app_id` (already returned by the upload / stored in the operation output) to link the TestFlight page rows and the Builds panel straight to `appstoreconnect.apple.com/apps/{id}/testflight/ios` instead of the generic apps list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)