### PR TITLE
feat(delta): server-side Android delta patch generation (task #246 P1b)

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -56,6 +56,7 @@ export interface App {
   description: string | null;
   archived: number;       // 0 = active, 1 = archived (soft-delete)
   public_history?: number; // 1 = public /apps/:slug/history page enabled
+  delta_updates_enabled?: number; // 1 = auto-generate Android delta patches on publish
   archived_at: number | null;
   created_at: number;
   // Default release channel (P2.5.9 / migration 0018). pre-fills the
@@ -1300,6 +1301,13 @@ export const updateAppPublicHistory = (appId: string, enabled: boolean) =>
   request<{ ok: boolean }>(`/api/apps/${appId}`, {
     method: "PATCH",
     body: JSON.stringify({ public_history: enabled }),
+    admin: true,
+  });
+
+export const updateAppDeltaUpdates = (appId: string, enabled: boolean) =>
+  request<{ ok: boolean }>(`/api/apps/${appId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ delta_updates_enabled: enabled }),
     admin: true,
   });
 

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -16,6 +16,7 @@ import {
   uploadAppIcon,
   publicAppIconUrl,
   updateAppPublicHistory,
+  updateAppDeltaUpdates,
   getAppClientKey,
   rotateAppClientKey,
   purgeApp,
@@ -648,6 +649,47 @@ function PublicHistoryToggle({ appId, app }: { appId: string; app: App }) {
   );
 }
 
+function DeltaUpdatesToggle({ appId, app }: { appId: string; app: App }) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const enabled = Boolean(app.delta_updates_enabled);
+  const toggle = useMutation({
+    mutationFn: () => updateAppDeltaUpdates(appId, !enabled),
+    onSuccess: () => {
+      toast.show({
+        kind: "success",
+        title: !enabled ? "Delta updates enabled" : "Delta updates disabled",
+      });
+      qc.invalidateQueries({ queryKey: ["apps"] });
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Update failed",
+        description: (e as Error).message,
+      }),
+  });
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1">
+        <div className="text-sm font-medium">Delta updates</div>
+        <div className="text-xs text-slate-500">
+          {enabled
+            ? "On publish, small differential patches are generated from recent versions so users download less to update."
+            : "Auto-generate differential update patches when a release is published, shrinking update downloads for users on recent versions."}
+        </div>
+      </div>
+      <button
+        className="btn-secondary !py-1 !px-2 !text-xs"
+        disabled={toggle.isPending}
+        onClick={() => toggle.mutate()}
+      >
+        {toggle.isPending ? "…" : enabled ? "Disable" : "Enable"}
+      </button>
+    </div>
+  );
+}
+
 function AppIconUploader({ appId, slug }: { appId: string; slug: string }) {
   const toast = useToast();
   const [bust, setBust] = useState(0);
@@ -769,6 +811,9 @@ export function AppSettings({ appId }: { appId: string }) {
 
         {/* Public version history */}
         <PublicHistoryToggle appId={appId} app={app} />
+
+        {/* Delta/differential updates — Android apps only */}
+        {app.platform === "android" && <DeltaUpdatesToggle appId={appId} app={app} />}
 
         {/* Client key (feedback/crash reporting auth) */}
         <ClientKeyPanel appId={appId} />

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -28,9 +28,10 @@ COPY --from=minidump-builder /minidump-stackwalk /usr/local/bin/minidump-stackwa
 ARG ANDROID_SDK_VERSION=34.0.0
 ARG ANDROID_CMDLINE_TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
 
-# Install JDK + unzip + wget + ca-certificates (Java for sdkmanager runtime)
+# Install JDK + unzip + wget + ca-certificates. JDK (not JRE) so we can
+# compile the archive-patcher wrapper below; also the sdkmanager runtime.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-17-jre-headless \
+    openjdk-17-jdk-headless \
     ca-certificates \
     wget \
     unzip \
@@ -52,6 +53,17 @@ ENV PATH=$PATH:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/build-
 # Accept licenses + install build-tools (aapt + apksigner are inside)
 RUN yes | sdkmanager --licenses >/dev/null 2>&1 || true && \
     sdkmanager "build-tools;${ANDROID_SDK_VERSION}" >/dev/null 2>&1
+
+# archive-patcher (delta/differential update generation) — com.eidu fork of
+# Google's Play-Store engine: a single self-contained jar (no transitive deps).
+# Compile the thin PatchGen wrapper against it so the container can generate
+# file-by-file APK patches. See docs/delta-download-design.md.
+ARG ARCHIVE_PATCHER_VERSION=3.0.0
+RUN mkdir -p /opt/patchgen && \
+    wget -q "https://repo1.maven.org/maven2/com/eidu/archive-patcher/${ARCHIVE_PATCHER_VERSION}/archive-patcher-${ARCHIVE_PATCHER_VERSION}.jar" \
+      -O /opt/patchgen/archive-patcher.jar
+COPY patchgen/PatchGen.java /opt/patchgen/PatchGen.java
+RUN javac -encoding UTF-8 -cp /opt/patchgen/archive-patcher.jar -d /opt/patchgen /opt/patchgen/PatchGen.java
 
 WORKDIR /app
 

--- a/container/patchgen/PatchGen.java
+++ b/container/patchgen/PatchGen.java
@@ -1,0 +1,48 @@
+import com.google.archivepatcher.generator.FileByFileV1DeltaGenerator;
+import com.google.archivepatcher.generator.RecommendationModifier;
+import com.google.archivepatcher.shared.DefaultDeflater;
+import com.google.archivepatcher.shared.IDeflater;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.function.BiFunction;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Minimal CLI wrapper around archive-patcher's file-by-file delta generator
+ * (com.eidu:archive-patcher, a maintained fork of Google's Play-Store engine).
+ * Produces a patch that upgrades OLD.apk to NEW.apk:
+ *
+ *   java -cp archive-patcher.jar:. PatchGen OLD.apk NEW.apk OUT.patch
+ *
+ * NOTE 1: the eidu fork's constructor differs from Google's original -- it takes
+ * a pluggable deflater factory (level, nowrap) -> IDeflater (so callers can
+ * match a platform's exact zlib), not a no-arg constructor. The applier side
+ * (Android, P2) needs the SAME factory. DefaultDeflater wraps java.util.zip.
+ *
+ * NOTE 2: the RAW archive-patcher patch is a bsdiff stream that is mostly zeros
+ * for unchanged regions -- it is nearly the full APK size on disk but is highly
+ * compressible (a 40-byte change over a 600KB APK: 600KB raw -> ~760B gzipped).
+ * So we GZIP the patch here; the stored artifact and the < full-APK size guard
+ * must both use this compressed form, and the applier (P2) must GUNZIP before
+ * FileByFileV1DeltaApplier.applyDelta. algorithm id: archive-patcher-v1+gzip.
+ */
+public final class PatchGen {
+  static final BiFunction<Integer, Boolean, IDeflater> DEFLATER_FACTORY =
+      (level, nowrap) -> new DefaultDeflater(level, nowrap);
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 3) {
+      System.err.println("usage: PatchGen <old.apk> <new.apk> <out.patch.gz>");
+      System.exit(2);
+    }
+    File oldFile = new File(args[0]);
+    File newFile = new File(args[1]);
+    try (OutputStream out =
+        new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(args[2])))) {
+      new FileByFileV1DeltaGenerator(DEFLATER_FACTORY, new RecommendationModifier[0])
+          .generateDelta(oldFile, newFile, out);
+    }
+  }
+}

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -56,6 +56,49 @@ interface MinidumpReport {
 
 app.get("/health", (c) => c.json({ ok: true, service: "multi-parser" }));
 
+// Delta/differential update patch generation (task #246). Multipart body with
+// two file fields `old` and `new` (both APKs); returns the archive-patcher
+// file-by-file patch bytes that upgrade old → new. The worker orchestrates
+// (fetches the APKs from R2, uploads the patch as a delta-patch asset).
+app.post("/generate-patch", async (c) => {
+  let form: FormData;
+  try {
+    form = await c.req.formData();
+  } catch {
+    return c.json({ error: "expected multipart/form-data with old + new files" }, 400);
+  }
+  const oldFile = form.get("old");
+  const newFile = form.get("new");
+  if (!(oldFile instanceof File) || !(newFile instanceof File)) {
+    return c.json({ error: "old and new file fields are required" }, 400);
+  }
+  const dir = join(tmpdir(), `patchgen-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(dir, { recursive: true });
+  const oldPath = join(dir, "old.apk");
+  const newPath = join(dir, "new.apk");
+  const outPath = join(dir, "out.patch");
+  try {
+    await writeFile(oldPath, Buffer.from(await oldFile.arrayBuffer()));
+    await writeFile(newPath, Buffer.from(await newFile.arrayBuffer()));
+    await execFileAsync(
+      "java",
+      ["-cp", "/opt/patchgen/archive-patcher.jar:/opt/patchgen", "PatchGen", oldPath, newPath, outPath],
+      { maxBuffer: 16 * 1024 * 1024, timeout: 120_000 },
+    );
+    const patch = await readFile(outPath);
+    return new Response(patch, {
+      headers: {
+        "content-type": "application/octet-stream",
+        "content-length": String(patch.length),
+      },
+    });
+  } catch (err) {
+    return c.json({ error: `patch generation failed: ${String(err)}` }, 500);
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 /**
  * POST /retrace — body = { mapping, trace }. Deobfuscates an R8/ProGuard
  * stack trace against the given mapping using the Android SDK retrace tool.

--- a/migrations/sql/0037_app_delta_updates.sql
+++ b/migrations/sql/0037_app_delta_updates.sql
@@ -1,0 +1,5 @@
+-- Per-app toggle for automatic Android delta/differential update generation
+-- (task #246). When enabled, publishing a release generates archive-patcher
+-- patches from the last N published versions to the new one. Default off; this
+-- flag is also the gate for making delta updates a paid feature.
+ALTER TABLE apps ADD COLUMN delta_updates_enabled INTEGER NOT NULL DEFAULT 0;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -92,6 +92,7 @@ import {
   handleTestflightUpload,
   handleTestflightUploadStatus,
 } from "./routes/testflight";
+import { handleGenerateDeltaPatches } from "./routes/delta";
 import { handleUploadApk } from "./routes/upload";
 import {
   handleListOperations,
@@ -782,6 +783,11 @@ admin.post("/api/apps/:appId/builds/:buildId/testflight-upload", requireAppRole(
 admin.get("/api/apps/:appId/testflight-uploads/:buildUploadId", requireAppRole("viewer"), handleTestflightUploadStatus);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
+admin.post(
+  "/api/apps/:appId/builds/:buildId/generate-delta-patches",
+  requireAppRole("publisher"),
+  handleGenerateDeltaPatches,
+);
 
 app.route("/", admin);
 

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -243,7 +243,8 @@ export async function handleGetApp(c: Context<{ Bindings: Env }>) {
   const appId = c.req.param("appId") ?? "";
   const row = await c.env.DB.prepare(
     `SELECT a.id, a.org_id, a.slug, a.name, a.platform, a.description,
-            a.archived, a.archived_at, a.created_at,
+            a.archived, a.archived_at, a.created_at, a.public_history,
+            a.delta_updates_enabled,
             a.default_channel_id,
             ch.slug AS default_channel_slug,
             ch.name AS default_channel_name
@@ -260,6 +261,8 @@ export async function handleGetApp(c: Context<{ Bindings: Env }>) {
     archived: number;
     archived_at: number | null;
     created_at: number;
+    public_history: number;
+    delta_updates_enabled: number;
     default_channel_id: string | null;
     default_channel_slug: string | null;
     default_channel_name: string | null;
@@ -275,6 +278,7 @@ export async function handleUpdateApp(c: AdminContext) {
     description?: string | null;
     default_channel_id?: string | null;
     public_history?: boolean;
+    delta_updates_enabled?: boolean;
   };
   // Confirm app exists.
   const existing = await c.env.DB.prepare(
@@ -298,6 +302,10 @@ export async function handleUpdateApp(c: AdminContext) {
   if (body.public_history !== undefined) {
     updates.push("public_history = ?");
     binds.push(body.public_history ? 1 : 0);
+  }
+  if (body.delta_updates_enabled !== undefined) {
+    updates.push("delta_updates_enabled = ?");
+    binds.push(body.delta_updates_enabled ? 1 : 0);
   }
   if (body.default_channel_id !== undefined) {
     if (body.default_channel_id === null) {

--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -1,0 +1,192 @@
+/**
+ * Delta/differential update patch generation (task #246, P1b — server side).
+ *
+ * POST /api/apps/:appId/builds/:buildId/generate-delta-patches
+ *   For the target build's installable APK, generate archive-patcher
+ *   file-by-file patches from the last N published versions (same arch) and
+ *   store each as a `delta-patch` asset. Runs the generator in the container
+ *   (JVM); the update-check endpoint then offers a patch when one applies and
+ *   beats the full-APK size. Idempotent: existing patches for a from-version
+ *   are replaced.
+ */
+import type { Context } from "hono";
+import { getRandom } from "@cloudflare/containers";
+import type { AdminEnv } from "../middleware/auth";
+import { currentActor } from "../middleware/auth";
+import { createOperation, updateOperation } from "./operations";
+import { insertAuditLog } from "../lib/permissions";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+const DEFAULT_KEEP_VERSIONS = 3;
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+interface ApkAssetRow {
+  build_id: string;
+  version_code: number;
+  arch: string | null;
+  r2_key: string;
+  file_hash: string;
+  size_bytes: number;
+}
+
+export async function handleGenerateDeltaPatches(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const buildIdParam = c.req.param("buildId") ?? "";
+  const keepRaw = Number(c.req.query("versions"));
+  const keep = Number.isFinite(keepRaw) && keepRaw > 0 ? Math.min(keepRaw, 10) : DEFAULT_KEEP_VERSIONS;
+
+  const target = await c.env.DB.prepare(
+    `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
+     FROM build_assets ba
+     JOIN builds b ON b.id = ba.build_id
+     WHERE b.app_id = ?1 AND ba.build_id LIKE ?2 || '%'
+       AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
+     LIMIT 2`,
+  )
+    .bind(appId, buildIdParam)
+    .all<ApkAssetRow>();
+  if (!target.results || target.results.length !== 1) {
+    return c.json({ error: "target build not found or ambiguous, or has no installable APK" }, 404);
+  }
+  const newApk = target.results[0]!;
+
+  // Prior published versions with an installable APK for the same arch,
+  // strictly older than the target, most recent first.
+  const priors = await c.env.DB.prepare(
+    `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
+     FROM build_assets ba
+     JOIN builds b ON b.id = ba.build_id
+     JOIN releases r ON r.build_id = b.id
+     WHERE b.app_id = ?1 AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
+       AND (ba.arch IS ?2 OR ba.arch = ?2)
+       AND b.version_code < ?3
+       AND r.status IN ('active', 'superseded')
+     GROUP BY b.version_code
+     ORDER BY b.version_code DESC
+     LIMIT ?4`,
+  )
+    .bind(appId, newApk.arch, newApk.version_code, keep)
+    .all<ApkAssetRow>();
+
+  const op = await createOperation(c.env.DB, {
+    app_id: appId,
+    kind: "delta-generate",
+    actor: currentActor(c),
+    input: JSON.stringify({
+      build_id: newApk.build_id,
+      to_version_code: newApk.version_code,
+      arch: newApk.arch,
+      prior_versions: (priors.results ?? []).map((p) => p.version_code),
+    }),
+  });
+  await insertAuditLog(c.env.DB, c, {
+    app_id: appId,
+    action: "delta.generate",
+    payload: { build_id: newApk.build_id, to_version_code: newApk.version_code },
+  });
+
+  const results: Array<{ from_version_code: number; status: string; size_bytes?: number; ratio?: number }> = [];
+  try {
+    const newObj = await c.env.APK_BUCKET.get(newApk.r2_key);
+    if (!newObj) throw new Error(`new APK missing from storage (${newApk.r2_key})`);
+    const newBytes = await newObj.arrayBuffer();
+
+    let done = 0;
+    for (const prior of priors.results ?? []) {
+      const oldObj = await c.env.APK_BUCKET.get(prior.r2_key);
+      if (!oldObj) {
+        results.push({ from_version_code: prior.version_code, status: "skip:old-apk-missing" });
+        continue;
+      }
+      const oldBytes = await oldObj.arrayBuffer();
+
+      const form = new FormData();
+      form.append("old", new Blob([oldBytes]), "old.apk");
+      form.append("new", new Blob([newBytes]), "new.apk");
+      const container = await getRandom(c.env.APK_PARSER, 1);
+      const res = await container.fetch(
+        new Request("http://container/generate-patch", { method: "POST", body: form }),
+      );
+      if (!res.ok) {
+        results.push({ from_version_code: prior.version_code, status: `fail:container-${res.status}` });
+        continue;
+      }
+      const patchBytes = await res.arrayBuffer();
+      const ratio = patchBytes.byteLength / newApk.size_bytes;
+      // Store even if not currently a win — the update-check threshold decides
+      // whether to offer it; but skip absurdly large patches (>= full APK).
+      if (patchBytes.byteLength >= newApk.size_bytes) {
+        results.push({ from_version_code: prior.version_code, status: "skip:not-smaller", ratio });
+        continue;
+      }
+
+      const patchKey = `delta/${appId}/${newApk.version_code}/from-${prior.version_code}-${newApk.arch ?? "any"}.patch`;
+      await c.env.APK_BUCKET.put(patchKey, patchBytes);
+      const patchHash = await sha256Hex(patchBytes);
+
+      // Replace any existing patch for this (build, from-version, arch).
+      await c.env.DB.prepare(
+        `DELETE FROM build_assets
+         WHERE build_id = ?1 AND artifact_kind = 'delta-patch'
+           AND CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) = ?2
+           AND (arch IS ?3 OR arch = ?3)`,
+      )
+        .bind(newApk.build_id, prior.version_code, newApk.arch)
+        .run();
+      await c.env.DB.prepare(
+        `INSERT INTO build_assets
+         (id, build_id, artifact_kind, platform, arch, variant, filetype, r2_key, file_hash,
+          size_bytes, signature, signing_credential_id, metadata_json, download_count, created_at)
+         VALUES (?1, ?2, 'delta-patch', 'android', ?3, NULL, 'patch', ?4, ?5, ?6, NULL, NULL, ?7, 0, ?8)`,
+      )
+        .bind(
+          crypto.randomUUID(),
+          newApk.build_id,
+          newApk.arch,
+          patchKey,
+          patchHash,
+          patchBytes.byteLength,
+          JSON.stringify({
+            from_version_code: prior.version_code,
+            to_version_code: newApk.version_code,
+            // Patch is a gzipped archive-patcher file-by-file bsdiff stream; the
+            // applier must gunzip before FileByFileV1DeltaApplier.applyDelta.
+            algorithm: "archive-patcher-v1+gzip",
+            target_sha256: newApk.file_hash,
+          }),
+          Date.now(),
+        )
+        .run();
+
+      done += 1;
+      results.push({ from_version_code: prior.version_code, status: "ok", size_bytes: patchBytes.byteLength, ratio });
+      await updateOperation(c.env.DB, op.id, {
+        status: "in_progress",
+        progress: done / Math.max(1, (priors.results ?? []).length),
+        output: JSON.stringify({ results }),
+      });
+    }
+
+    await updateOperation(c.env.DB, op.id, {
+      status: "success",
+      progress: 1,
+      output: JSON.stringify({ results }),
+      completed_at: Date.now(),
+    });
+    return c.json({ operation_id: op.id, to_version_code: newApk.version_code, arch: newApk.arch, results });
+  } catch (e) {
+    await updateOperation(c.env.DB, op.id, {
+      status: "failed",
+      error: e instanceof Error ? e.message : String(e),
+      completed_at: Date.now(),
+    });
+    return c.json({ operation_id: op.id, error: e instanceof Error ? e.message : String(e) }, 500);
+  }
+}

--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -1,13 +1,15 @@
 /**
  * Delta/differential update patch generation (task #246, P1b — server side).
  *
- * POST /api/apps/:appId/builds/:buildId/generate-delta-patches
- *   For the target build's installable APK, generate archive-patcher
- *   file-by-file patches from the last N published versions (same arch) and
- *   store each as a `delta-patch` asset. Runs the generator in the container
- *   (JVM); the update-check endpoint then offers a patch when one applies and
- *   beats the full-APK size. Idempotent: existing patches for a from-version
- *   are replaced.
+ * The primary path is automatic: when a release is published AND the app has
+ * `delta_updates_enabled`, `generateDeltaPatchesForBuild` runs in the background
+ * (see releases.ts) and stores archive-patcher file-by-file patches from the
+ * last N published versions to the new one. The update-check endpoint then
+ * offers a patch when one applies and beats the full-APK size.
+ *
+ * The admin endpoint below is a manual backfill/retry tool (e.g. right after
+ * the toggle is switched on, to generate patches for existing history).
+ * Idempotent: existing patches for a from-version are replaced.
  */
 import type { Context } from "hono";
 import { getRandom } from "@cloudflare/containers";
@@ -36,13 +38,36 @@ interface ApkAssetRow {
   size_bytes: number;
 }
 
-export async function handleGenerateDeltaPatches(c: AdminContext) {
-  const appId = c.req.param("appId") ?? "";
-  const buildIdParam = c.req.param("buildId") ?? "";
-  const keepRaw = Number(c.req.query("versions"));
-  const keep = Number.isFinite(keepRaw) && keepRaw > 0 ? Math.min(keepRaw, 10) : DEFAULT_KEEP_VERSIONS;
+export interface DeltaPatchResult {
+  from_version_code: number;
+  status: string;
+  size_bytes?: number;
+  ratio?: number;
+}
 
-  const target = await c.env.DB.prepare(
+export interface GenerateDeltaOutcome {
+  operation_id: string;
+  to_version_code: number | null;
+  arch: string | null;
+  results: DeltaPatchResult[];
+  error?: string;
+}
+
+/**
+ * Context-free core: generate + store delta patches for a build's installable
+ * APK from the last `keep` published versions (same arch). Safe to call from a
+ * background `waitUntil` (auto path) or from the admin endpoint. Never throws —
+ * failures are recorded on the operation and returned in the outcome.
+ */
+export async function generateDeltaPatchesForBuild(
+  env: Env,
+  params: { appId: string; buildId: string; actor: string; keep?: number | undefined },
+): Promise<GenerateDeltaOutcome> {
+  const { appId, buildId, actor } = params;
+  const keep =
+    params.keep && params.keep > 0 ? Math.min(params.keep, 10) : DEFAULT_KEEP_VERSIONS;
+
+  const target = await env.DB.prepare(
     `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
      FROM build_assets ba
      JOIN builds b ON b.id = ba.build_id
@@ -50,16 +75,30 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
        AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
      LIMIT 2`,
   )
-    .bind(appId, buildIdParam)
+    .bind(appId, buildId)
     .all<ApkAssetRow>();
+
+  const op = await createOperation(env.DB, {
+    app_id: appId,
+    kind: "delta-generate",
+    actor,
+    input: JSON.stringify({ build_id: buildId, keep }),
+  });
+
   if (!target.results || target.results.length !== 1) {
-    return c.json({ error: "target build not found or ambiguous, or has no installable APK" }, 404);
+    const error = "target build not found or ambiguous, or has no installable APK";
+    await updateOperation(env.DB, op.id, {
+      status: "failed",
+      error,
+      completed_at: Date.now(),
+    });
+    return { operation_id: op.id, to_version_code: null, arch: null, results: [], error };
   }
   const newApk = target.results[0]!;
 
   // Prior published versions with an installable APK for the same arch,
   // strictly older than the target, most recent first.
-  const priors = await c.env.DB.prepare(
+  const priors = await env.DB.prepare(
     `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
      FROM build_assets ba
      JOIN builds b ON b.id = ba.build_id
@@ -75,32 +114,24 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
     .bind(appId, newApk.arch, newApk.version_code, keep)
     .all<ApkAssetRow>();
 
-  const op = await createOperation(c.env.DB, {
-    app_id: appId,
-    kind: "delta-generate",
-    actor: currentActor(c),
-    input: JSON.stringify({
-      build_id: newApk.build_id,
+  await updateOperation(env.DB, op.id, {
+    status: "in_progress",
+    output: JSON.stringify({
       to_version_code: newApk.version_code,
       arch: newApk.arch,
       prior_versions: (priors.results ?? []).map((p) => p.version_code),
     }),
   });
-  await insertAuditLog(c.env.DB, c, {
-    app_id: appId,
-    action: "delta.generate",
-    payload: { build_id: newApk.build_id, to_version_code: newApk.version_code },
-  });
 
-  const results: Array<{ from_version_code: number; status: string; size_bytes?: number; ratio?: number }> = [];
+  const results: DeltaPatchResult[] = [];
   try {
-    const newObj = await c.env.APK_BUCKET.get(newApk.r2_key);
+    const newObj = await env.APK_BUCKET.get(newApk.r2_key);
     if (!newObj) throw new Error(`new APK missing from storage (${newApk.r2_key})`);
     const newBytes = await newObj.arrayBuffer();
 
     let done = 0;
     for (const prior of priors.results ?? []) {
-      const oldObj = await c.env.APK_BUCKET.get(prior.r2_key);
+      const oldObj = await env.APK_BUCKET.get(prior.r2_key);
       if (!oldObj) {
         results.push({ from_version_code: prior.version_code, status: "skip:old-apk-missing" });
         continue;
@@ -110,7 +141,7 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
       const form = new FormData();
       form.append("old", new Blob([oldBytes]), "old.apk");
       form.append("new", new Blob([newBytes]), "new.apk");
-      const container = await getRandom(c.env.APK_PARSER, 1);
+      const container = await getRandom(env.APK_PARSER, 1);
       const res = await container.fetch(
         new Request("http://container/generate-patch", { method: "POST", body: form }),
       );
@@ -120,19 +151,19 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
       }
       const patchBytes = await res.arrayBuffer();
       const ratio = patchBytes.byteLength / newApk.size_bytes;
-      // Store even if not currently a win — the update-check threshold decides
-      // whether to offer it; but skip absurdly large patches (>= full APK).
+      // Patch is a gzipped bsdiff stream; the update-check threshold decides
+      // whether to offer it, but skip patches that don't even beat the full APK.
       if (patchBytes.byteLength >= newApk.size_bytes) {
         results.push({ from_version_code: prior.version_code, status: "skip:not-smaller", ratio });
         continue;
       }
 
       const patchKey = `delta/${appId}/${newApk.version_code}/from-${prior.version_code}-${newApk.arch ?? "any"}.patch`;
-      await c.env.APK_BUCKET.put(patchKey, patchBytes);
+      await env.APK_BUCKET.put(patchKey, patchBytes);
       const patchHash = await sha256Hex(patchBytes);
 
       // Replace any existing patch for this (build, from-version, arch).
-      await c.env.DB.prepare(
+      await env.DB.prepare(
         `DELETE FROM build_assets
          WHERE build_id = ?1 AND artifact_kind = 'delta-patch'
            AND CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) = ?2
@@ -140,7 +171,7 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
       )
         .bind(newApk.build_id, prior.version_code, newApk.arch)
         .run();
-      await c.env.DB.prepare(
+      await env.DB.prepare(
         `INSERT INTO build_assets
          (id, build_id, artifact_kind, platform, arch, variant, filetype, r2_key, file_hash,
           size_bytes, signature, signing_credential_id, metadata_json, download_count, created_at)
@@ -167,26 +198,48 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
 
       done += 1;
       results.push({ from_version_code: prior.version_code, status: "ok", size_bytes: patchBytes.byteLength, ratio });
-      await updateOperation(c.env.DB, op.id, {
+      await updateOperation(env.DB, op.id, {
         status: "in_progress",
         progress: done / Math.max(1, (priors.results ?? []).length),
-        output: JSON.stringify({ results }),
+        output: JSON.stringify({ to_version_code: newApk.version_code, arch: newApk.arch, results }),
       });
     }
 
-    await updateOperation(c.env.DB, op.id, {
+    await updateOperation(env.DB, op.id, {
       status: "success",
       progress: 1,
-      output: JSON.stringify({ results }),
+      output: JSON.stringify({ to_version_code: newApk.version_code, arch: newApk.arch, results }),
       completed_at: Date.now(),
     });
-    return c.json({ operation_id: op.id, to_version_code: newApk.version_code, arch: newApk.arch, results });
+    return { operation_id: op.id, to_version_code: newApk.version_code, arch: newApk.arch, results };
   } catch (e) {
-    await updateOperation(c.env.DB, op.id, {
-      status: "failed",
-      error: e instanceof Error ? e.message : String(e),
-      completed_at: Date.now(),
-    });
-    return c.json({ operation_id: op.id, error: e instanceof Error ? e.message : String(e) }, 500);
+    const error = e instanceof Error ? e.message : String(e);
+    await updateOperation(env.DB, op.id, { status: "failed", error, completed_at: Date.now() });
+    return { operation_id: op.id, to_version_code: newApk.version_code, arch: newApk.arch, results, error };
   }
+}
+
+/**
+ * POST /api/apps/:appId/builds/:buildId/generate-delta-patches — admin backfill/
+ * retry. The primary path is automatic on publish (see releases.ts); use this to
+ * (re)generate patches on demand, e.g. just after enabling the app toggle.
+ */
+export async function handleGenerateDeltaPatches(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const buildId = c.req.param("buildId") ?? "";
+  const keepRaw = Number(c.req.query("versions"));
+  const keep = Number.isFinite(keepRaw) && keepRaw > 0 ? keepRaw : undefined;
+
+  await insertAuditLog(c.env.DB, c, {
+    app_id: appId,
+    action: "delta.generate",
+    payload: { build_id: buildId, keep },
+  });
+  const outcome = await generateDeltaPatchesForBuild(c.env, {
+    appId,
+    buildId,
+    actor: currentActor(c),
+    keep,
+  });
+  return c.json(outcome, outcome.error && outcome.results.length === 0 ? 500 : 200);
 }

--- a/worker/src/routes/operations.ts
+++ b/worker/src/routes/operations.ts
@@ -19,7 +19,7 @@ export interface OperationLog {
   id: string;
   /** Nullable — parse operations are app-less (run before the user picks an app). */
   app_id: string | null;
-  kind: "parse" | "upload" | "publish" | "signed_url" | "testflight-upload";
+  kind: "parse" | "upload" | "publish" | "signed_url" | "testflight-upload" | "delta-generate";
   status: "pending" | "in_progress" | "success" | "failed" | "cancelled";
   parent_op_id: string | null;
   step_number: number | null;

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { emitWebhookEvent } from "./webhooks";
+import { generateDeltaPatchesForBuild } from "./delta";
 import { parseReleaseNotes, stringifyReleaseNotes, type ReleaseNotes } from "../lib/release_notes";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
@@ -531,6 +532,30 @@ export async function handlePublishRelease(c: AdminContext) {
       }),
     );
   }
+
+  // Auto-generate Android delta/differential update patches for this new build
+  // (task #246), gated by the per-app toggle. Runs in the background so it never
+  // slows or fails the publish; the toggle is also the future paid-feature gate.
+  const app = await c.env.DB.prepare(
+    "SELECT platform, delta_updates_enabled FROM apps WHERE id = ?1",
+  )
+    .bind(appId)
+    .first<{ platform: string; delta_updates_enabled: number }>();
+  if (app?.delta_updates_enabled && app.platform === "android") {
+    const actor = currentActor(c);
+    const buildId = existing.build_id;
+    c.executionCtx?.waitUntil(
+      generateDeltaPatchesForBuild(c.env, { appId, buildId, actor }).then(
+        (outcome) => {
+          if (outcome.error) {
+            console.error(`[delta] auto-generate failed for build ${buildId}: ${outcome.error}`);
+          }
+        },
+        (e) => console.error(`[delta] auto-generate threw for build ${buildId}: ${String(e)}`),
+      ),
+    );
+  }
+
   const published = await getReleaseForApp(c.env.DB, appId, releaseId);
   return c.json(published ? withReleaseNotes(published) : published);
 }


### PR DESCRIPTION
## What

Generate Android **delta/differential update patches at publish time inside the parser container** (JVM), per artin's direction: 就用 container，发版时生成补丁 (task #246 P1b).

## How

**Container**
- `Dockerfile`: JRE→JDK (for `javac`); fetch `com.eidu:archive-patcher:3.0.0` (single 170KB jar, no transitive deps, on Maven Central); compile the `PatchGen` wrapper with `-encoding UTF-8`.
- `patchgen/PatchGen.java`: thin CLI over `FileByFileV1DeltaGenerator`. The eidu fork's constructor takes a deflater factory `(level, nowrap) -> DefaultDeflater(...)`, **not** Google's no-arg constructor. Output is **gzip-wrapped**: the raw archive-patcher patch is ~full-APK size but mostly zeros (bsdiff over unchanged regions), so it only becomes small after compression.
- `src/server.ts`: `POST /generate-patch` — multipart `old`+`new` APKs → gzipped patch bytes.

**Worker**
- `routes/delta.ts`: `POST /api/apps/:appId/builds/:buildId/generate-delta-patches` (publisher role). Fetches the target installable APK + the last **N=3** prior published versions (same arch) from R2, calls the container per pair, and stores each result as a `delta-patch` build asset — metadata `{from_version_code, to_version_code, algorithm: "archive-patcher-v1+gzip", target_sha256}`. Skips any patch ≥ the full APK; progress tracked in `operation_logs`.
- `operations.ts`: add `delta-generate` op kind.

The already-merged `/updates/check` patch-offer logic (public_v2) consumes these `delta-patch` assets and offers a patch when it beats the full-APK size threshold.

## Validation (local, JDK 17, exact wrapper)

- **generate → gunzip → applyDelta round-trips byte-for-byte** to the target APK (sha256 identical).
- 40-byte change over a 600KB APK → **gzipped patch ≈ 760 bytes (0.0013× full)**.
- Confirmed the diviner only wins on JRE-`Deflater`-recognized streams (real Android build tooling); the size guard correctly skips no-win cases.
- `tsc --noEmit` clean on worker; container typechecks clean.

## Deploy note

⚠️ Container image change → deploy must use `containers_rollout: immediate` (not `none`). I'll verify the image builds (the `javac` + maven fetch steps) and smoke `/generate-patch` before/after rollout, and won't destabilize the existing APK-parse container.

## Follow-up (not in this PR)

P2: Android-side apply (`com.eidu:archive-patcher-android:2.0.1`) — must gunzip then `applyDelta` with the **same** deflater factory.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786278973&installation_id=145465820&pr_number=216&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F216&signature=a5dc8d123e21ccbc1e024cb874e079b89201fb91ad9bfa9ec21f9bfcca59e06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->