### PR TITLE
fix(delta): green main — dynamic container import + test schema

### DIFF
--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -12,7 +12,6 @@
  * Idempotent: existing patches for a from-version are replaced.
  */
 import type { Context } from "hono";
-import { getRandom } from "@cloudflare/containers";
 import type { AdminEnv } from "../middleware/auth";
 import { currentActor } from "../middleware/auth";
 import { createOperation, updateOperation } from "./operations";
@@ -141,6 +140,10 @@ export async function generateDeltaPatchesForBuild(
       const form = new FormData();
       form.append("old", new Blob([oldBytes]), "old.apk");
       form.append("new", new Blob([newBytes]), "new.apk");
+      // Dynamic import so this module carries no static @cloudflare/containers
+      // (cloudflare:workers) dependency — releases.ts imports this file, and a
+      // static container import would break the worker's vitest module graph.
+      const { getRandom } = await import("@cloudflare/containers");
       const container = await getRandom(env.APK_PARSER, 1);
       const res = await container.fetch(
         new Request("http://container/generate-patch", { method: "POST", body: form }),

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -95,7 +95,8 @@ function makeMockDb() {
     CREATE TABLE apps (
       id TEXT PRIMARY KEY, org_id TEXT, slug TEXT NOT NULL UNIQUE, name TEXT NOT NULL,
       platform TEXT NOT NULL, description TEXT, archived INTEGER NOT NULL DEFAULT 0,
-      archived_at INTEGER, created_at INTEGER NOT NULL, icon_r2_key TEXT, public_history INTEGER NOT NULL DEFAULT 0, client_key TEXT
+      archived_at INTEGER, created_at INTEGER NOT NULL, icon_r2_key TEXT, public_history INTEGER NOT NULL DEFAULT 0, client_key TEXT,
+      delta_updates_enabled INTEGER NOT NULL DEFAULT 0
     );
     CREATE TABLE channels (
       id TEXT PRIMARY KEY, app_id TEXT NOT NULL, slug TEXT NOT NULL,


### PR DESCRIPTION
## Why

PR #216 (delta generation) turned **main red**. `releases.ts` statically imports `delta.ts`, which statically imported `@cloudflare/containers` (`cloudflare:workers`). The worker's vitest module graph can't resolve `cloudflare:workers`, so 6 release/e2e tests failed at import time and the deploy's "Run checks" step aborted (nothing shipped).

## Fix

- **delta.ts**: import `getRandom` via `await import("@cloudflare/containers")` inside the generate loop, so the module has no static container dependency for importers (`releases.ts`) in the test graph. Runtime behaviour unchanged — `index.ts` already imports containers at the top level.
- **test/routes.test.ts**: add `delta_updates_enabled` to the in-memory `apps` schema (matches migration 0037), so `handlePublishRelease`'s new `SELECT platform, delta_updates_enabled` resolves.

## Verified

- All **98** worker tests pass.
- `worker` (tsc) + `admin` (vite) build clean.

Follow-up to #216; unblocks the Hands deploy (immediate container rollout).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786280084&installation_id=145465820&pr_number=218&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F218&signature=6952d9bc5ed3c70e5e6c4abce57859974238495c42119a532db5cf397e2b11c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->