### PR TITLE
fix(delta): container fetches source APKs via signed URLs (not multipart)

### DIFF
--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -56,40 +56,54 @@ interface MinidumpReport {
 
 app.get("/health", (c) => c.json({ ok: true, service: "multi-parser" }));
 
-// Delta/differential update patch generation (task #246). Multipart body with
-// two file fields `old` and `new` (both APKs); returns the archive-patcher
-// file-by-file patch bytes that upgrade old → new. The worker orchestrates
-// (fetches the APKs from R2, uploads the patch as a delta-patch asset).
+// Delta/differential update patch generation (task #246). JSON body with two
+// signed URLs `old_url` and `new_url` (both APKs in R2); the container fetches
+// them itself and returns the archive-patcher file-by-file patch that upgrades
+// old → new. URLs (not a multipart body) keep the worker→container request tiny
+// — pushing tens of MB of APK bytes through container.fetch hangs.
 app.post("/generate-patch", async (c) => {
-  let form: FormData;
+  let body: { old_url?: string; new_url?: string };
   try {
-    form = await c.req.formData();
+    body = await c.req.json();
   } catch {
-    return c.json({ error: "expected multipart/form-data with old + new files" }, 400);
+    return c.json({ error: "expected JSON body with old_url + new_url" }, 400);
   }
-  const oldFile = form.get("old");
-  const newFile = form.get("new");
-  if (!(oldFile instanceof File) || !(newFile instanceof File)) {
-    return c.json({ error: "old and new file fields are required" }, 400);
+  const oldUrl = body.old_url;
+  const newUrl = body.new_url;
+  if (typeof oldUrl !== "string" || typeof newUrl !== "string") {
+    return c.json({ error: "old_url and new_url are required" }, 400);
   }
   const dir = join(tmpdir(), `patchgen-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   await mkdir(dir, { recursive: true });
   const oldPath = join(dir, "old.apk");
   const newPath = join(dir, "new.apk");
   const outPath = join(dir, "out.patch");
+  const fetchApk = async (url: string, dest: string): Promise<number> => {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`fetch ${dest} failed: HTTP ${res.status}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    await writeFile(dest, buf);
+    return buf.length;
+  };
   try {
-    await writeFile(oldPath, Buffer.from(await oldFile.arrayBuffer()));
-    await writeFile(newPath, Buffer.from(await newFile.arrayBuffer()));
+    const [oldLen, newLen] = await Promise.all([
+      fetchApk(oldUrl, oldPath),
+      fetchApk(newUrl, newPath),
+    ]);
     await execFileAsync(
       "java",
       ["-cp", "/opt/patchgen/archive-patcher.jar:/opt/patchgen", "PatchGen", oldPath, newPath, outPath],
-      { maxBuffer: 16 * 1024 * 1024, timeout: 120_000 },
+      { maxBuffer: 16 * 1024 * 1024, timeout: 180_000 },
     );
     const patch = await readFile(outPath);
     return new Response(patch, {
       headers: {
         "content-type": "application/octet-stream",
         "content-length": String(patch.length),
+        "x-old-bytes": String(oldLen),
+        "x-new-bytes": String(newLen),
       },
     });
   } catch (err) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from "./routes/public";
 import {
   handlePublicR2Download,
+  handleInternalR2Download,
   handlePublicV2Latest,
   handlePublicV2UpdateCheck,
 } from "./routes/public_v2";
@@ -490,6 +491,8 @@ app.get("/public/v2/apps/:slug/latest", handlePublicV2Latest);
 app.get("/public/v2/apps/:slug/updates/check", handlePublicV2UpdateCheck);
 app.get("/public/v2/apps/:slug/release-notes", handlePublicReleaseNotesJson);
 app.get("/public/r2/:key", handlePublicR2Download);
+// Internal signed R2 fetch (delta-patch container pulls source APKs by key).
+app.get("/internal/r2/:key", handleInternalR2Download);
 app.get("/electron/:slug/:channel/:file", handleElectronGenericAsset);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);

--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -21,6 +21,8 @@ import type { AdminEnv } from "../middleware/auth";
 import { currentActor } from "../middleware/auth";
 import { createOperation, updateOperation, type OperationLog } from "./operations";
 import { insertAuditLog } from "../lib/permissions";
+import { generateInternalR2Url } from "./public_v2";
+import { requestOrigin } from "../lib/origin";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -66,6 +68,8 @@ export interface DeltaParams {
   buildId: string;
   actor: string;
   keep?: number | undefined;
+  // Public origin the container uses to fetch source APKs (e.g. https://hands.build).
+  origin: string;
 }
 
 /** Create the delta-generate operation row (pending). Returns it so callers can
@@ -159,27 +163,19 @@ export async function runDeltaGeneration(
 
     const { getRandom } = await import("@cloudflare/containers");
 
-    const newObj = await env.APK_BUCKET.get(newApk.r2_key);
-    if (!newObj) throw new Error(`new APK missing from storage (${newApk.r2_key})`);
-    const newBytes = await newObj.arrayBuffer();
-    await mark(`fetched new APK ${newBytes.byteLength}b from R2`);
+    // The container fetches the APKs itself from these signed URLs — we never
+    // load APK bytes into Worker memory, and the request to the container stays
+    // tiny (two URLs) instead of pushing ~56MB of multipart (which hangs).
+    const URL_TTL_SECONDS = 1800;
+    const newUrl = await generateInternalR2Url(env, newApk.r2_key, URL_TTL_SECONDS, params.origin);
+    await mark(`minted signed URL for new APK`);
 
     let done = 0;
     for (const prior of priorRows) {
-      const oldObj = await env.APK_BUCKET.get(prior.r2_key);
-      if (!oldObj) {
-        results.push({ from_version_code: prior.version_code, status: "skip:old-apk-missing" });
-        await mark(`v${prior.version_code}: old APK missing`);
-        continue;
-      }
-      const oldBytes = await oldObj.arrayBuffer();
-      await mark(`v${prior.version_code}: fetched old APK ${oldBytes.byteLength}b; calling container`);
+      const oldUrl = await generateInternalR2Url(env, prior.r2_key, URL_TTL_SECONDS, params.origin);
+      await mark(`v${prior.version_code}: calling container (url mode)`);
 
-      const form = new FormData();
-      form.append("old", new Blob([oldBytes]), "old.apk");
-      form.append("new", new Blob([newBytes]), "new.apk");
       const container = await getRandom(env.APK_PARSER, 1);
-
       const callStart = Date.now();
       const ac = new AbortController();
       const timer = setTimeout(() => ac.abort(), CONTAINER_TIMEOUT_MS);
@@ -188,7 +184,8 @@ export async function runDeltaGeneration(
         res = await container.fetch(
           new Request("http://container/generate-patch", {
             method: "POST",
-            body: form,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ old_url: oldUrl, new_url: newUrl }),
             signal: ac.signal,
           }),
         );
@@ -303,7 +300,13 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
   const buildId = c.req.param("buildId") ?? "";
   const keepRaw = Number(c.req.query("versions"));
   const keep = Number.isFinite(keepRaw) && keepRaw > 0 ? keepRaw : undefined;
-  const params: DeltaParams = { appId, buildId, actor: currentActor(c), keep };
+  const params: DeltaParams = {
+    appId,
+    buildId,
+    actor: currentActor(c),
+    keep,
+    origin: requestOrigin(c),
+  };
 
   await insertAuditLog(c.env.DB, c, {
     app_id: appId,

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -807,6 +807,56 @@ export async function generateSignedR2Url(
   return origin ? new URL(path, origin).toString() : path;
 }
 
+const INTERNAL_DOWNLOAD_PREFIX = "/internal/r2";
+
+/**
+ * Sign an internal R2 fetch URL (same HMAC scheme as the public one, different
+ * path + no release-status gate). Used by the delta-patch container to fetch
+ * source APKs from R2 by key — the request body to the container stays tiny
+ * (two URLs) instead of pushing tens of MB of APK bytes through container.fetch.
+ */
+export async function generateInternalR2Url(
+  env: Env,
+  key: string,
+  ttlSeconds: number,
+  origin?: string,
+): Promise<string> {
+  const expires = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const sig = await signDownloadUrl(env, key, expires);
+  const path = `${INTERNAL_DOWNLOAD_PREFIX}/${encodeURIComponent(key)}?expires=${expires}&sig=${sig}`;
+  return origin ? new URL(path, origin).toString() : path;
+}
+
+/**
+ * Serve an R2 object by key given a valid HMAC signature. The signature (over
+ * key+expiry with SIGNED_URL_SECRET) is the authorization — only the Worker can
+ * mint one — so this serves any object regardless of release status, unlike the
+ * public download. Internal use: the delta-patch container fetches source APKs.
+ */
+export async function handleInternalR2Download(c: Context<{ Bindings: Env }>) {
+  const key = c.req.param("key");
+  const expires = Number(c.req.query("expires"));
+  const sig = c.req.query("sig") ?? "";
+  if (!key) return c.json({ error: "key required" }, 400);
+  if (!Number.isFinite(expires)) {
+    return c.json({ error: "expires must be a unix timestamp" }, 400);
+  }
+  if (expires < Math.floor(Date.now() / 1000)) {
+    return c.json({ error: "download URL expired" }, 403);
+  }
+  const expectedSig = await signDownloadUrl(c.env, key, expires);
+  if (!sig || !constantTimeEqual(sig, expectedSig)) {
+    return c.json({ error: "invalid download signature" }, 403);
+  }
+  const object = await c.env.APK_BUCKET.get(key);
+  if (!object) return c.json({ error: "object not found" }, 404);
+  const headers = new Headers();
+  headers.set("content-type", "application/octet-stream");
+  headers.set("content-length", String(object.size));
+  headers.set("cache-control", "private, max-age=0, no-store");
+  return new Response(object.body, { headers });
+}
+
 function publicRequestOrigin(c: Context<{ Bindings: Env }>): string {
   return requestOrigin(c);
 }

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { emitWebhookEvent } from "./webhooks";
 import { generateDeltaPatchesForBuild } from "./delta";
+import { requestOrigin } from "../lib/origin";
 import { parseReleaseNotes, stringifyReleaseNotes, type ReleaseNotes } from "../lib/release_notes";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
@@ -544,8 +545,9 @@ export async function handlePublishRelease(c: AdminContext) {
   if (app?.delta_updates_enabled && app.platform === "android") {
     const actor = currentActor(c);
     const buildId = existing.build_id;
+    const origin = requestOrigin(c);
     c.executionCtx?.waitUntil(
-      generateDeltaPatchesForBuild(c.env, { appId, buildId, actor }).then(
+      generateDeltaPatchesForBuild(c.env, { appId, buildId, actor, origin }).then(
         (outcome) => {
           if (outcome.error) {
             console.error(`[delta] auto-generate failed for build ${buildId}: ${outcome.error}`);


### PR DESCRIPTION
## Root cause (from the operation breadcrumbs)

The delta hang was **not** R2 or Worker memory — the breadcrumbs proved both 28MB APKs were fetched from R2 in ~1.8s. The run froze **entirely inside `container.fetch("/generate-patch")`**, which never returned (even the 180s timeout didn't fire). `/parse` works with a ~28MB *raw* body, but `/generate-patch` pushed **~56MB as multipart** (two APKs) — that never reached the container.

## Fix — stop pushing APK bytes through `container.fetch`

- **New internal signed endpoint** `GET /internal/r2/:key` (`generateInternalR2Url` + `handleInternalR2Download` in public_v2): same HMAC scheme as the public download but **no release-status gate**, so it serves any source APK by key (incl. superseded priors). The signature (`SIGNED_URL_SECRET`) is the authorization — only the Worker can mint one.
- **container `/generate-patch`**: now takes JSON `{old_url, new_url}`, fetches both APKs itself (in parallel), runs PatchGen, returns the gzipped patch. Tiny request body.
- **delta.ts**: mint two signed internal URLs per pair, POST them as JSON — the Worker no longer loads any APK bytes into memory. `DeltaParams` gains `origin`; manual + auto paths pass it.

## Verified

- `tsc` clean (worker + container); **all 113 worker tests pass**.

⚠️ Container image change → deploy with `containers_rollout=immediate`. After deploy I'll re-run the raft-android 1.3.0 smoke and read the breadcrumbs to confirm the container now returns with real patch sizes/timings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786284265&installation_id=145465820&pr_number=223&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F223&signature=7ddefb4632c0dc24ce52289bbf18f88e511dfa69396b0939a695e1f0bb37b7ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->