### PR TITLE
feat(delta): generate Android delta patches in CI (not the container)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "dist",
+    "patchgen",
     "README.md"
   ],
   "scripts": {

--- a/packages/cli/patchgen/PatchGen.java
+++ b/packages/cli/patchgen/PatchGen.java
@@ -1,0 +1,48 @@
+import com.google.archivepatcher.generator.FileByFileV1DeltaGenerator;
+import com.google.archivepatcher.generator.RecommendationModifier;
+import com.google.archivepatcher.shared.DefaultDeflater;
+import com.google.archivepatcher.shared.IDeflater;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.function.BiFunction;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Minimal CLI wrapper around archive-patcher's file-by-file delta generator
+ * (com.eidu:archive-patcher, a maintained fork of Google's Play-Store engine).
+ * Produces a patch that upgrades OLD.apk to NEW.apk:
+ *
+ *   java -cp archive-patcher.jar:. PatchGen OLD.apk NEW.apk OUT.patch
+ *
+ * NOTE 1: the eidu fork's constructor differs from Google's original -- it takes
+ * a pluggable deflater factory (level, nowrap) -> IDeflater (so callers can
+ * match a platform's exact zlib), not a no-arg constructor. The applier side
+ * (Android, P2) needs the SAME factory. DefaultDeflater wraps java.util.zip.
+ *
+ * NOTE 2: the RAW archive-patcher patch is a bsdiff stream that is mostly zeros
+ * for unchanged regions -- it is nearly the full APK size on disk but is highly
+ * compressible (a 40-byte change over a 600KB APK: 600KB raw -> ~760B gzipped).
+ * So we GZIP the patch here; the stored artifact and the < full-APK size guard
+ * must both use this compressed form, and the applier (P2) must GUNZIP before
+ * FileByFileV1DeltaApplier.applyDelta. algorithm id: archive-patcher-v1+gzip.
+ */
+public final class PatchGen {
+  static final BiFunction<Integer, Boolean, IDeflater> DEFLATER_FACTORY =
+      (level, nowrap) -> new DefaultDeflater(level, nowrap);
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 3) {
+      System.err.println("usage: PatchGen <old.apk> <new.apk> <out.patch.gz>");
+      System.exit(2);
+    }
+    File oldFile = new File(args[0]);
+    File newFile = new File(args[1]);
+    try (OutputStream out =
+        new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(args[2])))) {
+      new FileByFileV1DeltaGenerator(DEFLATER_FACTORY, new RecommendationModifier[0])
+          .generateDelta(oldFile, newFile, out);
+    }
+  }
+}

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -6,8 +6,15 @@
 
 import type { Command } from "commander";
 import { existsSync, readFileSync } from "node:fs";
-import { basename, extname } from "node:path";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { apiRequest, apiUploadFile } from "../lib/api.js";
+
+const execFileAsync = promisify(execFile);
 
 interface BuildRow {
   id: string;
@@ -168,6 +175,10 @@ export function registerBuildCommands(program: Command): void {
       [],
     )
     .option(
+      "--generate-deltas <N>",
+      "After uploading, generate + upload archive-patcher delta patches from the last N published versions (needs a JDK on PATH — CI has one). Clients on those versions download the small patch instead of the full APK.",
+    )
+    .option(
       "--changelog <text>",
       "Inline changelog. Repeatable with lang=text for multiple languages.",
       collect,
@@ -204,6 +215,7 @@ export function registerBuildCommands(program: Command): void {
           dsym?: string;
           metadata?: string;
           deltaPatch?: string[];
+          generateDeltas?: string;
           changelog?: string[];
           changelogFile?: string[];
           sourceCommit?: string;
@@ -288,6 +300,24 @@ export function registerBuildCommands(program: Command): void {
               },
             }),
           );
