### PR TITLE
fix(hands): actionable 401 on app admin endpoints

### DIFF
--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -236,7 +236,32 @@ export async function ensureAppRole(c: AdminContext, appId: string, minimum: App
   }
   const account = currentAccount(c);
   if (!account) {
-    return { ok: false as const, response: c.json({ error: "unauthorized" }, 401) };
+    // Actionable 401: an agent that hit this with a valid-looking session got
+    // no resolvable account — tell it how to authenticate and that admin API
+    // access needs a role on the app, rather than a bare "unauthorized".
+    let origin = "https://hands.build";
+    try {
+      origin = new URL(c.req.url).origin;
+    } catch {
+      // keep default
+    }
+    return {
+      ok: false as const,
+      response: c.json(
+        {
+          error: "unauthorized",
+          code: "NOT_AUTHENTICATED",
+          required_role: minimum,
+          next_action:
+            `Authenticate first: humans use \`hands login\`; agents run ` +
+            `\`raft integration login --service <hands-service>\`. Then an admin must grant you the ` +
+            `'${minimum}' role on this app (Access → Members). Admins can perform the release action on your behalf.`,
+          login_url: `/api/auth/login?return=${encodeURIComponent("/")}`,
+          manage_url: `${origin}/apps/${appId}/access`,
+        },
+        401,
+      ),
+    };
   }
   const role = await getEffectiveRole(c.env.DB, account.id, { appId });
   const orgAllows =


### PR DESCRIPTION
The task #94 finalizer got a bare `{error:'unauthorized'}` hitting a release endpoint, with no hint to request access. Make the no-account 401 actionable — `code`, `required_role`, a `next_action` sentence (authenticate + ask an admin to grant the role at Access → Members), `login_url`, `manage_url` — matching the insufficient-role 403 which was already actionable.

Verification: tsc clean, 108/108 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)