### PR TITLE
fix(admin): hide redundant apps nav in app scope

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -230,15 +230,17 @@ function Header({ account }: { account: AuthAccount }) {
         )}
       </div>
       <nav className="flex min-h-0 w-full flex-1 flex-col items-stretch gap-1 px-2">
-        <NavLink
-          to="/apps"
-          end
-          className={railItem}
-          title={collapsed ? "Apps" : undefined}
-        >
-          <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-          {!collapsed && <span className="hidden md:inline">Apps</span>}
-        </NavLink>
+        {!appId && (
+          <NavLink
+            to="/apps"
+            end
+            className={railItem}
+            title={collapsed ? "Apps" : undefined}
+          >
+            <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+            {!collapsed && <span className="hidden md:inline">Apps</span>}
+          </NavLink>
+        )}
         <div className="relative w-full">
           <button
             type="button"


### PR DESCRIPTION
Hide the global Apps row while an app is selected because the app switcher already provides All apps. Keep the row on the unscoped Apps screen.

Validation: admin typecheck, production build, diff check.

Follow-up to task #127.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786279207&installation_id=145465820&pr_number=217&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F217&signature=be1aed5ec4d390264e5a30f8fd6675e770a2e0c24f98d2d8e28598cc0db2f8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->