### PR TITLE
fix(auth): session cookie on agent login (unblock raft integration)

### DIFF
--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -13,7 +13,14 @@
  */
 
 import type { Context, MiddlewareHandler } from "hono";
+import { getCookie } from "hono/cookie";
 import { loadDeployToken, sha256Hex, type AppDeployToken } from "../lib/deploy_tokens";
+
+// Session cookie carrying the Hands auth token. Set on the stateless agent-login
+// callback (routes/auth) so the raft CLI's Agent Login — which stores/replays a
+// Set-Cookie, not a JSON token — can authenticate; accepted here as a fallback
+// to Authorization: Bearer.
+export const SESSION_COOKIE = "hands_session";
 
 export const ACTIVE_ORG_HEADER = "x-hands-org-id";
 
@@ -155,9 +162,12 @@ export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
     const bearerToken = authHeader?.startsWith("Bearer ")
       ? authHeader.slice("Bearer ".length).trim()
       : undefined;
+    // Fall back to the session cookie (raft CLI Agent Login) when there is no
+    // Authorization: Bearer header. Bearer still takes precedence.
+    const sessionToken = bearerToken ?? getCookie(c, SESSION_COOKIE);
     const sessionAccount = await loadAccountFromAuthToken(
       c.env,
-      bearerToken,
+      sessionToken,
     );
     if (sessionAccount) {
       const account = await accountForRequestedOrg(

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -12,6 +12,7 @@ import {
   accountForRequestedOrg,
   ACTIVE_ORG_HEADER,
   loadAccountFromAuthToken,
+  SESSION_COOKIE,
   type AdminAccount,
 } from "../middleware/auth";
 import {
@@ -623,6 +624,17 @@ export async function handleRaftCallback(c: Context<{ Bindings: Env }>) {
       if (result.account.principal_type !== "agent") {
         return c.text("Missing local login state. Start again from /api/auth/login.", 400);
       }
+      // Stateless agent login (e.g. raft CLI `integration login`). The CLI stores
+      // and replays a Set-Cookie rather than the JSON token, so set the session
+      // cookie in addition to returning the token in the body.
+      setCookie(c, SESSION_COOKIE, result.authToken.token, {
+        httpOnly: true,
+        secure: secureCookie(c),
+        sameSite: "Lax",
+        ...sharedCookieDomainOption(c),
+        path: "/",
+        expires: new Date(result.authToken.expiresAt),
+      });
       c.header("cache-control", "no-store");
       return c.json(agentLoginJson(result));
     }
@@ -655,7 +667,7 @@ export async function handleAuthLogout(c: Context<{ Bindings: Env }>) {
   const bearerToken = authHeader?.startsWith("Bearer ")
     ? authHeader.slice("Bearer ".length).trim()
     : undefined;
-  const token = bearerToken;
+  const token = bearerToken ?? getCookie(c, SESSION_COOKIE);
   if (token) {
     const tokenHash = await sha256Hex(token);
     await c.env.DB.prepare(
@@ -664,6 +676,10 @@ export async function handleAuthLogout(c: Context<{ Bindings: Env }>) {
       .bind(now(), tokenHash)
       .run();
   }
+  deleteCookie(c, SESSION_COOKIE, {
+    ...sharedCookieDomainOption(c),
+    path: "/",
+  });
   return c.json({ ok: true });
 }
 


### PR DESCRIPTION
## Why

Hands moved to Bearer-only auth, but the raft CLI's Agent Login (`raft integration login`/`invoke`) stores and replays a **`Set-Cookie`**, not the JSON token Hands returns. So `integration login` failed with *"did not set a session cookie"* and every agent got 401 — this blocked all agent access to the Hands API (the delta prod smoke, and earlier Cindy's finalizer).

Per artin's decision: **option A** (B — the stateless-JSON contract — is undocumented and lives on the Raft platform side; docs say "contact Raft").

## Changes

- **routes/auth.ts**: the stateless agent-login callback branch now sets a `hands_session` cookie (httpOnly, Secure, SameSite=Lax, `domain=hands.build` in prod, expiring with the token) **in addition** to returning the token JSON. Browser SPA flow is untouched (still Bearer-in-hash).
- **middleware/auth.ts**: accept `hands_session` as a fallback when there's no `Authorization: Bearer` (Bearer still wins; deploy tokens stay Bearer-only). Exports `SESSION_COOKIE`.
- **logout**: also reads the token from the cookie and clears it.

## Verified

- `tsc` clean; **all 113 worker tests pass**.
- Post-merge/deploy I'll smoke `raft integration login`/`invoke --action list-apps` end-to-end, then run the delta functional smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786281663&installation_id=145465820&pr_number=221&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F221&signature=d63b54e75f50b16fdee27a3a8d404365839604765e98f8528db35a733b248284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->