### PR TITLE
feat(infra): split dashboard onto app domain

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -29,7 +29,8 @@ env:
   CLOUDFLARE_ACCOUNT_ID: a084c4564dfdce5a7775b08ece638a79
   HANDS_D1_DATABASE_NAME: hands-db
   HANDS_R2_BUCKET_NAME: hands-artifacts
-  HANDS_WORKER_DOMAIN: hands.build
+  HANDS_BUSINESS_DOMAIN: hands.build
+  HANDS_DASHBOARD_DOMAIN: app.hands.build
 
 jobs:
   deploy:
@@ -132,8 +133,7 @@ jobs:
           set -euo pipefail
           pnpm exec wrangler deploy \
             --config wrangler.hands.jsonc \
-            --containers-rollout "${{ inputs.containers_rollout }}" \
-            --domain "${HANDS_WORKER_DOMAIN}"
+            --containers-rollout "${{ inputs.containers_rollout }}"
 
       - name: Summary
         shell: bash
@@ -146,7 +146,8 @@ jobs:
             echo "| Ref | \`${GITHUB_REF_NAME}\` |"
             echo "| SHA | \`${GITHUB_SHA}\` |"
             echo "| Account | \`${CLOUDFLARE_ACCOUNT_ID}\` |"
-            echo "| Domain | \`${HANDS_WORKER_DOMAIN}\` |"
+            echo "| Business domain | \`${HANDS_BUSINESS_DOMAIN}\` |"
+            echo "| Dashboard domain | \`${HANDS_DASHBOARD_DOMAIN}\` |"
             echo "| D1 | \`${HANDS_D1_DATABASE_NAME}\` |"
             echo "| R2 | \`${HANDS_R2_BUCKET_NAME}\` |"
             echo "| Containers rollout | \`${{ inputs.containers_rollout }}\` |"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,15 @@
 
 ```sh
 # clone
-gh repo clone oranix-io/quiver
-cd quiver
+gh repo clone botiverse/hands
+cd hands
 
 # install
 pnpm install
 
 # set up worktree for a feature
-git worktree add -b feat/<lane>-<slice> ../quiver-<slice> main
-cd ../quiver-<slice>
+git worktree add -b feat/<lane>-<slice> ../hands-<slice> main
+cd ../hands-<slice>
 ```
 
 ## Deploy

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ The release platform for client apps, full loop.
 
 Hands runs the whole release loop: CI lands builds as drafts, agents review and publish with bilingual changelogs, staged rollouts meter exposure by device cohort, share pages handle ad-hoc distribution, and in-app feedback and crash reports come back as tickets — grouped by signature, symbolicated, and triageable by humans and AI agents through the same API. Reporting SDKs cover Android, iOS, HarmonyOS, and Electron — fully Cloudflare-native (Workers + Container + D1 + R2).
 