+        }
+        // Auto-generate deltas from the last N published versions (CI does the
+        // heavy archive-patcher work; the Worker just serves the source APKs +
+        // stores the patches). Needs a JDK on PATH.
+        if (opts.generateDeltas) {
+          const n = Number(opts.generateDeltas);
+          if (!Number.isFinite(n) || n <= 0) throw new Error(`--generate-deltas must be a positive number, got: ${opts.generateDeltas}`);
+          const generated = await generateAndUploadAndroidDeltas({
+            appId,
+            buildId: build.id,
+            newApkPath: opts.apk,
+            arch: opts.arch,
+            toVersionCode: versionCode,
+            targetSha256: installable.file_hash,
+            newApkSize: installable.size_bytes,
+            versions: n,
+          });
+          assets.push(...generated);
         }
         if (opts.mapping) {
           assets.push(
@@ -849,6 +879,105 @@ async function uploadAndRegisterAsset(
     file_hash: uploaded.file_hash,
     size_bytes: uploaded.size_bytes,
   };
+}
+
+const ARCHIVE_PATCHER_VERSION = "3.0.0";
+const ARCHIVE_PATCHER_URL = `https://repo1.maven.org/maven2/com/eidu/archive-patcher/${ARCHIVE_PATCHER_VERSION}/archive-patcher-${ARCHIVE_PATCHER_VERSION}.jar`;
+
+/**
+ * Prepare the archive-patcher toolchain in a temp dir: download the jar and
+ * compile the bundled PatchGen wrapper (needs javac/java on PATH — CI has a
+ * JDK for the Android build). Returns the classpath (jar:dir) to run PatchGen.
+ */
+async function ensureArchivePatcher(dir: string): Promise<string> {
+  const jarPath = join(dir, "archive-patcher.jar");
+  const res = await fetch(ARCHIVE_PATCHER_URL);
+  if (!res.ok) throw new Error(`failed to download archive-patcher jar: HTTP ${res.status}`);
+  await writeFile(jarPath, Buffer.from(await res.arrayBuffer()));
+  // PatchGen.java ships alongside the built CLI (package "patchgen" dir).
+  const patchGenSrc = fileURLToPath(new URL("../../patchgen/PatchGen.java", import.meta.url));
+  if (!existsSync(patchGenSrc)) {
+    throw new Error(`bundled PatchGen.java not found at ${patchGenSrc}`);
+  }
+  await execFileAsync("javac", ["-encoding", "UTF-8", "-cp", jarPath, "-d", dir, patchGenSrc]);
+  return `${jarPath}:${dir}`;
+}
+
+interface DeltaSource {
+  from_version_code: number;
+  arch: string | null;
+  size_bytes: number;
+  sha256: string;
+  url: string;
+}
+
+/**
+ * Generate archive-patcher delta patches from the last N published versions to
+ * the just-uploaded build, and upload each as a delta-patch asset. The Worker
+ * serves the source APKs (GET /api/apps/:id/delta-sources) and stores the
+ * patches; the CPU-heavy bsdiff runs here in CI. Skips patches that don't beat
+ * the full APK size.
+ */
+async function generateAndUploadAndroidDeltas(args: {
+  appId: string;
+  buildId: string;
+  newApkPath: string;
+  arch: string;
+  toVersionCode: number;
+  targetSha256: string;
+  newApkSize: number;
+  versions: number;
+}): Promise<Array<{ id: string; artifact_kind: string; filetype: string; file_hash: string; size_bytes: number }>> {
+  const { sources } = await apiRequest<{ sources: DeltaSource[] }>(
+    `/api/apps/${args.appId}/delta-sources`,
+    { query: { arch: args.arch, before: args.toVersionCode, limit: args.versions } },
+  );
+  if (!sources || sources.length === 0) {
+    console.error(`[delta] no prior published versions to diff against; skipping.`);
+    return [];
+  }
+
+  const work = await mkdtemp(join(tmpdir(), "hands-delta-"));
+  const uploaded: Array<{ id: string; artifact_kind: string; filetype: string; file_hash: string; size_bytes: number }> = [];
+  try {
+    const cp = await ensureArchivePatcher(work);
+    for (const src of sources) {
+      const oldPath = join(work, `old-${src.from_version_code}.apk`);
+      const patchPath = join(work, `from-${src.from_version_code}.patch.gz`);
+      const dl = await fetch(src.url);
+      if (!dl.ok) {
+        console.error(`[delta] v${src.from_version_code}: download failed HTTP ${dl.status}; skipping.`);
+        continue;
+      }
+      await writeFile(oldPath, Buffer.from(await dl.arrayBuffer()));
+      await execFileAsync("java", ["-cp", cp, "PatchGen", oldPath, args.newApkPath, patchPath], {
+        maxBuffer: 16 * 1024 * 1024,
+      });
+      const patchSize = readFileSync(patchPath).length;
+      if (patchSize >= args.newApkSize) {
+        console.error(`[delta] v${src.from_version_code}: patch ${patchSize}B not smaller than full APK ${args.newApkSize}B; skipping.`);
+        continue;
+      }
+      console.error(`[delta] v${src.from_version_code} -> v${args.toVersionCode}: patch ${patchSize}B (${(patchSize / args.newApkSize * 100).toFixed(1)}% of full)`);
+      uploaded.push(
+        await uploadAndRegisterAsset(args.appId, args.buildId, patchPath, {
+          artifact_kind: "delta-patch",
+          platform: "android",
+          arch: args.arch,
+          filetype: "patch",
+          metadata_json: {
+            from_version_code: src.from_version_code,
+            to_version_code: args.toVersionCode,
+            algorithm: "archive-patcher-v1+gzip",
+            target_sha256: args.targetSha256,
+          },
+        }),
+      );
+    }
+  } finally {
+    await rm(work, { recursive: true, force: true }).catch(() => {});
+  }
+  return uploaded;
 }
 
 export function inferElectronPlatform(filePath: string | undefined): string {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -93,7 +93,7 @@ import {
   handleTestflightUpload,
   handleTestflightUploadStatus,
 } from "./routes/testflight";
-import { handleGenerateDeltaPatches } from "./routes/delta";
+import { handleGenerateDeltaPatches, handleDeltaSources } from "./routes/delta";
 import { handleUploadApk } from "./routes/upload";
 import {
   handleListOperations,
@@ -794,6 +794,7 @@ admin.post(
   requireAppRole("publisher"),
   handleGenerateDeltaPatches,
 );
+admin.get("/api/apps/:appId/delta-sources", requireAppRole("publisher"), handleDeltaSources);
 
 app.route("/", admin);
 

--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -323,3 +323,49 @@ export async function handleGenerateDeltaPatches(c: AdminContext) {
   const outcome = await runDeltaGeneration(c.env, op, params);
   return c.json(outcome, outcome.error && outcome.results.length === 0 ? 500 : 200);
 }
+
+/**
+ * GET /api/apps/:appId/delta-sources?arch=<abi>&before=<version_code>&limit=<N>
+ * Returns short-lived signed download URLs for the last N published installable
+ * APKs (same arch, version_code < before). Used by the CLI/CI to fetch the
+ * source APKs, generate archive-patcher patches, and upload them via
+ * publish-android --delta-patch. Keeps patch generation out of the Worker.
+ */
+export async function handleDeltaSources(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const arch = c.req.query("arch") ?? null;
+  const before = Number(c.req.query("before"));
+  if (!Number.isFinite(before)) {
+    return c.json({ error: "before (version_code) must be a number" }, 400);
+  }
+  const limitRaw = Number(c.req.query("limit"));
+  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 10) : DEFAULT_KEEP_VERSIONS;
+
+  const priors = await c.env.DB.prepare(
+    `SELECT ba.build_id, b.version_code, ba.arch, ba.r2_key, ba.file_hash, ba.size_bytes
+     FROM build_assets ba
+     JOIN builds b ON b.id = ba.build_id
+     JOIN releases r ON r.build_id = b.id
+     WHERE b.app_id = ?1 AND ba.artifact_kind = 'installable' AND ba.filetype = 'apk'
+       AND (ba.arch IS ?2 OR ba.arch = ?2)
+       AND b.version_code < ?3
+       AND r.status IN ('active', 'superseded')
+     GROUP BY b.version_code
+     ORDER BY b.version_code DESC
+     LIMIT ?4`,
+  )
+    .bind(appId, arch, before, limit)
+    .all<ApkAssetRow>();
+
+  const origin = requestOrigin(c);
+  const sources = await Promise.all(
+    (priors.results ?? []).map(async (p) => ({
+      from_version_code: p.version_code,
+      arch: p.arch,
+      size_bytes: p.size_bytes,
+      sha256: p.file_hash,
+      url: await generateInternalR2Url(c.env, p.r2_key, 1800, origin),
+    })),
+  );
+  return c.json({ arch, before, sources });
+}


### PR DESCRIPTION
Per artin's call: **abandon the Worker/container generation** and generate deltas **in CI** — a full VM with a JDK, time, and CPU — then upload via the existing `--delta-patch` path.

Why: the container path was fully diagnosed (via `wrangler tail`) — the container works and reaches R2, but `waitUntil` is cancelled ~3s after the response, and archive-patcher file-by-file bsdiff over 28MB APKs takes >180s, which can't fit a Worker request or `waitUntil`. CI has none of those constraints.

## Changes

- **worker**: `GET /api/apps/:appId/delta-sources?arch&before&limit` — returns short-lived signed URLs (the internal `/internal/r2` endpoint, no release-status gate) for the last N published installable APKs, so CI can fetch the source APKs.
- **CLI**: `publish-android --generate-deltas <N>` — after uploading the APK, fetches the delta-sources, downloads each old APK, runs archive-patcher (bundled `patchgen/PatchGen.java` compiled at runtime against the eidu jar; needs a JDK on PATH — CI has one), uploads each gzipped patch as a `delta-patch` asset (`archive-patcher-v1+gzip`). Skips patches ≥ the full APK size.
- ship `patchgen/PatchGen.java` in the CLI package.

## Verified

- Bundled PatchGen compiles + generates a **762B patch for a 600KB APK** locally.
- CLI (12) + worker (113) tests pass.

## Follow-ups
- Publish the new CLI to npm (needs your word), then wire `--generate-deltas 3` into mobile's `android-release.yml`.
- The Worker/container generation path is left in place (toggle off) — I'll clean it up in a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786289928&installation_id=145465820&pr_number=226&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F226&signature=00b53a83799a02afefa30e859570225126fd2e0aca17eb2a6167f9c80bfb4e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->