### PR TITLE
chore: externalize production configuration

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -25,16 +25,21 @@ concurrency:
   group: hands-server-production
   cancel-in-progress: false
 
-env:
-  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
-  HANDS_D1_DATABASE_NAME: hands-db
-  HANDS_R2_BUCKET_NAME: hands-artifacts
-  HANDS_BUSINESS_DOMAIN: hands.build
-  HANDS_DASHBOARD_DOMAIN: app.hands.build
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
+      HANDS_WORKER_NAME: ${{ vars.HANDS_WORKER_NAME }}
+      HANDS_D1_DATABASE_NAME: ${{ vars.HANDS_D1_DATABASE_NAME }}
+      HANDS_D1_DATABASE_ID: ${{ vars.HANDS_D1_DATABASE_ID }}
+      HANDS_R2_BUCKET_NAME: ${{ vars.HANDS_R2_BUCKET_NAME }}
+      HANDS_BUSINESS_DOMAIN: ${{ vars.HANDS_BUSINESS_DOMAIN }}
+      HANDS_DASHBOARD_DOMAIN: ${{ vars.HANDS_DASHBOARD_DOMAIN }}
+      HANDS_CORS_ALLOWED_ORIGINS: ${{ vars.HANDS_CORS_ALLOWED_ORIGINS }}
+      HANDS_RAFT_ORIGIN: ${{ vars.HANDS_RAFT_ORIGIN }}
+      HANDS_RAFT_API_ORIGIN: ${{ vars.HANDS_RAFT_API_ORIGIN }}
+      HANDS_RAFT_CLIENT_ID: ${{ vars.HANDS_RAFT_CLIENT_ID }}
     steps:
       - uses: actions/checkout@v6
 
@@ -50,13 +55,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Render production Wrangler config
+        working-directory: worker
+        run: node scripts/render-production-config.mjs --output wrangler.hands.generated.jsonc
+
       - name: Generate Worker types
         working-directory: worker
         # Generate the business worker's Env from the hands config. The default
         # wrangler.jsonc is now the legacy proxy shim (shim-only vars), so
         # without --config the generated Env would lack DB/APK_BUCKET/ASSETS and
         # the src/index.ts typecheck below would fail.
-        run: pnpm exec wrangler types --config wrangler.hands.jsonc
+        run: pnpm exec wrangler types --config wrangler.hands.generated.jsonc
 
       - name: Run checks
         if: ${{ inputs.run_checks }}
@@ -83,7 +92,7 @@ jobs:
             exit 1
           fi
 
-          pnpm exec wrangler d1 info "${HANDS_D1_DATABASE_NAME}" --config wrangler.hands.jsonc >/dev/null
+          pnpm exec wrangler d1 info "${HANDS_D1_DATABASE_NAME}" --config wrangler.hands.generated.jsonc >/dev/null
 
           if ! pnpm exec wrangler r2 bucket info "${HANDS_R2_BUCKET_NAME}" >/dev/null 2>&1; then
             pnpm exec wrangler r2 bucket create "${HANDS_R2_BUCKET_NAME}"
@@ -96,7 +105,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pnpm exec wrangler d1 migrations apply "${HANDS_D1_DATABASE_NAME}" --remote --config wrangler.hands.jsonc
+          pnpm exec wrangler d1 migrations apply "${HANDS_D1_DATABASE_NAME}" --remote --config wrangler.hands.generated.jsonc
 
       - name: Configure Hands Worker secrets
         working-directory: worker
@@ -125,10 +134,11 @@ jobs:
             echo "Missing GitHub secret CLOUDFLARE_BOTIVERSE_ACCOUNT_ID." >&2
             exit 1
           fi
-          printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config wrangler.hands.jsonc
-          printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config wrangler.hands.jsonc
-          printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config wrangler.hands.jsonc
-          printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config wrangler.hands.jsonc
+          config=wrangler.hands.generated.jsonc
+          printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config "${config}"
+          printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config "${config}"
+          printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
+          printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
 
       - name: Deploy Hands Worker and admin assets
         working-directory: worker
@@ -138,7 +148,7 @@ jobs:
         run: |
           set -euo pipefail
           pnpm exec wrangler deploy \
-            --config wrangler.hands.jsonc \
+            --config wrangler.hands.generated.jsonc \
             --containers-rollout "${{ inputs.containers_rollout }}"
 
       - name: Summary
@@ -151,10 +161,5 @@ jobs:
             echo "|---|---|"
             echo "| Ref | \`${GITHUB_REF_NAME}\` |"
             echo "| SHA | \`${GITHUB_SHA}\` |"
-            echo "| Account | \`${CLOUDFLARE_ACCOUNT_ID}\` |"
-            echo "| Business domain | \`${HANDS_BUSINESS_DOMAIN}\` |"
-            echo "| Dashboard domain | \`${HANDS_DASHBOARD_DOMAIN}\` |"
-            echo "| D1 | \`${HANDS_D1_DATABASE_NAME}\` |"
-            echo "| R2 | \`${HANDS_R2_BUCKET_NAME}\` |"
             echo "| Containers rollout | \`${{ inputs.containers_rollout }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          HANDS_BUSINESS_DOMAIN: ${{ vars.HANDS_BUSINESS_DOMAIN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -56,8 +57,15 @@ jobs:
             echo "Missing GitHub secret CLOUDFLARE_API_TOKEN." >&2
             exit 1
           fi
+          if [[ -z "${HANDS_BUSINESS_DOMAIN:-}" ]]; then
+            echo "Missing GitHub variable HANDS_BUSINESS_DOMAIN." >&2
+            exit 1
+          fi
+          business_origin="https://${HANDS_BUSINESS_DOMAIN}"
           # Default wrangler.jsonc is the shim: no D1 migrations, no containers.
