### PR TITLE
docs: remove secret/token enumeration from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the worktree workflow and merge rules
 
 GitHub Actions owns production publishing so local machines do not need long-lived npm or Cloudflare credentials.
 
-Required repository secrets:
-
-- `NPM_TOKEN` — npm automation token with publish access to the `@botiverse` scope, used by the Node SDK and CLI publishing workflows.
-- `CLOUDFLARE_API_TOKEN` — Cloudflare API token allowed to deploy the Hands Worker and its assets.
-- `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id for the Worker deploy.
-- `CLOUDFLARE_BOTIVERSE_API_TOKEN` — Cloudflare API token for the Hands.
-- `HANDS_SIGNED_URL_SECRET` — HMAC signing secret written to the Hands Worker as `SIGNED_URL_SECRET` so migrated release downloads and share pages can generate signed Worker download URLs.
-- `HANDS_RAFT_CLIENT_SECRET
+Publishing and deploys read their npm, Cloudflare, and Hands Worker secrets from the repository's GitHub Actions secrets — configured in the repository settings, not documented here.
 
 Workflows:
 
-- `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm with the repository `NPM_TOKEN`. Trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
-- `Publish CLI` publishes `@botiverse/hands-cli` with the repository `NPM_TOKEN`. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.1`.
+- `Publish Hands Node SDK` publishes `@botiverse/hands-node` to npm with the repository npm token. Trigger it manually with the package version from `packages/node/package.json`, or push a tag like `node-v0.1.0`.
+- `Publish CLI` publishes `@botiverse/hands-cli` with the repository npm token. Publish the package's declared `@botiverse/hands-node` version first; the workflow verifies it exists, packs with pnpm so the workspace range becomes a normal npm semver range, and then publishes the tarball. Trigger it manually with the package version from `packages/cli/package.json`, or push a tag like `cli-v0.5.1`.
 - `Deploy Quiver Server` is the legacy compatibility deployment for `quiver.oranix.io`; it no longer owns the Hands dashboard or business data plane.
 - `Deploy Hands Server` deploys one Worker/admin bundle to the custom domains `hands.build` (business/API) and `app.hands.build` (dashboard/login) in the separate Hands Cloudflare account. It bootstraps `hands-db` and `hands-artifacts` if they do not exist, applies D1 migrations, and deploys with `worker/wrangler.hands.jsonc`. This workflow is manual-only so it cannot replace the existing Quiver deploy path accidentally.
 


### PR DESCRIPTION
Per artin — the README should not enumerate the repo's secrets. Removes the "Required repository secrets" list (NPM_TOKEN, CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_BOTIVERSE_API_TOKEN, HANDS_SIGNED_URL_SECRET, HANDS_RAFT_CLIENT_SECRET) and generalizes the workflow descriptions so they don't name the npm token. No credential values were ever committed; this removes the enumeration of secret names/purposes from the README.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786293535&installation_id=145465820&pr_number=227&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F227&signature=90251ebd3d0697134f738115d5cc86ebc29c5848bb57bcf2c11724182f485e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->