### PR TITLE
fix(ohos-sdk): stringify native-crash signal + named top frame (0.3.1)

### DIFF
--- a/clients/ohos/hands/changelog.md
+++ b/clients/ohos/hands/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.1
+
+- Fix native-crash signal formatting: hiAppEvent can deliver `signal` as a
+  structured object, which rendered as `[object Object]` in the ticket
+  summary; extract the signal name/code instead, and pick the first named
+  stack frame for the summary's top frame.
+
 ## 0.3.0
 
 - System-level fault capture via hiAppEvent (`APP_CRASH` + `APP_FREEZE`):

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "Oranix",

--- a/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
@@ -134,7 +134,7 @@ export class HandsFaultWatcher {
       const ex = exception as Record<string, Object>;
       const name = String(ex['name'] ?? '');
       const message = String(ex['message'] ?? '');
-      const signal = String(ex['signal'] ?? '');
+      const signal = HandsFaultWatcher.describeSignal(ex['signal']);
       if (name.length > 0) {
         result.cls = name;
       } else if (signal.length > 0) {
@@ -142,14 +142,51 @@ export class HandsFaultWatcher {
       }
       result.message = message;
       const frames = ex['frames'];
-      if (Array.isArray(frames) && frames.length > 0) {
-        const top = frames[0] as Record<string, Object>;
-        const file = String(top['file'] ?? top['symbol'] ?? '');
-        const offset = String(top['offset'] ?? '');
-        result.topFrame = offset.length > 0 ? `${file}+${offset}` : file;
+      if (Array.isArray(frames)) {
+        // The crashing frame is often a bare pc (empty file/symbol); use the
+        // first frame that actually names something.
+        for (const raw of frames as Array<Object>) {
+          const f = raw as Record<string, Object>;
+          const symbol = String(f['symbol'] ?? '');
+          const file = String(f['file'] ?? '');
+          const offset = String(f['offset'] ?? '');
+          const label = symbol.length > 0 ? symbol : file;
+          if (label.length > 0) {
+            result.topFrame = offset.length > 0 ? `${label}+${offset}` : label;
+            break;
+          }
+        }
       }
     }
     return result;
+  }
+
+  /**
+   * hiAppEvent may deliver the signal as a string or a structured object
+   * (e.g. { signal: 11, name: "SIGSEGV" }). String(obj) would produce
+   * "[object Object]", so pull out a human name/number instead.
+   */
+  private static describeSignal(signal: Object | undefined): string {
+    if (signal === undefined || signal === null) {
+      return '';
+    }
+    if (typeof signal !== 'object') {
+      return String(signal);
+    }
+    const s = signal as Record<string, Object>;
+    const parts: string[] = [];
+    const name = s['name'] ?? s['signal_name'];
+    const code = s['code'] ?? s['signal'] ?? s['number'];
+    if (name !== undefined && name !== null) parts.push(String(name));
+    if (code !== undefined && code !== null) parts.push(String(code));
+    if (parts.length > 0) {
+      return parts.join(' ');
+    }
+    try {
+      return JSON.stringify(signal);
+    } catch (error) {
+      return 'unknown';
+    }
   }
 
   private static joinLines(value: Object | undefined): string {

--- a/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
@@ -14,7 +14,7 @@ const TAG: string = 'HandsFeedbackClient';
 
 // Hands OHOS SDK version — reported in feedback/crash environment metadata.
 // Keep in sync with oh-package.json5 on release.
-const HANDS_SDK_VERSION: string = '0.3.0';
+const HANDS_SDK_VERSION: string = '0.3.1';
 
 // @ohos.batteryInfo BatteryChargeState: NONE=0, ENABLE=1, DISABLE=2, FULL=3.
 function ohBatteryStateName(status: number): string {


### PR DESCRIPTION
A real raft-ohos NativeCrash ticket (34f99d1d, captured by the 0.3.0 hiAppEvent watcher) showed `NativeCrash(signal [object Object])` — hiAppEvent delivers `signal` as a structured object, so `String()` mangled it. Extract the signal name/code, and pick the first frame that names a symbol/file for the summary top frame. Full fault.txt was always complete; this fixes the summary line only. The watcher itself is validated — that ticket carried a fully symbolicated K/N stack (StringCache#getResource → getNormalStringByName), the family CC-Cata's #555 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786276520&installation_id=145465820&pr_number=214&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F214&signature=21359b376740d91c6436074d8f0c47e9606317d365573afc039b90bf7ab4e26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->