### PR TITLE
fix(admin): persist organization tabs in URL

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -22,7 +22,7 @@ import { Releases } from "./pages/Releases";
 import { AppShares } from "./pages/Shares";
 import { AppFeedback, FeedbackTicketPage } from "./pages/Feedback";
 import { AppCrashes } from "./pages/Crashes";
-import { OrgSettings } from "./pages/OrgSettings";
+import { isOrgSettingsTab, OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
 import { OrgSwitcher, useClearOrgCache } from "./components/OrgSwitcher";
@@ -386,9 +386,12 @@ function LegacyPublishRedirect() {
 }
 
 function OrgSettingsRoute() {
-  const { orgId } = useParams();
+  const { orgId, tab } = useParams();
   if (!orgId) return null;
-  return <OrgSettings orgId={orgId} />;
+  if (!isOrgSettingsTab(tab)) {
+    return <Navigate to={`/orgs/${orgId}/general`} replace />;
+  }
+  return <OrgSettings orgId={orgId} tab={tab} />;
 }
 
 function SettingsPage() {
@@ -786,7 +789,7 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
         <Route path="/" element={<Navigate to="/apps" replace />} />
         <Route path="/apps" element={<AppsListWithNav />} />
         <Route path="/settings" element={<SettingsPage />} />
-        <Route path="/orgs/:orgId" element={<OrgSettingsPage />} />
+        <Route path="/orgs/:orgId/:tab?" element={<OrgSettingsPage />} />
         <Route path="/invites/:token" element={<AcceptInviteRoute />} />
         <Route path="/apps/:appId" element={<AppShell />}>
           <Route index element={<AppDetailRoute />} />

--- a/admin/src/pages/OrgSettings.tsx
+++ b/admin/src/pages/OrgSettings.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useState } from "react";
+import { NavLink } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createOrgInvite,
@@ -38,10 +39,27 @@ import {
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 
-type Tab = "general" | "members" | "invites" | "audit" | "webhooks";
+export const ORG_SETTINGS_TABS = [
+  "general",
+  "members",
+  "invites",
+  "audit",
+  "webhooks",
+] as const;
 
-export function OrgSettings({ orgId }: { orgId: string }) {
-  const [tab, setTab] = useState<Tab>("general");
+export type OrgSettingsTab = (typeof ORG_SETTINGS_TABS)[number];
+
+export function isOrgSettingsTab(tab: string | undefined): tab is OrgSettingsTab {
+  return ORG_SETTINGS_TABS.some((candidate) => candidate === tab);
+}
+
+export function OrgSettings({
+  orgId,
+  tab,
+}: {
+  orgId: string;
+  tab: OrgSettingsTab;
+}) {
   const me = useQuery({ queryKey: ["auth-me"], queryFn: () => getAuthMe() });
   const account = me.data?.account;
   const currentOrgId = account?.org_id ?? null;
@@ -71,12 +89,13 @@ export function OrgSettings({ orgId }: { orgId: string }) {
       )}
 
       <div className="flex gap-2 mb-4 border-b border-slate-200">
-        {(["general", "members", "invites", "audit", "webhooks"] as Tab[]).map((t) => (
-          <button
+        {ORG_SETTINGS_TABS.map((t) => (
+          <NavLink
             key={t}
-            onClick={() => setTab(t)}
-            className={`px-3 py-2 text-sm ${
-              tab === t
+            to={`/orgs/${orgId}/${t}`}
+            end
+            className={({ isActive }) => `px-3 py-2 text-sm ${
+              isActive
                 ? "border-b-2 border-blue-600 font-medium text-slate-900"
                 : "text-slate-500 hover:text-slate-700"
             }`}
@@ -90,7 +109,7 @@ export function OrgSettings({ orgId }: { orgId: string }) {
                   : t === "audit"
                     ? "Audit"
                     : "Webhooks"}
-          </button>
+          </NavLink>
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- move organization General/Members/Invites/Audit/Webhooks tab selection from component-local state into the route
- canonicalize `/orgs/:orgId` and unknown tab values to `/orgs/:orgId/general`
- use `NavLink` so tab clicks create normal browser history entries and direct links/refreshes restore the selected tab

## Validation
- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm --filter @botiverse/hands-admin build`
- `pnpm -w build`
- `pnpm -w test` (133 tests passed)
- `git diff --check`

## Known repository gate
- `pnpm -w lint` cannot start because the worker package uses ESLint 9 without an `eslint.config.{js,mjs,cjs}` file; this is pre-existing and unrelated to the admin-only diff.

Task: Raft #Hands task #124
