### PR TITLE
fix(auth): link Raft identities across servers

### DIFF
--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -125,7 +125,7 @@ export async function loadAccountFromAuthToken(
   return account;
 }
 
-async function withRequestedOrg(
+export async function accountForRequestedOrg(
   env: Env,
   account: AdminAccount,
   requestedOrgId: string | undefined,
@@ -134,23 +134,21 @@ async function withRequestedOrg(
   if (!orgId || orgId === account.org_id) return account;
 
   const membership = await env.DB.prepare(
-    `SELECT om.org_id, om.org_role
+    `SELECT linked.*, om.org_id, om.org_role
      FROM org_members om
      JOIN organizations o ON o.id = om.org_id
-     WHERE om.account_id = ?1
-       AND om.org_id = ?2
+     JOIN raft_accounts linked ON linked.id = om.account_id
+     WHERE linked.provider = ?1
+       AND linked.provider_subject = ?2
+       AND linked.principal_type = ?3
+       AND om.org_id = ?4
        AND o.archived = 0
      LIMIT 1`,
   )
-    .bind(account.id, orgId)
-    .first<{
-      org_id: string;
-      org_role: NonNullable<AdminAccount["org_role"]>;
-    }>();
+    .bind(account.provider, account.provider_subject, account.principal_type, orgId)
+    .first<AdminAccount>();
 
-  return membership
-    ? { ...account, org_id: membership.org_id, org_role: membership.org_role }
-    : account;
+  return membership ?? account;
 }
 
 export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
@@ -165,7 +163,7 @@ export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
       cookieToken || bearerToken,
     );
     if (sessionAccount) {
-      const account = await withRequestedOrg(
+      const account = await accountForRequestedOrg(
         c.env,
         sessionAccount,
         c.req.header(ACTIVE_ORG_HEADER),

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -9,6 +9,8 @@ import type { Context } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import {
   accountActor,
+  accountForRequestedOrg,
+  ACTIVE_ORG_HEADER,
   loadAccountFromAuthToken,
   SESSION_COOKIE,
   type AdminAccount,
@@ -451,11 +453,11 @@ export async function handleAuthMe(c: Context<{ Bindings: Env }>) {
   const bearerToken = authHeader?.startsWith("Bearer ")
     ? authHeader.slice("Bearer ".length).trim()
     : undefined;
-  const account = await loadAccountFromAuthToken(
+  const sessionAccount = await loadAccountFromAuthToken(
     c.env,
     getCookie(c, SESSION_COOKIE) || bearerToken,
   );
-  if (!account) {
+  if (!sessionAccount) {
     return c.json(
       {
         authenticated: false,
@@ -464,6 +466,11 @@ export async function handleAuthMe(c: Context<{ Bindings: Env }>) {
       401,
     );
   }
+  const account = await accountForRequestedOrg(
+    c.env,
+    sessionAccount,
+    c.req.header(ACTIVE_ORG_HEADER),
+  );
   return c.json({
     authenticated: true,
     account: {

--- a/worker/src/routes/orgs.ts
+++ b/worker/src/routes/orgs.ts
@@ -85,12 +85,28 @@ export async function handleListOrgs(c: AdminContext) {
   }
   const { results } = await c.env.DB.prepare(
     `SELECT o.id, o.slug, o.name, o.external_provider, o.external_id,
-            o.created_at, o.archived, om.org_role
+            o.created_at, o.archived,
+            CASE MAX(CASE om.org_role
+              WHEN 'owner' THEN 4
+              WHEN 'admin' THEN 3
+              WHEN 'member' THEN 2
+              ELSE 1
+            END)
+              WHEN 4 THEN 'owner'
+              WHEN 3 THEN 'admin'
+              WHEN 2 THEN 'member'
+              ELSE 'viewer'
+            END AS org_role
      FROM org_members om
      JOIN organizations o ON o.id = om.org_id
-     WHERE om.account_id = ?1
+     JOIN raft_accounts linked ON linked.id = om.account_id
+     WHERE linked.provider = ?1
+       AND linked.provider_subject = ?2
+       AND linked.principal_type = ?3
+     GROUP BY o.id, o.slug, o.name, o.external_provider, o.external_id,
+              o.created_at, o.archived
      ORDER BY o.created_at DESC`,
-  ).bind(account.id).all();
+  ).bind(account.provider, account.provider_subject, account.principal_type).all();
   return c.json({ orgs: results });
 }
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -24,7 +24,8 @@ import { requireCurrentOrgRole } from "../src/lib/permissions";
 import { httpsRedirectUrl, isSecureRequest, requestOrigin } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
 import { handleCreateApp, handleListApps } from "../src/routes/apps";
-import { handleAuthLogin } from "../src/routes/auth";
+import { handleAuthLogin, handleAuthMe } from "../src/routes/auth";
+import { handleListOrgs } from "../src/routes/orgs";
 
 // ---------- Test harness ----------
 
@@ -839,9 +840,14 @@ describe("quiver route handlers — SQL smoke", () => {
           server_role, username, display_name, avatar_url, raw_profile,
           created_at, updated_at, last_login_at)
          VALUES (?, 'raft', ?, 'server-primary', 'primary', 'human',
+                 NULL, ?, ?, NULL, '{}', ?, ?, ?),
+                (?, 'raft', ?, 'server-secondary', 'secondary', 'human',
                  NULL, ?, ?, NULL, '{}', ?, ?, ?)`,
       )
-      .bind("multi-org-user", "multi-org-sub", "multi", "Multi Org", now, now, now)
+      .bind(
+        "multi-org-primary", "multi-org-sub", "multi", "Multi Org", now, now, now,
+        "multi-org-secondary", "multi-org-sub", "multi", "Multi Org", now, now, now,
+      )
       .run();
     await env.DB
       .prepare(
@@ -849,8 +855,8 @@ describe("quiver route handlers — SQL smoke", () => {
          VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
       )
       .bind(
-        "member-primary", "org-primary", "multi-org-user", "owner", now,
-        "member-secondary", "org-secondary", "multi-org-user", "member", now,
+        "member-primary", "org-primary", "multi-org-primary", "owner", now,
+        "member-secondary", "org-secondary", "multi-org-secondary", "member", now,
       )
       .run();
     await env.DB
@@ -859,7 +865,7 @@ describe("quiver route handlers — SQL smoke", () => {
       )
       .bind(
         "session-multi-org",
-        "multi-org-user",
+        "multi-org-primary",
         createHash("sha256").update(token).digest("hex"),
         now,
         now + 60_000,
@@ -881,6 +887,8 @@ describe("quiver route handlers — SQL smoke", () => {
     testApp.use("*", authMiddleware as any);
     testApp.get("/api/apps", requireCurrentOrgRole("viewer") as any, handleListApps as any);
     testApp.post("/api/apps", requireCurrentOrgRole("member") as any, handleCreateApp as any);
+    testApp.get("/api/orgs", handleListOrgs as any);
+    testApp.get("/api/auth/me", handleAuthMe as any);
 
     const requestApps = (orgId?: string) =>
       testApp.request(
@@ -899,9 +907,45 @@ describe("quiver route handlers — SQL smoke", () => {
       apps: [{ id: "app-primary", org_id: "org-primary" }],
     });
 
+    const orgsResponse = await testApp.request(
+      "https://quiver-worker.test/api/orgs",
+      { headers: { authorization: `Bearer ${token}` } },
+      env as any,
+    );
+    const orgsBody = (await orgsResponse.json()) as {
+      orgs: Array<{ id: string; org_role: string }>;
+    };
+    expect(
+      orgsBody.orgs
+        .map(({ id, org_role }) => ({ id, org_role }))
+        .sort((a, b) => a.id.localeCompare(b.id)),
+    ).toEqual([
+      { id: "org-primary", org_role: "owner" },
+      { id: "org-secondary", org_role: "member" },
+    ]);
+
     const selectedResponse = await requestApps("org-secondary");
     await expect(selectedResponse.json()).resolves.toMatchObject({
       apps: [{ id: "app-secondary", org_id: "org-secondary" }],
+    });
+
+    const selectedMeResponse = await testApp.request(
+      "https://quiver-worker.test/api/auth/me",
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "x-hands-org-id": "org-secondary",
+        },
+      },
+      env as any,
+    );
+    await expect(selectedMeResponse.json()).resolves.toMatchObject({
+      account: {
+        id: "multi-org-secondary",
+        server_id: "server-secondary",
+        org_id: "org-secondary",
+        org_role: "member",
+      },
     });
 
     const createResponse = await testApp.request(


### PR DESCRIPTION
## Summary
- treat Raft `userinfo.sub` + principal type as the stable person/agent identity across server login contexts
- keep server-specific account rows intact, but resolve the account row associated with the selected org
- list org memberships across all linked server-account rows
- make `/api/auth/me` honor the selected-org request header, matching authenticated admin routes
- cover the existing two-login-row scenario: list both orgs, switch context, list/create apps in the second org, and reject an unrelated org id

## Why this is safe
Raft's OAuth userinfo implementation returns `sub: humanId` or `sub: agentId`; `server_id` is the current authorization context. This change does not infer identity from username/display name and does not destructively merge existing account/session rows.

## Validation
- `pnpm --filter @botiverse/hands-worker test` (110 passed)
- `pnpm --filter @botiverse/hands-worker build`
- `git diff --check`

Hands task #126 follow-up
