### PR TITLE
feat(hands): offer delta patches in /updates/check (delta P1, server)

### DIFF
--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -432,6 +432,22 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
   }
 
   bumpReleaseMetric(c, latest.scoped?.release_id, "offered");
+  // Delta (differential) download offer: if the client's installed version has
+  // a patch to the latest build for its arch, and that patch is meaningfully
+  // smaller than the full APK, offer it. The full `asset` stays the fallback;
+  // old SDKs ignore the extra `patch` field. See docs/delta-download-design.md.
+  const patch =
+    currentVersionCode > 0
+      ? await findDeltaPatch(c, {
+          buildId: latest.build.id,
+          fromVersionCode: currentVersionCode,
+          arch: requestedArch,
+          fullSizeBytes: asset.size_bytes,
+          origin: publicRequestOrigin(c),
+          ttl: latest.expires_in,
+        })
+      : null;
+
   return c.json({
     update_available: true,
     app: latest.app,
@@ -447,9 +463,68 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
       released_at: latest.build.released_at,
     },
     asset,
+    ...(patch ? { patch } : {}),
     scoped: latest.scoped,
     expires_in: latest.expires_in,
   });
+}
+
+/** Fraction of the full APK a patch must beat to be worth offering. */
+const DELTA_MAX_SIZE_RATIO = 0.7;
+
+/**
+ * Find a delta-patch asset on the target build that upgrades the client's
+ * installed version for its arch, returning a signed offer only when the patch
+ * is small enough to be a win. Patch assets carry
+ * metadata_json = {from_version_code, to_version_code, algorithm, target_sha256}.
+ */
+async function findDeltaPatch(
+  c: Context<{ Bindings: Env }>,
+  args: {
+    buildId: string;
+    fromVersionCode: number;
+    arch: string | null;
+    fullSizeBytes: number;
+    origin: string;
+    ttl: number;
+  },
+): Promise<{
+  from_version_code: number;
+  algorithm: string;
+  download_url: string;
+  size_bytes: number;
+  target_sha256: string | null;
+} | null> {
+  const row = await c.env.DB.prepare(
+    `SELECT r2_key, size_bytes, arch,
+            json_extract(metadata_json, '$.algorithm') AS algorithm,
+            json_extract(metadata_json, '$.target_sha256') AS target_sha256
+     FROM build_assets
+     WHERE build_id = ?1
+       AND artifact_kind = 'delta-patch'
+       AND CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) = ?2
+       AND (arch = ?3 OR arch IS NULL)
+     ORDER BY (arch = ?4) DESC
+     LIMIT 1`,
+  )
+    .bind(args.buildId, args.fromVersionCode, args.arch, args.arch)
+    .first<{
+      r2_key: string;
+      size_bytes: number;
+      arch: string | null;
+      algorithm: string | null;
+      target_sha256: string | null;
+    }>();
+  if (!row) return null;
+  // Only a win if it's meaningfully smaller than the full download.
+  if (row.size_bytes > args.fullSizeBytes * DELTA_MAX_SIZE_RATIO) return null;
+  return {
+    from_version_code: args.fromVersionCode,
+    algorithm: row.algorithm ?? "archive-patcher-v1",
+    download_url: await generateSignedR2Url(c.env, row.r2_key, args.ttl, args.origin),
+    size_bytes: row.size_bytes,
+    target_sha256: row.target_sha256,
+  };
 }
 
 export function selectBestAsset(

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3002,6 +3002,70 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(body.asset.download_url).toContain("&sig=");
   });
 
+  it("updates/check offers a delta patch when one applies and is small enough", async () => {
+    const env = makeEnv();
+    const { handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    await seedRelease(env, "rel-delta", "build-delta", [["full", "all"]], {
+      versionCode: 20,
+      versionName: "1.0.20",
+    });
+    // Full APK is 1000 bytes for arm64.
+    await seedAsset(env, "build-delta", "asset-full", { arch: "arm64-v8a", sizeBytes: 1000 });
+    // A patch 10→20 for arm64 that's 200 bytes (< 70% of 1000) → offered.
+    await seedAsset(env, "build-delta", "asset-patch-small", {
+      artifactKind: "delta-patch",
+      arch: "arm64-v8a",
+      filetype: "patch",
+      sizeBytes: 200,
+      r2Key: "apps/app-scope/patch-10-20.patch",
+      metadata: {
+        from_version_code: 10,
+        to_version_code: 20,
+        algorithm: "archive-patcher-v1",
+        target_sha256: "deadbeef",
+      },
+    });
+
+    const call = (currentCode: string) =>
+      handlePublicV2UpdateCheck(
+        makePublicContext(env, {
+          channel: "production",
+          product_type: "android-apk",
+          current_version_code: currentCode,
+          platform: "android",
+          arch: "arm64-v8a",
+        }),
+      );
+
+    // Client on 10 → patch offered with target hash + signed URL.
+    const offered = await responseJson<any>(await call("10"));
+    expect(offered.patch).toMatchObject({
+      from_version_code: 10,
+      algorithm: "archive-patcher-v1",
+      size_bytes: 200,
+      target_sha256: "deadbeef",
+    });
+    expect(offered.patch.download_url).toContain("patch-10-20.patch");
+    expect(offered.patch.download_url).toContain("&sig=");
+
+    // Client on 15 → no patch for that from-version → full only.
+    const noPatch = await responseJson<any>(await call("15"));
+    expect(noPatch.update_available).toBe(true);
+    expect(noPatch.patch).toBeUndefined();
+
+    // A too-large patch (>70% of full) is not offered.
+    await seedAsset(env, "build-delta", "asset-patch-big", {
+      artifactKind: "delta-patch",
+      arch: "arm64-v8a",
+      filetype: "patch",
+      sizeBytes: 900,
+      r2Key: "apps/app-scope/patch-5-20.patch",
+      metadata: { from_version_code: 5, to_version_code: 20, algorithm: "archive-patcher-v1" },
+    });
+    const bigPatch = await responseJson<any>(await call("5"));
+    expect(bigPatch.patch).toBeUndefined();
+  });
+
   it("public R2 download serves active release assets with a valid signature", async () => {
     const env = makeEnv();
     const { handlePublicR2Download, handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");


### PR DESCRIPTION
First slice of docs/delta-download-design.md (task #246). `/updates/check` adds a `patch` field when the target build has a `delta-patch` asset for the client's current_version_code + arch, only if < 70% of the full APK. Full asset stays the fallback; old SDKs ignore it. tsc clean, 109/109 (new test covers offered/not-matching/too-big). Generation (archive-patcher) + SDK applier follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)