-          pnpm exec wrangler deploy
+          pnpm exec wrangler deploy \
+            --var "PROXY_TARGET:${business_origin}" \
+            --var "REDIRECT_TARGET:${business_origin}"
 
       - name: Summary
         shell: bash
@@ -69,5 +77,5 @@ jobs:
             echo "|---|---|"
             echo "| Ref | \`${GITHUB_REF_NAME}\` |"
             echo "| SHA | \`${GITHUB_SHA}\` |"
-            echo "| Role | \`legacy proxy shim -> hands.build\` |"
+            echo "| Role | \`legacy proxy shim\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-hands-data.yml
+++ b/.github/workflows/sync-hands-data.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       sync_d1:
-        description: "Export quiver-db and import it into hands-db."
+        description: "Export the configured source D1 database and import it into the configured Hands D1 database."
         required: true
         type: boolean
         default: true
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: true
       sync_r2:
-        description: "Copy D1-referenced objects from quiver-apks to hands-artifacts."
+        description: "Copy D1-referenced objects between the configured source and Hands R2 buckets."
         required: true
         type: boolean
         default: true
@@ -30,15 +30,20 @@ concurrency:
   group: hands-data-sync
   cancel-in-progress: false
 
-env:
-  SOURCE_D1_DATABASE_NAME: quiver-db
-  TARGET_D1_DATABASE_NAME: hands-db
-  SOURCE_R2_BUCKET_NAME: quiver-apks
-  TARGET_R2_BUCKET_NAME: hands-artifacts
-
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      SOURCE_D1_DATABASE_NAME: ${{ vars.QUIVER_D1_DATABASE_NAME }}
+      TARGET_D1_DATABASE_NAME: ${{ vars.HANDS_D1_DATABASE_NAME }}
+      SOURCE_R2_BUCKET_NAME: ${{ vars.QUIVER_R2_BUCKET_NAME }}
+      TARGET_R2_BUCKET_NAME: ${{ vars.HANDS_R2_BUCKET_NAME }}
+      HANDS_WORKER_NAME: ${{ vars.HANDS_WORKER_NAME }}
+      HANDS_D1_DATABASE_NAME: ${{ vars.HANDS_D1_DATABASE_NAME }}
+      HANDS_D1_DATABASE_ID: ${{ vars.HANDS_D1_DATABASE_ID }}
+      HANDS_R2_BUCKET_NAME: ${{ vars.HANDS_R2_BUCKET_NAME }}
+      HANDS_BUSINESS_DOMAIN: ${{ vars.HANDS_BUSINESS_DOMAIN }}
+      HANDS_DASHBOARD_DOMAIN: ${{ vars.HANDS_DASHBOARD_DOMAIN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -53,6 +58,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Render production Wrangler config
+        working-directory: worker
+        run: node scripts/render-production-config.mjs --output wrangler.hands.generated.jsonc
 
       - name: Confirm one-way sync
         shell: bash
@@ -320,7 +329,7 @@ jobs:
           set -euo pipefail
           pnpm exec wrangler d1 execute "${TARGET_D1_DATABASE_NAME}" \
             --remote \
-            --config wrangler.hands.jsonc \
+            --config wrangler.hands.generated.jsonc \
             --file ../tmp/hands-sync/reset-hands-data.sql \
             --yes
 
@@ -335,7 +344,7 @@ jobs:
           set -euo pipefail
           pnpm exec wrangler d1 execute "${TARGET_D1_DATABASE_NAME}" \
             --remote \
-            --config wrangler.hands.jsonc \
+            --config wrangler.hands.generated.jsonc \
             --file ../tmp/hands-sync/quiver-data-ordered.sql \
             --yes
 
@@ -412,6 +421,6 @@ jobs:
           set -euo pipefail
           pnpm exec wrangler d1 execute "${TARGET_D1_DATABASE_NAME}" \
             --remote \
-            --config wrangler.hands.jsonc \
+            --config wrangler.hands.generated.jsonc \
             --json \
             --command "SELECT COUNT(*) AS apps FROM apps; SELECT COUNT(*) AS builds FROM builds; SELECT COUNT(*) AS build_assets FROM build_assets; SELECT COUNT(*) AS releases FROM releases; SELECT COUNT(*) AS feedback_tickets FROM feedback_tickets; SELECT COUNT(*) AS feedback_attachments FROM feedback_attachments; SELECT COUNT(*) AS device_pings FROM device_pings;"

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,6 @@ coverage/
 # Generated
 *.tsbuildinfo
 worker-configuration.d.ts
+worker/wrangler.*.generated.jsonc
 admin/public/docs/
 admin/public/docs.md

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -781,13 +781,8 @@ function CliCallback({ token }: { token: string }) {
 }
 
 function dashboardHref(account?: AuthAccount): string {
-  const dashboardOrigin = window.location.hostname === "hands.build"
-    ? "https://app.hands.build"
-    : "";
-  if (account) return `${dashboardOrigin}/apps`;
-  return dashboardOrigin
-    ? `${dashboardOrigin}/api/auth/login?return=${encodeURIComponent("/apps")}`
-    : loginUrl("/apps");
+  if (account) return "/apps";
+  return loginUrl("/apps");
 }
 
 function PublicLanding({ account }: { account?: AuthAccount }) {
@@ -978,7 +973,7 @@ const TERMINAL_DEMOS: {
       { text: "uploading APK and metadata...", tone: "muted" },
       { text: "creating release on channel main...", tone: "muted" },
       { text: "release: 14998dba-cfde-4002-8c01-230a2760f662", tone: "ok" },
-      { text: "share: https://hands.build/share/...", tone: "ok" },
+      { text: `share: ${window.location.origin}/share/...`, tone: "ok" },
     ],
   },
   {
@@ -1010,7 +1005,7 @@ const TERMINAL_DEMOS: {
     label: "Metrics",
     badge: "30d",
     lines: [
-      { text: "$ curl https://hands.build/api/apps/$APP_ID/analytics/versions?window_days=30" },
+      { text: `$ curl ${window.location.origin}/api/apps/$APP_ID/analytics/versions?window_days=30` },
       { text: "1.1.0   active devices 1,284   update offers 642", tone: "ok" },
       { text: "1.0.4   active devices   319   crash tickets 3", tone: "muted" },
     ],

--- a/admin/src/pages/Settings.tsx
+++ b/admin/src/pages/Settings.tsx
@@ -63,18 +63,6 @@ export function Settings() {
           <div className="text-slate-500">Raft Callback URL</div>
           <div className="font-mono">{raftCallbackUrl}</div>
         </div>
-        <div>
-          <div className="text-slate-500">D1 Database</div>
-          <div className="font-mono">hands-db</div>
-        </div>
-        <div>
-          <div className="text-slate-500">R2 Bucket</div>
-          <div className="font-mono">hands-artifacts</div>
-        </div>
-        <div>
-          <div className="text-slate-500">Container</div>
-          <div className="font-mono">apk-parser (Node 24 + aapt + apksigner)</div>
-        </div>
       </div>
     </div>
   );

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import tailwindcss from "tailwindcss";
-import autoprefixer from "autoprefixer";
 
 // Vite config for quiver admin SPA.
 // Dev: proxies /api to the local Worker (wrangler dev :8787).

--- a/clients/electron/src/common.ts
+++ b/clients/electron/src/common.ts
@@ -3,6 +3,7 @@
 
 /** IPC channel renderers use to forward scope updates to the main process. */
 export const CONTEXT_CHANNEL = "hands:context";
+export const DEFAULT_HANDS_ENDPOINT = "https://hands.build";
 
 export interface HandsBreadcrumb {
   message: string;
@@ -24,7 +25,7 @@ export interface HandsElectronOptions {
   appSlug: string;
   /** Public client key (Sentry-DSN model). Safe to ship in the app bundle. */
   clientKey: string;
-  /** Hands business origin. Defaults to https://hands.build. */
+  /** Hands business origin. Defaults to DEFAULT_HANDS_ENDPOINT. */
   endpoint?: string;
   /** Crashpad productName; defaults to appSlug. */
   productName?: string;
@@ -96,7 +97,7 @@ export function buildGlobalExtra(
 
 /** Build the minidump submit URL Crashpad POSTs to (client key in the query). */
 export function buildSubmitURL(options: HandsElectronOptions): string {
-  const endpoint = (options.endpoint ?? "https://hands.build").replace(/\/+$/, "");
+  const endpoint = (options.endpoint ?? DEFAULT_HANDS_ENDPOINT).replace(/\/+$/, "");
   return (
     `${endpoint}/public/v2/apps/${encodeURIComponent(options.appSlug)}/minidump` +
     `?client_key=${encodeURIComponent(options.clientKey)}`

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   CONTEXT_CHANNEL,
+  DEFAULT_HANDS_ENDPOINT,
   buildGlobalExtra,
   buildSubmitURL,
   toParam,
@@ -114,7 +115,7 @@ async function reportMetrics(options: HandsElectronOptions, force = false): Prom
   if (!force && state.lastPingAt > 0 && now - state.lastPingAt < METRICS_INTERVAL_MS) return false;
 
   const deviceId = state.deviceId || randomUUID();
-  const endpoint = (options.endpoint ?? "https://hands.build").replace(/\/+$/, "");
+  const endpoint = (options.endpoint ?? DEFAULT_HANDS_ENDPOINT).replace(/\/+$/, "");
   const url = `${endpoint}/public/v2/apps/${encodeURIComponent(options.appSlug)}/metrics`;
   const env = options.environment ?? "production";
   const metadata = {

--- a/clients/ios/Sources/Hands/Hands.h
+++ b/clients/ios/Sources/Hands/Hands.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// iOS, posting to a Hands server's public feedback endpoint.
 ///
 ///   [Hands installWithConfig:
-///       [HandsConfig configWithBaseUrl:@"https://hands.build"
+///       [HandsConfig configWithBaseUrl:@"https://your-hands-origin.example"
 ///                                     appSlug:@"my-app"
 ///                                     channel:@"main"
 ///                                   clientKey:@"qk_…"]];

--- a/clients/ohos/hands/src/main/ets/Hands.ets
+++ b/clients/ohos/hands/src/main/ets/Hands.ets
@@ -11,7 +11,7 @@ import { HandsFaultWatcher } from './HandsFaultWatcher';
  * from the Hands console).
  */
 export interface HandsConfig {
-  /** Hands server origin, e.g. https://hands.build (no trailing /). */
+  /** Hands server origin, e.g. https://your-hands-origin.example (no trailing /). */
   baseUrl: string;
   /** App slug in the Hands console. */
   appSlug: string;

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -80,7 +80,7 @@ app.post("/generate-patch", async (c) => {
   const outPath = join(dir, "out.patch");
   // Fetch with a timeout so a stuck/blocked egress fails fast with a diagnostic
   // (which URL, timeout vs error) instead of hanging the whole request — the
-  // container reaching back to hands.build is the current unknown.
+  // the container reaching back to the configured business origin is the current unknown.
   const fetchApk = async (url: string, dest: string): Promise<number> => {
     const started = Date.now();
     const ac = new AbortController();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       eslint:
         specifier: ^9.17.0
         version: 9.39.4(jiti@2.7.0)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -735,89 +738,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -911,66 +930,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1047,24 +1079,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
@@ -1540,6 +1576,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1586,24 +1625,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3229,6 +3272,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   keyv@4.5.4:
     dependencies:

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -13,6 +13,8 @@ declare global {
     RAFT_API_ORIGIN?: string;
     RAFT_CLIENT_ID?: string;
     CORS_ALLOWED_ORIGINS?: string;
+    BUSINESS_ORIGIN?: string;
+    DASHBOARD_ORIGIN?: string;
     SIGNED_URL_SECRET?: string;
     R2_ACCOUNT_ID?: string;
     R2_BUCKET_NAME?: string;

--- a/worker/package.json
+++ b/worker/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^22.10.0",
     "better-sqlite3": "^11.5.0",
     "eslint": "^9.17.0",
+    "jsonc-parser": "^3.3.1",
     "typescript": "^5.9.3",
     "vitest": "^2.1.8",
     "wrangler": "^4.88.0"

--- a/worker/scripts/render-production-config.mjs
+++ b/worker/scripts/render-production-config.mjs
@@ -1,0 +1,81 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse, printParseErrorCode } from "jsonc-parser";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workerDir = resolve(scriptDir, "..");
+const sourcePath = resolve(workerDir, "wrangler.hands.jsonc");
+const outputArgIndex = process.argv.indexOf("--output");
+const outputPath = resolve(
+  workerDir,
+  outputArgIndex >= 0 && process.argv[outputArgIndex + 1]
+    ? process.argv[outputArgIndex + 1]
+    : "wrangler.hands.generated.jsonc",
+);
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment value ${name}`);
+  return value;
+}
+
+function domain(name) {
+  const value = required(name);
+  if (!/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i.test(value)) {
+    throw new Error(`${name} must be a hostname without a scheme or path`);
+  }
+  return value.toLowerCase();
+}
+
+function uuid(name) {
+  const value = required(name);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+    throw new Error(`${name} must be a UUID`);
+  }
+  return value;
+}
+
+const errors = [];
+const config = parse(readFileSync(sourcePath, "utf8"), errors, {
+  allowTrailingComma: true,
+  disallowComments: false,
+});
+if (errors.length > 0 || !config || typeof config !== "object") {
+  const detail = errors.map((error) => printParseErrorCode(error.error)).join(", ");
+  throw new Error(`Unable to parse ${sourcePath}: ${detail || "invalid JSONC"}`);
+}
+
+const businessDomain = domain("HANDS_BUSINESS_DOMAIN");
+const dashboardDomain = domain("HANDS_DASHBOARD_DOMAIN");
+const d1 = config.d1_databases?.find((binding) => binding.binding === "DB");
+const r2 = config.r2_buckets?.find((binding) => binding.binding === "APK_BUCKET");
+if (!d1 || !r2) throw new Error("Hands DB or APK_BUCKET binding is missing from the base config");
+
+config.name = required("HANDS_WORKER_NAME");
+const configuredRoutes = new Set(
+  (config.routes ?? []).filter((route) => route.custom_domain).map((route) => route.pattern),
+);
+for (const expected of [businessDomain, dashboardDomain]) {
+  if (!configuredRoutes.has(expected)) {
+    throw new Error(`Checked-in custom-domain route does not match ${expected}`);
+  }
+}
+d1.database_name = required("HANDS_D1_DATABASE_NAME");
+d1.database_id = uuid("HANDS_D1_DATABASE_ID");
+r2.bucket_name = required("HANDS_R2_BUCKET_NAME");
+config.vars = {
+  ...config.vars,
+  ENVIRONMENT: "production",
+  BUSINESS_ORIGIN: `https://${businessDomain}`,
+  DASHBOARD_ORIGIN: `https://${dashboardDomain}`,
+  CORS_ALLOWED_ORIGINS: required("HANDS_CORS_ALLOWED_ORIGINS"),
+  RAFT_ORIGIN: required("HANDS_RAFT_ORIGIN"),
+  RAFT_API_ORIGIN: required("HANDS_RAFT_API_ORIGIN"),
+  RAFT_CLIENT_ID: required("HANDS_RAFT_CLIENT_ID"),
+  R2_BUCKET_NAME: r2.bucket_name,
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+console.log(`Rendered production Wrangler config: ${outputPath}`);

--- a/worker/src/lib/origin.ts
+++ b/worker/src/lib/origin.ts
@@ -1,7 +1,54 @@
 import type { Context } from "hono";
 
-export const BUSINESS_ORIGIN = "https://hands.build";
-export const DASHBOARD_ORIGIN = "https://app.hands.build";
+function configuredOrigin(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if ((url.protocol !== "https:" && url.protocol !== "http:") || url.pathname !== "/") {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+type OriginFallback = string | (() => string);
+
+function resolveFallback(fallback: OriginFallback | undefined): string | null {
+  if (!fallback) return null;
+  return typeof fallback === "function" ? fallback() : fallback;
+}
+
+export function businessOrigin(env: Env, fallback?: OriginFallback): string {
+  const configured = configuredOrigin(env.BUSINESS_ORIGIN);
+  if (configured) return configured;
+  const resolvedFallback = resolveFallback(fallback);
+  if (resolvedFallback) return resolvedFallback;
+  if (String(env.ENVIRONMENT) !== "production") return "http://localhost";
+  throw new Error("BUSINESS_ORIGIN is not configured");
+}
+
+export function dashboardOrigin(env: Env, fallback?: OriginFallback): string {
+  const configured = configuredOrigin(env.DASHBOARD_ORIGIN);
+  if (configured) return configured;
+  const resolvedFallback = resolveFallback(fallback);
+  if (resolvedFallback) return resolvedFallback;
+  if (String(env.ENVIRONMENT) !== "production") return "http://localhost";
+  throw new Error("DASHBOARD_ORIGIN is not configured");
+}
+
+export function configuredProductionHost(env: Env, hostname: string): boolean {
+  const business = configuredOrigin(env.BUSINESS_ORIGIN);
+  const dashboard = configuredOrigin(env.DASHBOARD_ORIGIN);
+  return hostname === (business && new URL(business).hostname) ||
+    hostname === (dashboard && new URL(dashboard).hostname);
+}
+
+export function sharedCookieDomain(env: Env): string | null {
+  const business = configuredOrigin(env.BUSINESS_ORIGIN);
+  return business ? new URL(business).hostname : null;
+}
 
 function headerScheme(c: Context<any>): string | null {
   const header = typeof c.req.header === "function" ? c.req.header.bind(c.req) : null;

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -1,7 +1,7 @@
 import type { Context, MiddlewareHandler } from "hono";
 import { currentActorInfo, type AdminAccount, type AdminEnv } from "../middleware/auth";
 import type { AppDeployToken } from "./deploy_tokens";
-import { DASHBOARD_ORIGIN } from "./origin";
+import { dashboardOrigin } from "./origin";
 
 export type OrgRole = "owner" | "admin" | "member" | "viewer";
 export type AppRole = "admin" | "publisher" | "viewer";
@@ -160,9 +160,9 @@ function forbiddenRole(
     // request URL/method unavailable (e.g. tests) — keep defaults
   }
   const manageUrl = ids.org_id
-    ? `${DASHBOARD_ORIGIN}/orgs/${ids.org_id}/members`
+    ? `${dashboardOrigin(c.env)}/orgs/${ids.org_id}/members`
     : ids.app_id
-      ? `${DASHBOARD_ORIGIN}/apps/${ids.app_id}/settings`
+      ? `${dashboardOrigin(c.env)}/apps/${ids.app_id}/settings`
       : null;
   // Admin-native, actionable error: tell the caller (agent or human) exactly
   // what to do next — who can grant the role, where, and that an admin can
@@ -250,7 +250,7 @@ export async function ensureAppRole(c: AdminContext, appId: string, minimum: App
             `\`raft integration login --service <hands-service>\`. Then an admin must grant you the ` +
             `'${minimum}' role on this app (Access → Members). Admins can perform the release action on your behalf.`,
           login_url: `/api/auth/login?return=${encodeURIComponent("/")}`,
-          manage_url: `${DASHBOARD_ORIGIN}/apps/${appId}/settings`,
+          manage_url: `${dashboardOrigin(c.env)}/apps/${appId}/settings`,
         },
         401,
       ),

--- a/worker/src/proxy-shim.ts
+++ b/worker/src/proxy-shim.ts
@@ -1,21 +1,21 @@
 /**
  * Legacy proxy shim for `quiver-worker`.
  *
- * After the Hands migration, `quiver.oranix.io` no longer runs the business
- * worker — all business logic, D1, and R2 live on `hands-worker`
- * (`hands.build`). This shim is the ONLY thing `quiver-worker` deploys going
+ * After the Hands migration, the legacy domain no longer runs the business
+ * worker — all business logic, D1, and R2 live on the Hands worker
+ * (the configured business origin). This shim is the ONLY thing `quiver-worker` deploys going
  * forward. It exists purely to keep the legacy domain working for two very
  * different classes of traffic:
  *
  *   1. Machine / API paths (installed apps + CI): transparently
  *      reverse-proxied to the Hands worker, preserving method, body, query,
  *      and headers. Existing shipped apps POST feedback / crash / metrics and
- *      GET update-checks against `quiver.oranix.io/public/*`; a 302 here would
+ *      GET update-checks against the legacy `/public/*` routes; a 302 here would
  *      drop the POST body/headers (multipart), so these MUST be proxied, never
  *      redirected. Writes land in the Hands DB via the proxy — single source
  *      of truth, no divergence.
  *
- *   2. Human pages (browsers): 302-redirected to `hands.build` so people land
+ *   2. Human pages (browsers): 302-redirected to the configured business origin
  *      on the canonical new domain.
  *
  * The shim holds NO D1 / R2 / Container bindings and never touches the legacy
@@ -26,14 +26,14 @@
 export interface ShimEnv {
   /**
    * Origin serving the Hands business worker, no trailing slash. Points at the
-   * worker's direct `workers.dev` route (NOT `hands.build`) to skip the edge
+   * worker's direct `workers.dev` route to skip the edge
    * cache and avoid any custom-domain loop, e.g.
-   * `https://hands-worker.botiverse.workers.dev`.
+   * a configured direct Worker origin.
    */
   PROXY_TARGET: string;
   /**
    * Origin humans are 302-redirected to, no trailing slash, e.g.
-   * `https://hands.build`.
+   * the configured business origin.
    */
   REDIRECT_TARGET: string;
 }

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -16,10 +16,12 @@ import {
   type AdminAccount,
 } from "../middleware/auth";
 import {
-  BUSINESS_ORIGIN,
-  DASHBOARD_ORIGIN,
+  businessOrigin,
+  configuredProductionHost,
+  dashboardOrigin,
   isSecureRequest,
   requestOrigin,
+  sharedCookieDomain,
 } from "../lib/origin";
 
 const LOGIN_PENDING_COOKIE = "quiver_raft_login_pending";
@@ -67,17 +69,20 @@ function secureCookie(c: Context<{ Bindings: Env }>): boolean {
 
 function isHandsProductionHost(c: Context<{ Bindings: Env }>): boolean {
   const hostname = new URL(c.req.url).hostname;
-  return hostname === "hands.build" || hostname === "app.hands.build";
+  return configuredProductionHost(c.env, hostname);
 }
 
 function sharedCookieDomainOption(
   c: Context<{ Bindings: Env }>,
 ): { domain: string } | Record<string, never> {
-  return isHandsProductionHost(c) ? { domain: "hands.build" } : {};
+  const domain = sharedCookieDomain(c.env);
+  return isHandsProductionHost(c) && domain ? { domain } : {};
 }
 
 function callbackUrl(c: Context<{ Bindings: Env }>): string {
-  const origin = isHandsProductionHost(c) ? BUSINESS_ORIGIN : appOrigin(c);
+  const origin = isHandsProductionHost(c)
+    ? businessOrigin(c.env, () => appOrigin(c))
+    : appOrigin(c);
   return `${origin}/login/raft/callback`;
 }
 
@@ -85,7 +90,9 @@ function browserReturnUrl(
   c: Context<{ Bindings: Env }>,
   returnPath: string,
 ): string {
-  return isHandsProductionHost(c) ? `${DASHBOARD_ORIGIN}${returnPath}` : returnPath;
+  return isHandsProductionHost(c)
+    ? `${dashboardOrigin(c.env, () => appOrigin(c))}${returnPath}`
+    : returnPath;
 }
 
 function requireRaftConfig(c: Context<{ Bindings: Env }>) {
@@ -93,11 +100,15 @@ function requireRaftConfig(c: Context<{ Bindings: Env }>) {
   const clientSecret = c.env.RAFT_CLIENT_SECRET;
   const raftOrigin = c.env.RAFT_ORIGIN;
   const raftApiOrigin = c.env.RAFT_API_ORIGIN;
+  const business = c.env.BUSINESS_ORIGIN;
+  const dashboard = c.env.DASHBOARD_ORIGIN;
   const missing = [
     clientId ? undefined : "RAFT_CLIENT_ID",
     clientSecret ? undefined : "RAFT_CLIENT_SECRET",
     raftOrigin ? undefined : "RAFT_ORIGIN",
     raftApiOrigin ? undefined : "RAFT_API_ORIGIN",
+    business ? undefined : "BUSINESS_ORIGIN",
+    dashboard ? undefined : "DASHBOARD_ORIGIN",
   ].filter((key): key is string => Boolean(key));
   if (missing.length > 0) {
     return {
@@ -170,7 +181,7 @@ export async function createSignedJwt(
   if (!secret) throw new Error("SIGNED_URL_SECRET or RAFT_CLIENT_SECRET is required for auth JWTs");
   const header = base64UrlUtf8(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const payload = base64UrlUtf8(JSON.stringify({
-    iss: "https://hands.build",
+    iss: businessOrigin(env),
     aud: "hands-dashboard",
     sub: accountId,
     jti: jwtId,

--- a/worker/src/routes/delta.ts
+++ b/worker/src/routes/delta.ts
@@ -68,7 +68,7 @@ export interface DeltaParams {
   buildId: string;
   actor: string;
   keep?: number | undefined;
-  // Public origin the container uses to fetch source APKs (e.g. https://hands.build).
+  // Public origin the container uses to fetch source APKs.
   origin: string;
 }
 

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -12,7 +12,7 @@ import { currentActor, type AdminEnv } from "../middleware/auth";
 import { emitWebhookEvent } from "./webhooks";
 import { presignR2UploadUrl } from "../lib/r2_presign";
 import { generateSignedR2Url } from "./public_v2";
-import { DASHBOARD_ORIGIN, requestOrigin } from "../lib/origin";
+import { dashboardOrigin, requestOrigin } from "../lib/origin";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -412,7 +412,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     : versionCode != null
       ? String(versionCode)
       : null;
-  const ticketUrl = `${DASHBOARD_ORIGIN}/apps/${app.id}/feedback/${ticketId}`;
+  const ticketUrl = `${dashboardOrigin(c.env)}/apps/${app.id}/feedback/${ticketId}`;
   const reference = [app.slug, versionLabel, `ticket ${ticketId}`]
     .filter(Boolean)
     .join(" · ");

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -44,6 +44,8 @@ interface MockEnv {
   RAFT_CLIENT_SECRET: string;
   RAFT_ORIGIN: string;
   RAFT_API_ORIGIN: string;
+  BUSINESS_ORIGIN: string;
+  DASHBOARD_ORIGIN: string;
   SIGNED_URL_SECRET?: string;
   SIGNED_URL_TTL_SECONDS: string;
   R2_ACCOUNT_ID?: string;
@@ -525,8 +527,10 @@ function makeMockEnv(): MockEnv {
     ADMIN_API_TOKEN: "test-token-123",
     RAFT_CLIENT_ID: "quiver-test",
     RAFT_CLIENT_SECRET: "test-secret",
-    RAFT_ORIGIN: "https://app.raft.build",
-    RAFT_API_ORIGIN: "https://api.raft.build",
+    RAFT_ORIGIN: "https://raft.example",
+    RAFT_API_ORIGIN: "https://raft-api.example",
+    BUSINESS_ORIGIN: "https://business.example",
+    DASHBOARD_ORIGIN: "https://dashboard.example",
     SIGNED_URL_SECRET: "test-signed-url-secret",
     SIGNED_URL_TTL_SECONDS: "3600",
     APK_PARSER: null,
@@ -796,7 +800,7 @@ describe("quiver route handlers — SQL smoke", () => {
     expect(viewerBody.next_action as string).toContain("member");
     expect(viewerBody.next_action as string).toContain("/members");
     expect(viewerBody.manage_url).toBe(
-      "https://app.hands.build/orgs/raft_create/members",
+      "https://dashboard.example/orgs/raft_create/members",
     );
 
     const memberResponse = await testApp.request(
@@ -1390,7 +1394,7 @@ describe("auth origin handling", () => {
     expect(parts).toHaveLength(3);
     const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8"));
     expect(payload).toMatchObject({
-      iss: "https://hands.build",
+      iss: "https://business.example",
       aud: "hands-dashboard",
       sub: "account-1",
       jti: "session-1",
@@ -1402,34 +1406,34 @@ describe("auth origin handling", () => {
 
   it("redirects Login with Raft through the current Raft setup route", async () => {
     const env = makeMockEnv();
-    env.RAFT_CLIENT_ID = "hands-4cc7a2";
+    env.RAFT_CLIENT_ID = "test-client";
     const app = new Hono<{ Bindings: MockEnv }>();
     app.get("/api/auth/login", handleAuthLogin);
 
     const res = await app.request(
-      "https://hands.build/api/auth/login?return=%2F",
+      "https://business.example/api/auth/login?return=%2F",
       {},
       env as any,
     );
 
     expect(res.status).toBe(302);
     const location = new URL(res.headers.get("location") ?? "");
-    expect(location.origin).toBe("https://app.raft.build");
+    expect(location.origin).toBe("https://raft.example");
     expect(location.pathname).toBe("/login-with-raft/setup");
-    expect(location.searchParams.get("client_id")).toBe("hands-4cc7a2");
+    expect(location.searchParams.get("client_id")).toBe("test-client");
     expect(location.searchParams.get("return_to")).toBe(
-      "https://hands.build/login/raft/callback",
+      "https://business.example/login/raft/callback",
     );
   });
 
   it("shares browser login state across the dashboard and registered callback hosts", async () => {
     const env = makeMockEnv();
-    env.RAFT_CLIENT_ID = "hands-4cc7a2";
+    env.RAFT_CLIENT_ID = "test-client";
     const app = new Hono<{ Bindings: MockEnv }>();
     app.get("/api/auth/login", handleAuthLogin);
 
     const res = await app.request(
-      "https://app.hands.build/api/auth/login?return=%2Fapps%2Fapp-1%2Fsettings",
+      "https://dashboard.example/api/auth/login?return=%2Fapps%2Fapp-1%2Fsettings",
       {},
       env as any,
     );
@@ -1437,14 +1441,14 @@ describe("auth origin handling", () => {
     expect(res.status).toBe(302);
     const location = new URL(res.headers.get("location") ?? "");
     expect(location.searchParams.get("return_to")).toBe(
-      "https://hands.build/login/raft/callback",
+      "https://business.example/login/raft/callback",
     );
-    expect(res.headers.get("set-cookie")?.toLowerCase()).toContain("domain=hands.build");
+    expect(res.headers.get("set-cookie")?.toLowerCase()).toContain("domain=business.example");
   });
 
   it("keeps localhost auth callbacks and cookies host-local", async () => {
     const env = makeMockEnv();
-    env.RAFT_CLIENT_ID = "hands-4cc7a2";
+    env.RAFT_CLIENT_ID = "test-client";
     const app = new Hono<{ Bindings: MockEnv }>();
     app.get("/api/auth/login", handleAuthLogin);
 
@@ -1464,13 +1468,13 @@ describe("auth origin handling", () => {
   it("canonicalizes public http custom-domain requests to https", () => {
     const ctx = {
       req: {
-        url: "http://quiver.oranix.io/api/auth/login?return=/apps",
+        url: "http://legacy.example/api/auth/login?return=/apps",
         header: () => null,
       },
     };
-    expect(requestOrigin(ctx as any)).toBe("https://quiver.oranix.io");
+    expect(requestOrigin(ctx as any)).toBe("https://legacy.example");
     expect(isSecureRequest(ctx as any)).toBe(true);
-    expect(httpsRedirectUrl(ctx as any)).toBe("https://quiver.oranix.io/api/auth/login?return=/apps");
+    expect(httpsRedirectUrl(ctx as any)).toBe("https://legacy.example/api/auth/login?return=/apps");
   });
 
   it("preserves localhost http origins for local development", () => {
@@ -1488,11 +1492,11 @@ describe("auth origin handling", () => {
   it("respects forwarded https scheme", () => {
     const ctx = {
       req: {
-        url: "http://quiver.oranix.io/api/auth/login?return=/apps",
+        url: "http://legacy.example/api/auth/login?return=/apps",
         header: (name: string) => (name === "x-forwarded-proto" ? "https" : null),
       },
     };
-    expect(requestOrigin(ctx as any)).toBe("https://quiver.oranix.io");
+    expect(requestOrigin(ctx as any)).toBe("https://legacy.example");
     expect(isSecureRequest(ctx as any)).toBe(true);
     expect(httpsRedirectUrl(ctx as any)).toBeNull();
   });
@@ -4534,7 +4538,7 @@ describe("quiver public API v2 — scope resolution", () => {
     const submitContext = {
       env,
       req: {
-        url: "https://quiver.oranix.io/public/v2/apps/scope-app/feedback",
+        url: "https://legacy.example/public/v2/apps/scope-app/feedback",
         param: (name: string) => (name === "slug" ? "scope-app" : ""),
         header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
         query: () => undefined,
@@ -4552,7 +4556,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(submittedBody.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(submittedBody.reference).toContain(`ticket ${submittedBody.id}`);
     expect(submittedBody.ticket_url).toBe(
-      `https://app.hands.build/apps/app-scope/feedback/${submittedBody.id}`,
+      `https://dashboard.example/apps/app-scope/feedback/${submittedBody.id}`,
     );
     expect(putCalls.length).toBe(1);
     expect(putCalls[0]!.key).toContain("feedback/app-scope/");

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -1,12 +1,14 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "hands-worker",
+  "name": "local-hands-worker",
   "main": "src/index.ts",
   "compatibility_date": "2025-10-08",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "upload_source_maps": true,
 
+  // Custom-domain routes must remain literal Wrangler bindings. Other
+  // production identifiers are rendered from repository Variables.
   "routes": [
     { "pattern": "hands.build", "custom_domain": true },
     { "pattern": "app.hands.build", "custom_domain": true }
@@ -15,15 +17,15 @@
   "r2_buckets": [
     {
       "binding": "APK_BUCKET",
-      "bucket_name": "hands-artifacts"
+      "bucket_name": "local-artifacts"
     }
   ],
 
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "hands-db",
-      "database_id": "13d02825-af01-40f8-8f3d-a4356649628f",
+      "database_name": "local-db",
+      "database_id": "00000000-0000-0000-0000-000000000000",
       "migrations_dir": "../migrations/sql"
     }
   ],
@@ -60,21 +62,10 @@
   },
 
   "vars": {
-    "ENVIRONMENT": "production",
+    "ENVIRONMENT": "development",
     "MAX_APK_SIZE_MB": "200",
     "SIGNED_URL_TTL_SECONDS": "3600",
-    // R2_ACCOUNT_ID is set as a Worker secret by the deploy workflow (from the
-    // CLOUDFLARE_ACCOUNT_ID repository secret) rather than hard-coded here.
-    "R2_BUCKET_NAME": "hands-artifacts",
-    "R2_PRESIGNED_DOWNLOAD_TTL_SECONDS": "3600",
-    // quiver.oranix.io is included as a cutover/cache safety net: a browser
-    // still running a cached admin SPA from the legacy domain may fire /api/*
-    // (proxied through the shim) with Origin: https://quiver.oranix.io before it
-    // follows the 302 to hands.build. Native SDKs don't use CORS.
-    "CORS_ALLOWED_ORIGINS": "https://hands.build,https://app.hands.build,https://quiver.oranix.io,http://localhost:5173",
-    "RAFT_ORIGIN": "https://app.raft.build",
-    "RAFT_API_ORIGIN": "https://api.raft.build",
-    "RAFT_CLIENT_ID": "hands-4cc7a2"
+    "R2_PRESIGNED_DOWNLOAD_TTL_SECONDS": "3600"
   },
 
   "assets": {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -3,31 +3,19 @@
   "name": "quiver-worker",
 
   // quiver-worker is now a LEGACY PROXY SHIM, not the business worker.
-  // See src/proxy-shim.ts for the full rationale. It keeps quiver.oranix.io
+  // See src/proxy-shim.ts for the full rationale. It keeps the legacy domain
   // working after the Hands migration:
   //   - machine/API paths  -> reverse-proxied to the Hands worker (writes land
   //                           in the Hands DB; POST bodies preserved)
-  //   - human pages        -> 302 to hands.build
+  //   - human pages        -> 302 to the configured business origin
   // It holds NO D1 / R2 / Container / cron bindings and never touches the
   // legacy database. The business worker + its bindings + the webhook-reaper
-  // cron all live in wrangler.hands.jsonc (name "hands-worker").
+  // cron all live in the rendered Hands production config.
   "main": "src/proxy-shim.ts",
   "compatibility_date": "2025-10-08",
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "upload_source_maps": true,
-
-  // Non-secret config for the shim.
-  "vars": {
-    // Origin serving the Hands business worker. hands.build routes to
-    // hands-worker; quiver never appears in that path, so there is no loop.
-    // (The direct hands-worker.botiverse.workers.dev route is not enabled, so
-    // we proxy via the custom domain; GET edge-caching there is benign, POSTs
-    // are not cached.) No trailing slash.
-    "PROXY_TARGET": "https://hands.build",
-    // Canonical domain humans are 302-redirected to. No trailing slash.
-    "REDIRECT_TARGET": "https://hands.build"
-  },
 
   // The business quiver-worker previously bound the ApkParserContainer Durable
   // Object (Cloudflare Container for APK parsing). The shim drops it, but


### PR DESCRIPTION
## Summary

- move deploy/sync domains, Worker/D1/R2 identifiers, CORS, and Raft public configuration to GitHub repository Variables
- render an ignored production Wrangler config during CI, while keeping checked-in resource identifiers local-safe
- keep Wrangler custom-domain routes literal, as required for domain binding, and validate that they match the configured Variables
- keep actual credentials and the Cloudflare account ID in GitHub Secrets
- remove production endpoint fallbacks from Worker and Admin infrastructure code
- keep shared public endpoint defaults in client artifacts (SDKs and CLI)
- remove browser-visible infrastructure resource details from Settings

## Repository configuration

The following repository Variables are configured: `HANDS_WORKER_NAME`, `HANDS_D1_DATABASE_NAME`, `HANDS_D1_DATABASE_ID`, `HANDS_R2_BUCKET_NAME`, `HANDS_BUSINESS_DOMAIN`, `HANDS_DASHBOARD_DOMAIN`, `HANDS_CORS_ALLOWED_ORIGINS`, `HANDS_RAFT_ORIGIN`, `HANDS_RAFT_API_ORIGIN`, `HANDS_RAFT_CLIENT_ID`, `QUIVER_D1_DATABASE_NAME`, and `QUIVER_R2_BUCKET_NAME`.

The temporary same-name Secrets created during initial investigation were removed. Credential Secrets and `CLOUDFLARE_BOTIVERSE_ACCOUNT_ID` remain Secrets.

## Boundary

- GitHub Variables: CI/deploy domains, resource names and IDs, CORS, and public Raft integration configuration.
- GitHub Secrets: actual credentials and the Cloudflare account ID.
- Literal public values: SDK/CLI defaults, static documentation and branding URLs, and Wrangler custom-domain routes.
- The renderer checks literal route bindings against the domain Variables so configuration drift fails before deployment.

## Validation

- Worker tests: 113 passed
- Worker TypeScript build passed with generated production types
- CLI tests: 12 passed; CLI + Node builds passed
- Electron typecheck and build passed
- Admin typecheck and production build passed
- YAML parse passed for all three changed workflows
- production Wrangler render + full Worker/container dry-run passed
- legacy proxy shim dry-run with injected vars passed
- `git diff --check` passed
- current-tree credential-shape scan found only intentional test fixtures/placeholders; README history scan found no credential-shaped value

Closes task #134.
