### PR TITLE
feat(cli): actionable auth guidance + bearer token in whoami (0.5.2)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -5,6 +5,15 @@
 import type { Command } from "commander";
 import { apiRequest, QuiverApiError, getApiBase } from "../lib/api.js";
 import { resolveSessionCookie } from "../lib/config.js";
+import { readEnv } from "../lib/env.js";
+
+const NO_AUTH_HELP =
+  "Not authenticated. Choose one:\n" +
+  "  • Agents / CI: set HANDS_BEARER_TOKEN to a deploy token\n" +
+  "      (console → App → Settings → Deploy Tokens; publisher role to release).\n" +
+  "  • Humans: run `hands login` (browser session).\n" +
+  "  • Raft agents: `raft integration login --service <hands-service>`, then export the\n" +
+  "      session as HANDS_SESSION_COOKIE.";
 
 interface MeResponse {
   account?: {
@@ -29,8 +38,9 @@ export function registerWhoamiCommand(program: Command): void {
     .description("Print the currently authenticated account + roles.")
     .option("--json", "Output machine-readable JSON.", false)
     .action(async (opts: { json?: boolean }) => {
-      if (!resolveSessionCookie()) {
-        console.error("Not logged in. Run `quiver login` first.");
+      const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
+      if (!bearer && !resolveSessionCookie()) {
+        console.error(NO_AUTH_HELP);
         process.exit(1);
       }
       try {
@@ -52,7 +62,7 @@ export function registerWhoamiCommand(program: Command): void {
         console.log(`  api:     ${getApiBase()}`);
       } catch (e) {
         if (e instanceof QuiverApiError && e.status === 401) {
-          console.error("Not authenticated. Run `quiver login` to refresh.");
+          console.error(NO_AUTH_HELP);
           process.exit(1);
         }
         throw e;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.1")
+  .version("0.5.2")
   .option(
     "--api <url>",
     "Quiver Worker base URL (default: https://quiver.oranix.io or $QUIVER_API)",


### PR DESCRIPTION
Task #94 finalizer (Cindy) got `Not logged in. Run quiver login first.` and couldn't tell how an agent should authenticate. Two fixes:

- `whoami` accepted only a session cookie in its pre-check, so `HANDS_BEARER_TOKEN` (which `apiRequest` already honors) was wrongly rejected. Accept the bearer.
- Replace the bare message with the three real auth paths: `HANDS_BEARER_TOKEN` (agents/CI deploy token), `hands login` (humans), `raft integration login` → `HANDS_SESSION_COOKIE` (Raft agents).

Pairs with the server-side actionable 401 (#203, deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)