### PR TITLE
feat(admin): add collapsible organization sidebar

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -10,7 +10,25 @@ import {
   Link,
 } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Building2, ChevronsUpDown, LayoutGrid, Plus } from "lucide-react";
+import {
+  Bug,
+  ChevronDown,
+  ChevronsUpDown,
+  Gauge,
+  LayoutGrid,
+  MessageSquare,
+  Package,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plane,
+  Plus,
+  Radio,
+  Rocket,
+  ScrollText,
+  Settings as SettingsIcon,
+  Share2,
+  type LucideIcon,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { AppsList } from "./pages/AppsList";
 import { AppChannels, AppDetail, AppSettings } from "./pages/AppDetail";
@@ -26,7 +44,15 @@ import { isOrgSettingsTab, OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
 import { OrgSwitcher, useClearOrgCache } from "./components/OrgSwitcher";
-import { getAuthMe, listApps, listOrgs, loginUrl, logout, type AuthAccount } from "./lib/api";
+import {
+  clearActiveOrgId,
+  getAuthMe,
+  listApps,
+  listOrgs,
+  loginUrl,
+  logout,
+  type AuthAccount,
+} from "./lib/api";
 
 function RaftIcon({ className = "" }: { className?: string }) {
   return (
@@ -81,21 +107,52 @@ function QuiverMark({ className = "" }: { className?: string }) {
   );
 }
 
+const SIDEBAR_COLLAPSED_KEY = "hands:sidebar-collapsed";
+
 function Header({ account }: { account: AuthAccount }) {
+  const navigate = useNavigate();
   const onLogout = async () => {
     await logout();
+    clearActiveOrgId();
     window.location.assign("/");
   };
-  const orgHref = account.org_id ? `/orgs/${account.org_id}` : "/orgs/placeholder";
+  const location = useLocation();
+  const appId = location.pathname.startsWith("/apps/")
+    ? location.pathname.split("/")[2] ?? null
+    : null;
   const orgs = useQuery({
-    queryKey: ["orgs", account.id],
+    queryKey: ["orgs"],
     queryFn: () => listOrgs(),
     enabled: !!account.id,
   });
+  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
   const switchOrg = useClearOrgCache();
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
   const [showOrgSwitcher, setShowOrgSwitcher] = useState(false);
+  const [showAppSwitcher, setShowAppSwitcher] = useState(false);
   const [showAccountMenu, setShowAccountMenu] = useState(false);
+  const appSwitcherRef = useRef<HTMLDivElement | null>(null);
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
+  const currentOrg = orgs.data?.orgs.find((org) => org.id === account.org_id);
+  const currentApp = apps.data?.apps.find((app) => app.id === appId);
+  const otherApps = (apps.data?.apps ?? []).filter(
+    (app) => app.id !== appId && !app.archived,
+  );
+  const appBase = appId ? `/apps/${appId}` : null;
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+    } catch {
+      // Storage can be unavailable in private/restricted browser contexts.
+    }
+  }, [collapsed]);
 
   useEffect(() => {
     if (!showAccountMenu) return;
@@ -118,58 +175,231 @@ function Header({ account }: { account: AuthAccount }) {
     };
   }, [showAccountMenu]);
 
+  useEffect(() => {
+    if (!showAppSwitcher) return;
+    function onPointerDown(event: MouseEvent) {
+      if (
+        appSwitcherRef.current &&
+        !appSwitcherRef.current.contains(event.target as Node)
+      ) {
+        setShowAppSwitcher(false);
+      }
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setShowAppSwitcher(false);
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [showAppSwitcher]);
+
   const railItem = ({ isActive }: { isActive: boolean }) =>
-    `flex w-full flex-col items-center gap-0.5 rounded-md px-1 py-2 text-[11px] leading-none ${
+    `flex w-full items-center rounded-md py-2 text-sm ${collapsed ? "flex-col gap-0.5 px-1 text-[11px] leading-none" : "gap-2 px-2"} ${
       isActive
         ? "bg-slate-100 font-medium text-slate-950"
         : "text-slate-500 hover:bg-slate-100 hover:text-slate-950"
     }`;
 
   return (
-    <header className="sticky top-0 h-screen flex w-16 flex-none flex-col items-center border-r border-slate-200 bg-white py-3">
-      <Link to="/" aria-label="Hands" className="mb-4">
-        <QuiverMark className="h-9 w-9" />
-      </Link>
-      <nav className="flex w-full flex-col items-stretch gap-1 px-2">
-        <NavLink to="/apps" end={false} className={railItem}>
+    <header
+      className={`sticky top-0 flex h-screen flex-none flex-col border-r border-slate-200 bg-white py-3 transition-[width] duration-150 ${
+        collapsed ? "w-16 items-center" : "w-16 items-stretch md:w-60"
+      }`}
+    >
+      <div className={`mb-4 flex h-9 items-center ${collapsed ? "justify-center" : "justify-between px-3"}`}>
+        <Link to="/" aria-label="Hands" className="flex min-w-0 items-center gap-2">
+          <QuiverMark className="h-9 w-9 flex-none" />
+          {!collapsed && <span className="hidden truncate text-sm font-semibold text-slate-900 md:inline">Hands</span>}
+        </Link>
+        {!collapsed && (
+          <button
+            type="button"
+            className="icon-button hidden h-8 w-8 md:flex"
+            onClick={() => setCollapsed(true)}
+            title="Collapse sidebar"
+            aria-label="Collapse sidebar"
+          >
+            <PanelLeftClose className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+      <nav className="flex min-h-0 w-full flex-1 flex-col items-stretch gap-1 px-2">
+        <NavLink
+          to="/apps"
+          end
+          className={railItem}
+          title={collapsed ? "Apps" : undefined}
+        >
           <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-          Apps
+          {!collapsed && <span className="hidden md:inline">Apps</span>}
         </NavLink>
         <div className="relative w-full">
-          <NavLink
-            to={orgHref}
-            onClick={(e) => {
-              if (orgs.data && orgs.data.orgs.length > 1) {
-                e.preventDefault();
-                setShowOrgSwitcher((s) => !s);
-              }
-            }}
-            className={railItem}
-            aria-label={
-              account.org_id
-                ? `Org ${account.server_slug ?? account.server_id}, role ${account.org_role ?? "none"}`
-                : "Org settings"
-            }
+          <button
+            type="button"
+            onClick={() => setShowOrgSwitcher((open) => !open)}
+            onMouseDown={(event) => event.stopPropagation()}
+            className={railItem({ isActive: location.pathname.startsWith("/orgs/") })}
+            aria-haspopup="menu"
+            aria-expanded={showOrgSwitcher}
+            aria-label={`Organization ${currentOrg?.name ?? account.server_slug ?? account.server_id}`}
+            title={collapsed ? currentOrg?.name ?? "Switch organization" : undefined}
           >
-            <Building2 className="h-4 w-4" aria-hidden="true" />
-            Org
-          </NavLink>
-          {showOrgSwitcher && orgs.data && orgs.data.orgs.length > 1 && (
-            <div className="absolute left-full top-0 z-40 ml-2">
+            <span className="flex h-6 w-6 flex-none items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-[10px] font-semibold text-slate-600">
+              {(currentOrg?.name ?? account.server_slug ?? "O").slice(0, 1).toUpperCase()}
+            </span>
+            {!collapsed && (
+              <>
+                <span className="hidden min-w-0 flex-1 text-left md:block">
+                  <span className="block truncate font-medium text-slate-800">
+                    {currentOrg?.name ?? account.server_slug ?? "Organization"}
+                  </span>
+                  <span className="block truncate text-xs text-slate-400">
+                    {account.org_role ?? "member"}
+                  </span>
+                </span>
+                <ChevronDown className="hidden h-4 w-4 text-slate-400 md:block" aria-hidden="true" />
+              </>
+            )}
+          </button>
+          {showOrgSwitcher && (
+            <div
+              className={`absolute z-40 ${
+                collapsed ? "left-full top-0 ml-2" : "left-0 top-full mt-1"
+              }`}
+            >
               <OrgSwitcher
                 currentOrgId={account.org_id ?? null}
-                buttonLabel={`Switch organization (${orgs.data.orgs.length} members of)`}
+                buttonLabel="Switch organization"
                 onClose={() => setShowOrgSwitcher(false)}
-                onSwitch={switchOrg}
+                onSwitch={(org) => {
+                  switchOrg(org);
+                  setShowOrgSwitcher(false);
+                  window.location.assign("/apps");
+                }}
               />
             </div>
           )}
         </div>
+        {appId && appBase && (
+          <>
+            <div ref={appSwitcherRef} className="relative w-full border-t border-slate-100 pt-2">
+              <button
+                type="button"
+                className={railItem({ isActive: false })}
+                onClick={() => setShowAppSwitcher((open) => !open)}
+                aria-haspopup="menu"
+                aria-expanded={showAppSwitcher}
+                title={collapsed ? currentApp?.name ?? "Switch app" : undefined}
+              >
+                <span className="flex h-6 w-6 flex-none items-center justify-center rounded-md bg-sky-50 text-[10px] font-semibold text-sky-700">
+                  {(currentApp?.name ?? "A").slice(0, 1).toUpperCase()}
+                </span>
+                {!collapsed && (
+                  <>
+                    <span className="hidden min-w-0 flex-1 text-left md:block">
+                      <span className="block truncate font-medium text-slate-800">
+                        {currentApp?.name ?? "Loading app…"}
+                      </span>
+                      <span className="block truncate text-xs font-mono text-slate-400">
+                        {currentApp?.slug}
+                      </span>
+                    </span>
+                    <ChevronsUpDown className="hidden h-4 w-4 text-slate-400 md:block" aria-hidden="true" />
+                  </>
+                )}
+              </button>
+              {showAppSwitcher && (
+                <div
+                  className={`absolute z-40 w-64 rounded-md border border-slate-200 bg-white py-1 shadow-lg ${
+                    collapsed ? "left-full top-0 ml-2" : "left-0 top-full mt-1"
+                  }`}
+                >
+                  {otherApps.map((app) => (
+                    <button
+                      key={app.id}
+                      type="button"
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
+                      onClick={() => {
+                        setShowAppSwitcher(false);
+                        const section = location.pathname.split("/")[3] ?? "";
+                        navigate(section ? `/apps/${app.id}/${section}` : `/apps/${app.id}`);
+                      }}
+                    >
+                      <span className="truncate">{app.name}</span>
+                      <span className="badge-blue ml-auto">{app.platform}</span>
+                    </button>
+                  ))}
+                  {otherApps.length === 0 && (
+                    <div className="px-3 py-2 text-xs text-slate-400">No other apps</div>
+                  )}
+                  <Link
+                    to="/apps?new=1"
+                    className="mt-1 flex items-center gap-1.5 border-t border-slate-100 px-3 py-2 text-xs text-slate-600 hover:bg-slate-50"
+                    onClick={() => setShowAppSwitcher(false)}
+                  >
+                    <Plus className="h-3.5 w-3.5" aria-hidden="true" /> New app
+                  </Link>
+                  <Link
+                    to="/apps?all=1"
+                    className="flex items-center gap-1.5 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50"
+                    onClick={() => setShowAppSwitcher(false)}
+                  >
+                    <LayoutGrid className="h-3.5 w-3.5" aria-hidden="true" /> All apps
+                  </Link>
+                </div>
+              )}
+            </div>
+            <div className="mt-1 flex-1 overflow-y-auto">
+              {APP_NAV_SECTIONS.map((section) => (
+                <div key={section.label} className="mb-3">
+                  {!collapsed && (
+                    <div className="hidden px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-400 md:block">
+                      {section.label}
+                    </div>
+                  )}
+                  <div className="space-y-0.5">
+                    {section.items.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <NavLink
+                          key={item.label}
+                          to={item.to ? `${appBase}/${item.to}` : appBase}
+                          end={item.end ?? false}
+                          className={railItem}
+                          title={collapsed ? item.label : undefined}
+                        >
+                          <Icon className="h-4 w-4 flex-none" aria-hidden="true" />
+                          {!collapsed && <span className="hidden md:inline">{item.label}</span>}
+                        </NavLink>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </nav>
-      <div ref={accountMenuRef} className="relative mt-auto flex w-full flex-col items-center px-2">
+      <div ref={accountMenuRef} className="relative mt-auto flex w-full flex-col px-2">
+        {collapsed && (
+          <button
+            type="button"
+            className="mb-2 hidden h-9 w-full items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-950 md:flex"
+            onClick={() => setCollapsed(false)}
+            title="Expand sidebar"
+            aria-label="Expand sidebar"
+          >
+            <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+          </button>
+        )}
         <button
           type="button"
-          className="rounded-full outline-none hover:ring-2 hover:ring-slate-200"
+          className={`flex w-full items-center rounded-md outline-none hover:bg-slate-100 ${
+            collapsed ? "justify-center p-1" : "gap-2 px-2 py-2 text-left"
+          }`}
           onClick={() => setShowAccountMenu((open) => !open)}
           aria-haspopup="menu"
           aria-expanded={showAccountMenu}
@@ -184,6 +414,16 @@ function Header({ account }: { account: AuthAccount }) {
           ) : (
             <span className="flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-slate-100 text-xs font-semibold text-slate-600">
               {account.display_name.slice(0, 1).toUpperCase()}
+            </span>
+          )}
+          {!collapsed && (
+            <span className="hidden min-w-0 flex-1 md:block">
+              <span className="block truncate text-sm font-medium text-slate-800">
+                {account.display_name}
+              </span>
+              <span className="block truncate text-xs text-slate-400">
+                {account.server_slug || account.server_id}
+              </span>
             </span>
           )}
         </button>
@@ -880,128 +1120,31 @@ function AppsListWithNav() {
   );
 }
 
-const APP_NAV_SECTIONS: Array<{ label: string; items: Array<{ to: string; label: string; end?: boolean }> }> = [
+const APP_NAV_SECTIONS: Array<{
+  label: string;
+  items: Array<{ to: string; label: string; icon: LucideIcon; end?: boolean }>;
+}> = [
   {
     label: "Distribute",
     items: [
-      { to: "", label: "Overview", end: true },
-      { to: "channels", label: "Channels" },
-      { to: "releases", label: "Releases" },
-      { to: "builds", label: "Builds" },
-      { to: "testflight", label: "TestFlight" },
-      { to: "shares", label: "Shares" },
+      { to: "", label: "Overview", icon: Gauge, end: true },
+      { to: "channels", label: "Channels", icon: Radio },
+      { to: "releases", label: "Releases", icon: Rocket },
+      { to: "builds", label: "Builds", icon: Package },
+      { to: "testflight", label: "TestFlight", icon: Plane },
+      { to: "shares", label: "Shares", icon: Share2 },
     ],
   },
   {
     label: "Operate",
     items: [
-      { to: "feedback", label: "Feedback" },
-      { to: "crashes", label: "Crashes" },
-      { to: "audit", label: "Audit" },
-      { to: "settings", label: "Settings" },
+      { to: "feedback", label: "Feedback", icon: MessageSquare },
+      { to: "crashes", label: "Crashes", icon: Bug },
+      { to: "audit", label: "Audit", icon: ScrollText },
+      { to: "settings", label: "Settings", icon: SettingsIcon },
     ],
   },
 ];
-
-function AppSidebar() {
-  const { appId } = useParams();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [switcherOpen, setSwitcherOpen] = useState(false);
-  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
-  if (!appId) return null;
-  const app = apps.data?.apps.find((a) => a.id === appId);
-  const others = (apps.data?.apps ?? []).filter((a) => a.id !== appId && !a.archived);
-  const base = `/apps/${appId}`;
-
-  return (
-    <aside className="hidden md:flex w-60 flex-none flex-col border-r border-slate-200 bg-white">
-      <div className="relative border-b border-slate-100 p-3">
-        <button
-          type="button"
-          className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-2 text-left hover:bg-slate-50"
-          onClick={() => setSwitcherOpen((v) => !v)}
-          aria-haspopup="menu"
-          aria-expanded={switcherOpen}
-        >
-          <span className="min-w-0">
-            <span className="block truncate text-sm font-semibold text-slate-900">
-              {app?.name ?? "…"}
-            </span>
-            <span className="mt-0.5 flex items-center gap-1.5">
-              {app?.platform && <span className="badge-blue">{app.platform}</span>}
-              <span className="truncate text-xs text-slate-400 font-mono">{app?.slug}</span>
-            </span>
-          </span>
-          <ChevronsUpDown className="h-4 w-4 text-slate-400" aria-hidden="true" />
-        </button>
-        {switcherOpen && (
-          <div className="absolute left-3 right-3 top-full z-30 -mt-1 rounded-md border border-slate-200 bg-white py-1 shadow-lg">
-            {others.map((a) => (
-              <button
-                key={a.id}
-                type="button"
-                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50"
-                onClick={() => {
-                  setSwitcherOpen(false);
-                  const section = location.pathname.split("/")[3] ?? "";
-                  navigate(section ? `/apps/${a.id}/${section}` : `/apps/${a.id}`);
-                }}
-              >
-                <span className="truncate">{a.name}</span>
-                <span className="badge-blue ml-auto">{a.platform}</span>
-              </button>
-            ))}
-            {others.length === 0 && (
-              <div className="px-3 py-2 text-xs text-slate-400">No other apps</div>
-            )}
-            <Link
-              to="/apps?new=1"
-              className="mt-1 flex items-center gap-1.5 border-t border-slate-100 px-3 py-2 text-xs text-slate-600 hover:bg-slate-50"
-              onClick={() => setSwitcherOpen(false)}
-            >
-              <Plus className="h-3.5 w-3.5" aria-hidden="true" /> New app
-            </Link>
-            <Link
-              to="/apps?all=1"
-              className="flex items-center gap-1.5 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50"
-              onClick={() => setSwitcherOpen(false)}
-            >
-              <LayoutGrid className="h-3.5 w-3.5" aria-hidden="true" /> All apps
-            </Link>
-          </div>
-        )}
-      </div>
-      <nav className="flex-1 overflow-y-auto p-3">
-        {APP_NAV_SECTIONS.map((section) => (
-          <div key={section.label} className="mb-4">
-            <div className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-              {section.label}
-            </div>
-            <div className="space-y-0.5">
-              {section.items.map((item) => (
-                <NavLink
-                  key={item.label}
-                  to={item.to ? `${base}/${item.to}` : base}
-                  end={item.end ?? false}
-                  className={({ isActive }) =>
-                    `block rounded-md px-2 py-1.5 text-sm ${
-                      isActive
-                        ? "bg-slate-100 font-medium text-slate-950"
-                        : "text-slate-600 hover:bg-slate-50 hover:text-slate-950"
-                    }`
-                  }
-                >
-                  {item.label}
-                </NavLink>
-              ))}
-            </div>
-          </div>
-        ))}
-      </nav>
-    </aside>
-  );
-}
 
 const LAST_APP_KEY = "quiver:last-app-id";
 
@@ -1018,7 +1161,6 @@ function AppShell() {
   }, [appId]);
   return (
     <div className="flex flex-1 min-h-0 items-stretch">
-      <AppSidebar />
       <div className="min-w-0 flex-1">
         <div className="md:hidden">
           <AppContextNav />

--- a/admin/src/components/OrgSwitcher.tsx
+++ b/admin/src/components/OrgSwitcher.tsx
@@ -1,10 +1,5 @@
 /**
- * OrgSwitcher — top-bar dropdown for switching between orgs the user is in.
- *
- * v1: most users are in a single org (Raft server). The dropdown is a
- * no-op for them. When the user is in 2+ orgs (multi-Raft-server case),
- * the chevron appears in the Org nav link and clicking opens a dropdown
- * listing the orgs.
+ * OrgSwitcher — sidebar dropdown for switching the active organization.
  *
  * P5.4.6 follow-up (task #23): when switching orgs, the SPA invalidates
  * the entire TanStack Query cache so apps / channels / releases / audit
@@ -13,8 +8,9 @@
 
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Settings } from "lucide-react";
 import { Link } from "react-router-dom";
-import { listOrgs, type Org } from "../lib/api";
+import { getAuthMe, listOrgs, setActiveOrgId, type Org } from "../lib/api";
 
 export function OrgSwitcher({
   currentOrgId,
@@ -27,7 +23,6 @@ export function OrgSwitcher({
   onClose: () => void;
   onSwitch?: (org: Org) => void;
 }) {
-  const qc = useQueryClient();
   const orgs = useQuery({ queryKey: ["orgs"], queryFn: () => listOrgs() });
   const ref = useRef<HTMLDivElement>(null);
 
@@ -45,7 +40,7 @@ export function OrgSwitcher({
   return (
     <div
       ref={ref}
-      className="absolute top-full left-0 mt-1 w-72 bg-white border border-slate-200 rounded-md shadow-lg z-30"
+      className="w-72 rounded-md border border-slate-200 bg-white shadow-lg"
     >
       <div className="text-xs text-slate-500 px-3 py-2 border-b border-slate-100">
         {buttonLabel}
@@ -62,18 +57,14 @@ export function OrgSwitcher({
         {orgs.data?.orgs.map((o: Org) => {
           const isCurrent = o.id === currentOrgId;
           return (
-            <Link
+            <button
+              type="button"
               key={o.id}
-              to={`/orgs/${o.id}`}
               onClick={() => {
-                // Invalidate the entire query cache on org switch so apps
-                // / channels / releases / members / audit / etc. don't
-                // leak across org boundaries. The destination page will
-                // re-fetch what it needs.
                 if (onSwitch && !isCurrent) onSwitch(o);
                 onClose();
               }}
-              className={`flex items-center gap-2 px-3 py-2 text-sm hover:bg-slate-50 ${
+              className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50 ${
                 isCurrent ? "bg-slate-50 font-medium" : ""
               }`}
             >
@@ -90,13 +81,22 @@ export function OrgSwitcher({
                   <div className="text-xs text-slate-500 font-mono">{o.slug}</div>
                 )}
               </span>
-              {isCurrent && <span className="text-xs text-blue-600">●</span>}
-            </Link>
+              {isCurrent && <Check className="h-4 w-4 text-slate-700" aria-hidden="true" />}
+            </button>
           );
         })}
       </div>
-      <div className="text-xs text-slate-400 px-3 py-2 border-t border-slate-100">
-        Multi-org: switching invalidates cache and reloads.
+      <div className="border-t border-slate-100 p-1">
+        {currentOrgId && (
+          <Link
+            to={`/orgs/${currentOrgId}`}
+            onClick={onClose}
+            className="flex items-center gap-2 rounded px-2 py-2 text-sm text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+            Organization settings
+          </Link>
+        )}
       </div>
     </div>
   );
@@ -106,6 +106,7 @@ export function OrgSwitcher({
 export function useClearOrgCache() {
   const qc = useQueryClient();
   return (org: Org) => {
+    setActiveOrgId(org.id);
     // Wipe the entire query cache for the previous org. This includes:
     //   - orgs list (will refetch with the new org at the top)
     //   - org-members / invites / audit-logs / webhooks
@@ -114,8 +115,7 @@ export function useClearOrgCache() {
     qc.removeQueries();
     // Re-prefetch the orgs list + auth-me in the background so the
     // new-org landing page doesn't show stale top bar.
-    qc.prefetchQuery({ queryKey: ["auth-me"], queryFn: () => fetch("/api/auth/me").then((r) => r.json()) });
+    qc.prefetchQuery({ queryKey: ["auth-me"], queryFn: () => getAuthMe() });
     qc.prefetchQuery({ queryKey: ["orgs"], queryFn: () => listOrgs() });
-    void org; // currently unused — kept for future per-org cache logic
   };
 }

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -14,6 +14,31 @@
 // the same origin (via wrangler [assets] binding), so API_BASE is empty
 // and requests go to the same host. In dev, Vite proxies /api → wrangler dev.
 const API_BASE = (import.meta as any).env?.VITE_API_BASE_URL ?? "";
+export const ACTIVE_ORG_STORAGE_KEY = "hands:active-org-id";
+
+export function getActiveOrgId(): string | null {
+  try {
+    return window.localStorage.getItem(ACTIVE_ORG_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveOrgId(orgId: string): void {
+  try {
+    window.localStorage.setItem(ACTIVE_ORG_STORAGE_KEY, orgId);
+  } catch {
+    // Storage can be unavailable in private/restricted browser contexts.
+  }
+}
+
+export function clearActiveOrgId(): void {
+  try {
+    window.localStorage.removeItem(ACTIVE_ORG_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable in private/restricted browser contexts.
+  }
+}
 
 export class ApiError extends Error {
   constructor(public status: number, public body: unknown, message: string) {
@@ -328,6 +353,8 @@ async function request<T>(
 ): Promise<T> {
   const headers = new Headers(init.headers);
   headers.set("content-type", "application/json");
+  const activeOrgId = getActiveOrgId();
+  if (activeOrgId) headers.set("x-hands-org-id", activeOrgId);
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
     headers,

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -17,6 +17,7 @@ import { getCookie } from "hono/cookie";
 import { loadDeployToken, sha256Hex, type AppDeployToken } from "../lib/deploy_tokens";
 
 export const SESSION_COOKIE = "quiver_session";
+export const ACTIVE_ORG_HEADER = "x-hands-org-id";
 
 export type AdminAccount = {
   id: string;
@@ -124,6 +125,34 @@ export async function loadAccountFromAuthToken(
   return account;
 }
 
+async function withRequestedOrg(
+  env: Env,
+  account: AdminAccount,
+  requestedOrgId: string | undefined,
+): Promise<AdminAccount> {
+  const orgId = requestedOrgId?.trim();
+  if (!orgId || orgId === account.org_id) return account;
+
+  const membership = await env.DB.prepare(
+    `SELECT om.org_id, om.org_role
+     FROM org_members om
+     JOIN organizations o ON o.id = om.org_id
+     WHERE om.account_id = ?1
+       AND om.org_id = ?2
+       AND o.archived = 0
+     LIMIT 1`,
+  )
+    .bind(account.id, orgId)
+    .first<{
+      org_id: string;
+      org_role: NonNullable<AdminAccount["org_role"]>;
+    }>();
+
+  return membership
+    ? { ...account, org_id: membership.org_id, org_role: membership.org_role }
+    : account;
+}
+
 export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
   async (c, next) => {
     const cookieToken = getCookie(c, SESSION_COOKIE);
@@ -131,11 +160,16 @@ export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
     const bearerToken = authHeader?.startsWith("Bearer ")
       ? authHeader.slice("Bearer ".length).trim()
       : undefined;
-    const account = await loadAccountFromAuthToken(
+    const sessionAccount = await loadAccountFromAuthToken(
       c.env,
       cookieToken || bearerToken,
     );
-    if (account) {
+    if (sessionAccount) {
+      const account = await withRequestedOrg(
+        c.env,
+        sessionAccount,
+        c.req.header(ACTIVE_ORG_HEADER),
+      );
       c.set("admin_account", account);
       c.set("admin_actor", accountActor(account));
       if (account.org_id) c.set("org_id", account.org_id);

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -23,7 +23,7 @@ import { authMiddleware } from "../src/middleware/auth";
 import { requireCurrentOrgRole } from "../src/lib/permissions";
 import { httpsRedirectUrl, isSecureRequest, requestOrigin } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
-import { handleCreateApp } from "../src/routes/apps";
+import { handleCreateApp, handleListApps } from "../src/routes/apps";
 import { handleAuthLogin } from "../src/routes/auth";
 
 // ---------- Test harness ----------
@@ -815,6 +815,122 @@ describe("quiver route handlers — SQL smoke", () => {
       .bind("member-app")
       .all();
     expect(seededChannels.results.map((row: any) => row.slug)).toEqual(["main", "nightly", "preview"]);
+  });
+
+  it("uses a validated selected-org header for org-scoped app requests", async () => {
+    const now = Date.now();
+    const token = "multi-org-token";
+
+    await env.DB
+      .prepare(
+        `INSERT INTO organizations
+         (id, slug, name, external_provider, external_id, created_at, archived)
+         VALUES (?, ?, ?, 'raft', ?, ?, 0), (?, ?, ?, 'raft', ?, ?, 0)`,
+      )
+      .bind(
+        "org-primary", "primary", "Primary", "server-primary", now,
+        "org-secondary", "secondary", "Secondary", "server-secondary", now,
+      )
+      .run();
+    await env.DB
+      .prepare(
+        `INSERT INTO raft_accounts
+         (id, provider, provider_subject, server_id, server_slug, principal_type,
+          server_role, username, display_name, avatar_url, raw_profile,
+          created_at, updated_at, last_login_at)
+         VALUES (?, 'raft', ?, 'server-primary', 'primary', 'human',
+                 NULL, ?, ?, NULL, '{}', ?, ?, ?)`,
+      )
+      .bind("multi-org-user", "multi-org-sub", "multi", "Multi Org", now, now, now)
+      .run();
+    await env.DB
+      .prepare(
+        `INSERT INTO org_members (id, org_id, account_id, org_role, joined_at)
+         VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "member-primary", "org-primary", "multi-org-user", "owner", now,
+        "member-secondary", "org-secondary", "multi-org-user", "member", now,
+      )
+      .run();
+    await env.DB
+      .prepare(
+        "INSERT INTO raft_sessions (id, account_id, token_hash, created_at, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        "session-multi-org",
+        "multi-org-user",
+        createHash("sha256").update(token).digest("hex"),
+        now,
+        now + 60_000,
+        now,
+      )
+      .run();
+    await env.DB
+      .prepare(
+        `INSERT INTO apps (id, org_id, slug, name, platform, created_at)
+         VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "app-primary", "org-primary", "primary-app", "Primary App", "android", now,
+        "app-secondary", "org-secondary", "secondary-app", "Secondary App", "ios", now,
+      )
+      .run();
+
+    const testApp = new Hono<{ Bindings: Env }>();
+    testApp.use("*", authMiddleware as any);
+    testApp.get("/api/apps", requireCurrentOrgRole("viewer") as any, handleListApps as any);
+    testApp.post("/api/apps", requireCurrentOrgRole("member") as any, handleCreateApp as any);
+
+    const requestApps = (orgId?: string) =>
+      testApp.request(
+        "https://quiver-worker.test/api/apps",
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            ...(orgId ? { "x-hands-org-id": orgId } : {}),
+          },
+        },
+        env as any,
+      );
+
+    const defaultResponse = await requestApps();
+    await expect(defaultResponse.json()).resolves.toMatchObject({
+      apps: [{ id: "app-primary", org_id: "org-primary" }],
+    });
+
+    const selectedResponse = await requestApps("org-secondary");
+    await expect(selectedResponse.json()).resolves.toMatchObject({
+      apps: [{ id: "app-secondary", org_id: "org-secondary" }],
+    });
+
+    const createResponse = await testApp.request(
+      "https://quiver-worker.test/api/apps",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+          "x-hands-org-id": "org-secondary",
+        },
+        body: JSON.stringify({
+          slug: "secondary-created",
+          name: "Secondary Created",
+          platform: "android",
+        }),
+      },
+      env as any,
+    );
+    expect(createResponse.status).toBe(201);
+    await expect(createResponse.json()).resolves.toMatchObject({
+      org_id: "org-secondary",
+      slug: "secondary-created",
+    });
+
+    const invalidResponse = await requestApps("org-not-a-member");
+    await expect(invalidResponse.json()).resolves.toMatchObject({
+      apps: [{ id: "app-primary", org_id: "org-primary" }],
+    });
   });
 
   it("apps are scoped by org_id", async () => {


### PR DESCRIPTION
## Summary
- replace the separate global rail + app sidebar with one collapsible sidebar
- keep org, app, and app-section navigation in the same surface with icon-only collapsed mode and persisted preference
- make organization selection a real request context, so app listing and app creation follow the selected org
- validate requested orgs against the signed-in account's memberships before applying them
- keep mobile at a stable compact icon rail while retaining the existing mobile app tabs

## Validation
- `pnpm --filter @botiverse/hands-worker test` (110 passed)
- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm --filter @botiverse/hands-admin build`
- `git diff --check origin/main...HEAD`

The in-app browser surface was unavailable in this agent session, so runtime visual review remains for PR review; TypeScript, production bundling, responsive constraints, and interaction state paths are covered locally.

Hands task #126
