### PR TITLE
fix(delta): container standard-1 + synchronous manual generation

### DIFF
--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -313,13 +313,13 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
     action: "delta.generate",
     payload: { build_id: buildId, keep },
   });
+  // Run synchronously within the request: a waitUntil background task is
+  // cancelled ~seconds after the response ("waitUntil() tasks did not complete
+  // within the allowed time"), which killed the wait on the container before it
+  // finished. Container-backed subrequests keep this invocation alive while the
+  // patch is generated. (The auto-on-publish path in releases.ts still uses
+  // waitUntil and will need a Queue for production — see note there.)
   const op = await createDeltaGenerationOp(c.env, params);
-  const run = runDeltaGeneration(c.env, op, params);
-  if (c.executionCtx?.waitUntil) {
-    c.executionCtx.waitUntil(run);
-  } else {
-    // No execution context (e.g. tests) — run inline so behaviour is defined.
-    await run;
-  }
-  return c.json({ operation_id: op.id, status: "started" }, 202);
+  const outcome = await runDeltaGeneration(c.env, op, params);
+  return c.json(outcome, outcome.error && outcome.results.length === 0 ? 500 : 200);
 }

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -537,6 +537,10 @@ export async function handlePublishRelease(c: AdminContext) {
   // Auto-generate Android delta/differential update patches for this new build
   // (task #246), gated by the per-app toggle. Runs in the background so it never
   // slows or fails the publish; the toggle is also the future paid-feature gate.
+  // NOTE: waitUntil is cancelled ~seconds after the response, so for real (large)
+  // APKs this won't finish — before enabling the toggle in production, move this
+  // to a Cloudflare Queue (enqueue here, generate in the consumer). The manual
+  // endpoint runs synchronously and is unaffected.
   const app = await c.env.DB.prepare(
     "SELECT platform, delta_updates_enabled FROM apps WHERE id = ?1",
   )

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -32,7 +32,10 @@
     {
       "class_name": "ApkParserContainer",
       "image": "../container/Dockerfile",
-      "max_instances": 3
+      "max_instances": 3,
+      // Default (dev) is 256 MiB / (1/16) vCPU — too small for the JVM
+      // file-by-file bsdiff over ~28MB APKs (delta generation, task #246).
+      "instance_type": "standard-1"
     }
   ],
 


### PR DESCRIPTION
Root cause fully confirmed via `wrangler tail` (artin's CF logs):
- The container **successfully fetched both APKs** from hands.build (`GET /internal/r2 … Ok` ×2) — loopback/egress is fine, **no R2 S3 creds needed**.
- The killer: `waitUntil() tasks did not complete within the allowed time … cancelled` → the worker's wait on the container was `Canceled` ~3s after the 202 response.
- Plus the container was **undersized**: no `instance_type` = default `dev` (256 MiB / 1/16 vCPU), too small for JVM bsdiff over ~28MB APKs.

Fixes:
- `wrangler.hands.jsonc`: container `instance_type: "standard-1"` (4 GiB / more vCPU).
- `delta.ts`: manual endpoint runs generation **synchronously within the request** (container-backed subrequests keep the invocation alive) instead of a cancellable `waitUntil`.
- `releases.ts`: noted the auto-on-publish path still uses `waitUntil` and must move to a Cloudflare Queue before the toggle is enabled in production.

`tsc` clean; **113 worker tests pass**. Container config change → deploy `immediate`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288219&installation_id=145465820&pr_number=225&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F225&signature=76b1cc6aa3f631ee3f7582d6d32dfeccfe645c2835bb0364b889f61c050dd6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->