### PR TITLE
fix(delta): container fetch timeout + diagnostic

### DIFF
--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -78,14 +78,34 @@ app.post("/generate-patch", async (c) => {
   const oldPath = join(dir, "old.apk");
   const newPath = join(dir, "new.apk");
   const outPath = join(dir, "out.patch");
+  // Fetch with a timeout so a stuck/blocked egress fails fast with a diagnostic
+  // (which URL, timeout vs error) instead of hanging the whole request — the
+  // container reaching back to hands.build is the current unknown.
   const fetchApk = async (url: string, dest: string): Promise<number> => {
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`fetch ${dest} failed: HTTP ${res.status}`);
+    const started = Date.now();
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), 60_000);
+    try {
+      const res = await fetch(url, { signal: ac.signal });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const buf = Buffer.from(await res.arrayBuffer());
+      await writeFile(dest, buf);
+      return buf.length;
+    } catch (e) {
+      const why = ac.signal.aborted ? "timeout 60s" : String(e);
+      const host = (() => {
+        try {
+          return new URL(url).host;
+        } catch {
+          return "?";
+        }
+      })();
+      throw new Error(`fetch ${dest} from ${host} failed after ${Date.now() - started}ms: ${why}`);
+    } finally {
+      clearTimeout(timer);
     }
-    const buf = Buffer.from(await res.arrayBuffer());
-    await writeFile(dest, buf);
-    return buf.length;
   };
   try {
     const [oldLen, newLen] = await Promise.all([


### PR DESCRIPTION
Self-diagnosing step (per artin: iterate via CI, no CF token needed). The URL-fetch image still hangs at the container call; the open question is whether the container can reach back to hands.build. This wraps the container's `fetch(signed_url)` in a 60s AbortController timeout and, on failure, throws a diagnostic naming the host + elapsed ms + timeout-vs-error. Instead of hanging forever, the container returns 500 with e.g. "fetch old.apk from hands.build failed after 60000ms: timeout 60s", which the worker records as an operation breadcrumb — telling us definitively whether egress/loopback is the cause. Container change → `containers_rollout=immediate`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786286833&installation_id=145465820&pr_number=224&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F224&signature=7a4c1594647d04f9d62b3f42495b1478d3ee73d65300170bbeb347109881d51f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->