### PR TITLE
fix(delta): async generation + timeout + operation breadcrumbs (diagnose the hang)

### DIFF
--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -2,24 +2,32 @@
  * Delta/differential update patch generation (task #246, P1b — server side).
  *
  * The primary path is automatic: when a release is published AND the app has
- * `delta_updates_enabled`, `generateDeltaPatchesForBuild` runs in the background
- * (see releases.ts) and stores archive-patcher file-by-file patches from the
- * last N published versions to the new one. The update-check endpoint then
- * offers a patch when one applies and beats the full-APK size.
+ * `delta_updates_enabled`, generation runs in the background (see releases.ts)
+ * and stores archive-patcher file-by-file patches from the last N published
+ * versions to the new one. The update-check endpoint then offers a patch when
+ * one applies and beats the full-APK size.
  *
- * The admin endpoint below is a manual backfill/retry tool (e.g. right after
- * the toggle is switched on, to generate patches for existing history).
- * Idempotent: existing patches for a from-version are replaced.
+ * Generation is ASYNC: the caller creates an operation, kicks the work off in
+ * the background (waitUntil), and returns the operation id immediately. Progress
+ * — including per-substep breadcrumbs and timings — is written to the operation
+ * so it doubles as a diagnostic log channel (we can't `wrangler tail` from every
+ * environment). Each container call is bounded by a timeout so a stuck call
+ * fails fast with a diagnostic instead of hanging the whole run.
+ *
+ * The admin endpoint below is a manual backfill/retry tool.
  */
 import type { Context } from "hono";
 import type { AdminEnv } from "../middleware/auth";
 import { currentActor } from "../middleware/auth";
-import { createOperation, updateOperation } from "./operations";
+import { createOperation, updateOperation, type OperationLog } from "./operations";
 import { insertAuditLog } from "../lib/permissions";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
 const DEFAULT_KEEP_VERSIONS = 3;
+// A single container generate-patch call must return within this budget;
+// includes container cold-start (Cloudflare containers cold-start ~1-2 min).
+const CONTAINER_TIMEOUT_MS = 180_000;
 
 async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", bytes);
@@ -42,6 +50,7 @@ export interface DeltaPatchResult {
   status: string;
   size_bytes?: number;
   ratio?: number;
+  ms?: number;
 }
 
 export interface GenerateDeltaOutcome {
@@ -52,112 +61,160 @@ export interface GenerateDeltaOutcome {
   error?: string;
 }
 
-/**
- * Context-free core: generate + store delta patches for a build's installable
- * APK from the last `keep` published versions (same arch). Safe to call from a
- * background `waitUntil` (auto path) or from the admin endpoint. Never throws —
- * failures are recorded on the operation and returned in the outcome.
- */
-export async function generateDeltaPatchesForBuild(
+export interface DeltaParams {
+  appId: string;
+  buildId: string;
+  actor: string;
+  keep?: number | undefined;
+}
+
+/** Create the delta-generate operation row (pending). Returns it so callers can
+ * surface the id immediately and run the work in the background. */
+export async function createDeltaGenerationOp(
   env: Env,
-  params: { appId: string; buildId: string; actor: string; keep?: number | undefined },
+  params: DeltaParams,
+): Promise<OperationLog> {
+  const keep =
+    params.keep && params.keep > 0 ? Math.min(params.keep, 10) : DEFAULT_KEEP_VERSIONS;
+  return createOperation(env.DB, {
+    app_id: params.appId,
+    kind: "delta-generate",
+    actor: params.actor,
+    input: JSON.stringify({ build_id: params.buildId, keep }),
+  });
+}
+
+/**
+ * Run the generation for an already-created operation. Never throws — records
+ * outcome + step breadcrumbs on the operation. Safe to call from waitUntil.
+ */
+export async function runDeltaGeneration(
+  env: Env,
+  op: OperationLog,
+  params: DeltaParams,
 ): Promise<GenerateDeltaOutcome> {
-  const { appId, buildId, actor } = params;
+  const { appId, buildId } = params;
   const keep =
     params.keep && params.keep > 0 ? Math.min(params.keep, 10) : DEFAULT_KEEP_VERSIONS;
 
-  const target = await env.DB.prepare(
-    `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
-     FROM build_assets ba
-     JOIN builds b ON b.id = ba.build_id
-     WHERE b.app_id = ?1 AND ba.build_id LIKE ?2 || '%'
-       AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
-     LIMIT 2`,
-  )
-    .bind(appId, buildId)
-    .all<ApkAssetRow>();
-
-  const op = await createOperation(env.DB, {
-    app_id: appId,
-    kind: "delta-generate",
-    actor,
-    input: JSON.stringify({ build_id: buildId, keep }),
-  });
-
-  if (!target.results || target.results.length !== 1) {
-    const error = "target build not found or ambiguous, or has no installable APK";
+  const t0 = Date.now();
+  const steps: string[] = [];
+  const results: DeltaPatchResult[] = [];
+  let meta: Record<string, unknown> = {};
+  // Push a timestamped breadcrumb and persist it so the operation is a live log.
+  const mark = async (
+    step: string,
+    patch?: Partial<Pick<OperationLog, "status" | "progress">>,
+  ) => {
+    steps.push(`+${Date.now() - t0}ms ${step}`);
     await updateOperation(env.DB, op.id, {
-      status: "failed",
-      error,
-      completed_at: Date.now(),
-    });
-    return { operation_id: op.id, to_version_code: null, arch: null, results: [], error };
-  }
-  const newApk = target.results[0]!;
+      ...(patch ?? {}),
+      output: JSON.stringify({ ...meta, steps, results }),
+    }).catch(() => {});
+  };
 
-  // Prior published versions with an installable APK for the same arch,
-  // strictly older than the target, most recent first.
-  const priors = await env.DB.prepare(
-    `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
-     FROM build_assets ba
-     JOIN builds b ON b.id = ba.build_id
-     JOIN releases r ON r.build_id = b.id
-     WHERE b.app_id = ?1 AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
-       AND (ba.arch IS ?2 OR ba.arch = ?2)
-       AND b.version_code < ?3
-       AND r.status IN ('active', 'superseded')
-     GROUP BY b.version_code
-     ORDER BY b.version_code DESC
-     LIMIT ?4`,
-  )
-    .bind(appId, newApk.arch, newApk.version_code, keep)
-    .all<ApkAssetRow>();
+  try {
+    const target = await env.DB.prepare(
+      `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
+       FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       WHERE b.app_id = ?1 AND ba.build_id LIKE ?2 || '%'
+         AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
+       LIMIT 2`,
+    )
+      .bind(appId, buildId)
+      .all<ApkAssetRow>();
+    if (!target.results || target.results.length !== 1) {
+      const error = "target build not found or ambiguous, or has no installable APK";
+      await updateOperation(env.DB, op.id, { status: "failed", error, completed_at: Date.now() });
+      return { operation_id: op.id, to_version_code: null, arch: null, results: [], error };
+    }
+    const newApk = target.results[0]!;
 
-  await updateOperation(env.DB, op.id, {
-    status: "in_progress",
-    output: JSON.stringify({
+    const priors = await env.DB.prepare(
+      `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
+       FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       JOIN releases r ON r.build_id = b.id
+       WHERE b.app_id = ?1 AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
+         AND (ba.arch IS ?2 OR ba.arch = ?2)
+         AND b.version_code < ?3
+         AND r.status IN ('active', 'superseded')
+       GROUP BY b.version_code
+       ORDER BY b.version_code DESC
+       LIMIT ?4`,
+    )
+      .bind(appId, newApk.arch, newApk.version_code, keep)
+      .all<ApkAssetRow>();
+    const priorRows = priors.results ?? [];
+    meta = {
       to_version_code: newApk.version_code,
       arch: newApk.arch,
-      prior_versions: (priors.results ?? []).map((p) => p.version_code),
-    }),
-  });
+      new_apk_bytes: newApk.size_bytes,
+      prior_versions: priorRows.map((p) => p.version_code),
+    };
+    await mark(`resolved target vc${newApk.version_code} + ${priorRows.length} priors`, {
+      status: "in_progress",
+    });
 
-  const results: DeltaPatchResult[] = [];
-  try {
+    const { getRandom } = await import("@cloudflare/containers");
+
     const newObj = await env.APK_BUCKET.get(newApk.r2_key);
     if (!newObj) throw new Error(`new APK missing from storage (${newApk.r2_key})`);
     const newBytes = await newObj.arrayBuffer();
+    await mark(`fetched new APK ${newBytes.byteLength}b from R2`);
 
     let done = 0;
-    for (const prior of priors.results ?? []) {
+    for (const prior of priorRows) {
       const oldObj = await env.APK_BUCKET.get(prior.r2_key);
       if (!oldObj) {
         results.push({ from_version_code: prior.version_code, status: "skip:old-apk-missing" });
+        await mark(`v${prior.version_code}: old APK missing`);
         continue;
       }
       const oldBytes = await oldObj.arrayBuffer();
+      await mark(`v${prior.version_code}: fetched old APK ${oldBytes.byteLength}b; calling container`);
 
       const form = new FormData();
       form.append("old", new Blob([oldBytes]), "old.apk");
       form.append("new", new Blob([newBytes]), "new.apk");
-      // Dynamic import so this module carries no static @cloudflare/containers
-      // (cloudflare:workers) dependency — releases.ts imports this file, and a
-      // static container import would break the worker's vitest module graph.
-      const { getRandom } = await import("@cloudflare/containers");
       const container = await getRandom(env.APK_PARSER, 1);
-      const res = await container.fetch(
-        new Request("http://container/generate-patch", { method: "POST", body: form }),
-      );
+
+      const callStart = Date.now();
+      const ac = new AbortController();
+      const timer = setTimeout(() => ac.abort(), CONTAINER_TIMEOUT_MS);
+      let res: Response;
+      try {
+        res = await container.fetch(
+          new Request("http://container/generate-patch", {
+            method: "POST",
+            body: form,
+            signal: ac.signal,
+          }),
+        );
+      } catch (err) {
+        clearTimeout(timer);
+        const ms = Date.now() - callStart;
+        const reason = ac.signal.aborted ? `timeout after ${CONTAINER_TIMEOUT_MS}ms` : String(err);
+        results.push({ from_version_code: prior.version_code, status: `fail:container-call (${reason})`, ms });
+        await mark(`v${prior.version_code}: container call FAILED in ${ms}ms — ${reason}`);
+        continue;
+      }
+      clearTimeout(timer);
+      const ms = Date.now() - callStart;
+
       if (!res.ok) {
-        results.push({ from_version_code: prior.version_code, status: `fail:container-${res.status}` });
+        const body = await res.text().catch(() => "");
+        results.push({ from_version_code: prior.version_code, status: `fail:container-${res.status}`, ms });
+        await mark(`v${prior.version_code}: container ${res.status} in ${ms}ms — ${body.slice(0, 200)}`);
         continue;
       }
       const patchBytes = await res.arrayBuffer();
       const ratio = patchBytes.byteLength / newApk.size_bytes;
-      // Patch is a gzipped bsdiff stream; the update-check threshold decides
-      // whether to offer it, but skip patches that don't even beat the full APK.
+      await mark(`v${prior.version_code}: container OK in ${ms}ms, patch ${patchBytes.byteLength}b (ratio ${ratio.toFixed(4)})`);
+
       if (patchBytes.byteLength >= newApk.size_bytes) {
-        results.push({ from_version_code: prior.version_code, status: "skip:not-smaller", ratio });
+        results.push({ from_version_code: prior.version_code, status: "skip:not-smaller", ratio, ms });
         continue;
       }
 
@@ -165,7 +222,6 @@ export async function generateDeltaPatchesForBuild(
       await env.APK_BUCKET.put(patchKey, patchBytes);
       const patchHash = await sha256Hex(patchBytes);
 
-      // Replace any existing patch for this (build, from-version, arch).
       await env.DB.prepare(
         `DELETE FROM build_assets
          WHERE build_id = ?1 AND artifact_kind = 'delta-patch'
@@ -190,8 +246,8 @@ export async function generateDeltaPatchesForBuild(
           JSON.stringify({
             from_version_code: prior.version_code,
             to_version_code: newApk.version_code,
-            // Patch is a gzipped archive-patcher file-by-file bsdiff stream; the
-            // applier must gunzip before FileByFileV1DeltaApplier.applyDelta.
+            // Gzipped archive-patcher file-by-file bsdiff stream; the applier
+            // must gunzip before FileByFileV1DeltaApplier.applyDelta.
             algorithm: "archive-patcher-v1+gzip",
             target_sha256: newApk.file_hash,
           }),
@@ -200,49 +256,67 @@ export async function generateDeltaPatchesForBuild(
         .run();
 
       done += 1;
-      results.push({ from_version_code: prior.version_code, status: "ok", size_bytes: patchBytes.byteLength, ratio });
-      await updateOperation(env.DB, op.id, {
-        status: "in_progress",
-        progress: done / Math.max(1, (priors.results ?? []).length),
-        output: JSON.stringify({ to_version_code: newApk.version_code, arch: newApk.arch, results }),
+      results.push({ from_version_code: prior.version_code, status: "ok", size_bytes: patchBytes.byteLength, ratio, ms });
+      await mark(`v${prior.version_code}: stored delta-patch`, {
+        progress: done / Math.max(1, priorRows.length),
       });
     }
 
     await updateOperation(env.DB, op.id, {
       status: "success",
       progress: 1,
-      output: JSON.stringify({ to_version_code: newApk.version_code, arch: newApk.arch, results }),
+      output: JSON.stringify({ ...meta, steps, results, total_ms: Date.now() - t0 }),
       completed_at: Date.now(),
     });
     return { operation_id: op.id, to_version_code: newApk.version_code, arch: newApk.arch, results };
   } catch (e) {
     const error = e instanceof Error ? e.message : String(e);
-    await updateOperation(env.DB, op.id, { status: "failed", error, completed_at: Date.now() });
-    return { operation_id: op.id, to_version_code: newApk.version_code, arch: newApk.arch, results, error };
+    await updateOperation(env.DB, op.id, {
+      status: "failed",
+      error,
+      output: JSON.stringify({ ...meta, steps, results, total_ms: Date.now() - t0 }),
+      completed_at: Date.now(),
+    });
+    return { operation_id: op.id, to_version_code: null, arch: null, results, error };
   }
 }
 
 /**
+ * Create the op and run generation to completion. Callers (e.g. the auto path in
+ * releases.ts) invoke this inside waitUntil and ignore the return value.
+ */
+export async function generateDeltaPatchesForBuild(
+  env: Env,
+  params: DeltaParams,
+): Promise<GenerateDeltaOutcome> {
+  const op = await createDeltaGenerationOp(env, params);
+  return runDeltaGeneration(env, op, params);
+}
+
+/**
  * POST /api/apps/:appId/builds/:buildId/generate-delta-patches — admin backfill/
- * retry. The primary path is automatic on publish (see releases.ts); use this to
- * (re)generate patches on demand, e.g. just after enabling the app toggle.
+ * retry. Async: creates the operation, runs generation in the background, and
+ * returns the operation id immediately (poll GET .../operations to watch it).
  */
 export async function handleGenerateDeltaPatches(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const buildId = c.req.param("buildId") ?? "";
   const keepRaw = Number(c.req.query("versions"));
   const keep = Number.isFinite(keepRaw) && keepRaw > 0 ? keepRaw : undefined;
+  const params: DeltaParams = { appId, buildId, actor: currentActor(c), keep };
 
   await insertAuditLog(c.env.DB, c, {
     app_id: appId,
     action: "delta.generate",
     payload: { build_id: buildId, keep },
   });
-  const outcome = await generateDeltaPatchesForBuild(c.env, {
-    appId,
-    buildId,
-    actor: currentActor(c),
-    keep,
-  });
-  return c.json(outcome, outcome.error && outcome.results.length === 0 ? 500 : 200);
+  const op = await createDeltaGenerationOp(c.env, params);
+  const run = runDeltaGeneration(c.env, op, params);
+  if (c.executionCtx?.waitUntil) {
+    c.executionCtx.waitUntil(run);
+  } else {
+    // No execution context (e.g. tests) — run inline so behaviour is defined.
+    await run;
+  }
+  return c.json({ operation_id: op.id, status: "started" }, 202);
 }


### PR DESCRIPTION
Follow-up to the delta smoke: the first container `generate-patch` call hung 5+ min on a real ~25MB APK and the operation froze at progress=0 with no visibility into where. This makes the path async + self-diagnosing so we can see exactly where it stalls (no `wrangler tail` available locally).

- Split into `createDeltaGenerationOp` + `runDeltaGeneration`; the manual endpoint returns the **operation id immediately (202)** and runs generation in `waitUntil` — no more hanging request.
- Write **timestamped step breadcrumbs + per-call timings** into the operation output (fetched new APK Nb → fetch old vX → calling container → container returned S in Nms → stored patch). The operation becomes the log channel.
- Bound each container call with an **AbortController timeout (180s)** — covers container cold-start (~1–2 min per moltworker) but fails fast with a diagnostic instead of hanging the whole run.

Auto path (releases.ts) unchanged. tsc clean; **113 worker tests pass**. Toggle still off by default.

After merge+deploy I'll re-trigger on raft-android 1.3.0 and read the operation breadcrumbs to pinpoint the stall.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786283250&installation_id=145465820&pr_number=222&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F222&signature=cb1856c26ce320d51bf9611a4e62c783fa9789dc0dcaf5efe406d186e2a3cb53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->