-- **Live instance:** <https://quiver.oranix.io>
-- **Docs:** <https://quiver.oranix.io/docs> · [Admin guide](https://quiver.oranix.io/docs/admin-user-guide/) · [CLI reference](https://quiver.oranix.io/docs/cli-reference/)
-- **API explorer:** <https://quiver.oranix.io/api-docs>
+- **Dashboard:** <https://app.hands.build>
+- **Business origin:** <https://hands.build>
+- **Docs:** <https://hands.build/docs> · [Admin guide](https://hands.build/docs/admin-user-guide/) · [CLI reference](https://hands.build/docs/cli-reference/)
+- **API explorer:** <https://hands.build/api-docs>
 - **CLI on npm:** [`@botiverse/hands-cli`](https://www.npmjs.com/package/@botiverse/hands-cli)
 
 The "Hands" metaphor: admins load build arrows into channels; clients pick the right one for their channel — and tell you where it landed.
@@ -29,7 +30,7 @@ $ npm exec --package @botiverse/hands-cli -- hands builds publish-android raft-a
 uploading APK and metadata...
 creating release on channel main...
 release: 14998dba-cfde-4002-8c01-230a2760f662
-share: https://quiver.oranix.io/share/...
+share: https://hands.build/share/...
 ```
 
 ## Architecture
@@ -41,7 +42,7 @@ share: https://quiver.oranix.io/share/...
        │ upload / list / download │
        ▼                          │
 ┌────────────────────────────────────────────────────────┐
-│ Cloudflare Worker (quiver)                            │
+│ Cloudflare Worker (Hands)                             │
 │ - API routes                                           │
 │ - Admin SPA static assets                              │
 │ - Auth (Login with Raft session cookie)                │
@@ -92,7 +93,7 @@ Worker configuration:
 - `RAFT_CLIENT_SECRET` as a Worker secret (`wrangler secret put RAFT_CLIENT_SECRET`)
 - `app.hands.build` is the canonical dashboard/login origin. `hands.build` remains the business/API origin for SDKs, CLI/agents, share/download pages, release notes, and docs.
 - Dashboard deep links received on `hands.build` redirect to the same path on `app.hands.build`. Public share/docs/history links received on `app.hands.build` redirect back to `hands.build`.
-- Keep the legacy `https://hands.build/login/raft/callback` registration during the cutover if existing browser logins may still be in flight; new logins use `https://app.hands.build/login/raft/callback`.
+- The Raft connected app must register the exact canonical callback `https://app.hands.build/login/raft/callback` before the dashboard domain is deployed.
 - Optional `RAFT_ALLOWED_SERVER_IDS` / `RAFT_ALLOWED_SERVER_SLUGS` can restrict admin login to specific Raft servers
 
 Do not put Raft client secrets in browser JavaScript, repository files, logs, or public channels.
@@ -124,7 +125,7 @@ Required repository secrets:
 - `NPM_TOKEN` — npm automation token with publish access to the `@botiverse` scope, used by the Node SDK and CLI publishing workflows.
 - `CLOUDFLARE_API_TOKEN` — Cloudflare API token allowed to deploy the Hands Worker and its assets.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
-- `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
+- `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the legacy Quiver proxy token.
 - `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
 - `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands-4cc7a2` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the canonical return URL `https://app.hands.build/login/raft/callback`.
 
@@ -132,7 +133,7 @@ Workflows:
 
 - `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm with the repository `NPM_TOKEN`. Trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
 - `Publish CLI` publishes `@botiverse/hands-cli` with the repository `NPM_TOKEN`. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.1`.
-- `Deploy Quiver Server` deploys the Worker plus bundled admin/docs assets. Trigger it manually, or push a tag like `server-v2026.07.04`. The default container rollout is `none`; choose `immediate` or `gradual` only when the APK parser container image changed.
+- `Deploy Quiver Server` is the legacy compatibility deployment for `quiver.oranix.io`; it no longer owns the Hands dashboard or business data plane.
 - `Deploy Hands Server` deploys one Worker/admin bundle to the custom domains `hands.build` (business/API) and `app.hands.build` (dashboard/login) in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ share: https://hands.build/share/...
 │ Cloudflare Worker (Hands)                             │
 │ - API routes                                           │
 │ - Admin SPA static assets                              │
-│ - Auth (Login with Raft session cookie)                │
+│ - Auth (Login with Raft + signed Hands JWT)            │
 │ - Signed URL issuance for R2                           │
 │ - D1 read/write for metadata                           │
 └──────┬───────────────────────────┬────────────────────┘
@@ -84,7 +84,7 @@ Admin access uses Login with Raft as the only production login path.
 Register the app in Raft with callback URL:
 
 ```text
-https://app.hands.build/login/raft/callback
+https://hands.build/login/raft/callback
 ```
 
 Worker configuration:
@@ -93,7 +93,7 @@ Worker configuration:
 - `RAFT_CLIENT_SECRET` as a Worker secret (`wrangler secret put RAFT_CLIENT_SECRET`)
 - `app.hands.build` is the canonical dashboard/login origin. `hands.build` remains the business/API origin for SDKs, CLI/agents, share/download pages, release notes, and docs.
 - Dashboard deep links received on `hands.build` redirect to the same path on `app.hands.build`. Public share/docs/history links received on `app.hands.build` redirect back to `hands.build`.
-- The Raft connected app must register the exact canonical callback `https://app.hands.build/login/raft/callback` before the dashboard domain is deployed.
+- Login starts from `app.hands.build`, uses the registered `https://hands.build/login/raft/callback`, then returns a signed Hands JWT to the dashboard in the URL fragment. The SPA stores the JWT locally and sends `Authorization: Bearer`; no browser session cookie is used.
 - Optional `RAFT_ALLOWED_SERVER_IDS` / `RAFT_ALLOWED_SERVER_SLUGS` can restrict admin login to specific Raft servers
 
 Do not put Raft client secrets in browser JavaScript, repository files, logs, or public channels.
@@ -127,7 +127,7 @@ Required repository secrets:
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the legacy Quiver proxy token.
 - `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
-- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands-4cc7a2` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the canonical return URL `https://app.hands.build/login/raft/callback`.
+- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands-4cc7a2` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The registered return URL remains `https://hands.build/login/raft/callback`.
 
 Workflows:
 

--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ Admin access uses Login with Raft as the only production login path.
 Register the app in Raft with callback URL:
 
 ```text
-https://quiver.oranix.io/login/raft/callback
+https://app.hands.build/login/raft/callback
 ```
 
 Worker configuration:
 
 - `RAFT_CLIENT_ID` in `worker/wrangler.jsonc`
 - `RAFT_CLIENT_SECRET` as a Worker secret (`wrangler secret put RAFT_CLIENT_SECRET`)
-- Public URLs and Raft callback URLs are generated from the incoming request origin. Register each public origin that should support login, for example `https://quiver.oranix.io/login/raft/callback`.
+- `app.hands.build` is the canonical dashboard/login origin. `hands.build` remains the business/API origin for SDKs, CLI/agents, share/download pages, release notes, and docs.
+- Dashboard deep links received on `hands.build` redirect to the same path on `app.hands.build`. Public share/docs/history links received on `app.hands.build` redirect back to `hands.build`.
+- Keep the legacy `https://hands.build/login/raft/callback` registration during the cutover if existing browser logins may still be in flight; new logins use `https://app.hands.build/login/raft/callback`.
 - Optional `RAFT_ALLOWED_SERVER_IDS` / `RAFT_ALLOWED_SERVER_SLUGS` can restrict admin login to specific Raft servers
 
 Do not put Raft client secrets in browser JavaScript, repository files, logs, or public channels.
@@ -124,14 +126,14 @@ Required repository secrets:
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
 - `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands/Botiverse account (`a084c4564dfdce5a7775b08ece638a79`). This is intentionally separate from the Quiver production token.
 - `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
-- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands-4cc7a2` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the return URL `https://hands.build/login/raft/callback`.
+- `HANDS_RAFT_CLIENT_SECRET` — Raft client secret for the `hands-4cc7a2` connected app, written to the Hands Worker as `RAFT_CLIENT_SECRET`. The app registration must allow the canonical return URL `https://app.hands.build/login/raft/callback`.
 
 Workflows:
 
 - `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm with the repository `NPM_TOKEN`. Trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
 - `Publish CLI` publishes `@botiverse/hands-cli` with the repository `NPM_TOKEN`. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.1`.
 - `Deploy Quiver Server` deploys the Worker plus bundled admin/docs assets. Trigger it manually, or push a tag like `server-v2026.07.04`. The default container rollout is `none`; choose `immediate` or `gradual` only when the APK parser container image changed.
-- `Deploy Hands Server` deploys the same Worker/admin bundle to `hands.build` in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
+- `Deploy Hands Server` deploys one Worker/admin bundle to the custom domains `hands.build` (business/API) and `app.hands.build` (dashboard/login) in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
 
 ## Credits
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,6 +1,7 @@
 # @botiverse/hands-admin
 
-SPA assets for quiver admin, served by the Cloudflare Worker.
+SPA assets for the Hands dashboard, served by the Cloudflare Worker at
+`https://app.hands.build`.
 
 Production admin access is Login with Raft only. The Worker owns the OAuth
 callback and sets an HttpOnly same-origin session cookie; this package does

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import {
   Bug,
+  Check,
   ChevronDown,
   ChevronsUpDown,
   Gauge,
@@ -22,6 +23,7 @@ import {
   PanelLeftOpen,
   Plane,
   Plus,
+  Copy,
   Radio,
   Rocket,
   ScrollText,
@@ -46,6 +48,7 @@ import { AppAccess } from "./pages/AppAccess";
 import { OrgSwitcher, useClearOrgCache } from "./components/OrgSwitcher";
 import {
   clearActiveOrgId,
+  getAuthToken,
   getAuthMe,
   listApps,
   listOrgs,
@@ -730,7 +733,49 @@ function AuthGate() {
     return <PublicLanding account={me.data.account} />;
   }
 
+  if (location.pathname === "/cli/callback") {
+    return <CliCallback token={getAuthToken() ?? ""} />;
+  }
+
   return <AuthenticatedApp account={me.data.account} />;
+}
+
+function CliCallback({ token }: { token: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <section className="w-full max-w-xl rounded-md border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-5 flex items-center gap-3">
+          <QuiverMark className="h-9 w-9" />
+          <div>
+            <h1 className="text-lg font-semibold text-slate-950">Hands CLI login</h1>
+            <p className="text-sm text-slate-500">Signed in with Raft</p>
+          </div>
+        </div>
+        <div className="flex items-stretch gap-2">
+          <input
+            readOnly
+            value={token}
+            aria-label="Hands JWT"
+            className="min-w-0 flex-1 rounded-md border border-slate-300 bg-slate-50 px-3 font-mono text-xs text-slate-700"
+            onFocus={(event) => event.currentTarget.select()}
+          />
+          <button
+            type="button"
+            className="icon-button h-10 w-10"
+            title="Copy JWT"
+            aria-label="Copy JWT"
+            onClick={async () => {
+              await navigator.clipboard.writeText(token);
+              setCopied(true);
+            }}
+          >
+            {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
 }
 
 function dashboardHref(account?: AuthAccount): string {

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -733,6 +733,16 @@ function AuthGate() {
   return <AuthenticatedApp account={me.data.account} />;
 }
 
+function dashboardHref(account?: AuthAccount): string {
+  const dashboardOrigin = window.location.hostname === "hands.build"
+    ? "https://app.hands.build"
+    : "";
+  if (account) return `${dashboardOrigin}/apps`;
+  return dashboardOrigin
+    ? `${dashboardOrigin}/api/auth/login?return=${encodeURIComponent("/apps")}`
+    : loginUrl("/apps");
+}
+
 function PublicLanding({ account }: { account?: AuthAccount }) {
   useEffect(() => {
     document.title = "Hands - Client release operations";
@@ -761,7 +771,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
             </a>
             <a
               className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-slate-900 bg-slate-950 px-4 font-medium text-white hover:bg-slate-800"
-              href={account ? "/apps" : loginUrl("/apps")}
+              href={dashboardHref(account)}
             >
               <RaftIcon className="h-5 w-5" />
               {account ? "Open dashboard" : "Login"}
@@ -803,7 +813,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <a
                   className="inline-flex h-11 items-center justify-center gap-2 rounded-md bg-slate-950 px-5 text-sm font-medium text-white hover:bg-slate-800"
-                  href={account ? "/apps" : loginUrl("/apps")}
+                  href={dashboardHref(account)}
                 >
                   <RaftIcon className="h-5 w-5" />
                   {account ? "Open dashboard" : "Login with Raft"}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -5,9 +5,9 @@
  * In prod: Vite-built static assets are served by the Worker; /api calls are
  * same-origin.
  *
- * Admin auth is Login with Raft. The Worker sets an HttpOnly same-origin
- * session cookie after /login/raft/callback; browser code never sees Raft
- * codes, access tokens, or client secrets.
+ * Admin auth is Login with Raft. The callback returns a Hands JWT in the URL
+ * fragment; the SPA stores it locally and sends it as Authorization: Bearer.
+ * Raft codes and client secrets never enter browser storage.
  */
 
 // API base URL: in production, the Worker serves both admin UI + API under
@@ -15,6 +15,53 @@
 // and requests go to the same host. In dev, Vite proxies /api → wrangler dev.
 const API_BASE = (import.meta as any).env?.VITE_API_BASE_URL ?? "";
 export const ACTIVE_ORG_STORAGE_KEY = "hands:active-org-id";
+export const AUTH_TOKEN_STORAGE_KEY = "hands:auth-token";
+
+export function getAuthToken(): string | null {
+  try {
+    return window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearAuthToken(): void {
+  try {
+    window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable in private/restricted browser contexts.
+  }
+}
+
+export function consumeAuthTokenFromUrl(): string | null {
+  if (typeof window === "undefined" || !window.location.hash) return null;
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  const token = params.get("access_token");
+  if (!token) return null;
+  try {
+    window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+  } catch {
+    return null;
+  }
+  params.delete("access_token");
+  params.delete("expires_at");
+  const remainingHash = params.toString();
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${window.location.search}${remainingHash ? `#${remainingHash}` : ""}`,
+  );
+  return token;
+}
+
+function addAuthHeader(headers: Headers): void {
+  const token = getAuthToken();
+  if (token && !headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+}
+
+consumeAuthTokenFromUrl();
 
 export function getActiveOrgId(): string | null {
   try {
@@ -353,12 +400,12 @@ async function request<T>(
 ): Promise<T> {
   const headers = new Headers(init.headers);
   headers.set("content-type", "application/json");
+  addAuthHeader(headers);
   const activeOrgId = getActiveOrgId();
   if (activeOrgId) headers.set("x-hands-org-id", activeOrgId);
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
     headers,
-    credentials: "include",
   });
   const text = await res.text();
   let body: unknown = text;
@@ -382,10 +429,15 @@ async function request<T>(
 export const getAuthMe = () =>
   request<{ authenticated: true; account: AuthAccount }>(`/api/auth/me`);
 
-export const logout = () =>
-  request<{ ok: boolean }>(`/api/auth/logout`, {
-    method: "POST",
-  });
+export const logout = async () => {
+  try {
+    return await request<{ ok: boolean }>(`/api/auth/logout`, {
+      method: "POST",
+    });
+  } finally {
+    clearAuthToken();
+  }
+};
 
 export const normalizeLoginReturnPath = (returnTo = window.location.pathname) => {
   if (!returnTo.startsWith("/") || returnTo.startsWith("//")) return "/";
@@ -396,7 +448,7 @@ export const normalizeLoginReturnPath = (returnTo = window.location.pathname) =>
 export const loginUrl = (returnTo = window.location.pathname) =>
   `${API_BASE}/api/auth/login?return=${encodeURIComponent(normalizeLoginReturnPath(returnTo))}`;
 
-// ---------- Admin API (requires Login with Raft session cookie in prod) ----------
+// ---------- Admin API (requires Login with Raft bearer JWT in prod) ----------
 
 export const listApps = () =>
   request<{ apps: App[] }>(`/api/apps`, { admin: true });
@@ -796,27 +848,42 @@ export const deleteOperation = (appId: string, opId: string) =>
   );
 
 /**
- * Open an EventSource (SSE) subscription for operation updates.
- * Returns the EventSource instance; caller is responsible for calling .close().
+ * Open a bearer-authenticated SSE subscription for operation updates.
  */
 export function streamOperations(
   appId: string,
   onOp: (op: Operation) => void,
   onError?: (e: unknown) => void,
-): EventSource {
+): { close: () => void } {
   const url = `${API_BASE}/api/apps/${appId}/operations/stream`;
-  const es = new EventSource(url, {
-    withCredentials: true,
-  });
-  es.addEventListener("op", (ev) => {
+  const controller = new AbortController();
+  void (async () => {
     try {
-      onOp(JSON.parse((ev as MessageEvent).data) as Operation);
-    } catch (e) {
-      onError?.(e);
+      const headers = new Headers({ accept: "text/event-stream" });
+      addAuthHeader(headers);
+      const response = await fetch(url, { headers, signal: controller.signal });
+      if (!response.ok || !response.body) throw new Error(`operation stream ${response.status}`);
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop() ?? "";
+        for (const event of events) {
+          const eventName = event.split("\n").find((line) => line.startsWith("event:"))?.slice(6).trim();
+          const data = event.split("\n").filter((line) => line.startsWith("data:"))
+            .map((line) => line.slice(5).trimStart()).join("\n");
+          if (eventName === "op" && data) onOp(JSON.parse(data) as Operation);
+        }
+      }
+    } catch (error) {
+      if (!controller.signal.aborted) onError?.(error);
     }
-  });
-  es.addEventListener("error", (ev) => onError?.(ev));
-  return es;
+  })();
+  return { close: () => controller.abort() };
 }
 
 // Multipart upload to the Worker, which stores in R2 and returns file_hash + r2_key.
@@ -826,10 +893,12 @@ export const uploadApk = async (
 ): Promise<{ file_hash: string; r2_key: string; size_bytes: number; original_filename: string }> => {
   const fd = new FormData();
   fd.append("apk", file);
+  const headers = new Headers();
+  addAuthHeader(headers);
   const res = await fetch(`${API_BASE}/api/apps/${appId}/upload`, {
     method: "POST",
+    headers,
     body: fd,
-    credentials: "include",
   });
   if (!res.ok) {
     throw new ApiError(res.status, await readErrorBody(res), `upload failed ${res.status}`);
@@ -1282,6 +1351,40 @@ export const feedbackAttachmentUrl = (appId: string, ticketId: string, attachmen
 export const feedbackAttachmentInlineUrl = (appId: string, ticketId: string, attachmentId: string) =>
   `/api/apps/${appId}/feedback/${ticketId}/attachments/${attachmentId}?inline=1`;
 
+export const getFeedbackAttachmentBlob = async (
+  appId: string,
+  ticketId: string,
+  attachmentId: string,
+  inline = false,
+): Promise<Blob> => {
+  const headers = new Headers();
+  addAuthHeader(headers);
+  const url = inline
+    ? feedbackAttachmentInlineUrl(appId, ticketId, attachmentId)
+    : feedbackAttachmentUrl(appId, ticketId, attachmentId);
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`attachment ${res.status}`);
+  return res.blob();
+};
+
+export const downloadFeedbackAttachment = async (
+  appId: string,
+  ticketId: string,
+  attachmentId: string,
+  filename: string,
+): Promise<void> => {
+  const blob = await getFeedbackAttachmentBlob(appId, ticketId, attachmentId);
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};
+
 export const getFeedbackAttachmentText = async (
   appId: string,
   ticketId: string,
@@ -1289,7 +1392,11 @@ export const getFeedbackAttachmentText = async (
   maxBytes = 200_000,
 ): Promise<string> => {
   const res = await fetch(feedbackAttachmentUrl(appId, ticketId, attachmentId), {
-    credentials: "include",
+    headers: (() => {
+      const headers = new Headers();
+      addAuthHeader(headers);
+      return headers;
+    })(),
   });
   if (!res.ok) throw new Error(`attachment ${res.status}`);
   const text = await res.text();
@@ -1304,11 +1411,12 @@ export const updateAppPublicHistory = (appId: string, enabled: boolean) =>
   });
 
 export const uploadAppIcon = async (appId: string, file: File) => {
+  const headers = new Headers({ "content-type": file.type || "image/png" });
+  addAuthHeader(headers);
   const res = await fetch(`${API_BASE}/api/apps/${appId}/icon`, {
     method: "PUT",
-    headers: { "content-type": file.type || "image/png" },
+    headers,
     body: file,
-    credentials: "include",
   });
   if (!res.ok) {
     const text = await res.text();

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -3,15 +3,15 @@
  * per-ticket page (/apps/:appId/feedback/:ticketId) so tickets are
  * shareable links. Tickets carry an assignee, status flow, and comments.
  */
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   addFeedbackComment,
-  feedbackAttachmentUrl,
-  feedbackAttachmentInlineUrl,
+  downloadFeedbackAttachment,
   getAuthMe,
   getFeedback,
+  getFeedbackAttachmentBlob,
   listFeedback,
   getDeviceDetail,
   getFeedbackAttachmentText,
@@ -388,22 +388,14 @@ function AttachmentList({
       {images.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2">
           {images.map((a) => {
-            const url = feedbackAttachmentInlineUrl(appId, ticketId, a.id);
             return (
-              <button
+              <AttachmentImage
                 key={a.id}
-                type="button"
-                className="group relative h-24 w-24 overflow-hidden rounded-md border border-slate-200 bg-slate-50"
-                onClick={() => setLightbox(url)}
-                title={a.filename}
-              >
-                <img
-                  src={url}
-                  alt={a.filename}
-                  loading="lazy"
-                  className="h-full w-full object-cover transition group-hover:opacity-90"
-                />
-              </button>
+                appId={appId}
+                ticketId={ticketId}
+                attachment={a}
+                onOpen={setLightbox}
+              />
             );
           })}
         </div>
@@ -413,14 +405,13 @@ function AttachmentList({
         <ul className="space-y-1 text-sm">
           {others.map((a) => (
             <li key={a.id}>
-              <a
+              <button
+                type="button"
                 className="text-blue-600 hover:underline"
-                href={feedbackAttachmentUrl(appId, ticketId, a.id)}
-                target="_blank"
-                rel="noopener noreferrer"
+                onClick={() => void downloadFeedbackAttachment(appId, ticketId, a.id, a.filename)}
               >
                 {a.filename}
-              </a>
+              </button>
               <span className="ml-2 text-xs text-slate-400">
                 {(a.size_bytes / 1024).toFixed(1)} KB
               </span>
@@ -450,6 +441,52 @@ function AttachmentList({
         </div>
       )}
     </div>
+  );
+}
+
+function AttachmentImage({
+  appId,
+  ticketId,
+  attachment,
+  onOpen,
+}: {
+  appId: string;
+  ticketId: string;
+  attachment: { id: string; filename: string };
+  onOpen: (url: string) => void;
+}) {
+  const image = useQuery({
+    queryKey: ["feedback-attachment-image", appId, ticketId, attachment.id],
+    queryFn: async () => URL.createObjectURL(
+      await getFeedbackAttachmentBlob(appId, ticketId, attachment.id, true),
+    ),
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    const url = image.data;
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [image.data]);
+
+  return (
+    <button
+      type="button"
+      className="group relative h-24 w-24 overflow-hidden rounded-md border border-slate-200 bg-slate-50"
+      onClick={() => image.data && onOpen(image.data)}
+      title={attachment.filename}
+      disabled={!image.data}
+    >
+      {image.data && (
+        <img
+          src={image.data}
+          alt={attachment.filename}
+          loading="lazy"
+          className="h-full w-full object-cover transition group-hover:opacity-90"
+        />
+      )}
+    </button>
   );
 }
 

--- a/admin/src/pages/Settings.tsx
+++ b/admin/src/pages/Settings.tsx
@@ -46,7 +46,7 @@ export function Settings() {
           />
           <p className="text-xs text-slate-500 pt-3 border-t border-slate-100">
             Login is via Login with Raft. The Worker owns the OAuth callback
-            and session cookie. To change role, ask an org owner / admin in
+            and signed JWT. To change role, ask an org owner / admin in
             the Org settings page.
           </p>
         </div>
@@ -56,7 +56,7 @@ export function Settings() {
       <div className="card space-y-3 text-sm">
         <p className="text-slate-600">
           Admin authentication is Login with Raft only. The Worker owns the
-          OAuth callback and session cookie; Cloudflare Access can be disabled
+          OAuth callback and bearer JWT; Cloudflare Access can be disabled
           after the Raft client secret is configured.
         </p>
         <div>

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -7,7 +7,7 @@ Android SDK for Hands server-side update checks and APK installation.
 ```kotlin
 repositories {
     maven {
-        url = uri("https://maven.pkg.github.com/oranix-io/hands")
+        url = uri("https://maven.pkg.github.com/botiverse/hands")
         credentials {
             username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
             password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
                 pom {
                     name.set("Hands Android SDK")
                     description.set("Android SDK for server-side Hands update checks and APK installation.")
-                    url.set("https://github.com/oranix-io/hands")
+                    url.set("https://github.com/botiverse/hands")
                     licenses {
                         license {
                             name.set("MIT License")
@@ -72,9 +72,9 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        connection.set("scm:git:https://github.com/oranix-io/hands.git")
-                        developerConnection.set("scm:git:ssh://git@github.com/oranix-io/hands.git")
-                        url.set("https://github.com/oranix-io/hands")
+                        connection.set("scm:git:https://github.com/botiverse/hands.git")
+                        developerConnection.set("scm:git:ssh://git@github.com/botiverse/hands.git")
+                        url.set("https://github.com/botiverse/hands")
                     }
                 }
             }
@@ -83,7 +83,7 @@ afterEvaluate {
         repositories {
             maven {
                 name = "GitHubPackages"
-                val repository = System.getenv("GITHUB_REPOSITORY") ?: "oranix-io/quiver"
+                val repository = System.getenv("GITHUB_REPOSITORY") ?: "botiverse/hands"
                 url = uri("https://maven.pkg.github.com/$repository")
                 credentials {
                     username = findProperty("gpr.user") as String?

--- a/clients/electron/README.md
+++ b/clients/electron/README.md
@@ -1,6 +1,6 @@
 # @botiverse/hands-electron
 
-Crash reporting for Electron apps, backed by [Hands](https://quiver.oranix.io).
+Crash reporting for Electron apps, backed by [Hands](https://hands.build).
 
 Electron's built-in [Crashpad](https://www.electronjs.org/docs/latest/api/crash-reporter)
 captures native minidumps for **both the main and renderer processes** and

--- a/clients/electron/src/common.ts
+++ b/clients/electron/src/common.ts
@@ -24,7 +24,7 @@ export interface HandsElectronOptions {
   appSlug: string;
   /** Public client key (Sentry-DSN model). Safe to ship in the app bundle. */
   clientKey: string;
-  /** Hands origin. Defaults to https://quiver.oranix.io. */
+  /** Hands business origin. Defaults to https://hands.build. */
   endpoint?: string;
   /** Crashpad productName; defaults to appSlug. */
   productName?: string;
@@ -96,7 +96,7 @@ export function buildGlobalExtra(
 
 /** Build the minidump submit URL Crashpad POSTs to (client key in the query). */
 export function buildSubmitURL(options: HandsElectronOptions): string {
-  const endpoint = (options.endpoint ?? "https://quiver.oranix.io").replace(/\/+$/, "");
+  const endpoint = (options.endpoint ?? "https://hands.build").replace(/\/+$/, "");
   return (
     `${endpoint}/public/v2/apps/${encodeURIComponent(options.appSlug)}/minidump` +
     `?client_key=${encodeURIComponent(options.clientKey)}`

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -114,7 +114,7 @@ async function reportMetrics(options: HandsElectronOptions, force = false): Prom
   if (!force && state.lastPingAt > 0 && now - state.lastPingAt < METRICS_INTERVAL_MS) return false;
 
   const deviceId = state.deviceId || randomUUID();
-  const endpoint = (options.endpoint ?? "https://quiver.oranix.io").replace(/\/+$/, "");
+  const endpoint = (options.endpoint ?? "https://hands.build").replace(/\/+$/, "");
   const url = `${endpoint}/public/v2/apps/${encodeURIComponent(options.appSlug)}/metrics`;
   const env = options.environment ?? "production";
   const metadata = {

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -6,7 +6,7 @@ crash reporting. Objective-C, no dependencies, iOS 14.1+.
 ## Install (CocoaPods, via git)
 
 ```ruby
-pod 'Hands', :git => 'https://github.com/oranix-io/hands.git', :tag => 'ios-v0.2.1'
+pod 'Hands', :git => 'https://github.com/botiverse/hands.git', :tag => 'ios-v0.2.1'
 ```
 
 ## Configure & start

--- a/clients/ohos/README.md
+++ b/clients/ohos/README.md
@@ -25,7 +25,7 @@ if it leaks).
 import { Hands } from '@botiverse/hands';
 
 Hands.install({
-  baseUrl: 'https://quiver.example.com',
+  baseUrl: 'https://hands.build',
   appSlug: 'my-app',
   channel: 'main',          // Hands release-channel routing field
   clientKey: 'qk_…',

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -5,8 +5,8 @@
   "main": "Index.ets",
   "author": "Oranix",
   "license": "MIT",
-  "homepage": "https://github.com/oranix-io/hands",
-  "repository": "https://github.com/oranix-io/hands",
+  "homepage": "https://github.com/botiverse/hands",
+  "repository": "https://github.com/botiverse/hands",
   "keywords": ["hands", "crash", "feedback", "harmonyos"],
   "dependencies": {}
 }

--- a/docs/account-org-invite.md
+++ b/docs/account-org-invite.md
@@ -14,7 +14,7 @@ Scope: long-lived schema and admin UX for organizations, teams, memberships, inv
 
 ## 1. Goals
 
-Hands today authenticates via Login with Raft (migration 0004) — `raft_accounts` + `raft_sessions`. A human account can sign in and operate on any app. **Agents (Raft `type='agent'`) are also first-class principals** — they can log in, get a session cookie, and act on Hands.
+Hands authenticates via Login with Raft (migration 0004) — `raft_accounts` + `raft_sessions`. A human account can sign in and operate on any app. **Agents (Raft `type='agent'`) are also first-class principals** — they can log in, receive a signed Hands JWT, and act through bearer auth.
 
 What's missing:
 - **Organizations** — group of apps owned by one team (humans + agents can co-own)
@@ -220,7 +220,7 @@ The existing `actor` TEXT column becomes display name; `actor_id` is the FK. Bac
 
 ### 5.1 Replace current auth with role-aware auth
 
-Current `authMiddleware` (in `worker/src/middleware/auth.ts`) only verifies Raft session cookie. We need:
+Current `authMiddleware` (in `worker/src/middleware/auth.ts`) verifies Hands JWT and scoped deploy-token bearer credentials. We need:
 
 ```typescript
 // After Raft auth succeeds:
@@ -265,7 +265,7 @@ const url = new URL(c.req.url);
 
 ### 5.3 Agent (Raft `type='agent'`) handling
 
-**Agents are first-class principals.** They can log in via Login with Raft the same way humans do, get a session cookie, and act on Hands with the same per-endpoint RBAC checks.
+**Agents are first-class principals.** They can log in via Login with Raft the same way humans do, get a signed JWT, and act on Hands with the same per-endpoint RBAC checks.
 
 Default role assignment on first login:
 - Human: `org_role='member'`, `app_role=null` (not a member of any app yet — must be granted per app)

--- a/docs/account-org-invite.md
+++ b/docs/account-org-invite.md
@@ -182,7 +182,7 @@ The existing `actor` TEXT column becomes display name; `actor_id` is the FK. Bac
    - Insert into invites (status='pending', expires_at=now+7d)
    - Generate signed magic-link token: `${invite.id}.${hmac_sha256(secret, invite.id)}`
    - Send email: "You've been invited to Acme Corp. Click here to accept."
-     Link: https://quiver.oranix.io/invites/${token}
+     Link: https://app.hands.build/invites/${token}
 
 3. If email not in raft_accounts yet, also send a "sign up to claim invite" hint
 ```
@@ -367,7 +367,7 @@ This is a small change to `worker/src/routes/auth.ts` that makes org context ava
   - `GET /api/invites/:token` (public) — show invite details
   - `POST /api/invites/:token/accept` (auth required) — link account, create membership
 - Email sender: use Cloudflare Email Service with a transactional template
-- Magic link format: `https://quiver.oranix.io/invites/${token}` with HMAC signature
+- Magic link format: `https://app.hands.build/invites/${token}` with HMAC signature
 
 ### Phase 5.4 — org settings UI + access tab (3 days)
 

--- a/docs/admin-user-guide.md
+++ b/docs/admin-user-guide.md
@@ -2,7 +2,7 @@
 
 The canonical, maintained version of this document is
 [`docs/public/admin-user-guide.md`](public/admin-user-guide.md), served at
-<https://quiver.oranix.io/docs/admin-user-guide/>.
+<https://hands.build/docs/admin-user-guide/>.
 
 This top-level copy previously drifted from reality (it described planned
 contracts and pre-release behavior). It was retired on 2026-07-04; the old

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,7 +2,7 @@
 
 The canonical, maintained version of this document is
 [`docs/public/cli-reference.md`](public/cli-reference.md), served at
-<https://quiver.oranix.io/docs/cli-reference/>.
+<https://hands.build/docs/cli-reference/>.
 
 This top-level copy previously drifted from reality (it described planned
 contracts and pre-release behavior). It was retired on 2026-07-04; the old

--- a/docs/public-api-reference.md
+++ b/docs/public-api-reference.md
@@ -2,7 +2,7 @@
 
 The canonical, maintained version of this document is
 [`docs/public/public-api-reference.md`](public/public-api-reference.md), served at
-<https://quiver.oranix.io/docs/public-api-reference/>.
+<https://hands.build/docs/public-api-reference/>.
 
 This top-level copy previously drifted from reality (it described planned
 contracts and pre-release behavior). It was retired on 2026-07-04; the old

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -144,7 +144,7 @@ Your account or deploy token does not have the required role for the action. The
   "current_role": "viewer",
   "resource": "POST /api/apps",            // the action you attempted
   "org_id": "…", "app_id": null,
-  "manage_url": "https://quiver.oranix.io/orgs/{orgId}/members"
+  "manage_url": "https://app.hands.build/orgs/{orgId}/members"
 }
 ```
 

--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -123,7 +123,7 @@ aggregate by signature across a fleet, call the API directly:
 
 ```bash
 curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  https://quiver.oranix.io/api/apps/<appId>/feedback/crash-groups
+  https://hands.build/api/apps/<appId>/feedback/crash-groups
 ```
 
 ## Attachments (diagnostics zips, logs)
@@ -150,9 +150,9 @@ APP_ID="$(hands apps get "$APP" --json \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 
 curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID"                       # ticket detail
+  "https://hands.build/api/apps/$APP_ID/feedback/$TICKET_ID"                       # ticket detail
 curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  "https://quiver.oranix.io/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
+  "https://hands.build/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
   -o diagnostics.zip                                                                     # raw attachment
 ```
 

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -101,7 +101,7 @@ The share URL is printed once; tokens are stored hashed.
 
 ```bash
 # create (API; CLI covers list/get)
-curl -X POST https://quiver.oranix.io/api/apps \
+curl -X POST https://hands.build/api/apps \
   -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"slug":"my-app","name":"My App","platform":"android"}'
@@ -114,9 +114,9 @@ product types, and get a **client key** (`qk_…`) that clients must send as
 
 ```bash
 curl -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  https://quiver.oranix.io/api/apps/<appId>/client-key          # read
+  https://hands.build/api/apps/<appId>/client-key          # read
 curl -X POST -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
-  https://quiver.oranix.io/api/apps/<appId>/rotate-client-key   # (re)generate
+  https://hands.build/api/apps/<appId>/rotate-client-key   # (re)generate
 ```
 
 Rotation invalidates the old key immediately — client builds must be updated
@@ -134,7 +134,7 @@ silently:
   "current_role": "viewer",
   "resource": "POST /api/apps",            // the action you attempted
   "org_id": "…", "app_id": null,
-  "manage_url": "https://quiver.oranix.io/orgs/{orgId}/members"
+  "manage_url": "https://app.hands.build/orgs/{orgId}/members"
 }
 ```
 

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -12,7 +12,7 @@ The SDK is published to GitHub Packages.
 // settings.gradle.kts or the module repositories block
 repositories {
     maven {
-        url = uri("https://maven.pkg.github.com/oranix-io/quiver")
+        url = uri("https://maven.pkg.github.com/botiverse/hands")
         credentials {
             username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
             password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.9.0")
+    implementation("build.hands:hands-android-sdk:0.10.1")
 }
 ```
 
@@ -29,7 +29,7 @@ Configuration (`BuildConfig` fields are a convenient place to keep these):
 
 | Value | Example |
 |---|---|
-| Base URL | `https://quiver.oranix.io` |
+| Base URL | `https://hands.build` |
 | App slug | `raft-android` |
 | Channel | `main` / `preview` / `nightly` / `debug` |
 

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -27,10 +27,8 @@ export HANDS_API=https://hands.build
 export HANDS_BEARER_TOKEN=<deploy-token>
 ```
 
-If `HANDS_API` is unset, the CLI defaults to `https://quiver.oranix.io`, which
-transparently proxies to `hands.build`; set `HANDS_API=https://hands.build` to
-call the current domain directly. `HANDS_AUTH_TOKEN` is also accepted as an
-alias for `HANDS_BEARER_TOKEN`.
+If `HANDS_API` is unset, the CLI defaults to `https://hands.build`.
+`HANDS_AUTH_TOKEN` is also accepted as an alias for `HANDS_BEARER_TOKEN`.
 
 Legacy `QUIVER_*` names still work: every variable is read as `HANDS_<name>`
 first, then `QUIVER_<name>`, so existing CI keeps working unchanged.
@@ -162,7 +160,7 @@ provider:
 ```ts
 autoUpdater.setFeedURL({
   provider: "generic",
-  url: "https://quiver.oranix.io/electron/raft-desktop/main"
+  url: "https://hands.build/electron/raft-desktop/main"
 });
 ```
 
@@ -270,7 +268,7 @@ so existing CI keeps working unchanged.
 
 | Variable | Required | Purpose |
 |---|---|---|
-| `HANDS_API` | No | Hands server base URL. Defaults to `https://quiver.oranix.io` (which proxies to `hands.build`). Set to `https://hands.build` to call the current domain directly. `HANDS_CLI_API` takes precedence if set. |
+| `HANDS_API` | No | Hands business API base URL. Defaults to `https://hands.build`. `HANDS_CLI_API` takes precedence if set. |
 | `HANDS_BEARER_TOKEN` | Yes | App-scoped deploy token for CI. |
 | `HANDS_AUTH_TOKEN` | No | Alias for `HANDS_BEARER_TOKEN` (tried first). |
 

--- a/docs/public/ios-sdk.md
+++ b/docs/public/ios-sdk.md
@@ -7,7 +7,7 @@ feedback endpoint. Objective-C, no dependencies, iOS 14.1+.
 ## Install (CocoaPods, via git)
 
 ```ruby
-pod 'Hands', :git => 'https://github.com/oranix-io/quiver.git', :tag => 'ios-v0.1.3'
+pod 'Hands', :git => 'https://github.com/botiverse/hands.git', :tag => 'ios-v0.2.1'
 ```
 
 ## Configure & start
@@ -21,7 +21,7 @@ bundle; rotate it from the console if it leaks).
 import Hands
 
 Hands.install(with: HandsConfig(
-    baseUrl: "https://quiver.example.com",
+    baseUrl: "https://hands.build",
     appSlug: "my-app",
     channel: "main",          // Hands release-channel routing field
     clientKey: "qk_…"

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -5,8 +5,8 @@ tickets** and **crash reporting** against a Hands server's
 public feedback endpoint. Mirrors the Android and iOS SDKs.
 
 > **Status:** the package is being published to ohpm. Until it's live,
-> consume the HAR from a local build of `clients/ohos` in the
-> [Hands repo](https://github.com/oranix-io/quiver).
+> consume the `@botiverse/hands@0.3.0` HAR from a local build of `clients/ohos`
+> in the [Hands repo](https://github.com/botiverse/hands).
 
 ## Install
 
@@ -27,7 +27,7 @@ import { Hands } from '@botiverse/hands';
 // In UIAbility onCreate — pass the context to wire the internal launch
 // logic (throttled device-analytics ping + pending-crash upload).
 Hands.install({
-  baseUrl: 'https://quiver.example.com',
+  baseUrl: 'https://hands.build',
   appSlug: 'my-app',
   channel: 'main',          // Hands release-channel routing field
   clientKey: 'qk_…',

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -11,7 +11,7 @@ Use the admin API or CLI for publishing. Use the public API from clients.
 ## Base URL
 
 ```text
-https://quiver.oranix.io
+https://hands.build
 ```
 
 Self-hosted deployments should use their own origin.
@@ -68,7 +68,7 @@ active release. The Android SDK sends the header automatically.
     "arch": "arm64-v8a",
     "filetype": "apk",
     "size_bytes": 29192396,
-    "download_url": "https://quiver.oranix.io/public/r2/…"
+    "download_url": "https://hands.build/public/r2/…"
   },
   "scoped": { "scope_type": "full", "scope_value": "all", "release_id": "…", "rollout_cohort_count": null }
 }
@@ -159,7 +159,7 @@ Hands:
 ```ts
 autoUpdater.setFeedURL({
   provider: "generic",
-  url: "https://quiver.oranix.io/electron/:appSlug/:channel"
+  url: "https://hands.build/electron/:appSlug/:channel"
 });
 ```
 
@@ -220,7 +220,7 @@ find and rotate the key in the app's Settings tab or via
 Returns `201` with the full ticket UUID in `id`, plus a copyable `reference`
 and `ticket_url`, for example `{ "id": "<ticket UUID>", "status": "open",
 "reference": "raft-android · 1.0.4 (1000400) · ticket <ticket UUID>",
-"ticket_url": "https://quiver.oranix.io/apps/<appId>/feedback/<ticket UUID>" }`.
+"ticket_url": "https://app.hands.build/apps/<appId>/feedback/<ticket UUID>" }`.
 Rate limit: 10 submissions per hour per app + client IP. Tickets appear in
 the admin Feedback tab; a `feedback:new` webhook fires for subscribed
 endpoints (crash tickets can additionally trigger `crash:new_group` /

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -47,7 +47,7 @@ Hands serves the active release at
 ```ts
 autoUpdater.setFeedURL({
   provider: "generic",
-  url: "https://quiver.oranix.io/electron/<appSlug>/<channel>"
+  url: "https://hands.build/electron/<appSlug>/<channel>"
 });
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,25 +48,24 @@ hands builds publish-android raft-android \
 
 ```bash
 export HANDS_API=https://hands.build
-export HANDS_SESSION_COOKIE=...   # paste from browser DevTools
+export HANDS_AUTH_TOKEN=...       # Hands JWT or an app deploy token
 hands whoami
 hands builds list myapp-android
 ```
 
 ## How auth works (v1)
 
-Raft OAuth today only supports the browser-redirect flow with HttpOnly
-cookies. The CLI can't intercept the redirect, so `hands login` asks
-you to:
+Raft OAuth uses a browser redirect. Hands converts the successful login into
+a signed JWT, so `hands login` asks you to:
 
 1. Open the printed URL in any browser.
 2. Sign in with Raft.
-3. Copy the `quiver_session` cookie value from DevTools.
+3. Copy the JWT shown on the Hands CLI callback page.
 4. Paste it back into the CLI.
 
-The token is saved to `$XDG_CONFIG_HOME/quiver/auth.json` (mode 0600).
-For CI, pass it via `HANDS_SESSION_COOKIE` instead. The legacy `QUIVER_*`
-aliases remain accepted for existing automation.
+The JWT is saved to `$XDG_CONFIG_HOME/quiver/auth.json` (mode 0600).
+For CI, pass it via `HANDS_AUTH_TOKEN` or `HANDS_BEARER_TOKEN`. The legacy
+`QUIVER_*` aliases remain accepted for existing automation.
 
 v2 will swap this for a true headless flow (Raft Device Flow or a
 `--token-stdin` service-user mode). See `publish-tasks.md` P3.4.x.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,8 +47,8 @@ hands builds publish-android raft-android \
 ## CI mode
 
 ```bash
-export QUIVER_API=https://quiver.oranix.io
-export QUIVER_SESSION_COOKIE=...   # paste from browser DevTools
+export HANDS_API=https://hands.build
+export HANDS_SESSION_COOKIE=...   # paste from browser DevTools
 hands whoami
 hands builds list myapp-android
 ```
@@ -65,7 +65,8 @@ you to:
 4. Paste it back into the CLI.
 
 The token is saved to `$XDG_CONFIG_HOME/quiver/auth.json` (mode 0600).
-For CI, pass it via `QUIVER_SESSION_COOKIE` instead.
+For CI, pass it via `HANDS_SESSION_COOKIE` instead. The legacy `QUIVER_*`
+aliases remain accepted for existing automation.
 
 v2 will swap this for a true headless flow (Raft Device Flow or a
 `--token-stdin` service-user mode). See `publish-tasks.md` P3.4.x.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oranix-io/quiver.git"
+    "url": "git+https://github.com/botiverse/hands.git"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -17,22 +17,33 @@ import fixturePolicy from "./fixtures/collect-policy.json";
 describe("config round-trip", () => {
   let dir: string;
   let originalXdg: string | undefined;
+  let originalHandsApi: string | undefined;
+  let originalQuiverApi: string | undefined;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "quiver-cli-"));
     originalXdg = process.env.XDG_CONFIG_HOME;
+    originalHandsApi = process.env.HANDS_API;
+    originalQuiverApi = process.env.QUIVER_API;
     process.env.XDG_CONFIG_HOME = dir;
+    delete process.env.HANDS_API;
+    delete process.env.QUIVER_API;
   });
 
   afterEach(() => {
     if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = originalXdg;
+    if (originalHandsApi === undefined) delete process.env.HANDS_API;
+    else process.env.HANDS_API = originalHandsApi;
+    if (originalQuiverApi === undefined) delete process.env.QUIVER_API;
+    else process.env.QUIVER_API = originalQuiverApi;
     if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
   });
 
   it("returns empty config when no file exists", async () => {
-    const { getConfig } = await import("../src/lib/config.js");
+    const { getConfig, resolveApiBase } = await import("../src/lib/config.js");
     expect(getConfig()).toEqual({});
+    expect(resolveApiBase()).toBe("https://hands.build");
   });
 
   it("saveConfig persists to the XDG path", async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -90,18 +90,19 @@ describe("apiRequest", () => {
     await new Promise<void>((r) => server.close(() => r()));
   });
 
-  it("sends the QUIVER_SESSION_COOKIE env var as a cookie header", async () => {
+  it("treats the legacy QUIVER_SESSION_COOKIE env var as bearer auth", async () => {
     process.env.QUIVER_SESSION_COOKIE = "abc123";
     process.env.QUIVER_API = baseUrl;
     const { apiRequest } = await import("../src/lib/api.js");
     const me = await apiRequest<{ account: { id: string } }>("/api/auth/me");
     expect(me.account.id).toBe("u1");
-    expect(lastCookie).toBe("abc123");
+    expect(lastAuthorization).toBe("Bearer abc123");
+    expect(lastCookie).toBeNull();
     delete process.env.QUIVER_SESSION_COOKIE;
     delete process.env.QUIVER_API;
   });
 
-  it("prefers QUIVER_AUTH_TOKEN as a bearer token over cookie auth", async () => {
+  it("prefers QUIVER_AUTH_TOKEN over the legacy session variable", async () => {
     process.env.QUIVER_SESSION_COOKIE = "cookie-token";
     process.env.QUIVER_AUTH_TOKEN = "bearer-token";
     process.env.QUIVER_API = baseUrl;

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -153,7 +153,7 @@ export function registerBuildCommands(program: Command): void {
     .requiredOption("--apk <path>", "Installable APK path.")
     .requiredOption("--version-name <name>", "Android versionName.")
     .requiredOption("--version-code <code>", "Android versionCode.")
-    .option("--channel <slug>", "Quiver channel slug.", "main")
+    .option("--channel <slug>", "Hands release channel slug.", "main")
     .option("--arch <abi>", "APK ABI/arch metadata.", "arm64-v8a")
     .option("--release-type <type>", "Release type metadata.", "stable")
     .option("--product-type <type>", "Product type metadata.", "android-apk")
@@ -571,7 +571,7 @@ export function registerBuildCommands(program: Command): void {
     .command("publish-electron <appIdOrSlug>")
     .description("Create an Electron generic-provider build/release and upload electron-builder output.")
     .requiredOption("--version-name <name>", "Electron app version.")
-    .requiredOption("--version-code <code>", "Quiver version code used for ordering.")
+    .requiredOption("--version-code <code>", "Hands version code used for ordering.")
     .option("--metadata <path>", "electron-builder latest*.yml file. Repeatable.", collect, [])
     .option("--installer <path>", "Electron installer/update artifact. Repeatable.", collect, [])
     .option("--blockmap <path>", "Electron .blockmap artifact. Repeatable.", collect, [])
@@ -581,7 +581,7 @@ export function registerBuildCommands(program: Command): void {
       collect,
       [],
     )
-    .option("--channel <slug>", "Quiver channel slug.", "main")
+    .option("--channel <slug>", "Hands release channel slug.", "main")
     .option("--platform <platform>", "Electron platform metadata. Defaults from metadata filename or win32.")
     .option("--arch <arch>", "Electron arch metadata.")
     .option("--release-type <type>", "Release type metadata.", "stable")

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -163,7 +163,7 @@ export function registerFeedbackCommands(program: Command): void {
     .alias("download")
     .description(
       "Download a feedback attachment to a file. Saves the raw bytes as-is — " +
-        "Quiver does not unzip or interpret the contents (the producing app owns the format).",
+        "Hands does not unzip or interpret the contents (the producing app owns the format).",
     )
     .option("-o, --output <path>", "Output file path. Defaults to the server filename in the cwd.")
     .action(

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -61,14 +61,14 @@ async function promptSecret(message: string): Promise<string> {
 export function registerLoginCommands(program: Command): void {
   const cmd = program
     .command("login")
-    .description("Authenticate the CLI against the Quiver Worker.")
+    .description("Authenticate the CLI against Hands.")
     .option(
       "--token <cookie>",
       "Paste the quiver_session cookie value (from your browser's DevTools).",
     )
     .option(
       "--api <url>",
-      "Override the Quiver Worker base URL for this login only.",
+      "Override the Hands business API URL for this login only.",
     )
     .option("--print-url", "Just print the login URL; don't prompt for a token.", false)
     .action(
@@ -85,7 +85,7 @@ export function registerLoginCommands(program: Command): void {
           return;
         }
 
-        console.log("To authenticate the quiver CLI:");
+        console.log("To authenticate the Hands CLI:");
         console.log("");
         console.log(`  1. Open this URL in any browser:`);
         console.log(`     ${loginUrl}`);
@@ -126,7 +126,7 @@ export function registerLoginCommands(program: Command): void {
         } catch (e) {
           if (e instanceof QuiverApiError && e.status === 401) {
             console.error(
-              `✘ Token rejected (401). Run \`quiver logout\` and try again.`,
+              `✘ Token rejected (401). Run \`hands logout\` and try again.`,
             );
             process.exit(1);
           }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -4,26 +4,21 @@
  * v1 flow (browser-required):
  *   1. CLI prints a URL: https://quiver-worker.../api/auth/login?return_to=...
  *   2. User opens the URL in any browser, signs in with Raft OAuth.
- *   3. After login the Worker redirects to /login/raft/callback which is the
- *      admin SPA — at this point the user has a HttpOnly `quiver_session`
- *      cookie in their browser for the Worker's origin.
- *   4. User opens DevTools → Application → Cookies → copies the cookie value.
- *   5. User runs `quiver login --token <cookie>` (or pastes when prompted).
+ *   3. Hands redirects to the dashboard's CLI callback page with a signed JWT.
+ *   4. User copies the JWT shown by that page and pastes it into the CLI.
  *
- * CI mode: `QUIVER_SESSION_COOKIE=... quiver whoami` — env var is read
- * directly, no file storage.
+ * CI mode: `HANDS_AUTH_TOKEN=... hands whoami` — env var is read directly,
+ * with no file storage.
  *
- * Why not OAuth Device Flow or PKCE? Raft OAuth today only supports the
- * browser redirect flow with HttpOnly cookies; the CLI can't intercept
- * the callback. Headless flow is a v2 (TBD: Raft Device Flow support or
- * dev-token bypass for service users).
+ * Raft OAuth still uses a browser redirect, while Hands turns the successful
+ * login into a copyable signed JWT for the CLI.
  */
 
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { Command } from "commander";
 import { apiRequest, getApiBase, QuiverApiError } from "../lib/api.js";
-import { saveConfig, getConfig } from "../lib/config.js";
+import { clearConfig, saveConfig, getConfig } from "../lib/config.js";
 
 async function promptSecret(message: string): Promise<string> {
   // Use a raw-mode readline so we can mask input with '*'.
@@ -63,8 +58,8 @@ export function registerLoginCommands(program: Command): void {
     .command("login")
     .description("Authenticate the CLI against Hands.")
     .option(
-      "--token <cookie>",
-      "Paste the quiver_session cookie value (from your browser's DevTools).",
+      "--token <jwt>",
+      "Paste the Hands JWT shown by the browser login callback.",
     )
     .option(
       "--api <url>",
@@ -90,15 +85,14 @@ export function registerLoginCommands(program: Command): void {
         console.log(`  1. Open this URL in any browser:`);
         console.log(`     ${loginUrl}`);
         console.log("");
-        console.log(`  2. Sign in with Raft. You'll land on the admin UI.`);
-        console.log(`  3. Open DevTools → Application → Cookies → copy the value of "quiver_session".`);
-        console.log(`  4. Paste it below.`);
+        console.log(`  2. Sign in with Raft. You'll land on the Hands CLI callback page.`);
+        console.log(`  3. Copy the JWT shown there and paste it below.`);
         console.log("");
 
         let token = opts.token;
         if (!token) {
           token = await promptSecret(
-            "quiver_session cookie value (input is hidden): ",
+            "Hands JWT (input is hidden): ",
           );
           if (token.length < 8) {
             console.error("Token looks too short (min 8 chars).");
@@ -107,7 +101,8 @@ export function registerLoginCommands(program: Command): void {
         }
 
         // Persist the token + apiBase to config file.
-        saveConfig({ apiBase, sessionCookie: token });
+        clearConfig();
+        saveConfig({ apiBase, authToken: token });
         console.log(`✔ Saved to ${configDisplayPath()}`);
         console.log(`  API base: ${apiBase}`);
 
@@ -137,15 +132,14 @@ export function registerLoginCommands(program: Command): void {
 
   program
     .command("logout")
-    .description("Clear the saved session cookie.")
+    .description("Clear the saved Hands JWT.")
     .action(() => {
       const cfg = getConfig();
-      if (!cfg.sessionCookie) {
-        console.log("Not logged in (no saved session cookie).");
+      if (!cfg.authToken && !cfg.sessionCookie) {
+        console.log("Not logged in (no saved Hands JWT).");
         return;
       }
-      delete (cfg as { sessionCookie?: string }).sessionCookie;
-      saveConfig(cfg);
+      clearConfig();
       console.log(`✔ Logged out (token cleared from ${configDisplayPath()}).`);
     });
 }
@@ -157,4 +151,4 @@ function configDisplayPath(): string {
   return `${dir}/quiver/auth.json`;
 }
 
-// silence "unused import" if user has no cookie in env
+// Keep the command module side-effect free when imported by tests.

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -4,16 +4,16 @@
 
 import type { Command } from "commander";
 import { apiRequest, QuiverApiError, getApiBase } from "../lib/api.js";
-import { resolveSessionCookie } from "../lib/config.js";
+import { resolveAuthToken } from "../lib/config.js";
 import { readEnv } from "../lib/env.js";
 
 const NO_AUTH_HELP =
   "Not authenticated. Choose one:\n" +
   "  • Agents / CI: set HANDS_BEARER_TOKEN to a deploy token\n" +
   "      (console → App → Settings → Deploy Tokens; publisher role to release).\n" +
-  "  • Humans: run `hands login` (browser session).\n" +
-  "  • Raft agents: `raft integration login --service <hands-service>`, then export the\n" +
-  "      session as HANDS_SESSION_COOKIE.";
+  "  • Humans: run `hands login` and paste the browser callback JWT.\n" +
+  "  • Raft agents: run `raft integration login --service <hands-service>` and use\n" +
+  "      the integration session through `raft integration invoke`.";
 
 interface MeResponse {
   account?: {
@@ -39,7 +39,7 @@ export function registerWhoamiCommand(program: Command): void {
     .option("--json", "Output machine-readable JSON.", false)
     .action(async (opts: { json?: boolean }) => {
       const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
-      if (!bearer && !resolveSessionCookie()) {
+      if (!bearer && !resolveAuthToken()) {
         console.error(NO_AUTH_HELP);
         process.exit(1);
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,14 +5,13 @@
  * Subcommands are registered via the registry module. This file only
  * handles top-level commander setup + global flags (--api, --json, --verbose).
  *
- * Auth model: the CLI doesn't store long-lived tokens. It uses the same
- * browser-cookie session as the admin SPA. Two ways to "log in":
+ * Auth model: the CLI stores the same signed Hands JWT as the admin SPA.
+ * Two ways to "log in":
  *   - `quiver login` — prints a URL to visit in any browser; the user
- *     completes Raft OAuth there, the Worker sets the quiver_session
- *     cookie, the user copies the cookie value back into the CLI.
- *   - `quiver login --token <cookie>` — paste an existing session cookie.
+ *     completes Raft OAuth there, then copies the JWT from the callback page.
+ *   - `hands login --token <jwt>` — paste an existing Hands JWT.
  *
- * For CI: `quiver login --token "$QUIVER_SESSION_COOKIE"`.
+ * For CI: set `HANDS_AUTH_TOKEN` or use an app-scoped deploy token.
  *
  * Token storage: ~/.config/quiver/auth.json (or $XDG_CONFIG_HOME/quiver/auth.json).
  */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,7 +39,7 @@ program
   .version("0.5.3")
   .option(
     "--api <url>",
-    "Quiver Worker base URL (default: https://quiver.oranix.io or $QUIVER_API)",
+    "Hands business API URL (default: https://hands.build or $HANDS_API)",
   )
   .option("--json", "Output machine-readable JSON (suppresses human output)", false)
   .option("--verbose", "Print HTTP request details for debugging", false)
@@ -90,7 +90,7 @@ registerLogsCommands(program);
 
 program
   .command("version")
-  .description("Print quiver CLI version")
+  .description("Print Hands CLI version")
   .action(() => {
     console.log(program.version());
   });

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -1,15 +1,14 @@
 /**
  * HTTP client for the Quiver Worker API.
  *
- * Mirrors the shape of admin/src/lib/api.ts but uses a CLI cookie instead
- * of the browser's `credentials: "include"` mechanism.
+ * Mirrors the shape of admin/src/lib/api.ts and sends the saved Hands JWT as
+ * Authorization: Bearer.
  *
  * Endpoints called by the CLI use `requireAppRole("viewer")` or
- * `requireOrgRole("member")` — they accept the HttpOnly session cookie
- * as long as the user has been logged in via `quiver login`.
+ * `requireOrgRole("member")` after the user has logged in via `hands login`.
  */
 
-import { resolveApiBase, resolveSessionCookie } from "./config.js";
+import { resolveApiBase, resolveAuthToken } from "./config.js";
 import { readEnv } from "./env.js";
 import { Blob } from "node:buffer";
 import { readFile } from "node:fs/promises";
@@ -57,10 +56,8 @@ export async function apiRequest<T = unknown>(
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
+  const bearer = resolveAuthToken();
   if (bearer) headers.authorization = `Bearer ${bearer}`;
-  const cookie = resolveSessionCookie();
-  if (!bearer && cookie) headers["cookie"] = cookie;
   let body: string | undefined;
   if (opts.body !== undefined) {
     headers["content-type"] = "application/json";
@@ -101,7 +98,6 @@ export async function apiUploadFile<T = unknown>(
   fieldName = "apk",
 ): Promise<T> {
   const url = new URL(path.startsWith("/") ? path : `/${path}`, getApiBase());
-  const cookie = resolveSessionCookie();
   const form = new FormData();
   const bytes = await readFile(filePath);
   form.append(fieldName, new Blob([bytes]), basename(filePath));
@@ -109,9 +105,8 @@ export async function apiUploadFile<T = unknown>(
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
+  const bearer = resolveAuthToken();
   if (bearer) headers.authorization = `Bearer ${bearer}`;
-  if (!bearer && cookie) headers.cookie = cookie;
 
   const res = await fetch(url.toString(), {
     method: "POST",

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -3,13 +3,12 @@
  *
  * Resolution order for any setting (first wins):
  *   1. CLI flag (--api, --token, ...)
- *   2. Environment variable (QUIVER_API, QUIVER_SESSION_COOKIE, ...)
+ *   2. Environment variable (HANDS_API, HANDS_AUTH_TOKEN, ...)
  *   3. File at $XDG_CONFIG_HOME/quiver/auth.json (default ~/.config/quiver/auth.json)
  *
  * The config file holds:
  *   - apiBase: the Quiver Worker URL the CLI talks to
- *   - sessionCookie: the HttpOnly `quiver_session` cookie value the
- *     Worker set after `quiver login` (or copied from the browser DevTools)
+ *   - authToken: the signed Hands JWT returned after `hands login`
  */
 
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
@@ -19,6 +18,8 @@ import { homedir } from "node:os";
 
 export interface CliConfig {
   apiBase?: string;
+  authToken?: string;
+  /** Legacy field read during migration from cookie-backed sessions. */
   sessionCookie?: string;
 }
 
@@ -47,7 +48,7 @@ export function saveConfig(patch: Partial<CliConfig>): CliConfig {
   const next: CliConfig = { ...current, ...patch };
   const path = configPath();
   mkdirSync(dirname(path), { recursive: true });
-  // 0600 — session cookie is sensitive.
+  // 0600 — the JWT is a sensitive bearer credential.
   writeFileSync(path, JSON.stringify(next, null, 2) + "\n", { mode: 0o600 });
   return next;
 }
@@ -55,6 +56,7 @@ export function saveConfig(patch: Partial<CliConfig>): CliConfig {
 export function clearConfig(): void {
   const current = getConfig();
   const next: CliConfig = { ...current };
+  delete next.authToken;
   delete next.sessionCookie;
   saveConfig(next);
 }
@@ -69,9 +71,10 @@ export function resolveApiBase(): string {
   return DEFAULT_API_BASE;
 }
 
-export function resolveSessionCookie(): string | undefined {
+export function resolveAuthToken(): string | undefined {
   // CI mode wins over file config (env vars are explicit).
-  const env = readEnv("SESSION_COOKIE");
+  const env = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN") ?? readEnv("SESSION_COOKIE");
   if (env) return env;
-  return getConfig().sessionCookie;
+  const config = getConfig();
+  return config.authToken ?? config.sessionCookie;
 }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -22,7 +22,7 @@ export interface CliConfig {
   sessionCookie?: string;
 }
 
-const DEFAULT_API_BASE = "https://quiver.oranix.io";
+const DEFAULT_API_BASE = "https://hands.build";
 
 function configPath(): string {
   const xdg = process.env.XDG_CONFIG_HOME;

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oranix-io/hands.git"
+    "url": "git+https://github.com/botiverse/hands.git"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -532,7 +532,7 @@ app.use("*", async (c, next) => {
   return next();
 });
 
-// Admin — protected by Quiver's Login with Raft session cookie.
+// Admin — protected by a Hands JWT or scoped deploy-token bearer auth.
 const admin = new Hono<{
   Bindings: Env;
   Variables: {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -164,7 +164,11 @@ import {
   requireOrgRole,
 } from "./lib/permissions";
 import { openApiDocument } from "./openapi";
-import { httpsRedirectUrl, requestOrigin } from "./lib/origin";
+import {
+  canonicalDomainRedirectUrl,
+  httpsRedirectUrl,
+  requestOrigin,
+} from "./lib/origin";
 
 // ---------- Container binding (APK parser) ----------
 //
@@ -321,6 +325,10 @@ app.use("*", async (c, next) => {
   const redirectUrl = httpsRedirectUrl(c);
   if (redirectUrl) {
     return c.redirect(redirectUrl, 308);
+  }
+  const domainRedirectUrl = canonicalDomainRedirectUrl(c);
+  if (domainRedirectUrl) {
+    return c.redirect(domainRedirectUrl, 308);
   }
   return next();
 });

--- a/worker/src/lib/origin.ts
+++ b/worker/src/lib/origin.ts
@@ -1,5 +1,8 @@
 import type { Context } from "hono";
 
+export const BUSINESS_ORIGIN = "https://hands.build";
+export const DASHBOARD_ORIGIN = "https://app.hands.build";
+
 function headerScheme(c: Context<any>): string | null {
   const header = typeof c.req.header === "function" ? c.req.header.bind(c.req) : null;
   const cfVisitor = header?.("cf-visitor");
@@ -45,4 +48,57 @@ export function httpsRedirectUrl(c: Context<any>): string | null {
   }
   url.protocol = "https:";
   return url.toString();
+}
+
+function isPublicBusinessPath(pathname: string): boolean {
+  return pathname === "/health" ||
+    pathname === "/openapi.json" ||
+    pathname === "/api-docs" ||
+    pathname === "/docs" ||
+    pathname === "/docs.md" ||
+    pathname.startsWith("/docs/") ||
+    pathname.startsWith("/public/") ||
+    pathname.startsWith("/electron/") ||
+    pathname.startsWith("/share/") ||
+    pathname.startsWith("/notes/") ||
+    pathname.startsWith("/.well-known/") ||
+    /^\/apps\/[^/]+\/history(?:\/|$)/.test(pathname);
+}
+
+function isDashboardPath(pathname: string): boolean {
+  return pathname === "/apps" ||
+    pathname.startsWith("/apps/") ||
+    pathname === "/settings" ||
+    pathname.startsWith("/settings/") ||
+    pathname.startsWith("/orgs/") ||
+    pathname.startsWith("/invites/") ||
+    pathname === "/cli/callback";
+}
+
+export function canonicalDomainRedirectUrl(c: Context<any>): string | null {
+  const method = String(c.req.method ?? "GET").toUpperCase();
+  if (method !== "GET" && method !== "HEAD") return null;
+
+  const url = new URL(c.req.url);
+  if (url.hostname === "hands.build") {
+    const acceptsHtml = (c.req.header?.("accept") ?? "").includes("text/html");
+    if (
+      (isDashboardPath(url.pathname) && !isPublicBusinessPath(url.pathname)) ||
+      (url.pathname === "/api/auth/login" && acceptsHtml)
+    ) {
+      return `${DASHBOARD_ORIGIN}${url.pathname}${url.search}`;
+    }
+    return null;
+  }
+
+  if (url.hostname === "app.hands.build") {
+    if (url.pathname === "/") {
+      return `${DASHBOARD_ORIGIN}/apps${url.search}`;
+    }
+    if (isPublicBusinessPath(url.pathname)) {
+      return `${BUSINESS_ORIGIN}${url.pathname}${url.search}`;
+    }
+  }
+
+  return null;
 }

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from "hono";
 import { currentActorInfo, type AdminAccount, type AdminEnv } from "../middleware/auth";
 import type { AppDeployToken } from "./deploy_tokens";
+import { DASHBOARD_ORIGIN } from "./origin";
 
 export type OrgRole = "owner" | "admin" | "member" | "viewer";
 export type AppRole = "admin" | "publisher" | "viewer";
@@ -151,19 +152,17 @@ function forbiddenRole(
   currentRole: string | null,
   ids: { org_id?: string | null; app_id?: string | null },
 ) {
-  let origin = "https://quiver.oranix.io";
   let resource = "";
   try {
     const u = new URL(c.req.url);
-    origin = u.origin;
     resource = `${c.req.method} ${u.pathname}`;
   } catch {
     // request URL/method unavailable (e.g. tests) — keep defaults
   }
   const manageUrl = ids.org_id
-    ? `${origin}/orgs/${ids.org_id}/members`
+    ? `${DASHBOARD_ORIGIN}/orgs/${ids.org_id}/members`
     : ids.app_id
-      ? `${origin}/apps/${ids.app_id}/access`
+      ? `${DASHBOARD_ORIGIN}/apps/${ids.app_id}/settings`
       : null;
   // Admin-native, actionable error: tell the caller (agent or human) exactly
   // what to do next — who can grant the role, where, and that an admin can
@@ -239,12 +238,6 @@ export async function ensureAppRole(c: AdminContext, appId: string, minimum: App
     // Actionable 401: an agent that hit this with a valid-looking session got
     // no resolvable account — tell it how to authenticate and that admin API
     // access needs a role on the app, rather than a bare "unauthorized".
-    let origin = "https://hands.build";
-    try {
-      origin = new URL(c.req.url).origin;
-    } catch {
-      // keep default
-    }
     return {
       ok: false as const,
       response: c.json(
@@ -257,7 +250,7 @@ export async function ensureAppRole(c: AdminContext, appId: string, minimum: App
             `\`raft integration login --service <hands-service>\`. Then an admin must grant you the ` +
             `'${minimum}' role on this app (Access → Members). Admins can perform the release action on your behalf.`,
           login_url: `/api/auth/login?return=${encodeURIComponent("/")}`,
-          manage_url: `${origin}/apps/${appId}/access`,
+          manage_url: `${DASHBOARD_ORIGIN}/apps/${appId}/settings`,
         },
         401,
       ),

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -4,8 +4,8 @@
  * Production uses Login with Raft exclusively:
  *   - /api/auth/login redirects to Raft setup.
  *   - /login/raft/callback exchanges the code server-side.
- *   - Admin routes require a Quiver auth token. Browsers carry it in the
- *     HttpOnly cookie; agents/CLIs carry the same token as Bearer auth.
+ *   - Admin routes require a signed Hands JWT in Authorization: Bearer.
+ *     Browsers, agents, and CLIs all use the same transport.
  *
  * A static bearer token is accepted only when ENVIRONMENT !== "production",
  * so local development and unit smoke tests can still call admin endpoints
@@ -13,10 +13,8 @@
  */
 
 import type { Context, MiddlewareHandler } from "hono";
-import { getCookie } from "hono/cookie";
 import { loadDeployToken, sha256Hex, type AppDeployToken } from "../lib/deploy_tokens";
 
-export const SESSION_COOKIE = "quiver_session";
 export const ACTIVE_ORG_HEADER = "x-hands-org-id";
 
 export type AdminAccount = {
@@ -153,14 +151,13 @@ export async function accountForRequestedOrg(
 
 export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
   async (c, next) => {
-    const cookieToken = getCookie(c, SESSION_COOKIE);
     const authHeader = c.req.header("authorization");
     const bearerToken = authHeader?.startsWith("Bearer ")
       ? authHeader.slice("Bearer ".length).trim()
       : undefined;
     const sessionAccount = await loadAccountFromAuthToken(
       c.env,
-      cookieToken || bearerToken,
+      bearerToken,
     );
     if (sessionAccount) {
       const account = await accountForRequestedOrg(
@@ -176,7 +173,7 @@ export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
       return;
     }
 
-    if (!cookieToken && bearerToken) {
+    if (bearerToken) {
       const deployToken = await loadDeployToken(c.env, bearerToken);
       if (deployToken) {
         c.set("admin_deploy_token", deployToken);

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -130,12 +130,7 @@ openApiDocument.components.securitySchemes = {
   bearerAuth: {
     type: "http",
     scheme: "bearer",
-    description: "Hands bearer token. Use app deploy tokens for CI and agents.",
-  },
-  cookieAuth: {
-    type: "apiKey",
-    in: "cookie",
-    name: "quiver_session",
-    description: "Browser session cookie set by Login with Raft.",
+    bearerFormat: "JWT",
+    description: "Hands JWT from Login with Raft, or an app deploy token for scoped CI/agent access.",
   },
 };

--- a/worker/src/openapi/common.ts
+++ b/worker/src/openapi/common.ts
@@ -163,7 +163,7 @@ export const AppRole = z.enum(["viewer", "publisher", "admin"]);
 export const OrgRole = z.enum(["owner", "admin", "member", "viewer"]);
 export const DeployTokenRole = z.enum(["viewer", "publisher"]);
 
-export const auth = [{ bearerAuth: [] }, { cookieAuth: [] }];
+export const auth = [{ bearerAuth: [] }];
 
 export const json = (schema: z.ZodType) => ({
   "application/json": { schema },

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1,8 +1,8 @@
 /**
  * Login with Raft routes.
  *
- * The Raft OAuth code and access token never leave the Worker. The browser
- * only receives Hands's own HttpOnly session cookie.
+ * The Raft OAuth code and Raft access token never leave the Worker. The
+ * browser receives a Hands-signed JWT for Authorization: Bearer requests.
  */
 
 import type { Context } from "hono";
@@ -12,10 +12,14 @@ import {
   accountForRequestedOrg,
   ACTIVE_ORG_HEADER,
   loadAccountFromAuthToken,
-  SESSION_COOKIE,
   type AdminAccount,
 } from "../middleware/auth";
-import { isSecureRequest, requestOrigin } from "../lib/origin";
+import {
+  BUSINESS_ORIGIN,
+  DASHBOARD_ORIGIN,
+  isSecureRequest,
+  requestOrigin,
+} from "../lib/origin";
 
 const LOGIN_PENDING_COOKIE = "quiver_raft_login_pending";
 const LOGIN_RETURN_COOKIE = "quiver_raft_return";
@@ -60,8 +64,27 @@ function secureCookie(c: Context<{ Bindings: Env }>): boolean {
   return isSecureRequest(c);
 }
 
+function isHandsProductionHost(c: Context<{ Bindings: Env }>): boolean {
+  const hostname = new URL(c.req.url).hostname;
+  return hostname === "hands.build" || hostname === "app.hands.build";
+}
+
+function sharedCookieDomainOption(
+  c: Context<{ Bindings: Env }>,
+): { domain: string } | Record<string, never> {
+  return isHandsProductionHost(c) ? { domain: "hands.build" } : {};
+}
+
 function callbackUrl(c: Context<{ Bindings: Env }>): string {
-  return `${appOrigin(c)}/login/raft/callback`;
+  const origin = isHandsProductionHost(c) ? BUSINESS_ORIGIN : appOrigin(c);
+  return `${origin}/login/raft/callback`;
+}
+
+function browserReturnUrl(
+  c: Context<{ Bindings: Env }>,
+  returnPath: string,
+): string {
+  return isHandsProductionHost(c) ? `${DASHBOARD_ORIGIN}${returnPath}` : returnPath;
 }
 
 function requireRaftConfig(c: Context<{ Bindings: Env }>) {
@@ -117,6 +140,56 @@ async function sha256Hex(input: string): Promise<string> {
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
+}
+
+function base64UrlUtf8(input: string): string {
+  return base64Utf8(input)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function base64UrlBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+export async function createSignedJwt(
+  env: Env,
+  accountId: string,
+  issuedAt: number,
+  expiresAt: number,
+  jwtId: string,
+): Promise<string> {
+  const secret = env.SIGNED_URL_SECRET || env.RAFT_CLIENT_SECRET;
+  if (!secret) throw new Error("SIGNED_URL_SECRET or RAFT_CLIENT_SECRET is required for auth JWTs");
+  const header = base64UrlUtf8(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64UrlUtf8(JSON.stringify({
+    iss: "https://hands.build",
+    aud: "hands-dashboard",
+    sub: accountId,
+    jti: jwtId,
+    iat: Math.floor(issuedAt / 1000),
+    exp: Math.floor(expiresAt / 1000),
+  }));
+  const signingInput = `${header}.${payload}`;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(`hands-auth-jwt-v1:${secret}`),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${base64UrlBytes(new Uint8Array(signature))}`;
 }
 
 function base64Utf8(input: string): string {
@@ -354,21 +427,22 @@ async function upsertRaftOrgMembership(
 }
 
 async function createAuthToken(
-  db: D1Database,
+  env: Env,
   accountId: string,
 ): Promise<{ token: string; expiresAt: number }> {
-  const token = randomToken();
-  const tokenHash = await sha256Hex(token);
   const timestamp = now();
   const ttlSeconds = 60 * 60 * 24 * 14;
   const expiresAt = timestamp + ttlSeconds * 1000;
-  await db
+  const sessionId = crypto.randomUUID();
+  const token = await createSignedJwt(env, accountId, timestamp, expiresAt, sessionId);
+  const tokenHash = await sha256Hex(token);
+  await env.DB
     .prepare(
       `INSERT INTO raft_sessions
        (id, account_id, token_hash, created_at, expires_at, last_seen_at, revoked_at)
        VALUES (?1, ?2, ?3, ?4, ?5, ?4, NULL)`,
     )
-    .bind(crypto.randomUUID(), accountId, tokenHash, timestamp, expiresAt)
+    .bind(sessionId, accountId, tokenHash, timestamp, expiresAt)
     .run();
   return { token, expiresAt };
 }
@@ -400,21 +474,8 @@ async function finalizeRaftLogin(
   const membership = await upsertRaftOrgMembership(c.env.DB, account);
   account.org_id = membership.org_id;
   account.org_role = membership.org_role;
-  const authToken = await createAuthToken(c.env.DB, account.id);
+  const authToken = await createAuthToken(c.env, account.id);
   return { account, authToken };
-}
-
-function setAuthCookie(
-  c: Context<{ Bindings: Env }>,
-  authToken: LoginResult["authToken"],
-) {
-  setCookie(c, SESSION_COOKIE, authToken.token, {
-    httpOnly: true,
-    secure: secureCookie(c),
-    sameSite: "Lax",
-    path: "/",
-    expires: new Date(authToken.expiresAt),
-  });
 }
 
 function agentLoginJson(result: LoginResult) {
@@ -455,7 +516,7 @@ export async function handleAuthMe(c: Context<{ Bindings: Env }>) {
     : undefined;
   const sessionAccount = await loadAccountFromAuthToken(
     c.env,
-    getCookie(c, SESSION_COOKIE) || bearerToken,
+    bearerToken,
   );
   if (!sessionAccount) {
     return c.json(
@@ -501,11 +562,12 @@ export async function handleAuthLogin(c: Context<{ Bindings: Env }>) {
   if (!config.ok) return config.response;
 
   const pending = randomToken(16);
-  const returnPath = normalizeReturnPath(c.req.query("return"));
+  const returnPath = normalizeReturnPath(c.req.query("return") ?? c.req.query("return_to"));
   setCookie(c, LOGIN_PENDING_COOKIE, pending, {
     httpOnly: true,
     secure: secureCookie(c),
     sameSite: "Lax",
+    ...sharedCookieDomainOption(c),
     path: "/",
     maxAge: 10 * 60,
   });
@@ -513,6 +575,7 @@ export async function handleAuthLogin(c: Context<{ Bindings: Env }>) {
     httpOnly: true,
     secure: secureCookie(c),
     sameSite: "Lax",
+    ...sharedCookieDomainOption(c),
     path: "/",
     maxAge: 10 * 60,
   });
@@ -560,16 +623,25 @@ export async function handleRaftCallback(c: Context<{ Bindings: Env }>) {
       if (result.account.principal_type !== "agent") {
         return c.text("Missing local login state. Start again from /api/auth/login.", 400);
       }
-      setAuthCookie(c, result.authToken);
       c.header("cache-control", "no-store");
       return c.json(agentLoginJson(result));
     }
 
-    setAuthCookie(c, result.authToken);
-    deleteCookie(c, LOGIN_PENDING_COOKIE, { path: "/" });
+    deleteCookie(c, LOGIN_PENDING_COOKIE, {
+      ...sharedCookieDomainOption(c),
+      path: "/",
+    });
     const returnPath = normalizeReturnPath(getCookie(c, LOGIN_RETURN_COOKIE));
-    deleteCookie(c, LOGIN_RETURN_COOKIE, { path: "/" });
-    return c.redirect(returnPath, 302);
+    deleteCookie(c, LOGIN_RETURN_COOKIE, {
+      ...sharedCookieDomainOption(c),
+      path: "/",
+    });
+    const destination = new URL(browserReturnUrl(c, returnPath), requestOrigin(c));
+    destination.hash = new URLSearchParams({
+      access_token: result.authToken.token,
+      expires_at: String(result.authToken.expiresAt),
+    }).toString();
+    return c.redirect(destination.toString(), 302);
   } catch (error) {
     console.error(
       `[raft-auth] callback failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -583,7 +655,7 @@ export async function handleAuthLogout(c: Context<{ Bindings: Env }>) {
   const bearerToken = authHeader?.startsWith("Bearer ")
     ? authHeader.slice("Bearer ".length).trim()
     : undefined;
-  const token = getCookie(c, SESSION_COOKIE) || bearerToken;
+  const token = bearerToken;
   if (token) {
     const tokenHash = await sha256Hex(token);
     await c.env.DB.prepare(
@@ -592,7 +664,6 @@ export async function handleAuthLogout(c: Context<{ Bindings: Env }>) {
       .bind(now(), tokenHash)
       .run();
   }
-  deleteCookie(c, SESSION_COOKIE, { path: "/" });
   return c.json({ ok: true });
 }
 
@@ -663,6 +734,12 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         description:
           "Start here — how to authenticate, what each action does, common crash/feedback flows, and docs links.",
         endpoint: { method: "GET", path: "/api/agent/help" },
+      },
+      {
+        name: "list-orgs",
+        description:
+          "List every organization the current Raft identity can access across linked servers, including role and server identity.",
+        endpoint: { method: "GET", path: "/api/orgs" },
       },
       {
         name: "list-apps",

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -12,7 +12,7 @@ import { currentActor, type AdminEnv } from "../middleware/auth";
 import { emitWebhookEvent } from "./webhooks";
 import { presignR2UploadUrl } from "../lib/r2_presign";
 import { generateSignedR2Url } from "./public_v2";
-import { requestOrigin } from "../lib/origin";
+import { DASHBOARD_ORIGIN, requestOrigin } from "../lib/origin";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -412,12 +412,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     : versionCode != null
       ? String(versionCode)
       : null;
-  let ticketUrl: string | null = null;
-  try {
-    ticketUrl = `${new URL(c.req.url).origin}/apps/${app.id}/feedback/${ticketId}`;
-  } catch {
-    ticketUrl = null;
-  }
+  const ticketUrl = `${DASHBOARD_ORIGIN}/apps/${app.id}/feedback/${ticketId}`;
   const reference = [app.slug, versionLabel, `ticket ${ticketId}`]
     .filter(Boolean)
     .join(" · ");

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -795,6 +795,9 @@ describe("quiver route handlers — SQL smoke", () => {
     expect(typeof viewerBody.next_action).toBe("string");
     expect(viewerBody.next_action as string).toContain("member");
     expect(viewerBody.next_action as string).toContain("/members");
+    expect(viewerBody.manage_url).toBe(
+      "https://app.hands.build/orgs/raft_create/members",
+    );
 
     const memberResponse = await testApp.request(
       "https://quiver-worker.test/api/apps",
@@ -4565,7 +4568,9 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(submittedBody.attachments).toBe(1);
     expect(submittedBody.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(submittedBody.reference).toContain(`ticket ${submittedBody.id}`);
-    expect(submittedBody.ticket_url).toContain(`/apps/app-scope/feedback/${submittedBody.id}`);
+    expect(submittedBody.ticket_url).toBe(
+      `https://app.hands.build/apps/app-scope/feedback/${submittedBody.id}`,
+    );
     expect(putCalls.length).toBe(1);
     expect(putCalls[0]!.key).toContain("feedback/app-scope/");
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -29,7 +29,7 @@ import {
 } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
 import { handleCreateApp, handleListApps } from "../src/routes/apps";
-import { handleAuthLogin, handleAuthMe } from "../src/routes/auth";
+import { createSignedJwt, handleAuthLogin, handleAuthMe } from "../src/routes/auth";
 import { handleListOrgs } from "../src/routes/orgs";
 
 // ---------- Test harness ----------
@@ -1394,6 +1394,24 @@ describe("auth origin handling", () => {
     },
   });
 
+  it("issues signed JWT-shaped Hands access tokens with scoped claims", async () => {
+    const env = makeMockEnv();
+    (env as any).SIGNED_URL_SECRET = "jwt-test-secret";
+    const token = await createSignedJwt(env as any, "account-1", 1_700_000_000_000, 1_700_001_000_000, "session-1");
+    const parts = token.split(".");
+    expect(parts).toHaveLength(3);
+    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8"));
+    expect(payload).toMatchObject({
+      iss: "https://hands.build",
+      aud: "hands-dashboard",
+      sub: "account-1",
+      jti: "session-1",
+      iat: 1_700_000_000,
+      exp: 1_700_001_000,
+    });
+    expect(parts[2]).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
   it("redirects Login with Raft through the current Raft setup route", async () => {
     const env = makeMockEnv();
     env.RAFT_CLIENT_ID = "hands-4cc7a2";
@@ -1414,6 +1432,45 @@ describe("auth origin handling", () => {
     expect(location.searchParams.get("return_to")).toBe(
       "https://hands.build/login/raft/callback",
     );
+  });
+
+  it("shares browser login state across the dashboard and registered callback hosts", async () => {
+    const env = makeMockEnv();
+    env.RAFT_CLIENT_ID = "hands-4cc7a2";
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/login", handleAuthLogin);
+
+    const res = await app.request(
+      "https://app.hands.build/api/auth/login?return=%2Fapps%2Fapp-1%2Fsettings",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.searchParams.get("return_to")).toBe(
+      "https://hands.build/login/raft/callback",
+    );
+    expect(res.headers.get("set-cookie")?.toLowerCase()).toContain("domain=hands.build");
+  });
+
+  it("keeps localhost auth callbacks and cookies host-local", async () => {
+    const env = makeMockEnv();
+    env.RAFT_CLIENT_ID = "hands-4cc7a2";
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/login", handleAuthLogin);
+
+    const res = await app.request(
+      "http://localhost:8787/api/auth/login?return=%2Fapps",
+      {},
+      env as any,
+    );
+
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.searchParams.get("return_to")).toBe(
+      "http://localhost:8787/login/raft/callback",
+    );
+    expect(res.headers.get("set-cookie")?.toLowerCase()).not.toContain("domain=");
   });
 
   it("canonicalizes public http custom-domain requests to https", () => {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -21,7 +21,12 @@ import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
 import { requireCurrentOrgRole } from "../src/lib/permissions";
-import { httpsRedirectUrl, isSecureRequest, requestOrigin } from "../src/lib/origin";
+import {
+  canonicalDomainRedirectUrl,
+  httpsRedirectUrl,
+  isSecureRequest,
+  requestOrigin,
+} from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
 import { handleCreateApp, handleListApps } from "../src/routes/apps";
 import { handleAuthLogin, handleAuthMe } from "../src/routes/auth";
@@ -1374,6 +1379,18 @@ describe("quiver route handlers — SQL smoke", () => {
 });
 
 describe("auth origin handling", () => {
+  const domainContext = (
+    url: string,
+    options: { method?: string; accept?: string } = {},
+  ) => ({
+    req: {
+      url,
+      method: options.method ?? "GET",
+      header: (name: string) =>
+        name.toLowerCase() === "accept" ? options.accept ?? null : null,
+    },
+  });
+
   it("redirects Login with Raft through the current Raft setup route", async () => {
     const env = makeMockEnv();
     env.RAFT_CLIENT_ID = "hands-4cc7a2";
@@ -1430,6 +1447,69 @@ describe("auth origin handling", () => {
     expect(requestOrigin(ctx as any)).toBe("https://quiver.oranix.io");
     expect(isSecureRequest(ctx as any)).toBe(true);
     expect(httpsRedirectUrl(ctx as any)).toBeNull();
+  });
+
+  it("moves dashboard deep links from hands.build to app.hands.build", () => {
+    const ctx = domainContext(
+      "https://hands.build/apps/app-1/settings?tab=access",
+    );
+    expect(canonicalDomainRedirectUrl(ctx as any)).toBe(
+      "https://app.hands.build/apps/app-1/settings?tab=access",
+    );
+  });
+
+  it("keeps public app history on the business domain", () => {
+    const ctx = domainContext(
+      "https://hands.build/apps/raft-android/history/release-1/download",
+    );
+    expect(canonicalDomainRedirectUrl(ctx as any)).toBeNull();
+  });
+
+  it("moves browser login to the dashboard domain but preserves API clients", () => {
+    const browser = domainContext(
+      "https://hands.build/api/auth/login?return=%2Fapps",
+      { accept: "text/html,application/xhtml+xml" },
+    );
+    expect(canonicalDomainRedirectUrl(browser as any)).toBe(
+      "https://app.hands.build/api/auth/login?return=%2Fapps",
+    );
+
+    const apiClient = domainContext(
+      "https://hands.build/api/auth/login?return=%2Fapps",
+      { accept: "application/json" },
+    );
+    expect(canonicalDomainRedirectUrl(apiClient as any)).toBeNull();
+  });
+
+  it("makes the dashboard root canonical and sends public pages back to hands.build", () => {
+    expect(
+      canonicalDomainRedirectUrl(
+        domainContext("https://app.hands.build/?from=bookmark") as any,
+      ),
+    ).toBe("https://app.hands.build/apps?from=bookmark");
+    expect(
+      canonicalDomainRedirectUrl(
+        domainContext("https://app.hands.build/share/token-1") as any,
+      ),
+    ).toBe("https://hands.build/share/token-1");
+    expect(
+      canonicalDomainRedirectUrl(
+        domainContext("https://app.hands.build/docs/cli-reference/") as any,
+      ),
+    ).toBe("https://hands.build/docs/cli-reference/");
+  });
+
+  it("keeps dashboard APIs on app.hands.build and never redirects mutations", () => {
+    expect(
+      canonicalDomainRedirectUrl(
+        domainContext("https://app.hands.build/api/apps") as any,
+      ),
+    ).toBeNull();
+    expect(
+      canonicalDomainRedirectUrl(
+        domainContext("https://hands.build/apps", { method: "POST" }) as any,
+      ),
+    ).toBeNull();
   });
 });
 

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -7,6 +7,11 @@
   "observability": { "enabled": true },
   "upload_source_maps": true,
 
+  "routes": [
+    { "pattern": "hands.build", "custom_domain": true },
+    { "pattern": "app.hands.build", "custom_domain": true }
+  ],
+
   "r2_buckets": [
     {
       "binding": "APK_BUCKET",
@@ -62,7 +67,7 @@
     // still running a cached admin SPA from the legacy domain may fire /api/*
     // (proxied through the shim) with Origin: https://quiver.oranix.io before it
     // follows the 302 to hands.build. Native SDKs don't use CORS.
-    "CORS_ALLOWED_ORIGINS": "https://hands.build,https://quiver.oranix.io,http://localhost:5173",
+    "CORS_ALLOWED_ORIGINS": "https://hands.build,https://app.hands.build,https://quiver.oranix.io,http://localhost:5173",
     "RAFT_ORIGIN": "https://app.raft.build",
     "RAFT_API_ORIGIN": "https://api.raft.build",
     "RAFT_CLIENT_ID": "hands-4cc7a2"


### PR DESCRIPTION
## Summary
- serve one Hands Worker on `hands.build` and `app.hands.build` with hostname-based canonical routing
- keep dashboard/login on `app.hands.build` while business, SDK, CLI, agent, share, download, notes, and docs stay on `hands.build`
- keep the already-registered Raft callback at `https://hands.build/login/raft/callback`, then return the browser to the app domain
- replace browser session cookies with signed Hands JWTs delivered in the callback URL fragment and sent as `Authorization: Bearer`
- refresh public README/docs/UI help, CLI and Electron defaults, SDK versions, repository metadata, and generated admin links to canonical Hands locations
- expose `list-orgs` in the agent manifest

## Auth transport
- Raft authorization code and Raft access token stay server-side
- Hands issues an HS256 JWT with issuer/audience/subject/jti/iat/exp claims and retains the session row for expiry/revocation
- SPA consumes the fragment once, removes it from the address bar, stores the JWT locally, and authenticates JSON, upload, attachment, icon, and SSE requests with Bearer
- CLI callback displays the JWT for copy/paste; CLI stores and sends it as Bearer
- only short-lived OAuth pending/return cookies remain for redirect correlation and are deleted at callback; there is no browser session cookie

## Redirect policy
- dashboard deep links on `hands.build` redirect to the same path/query on `app.hands.build`
- public/docs/share/history routes on `app.hands.build` redirect to `hands.build`
- mutations never redirect
- authenticated APIs remain callable on both hosts for CLI/agent compatibility

## Validation
- Worker tests: 118 passed
- CLI tests: 12 passed
- Worker build
- Admin typecheck and production build, including generated docs
- CLI build
- Electron typecheck
- frozen pnpm install
- Wrangler Hands deploy dry-run, including both custom-domain config and container build
- Android SDK and OHOS HAR PR checks passed before the JWT follow-up; new checks are running
- diff check

Tracks Hands task #127 and task #128.