### PR TITLE
feat(cli): --delta-patch upload for publish-android (delta P1b, 0.5.3)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -162,6 +162,12 @@ export function registerBuildCommands(program: Command): void {
     .option("--dsym <path>", "iOS dSYM archive (dSYM.zip) support artifact.")
     .option("--metadata <path>", "Build metadata JSON support artifact.")
     .option(
+      "--delta-patch <spec>",
+      "Delta patch as <from_version_code>=<path> (archive-patcher). Repeatable — clients on that version get offered this patch instead of the full APK.",
+      collect,
+      [],
+    )
+    .option(
       "--changelog <text>",
       "Inline changelog. Repeatable with lang=text for multiple languages.",
       collect,
@@ -197,6 +203,7 @@ export function registerBuildCommands(program: Command): void {
           symbols?: string;
           dsym?: string;
           metadata?: string;
+          deltaPatch?: string[];
           changelog?: string[];
           changelogFile?: string[];
           sourceCommit?: string;
@@ -250,14 +257,38 @@ export function registerBuildCommands(program: Command): void {
         });
 
         const assets = [];
-        assets.push(
-          await uploadAndRegisterAsset(appId, build.id, opts.apk, {
-            artifact_kind: "installable",
-            platform: "android",
-            arch: opts.arch,
-            filetype: "apk",
-          }),
-        );
+        const installable = await uploadAndRegisterAsset(appId, build.id, opts.apk, {
+          artifact_kind: "installable",
+          platform: "android",
+          arch: opts.arch,
+          filetype: "apk",
+        });
+        assets.push(installable);
+        // Delta patches: <from_version_code>=<path>. target_sha256 is the new
+        // APK's hash so the client can verify the reconstructed file. The
+        // server offers a patch only when it beats the full APK size.
+        for (const spec of opts.deltaPatch ?? []) {
+          const eq = spec.indexOf("=");
+          if (eq <= 0) throw new Error(`--delta-patch must be <from_version_code>=<path>, got: ${spec}`);
+          const fromVersionCode = Number(spec.slice(0, eq).trim());
+          const patchPath = spec.slice(eq + 1).trim();
+          if (!Number.isFinite(fromVersionCode)) throw new Error(`bad from_version_code in --delta-patch: ${spec}`);
+          if (!existsSync(patchPath)) throw new Error(`missing delta patch file: ${patchPath}`);
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, patchPath, {
+              artifact_kind: "delta-patch",
+              platform: "android",
+              arch: opts.arch,
+              filetype: "patch",
+              metadata_json: {
+                from_version_code: fromVersionCode,
+                to_version_code: versionCode,
+                algorithm: "archive-patcher-v1",
+                target_sha256: installable.file_hash,
+              },
+            }),
+          );
+        }
         if (opts.mapping) {
           assets.push(
             await uploadAndRegisterAsset(appId, build.id, opts.mapping, {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.2")
+  .version("0.5.3")
   .option(
     "--api <url>",
     "Quiver Worker base URL (default: https://quiver.oranix.io or $QUIVER_API)",


### PR DESCRIPTION
The upload outlet for delta patches (task #246). `publish-android --delta-patch <from_version_code>=<path>` (repeatable) uploads each patch as a `delta-patch` asset with `{from_version_code, to_version_code, algorithm, target_sha256}` — target_sha256 = the new APK's hash so the SDK can verify the reconstructed file. Pairs with the server offer (#208). The archive-patcher generation step (android-release CI) feeds this next.

Verified: CLI builds, `--delta-patch` renders in help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)