### PR TITLE
ci: add Deploy Preview (preview.hands.build)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,97 @@
+name: Deploy Preview
+
+# Deploys the current branch to a throwaway hands-worker-preview on
+# preview.hands.build for UI review (one branch at a time; reuses production
+# D1/R2 read-only). Run workflow -> Use workflow from: <branch>.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hands-preview
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
+      HANDS_WORKER_NAME: ${{ vars.HANDS_WORKER_NAME }}
+      HANDS_D1_DATABASE_NAME: ${{ vars.HANDS_D1_DATABASE_NAME }}
+      HANDS_D1_DATABASE_ID: ${{ vars.HANDS_D1_DATABASE_ID }}
+      HANDS_R2_BUCKET_NAME: ${{ vars.HANDS_R2_BUCKET_NAME }}
+      HANDS_BUSINESS_DOMAIN: ${{ vars.HANDS_BUSINESS_DOMAIN }}
+      HANDS_DASHBOARD_DOMAIN: ${{ vars.HANDS_DASHBOARD_DOMAIN }}
+      HANDS_CORS_ALLOWED_ORIGINS: ${{ vars.HANDS_CORS_ALLOWED_ORIGINS }}
+      HANDS_RAFT_ORIGIN: ${{ vars.HANDS_RAFT_ORIGIN }}
+      HANDS_RAFT_API_ORIGIN: ${{ vars.HANDS_RAFT_API_ORIGIN }}
+      HANDS_RAFT_CLIENT_ID: ${{ vars.HANDS_RAFT_CLIENT_ID }}
+      HANDS_PREVIEW_RAFT_CLIENT_ID: ${{ vars.HANDS_PREVIEW_RAFT_CLIENT_ID }}
+      PREVIEW_HOST: preview.${{ vars.HANDS_BUSINESS_DOMAIN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.12.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Render preview Wrangler config
+        working-directory: worker
+        run: node scripts/render-production-config.mjs --preview --output wrangler.hands.preview.jsonc
+
+      - name: Generate Worker types
+        working-directory: worker
+        run: pnpm exec wrangler types --config wrangler.hands.preview.jsonc
+
+      - name: Build admin assets
+        run: pnpm --filter @botiverse/hands-admin build
+
+      - name: Configure preview Worker secrets
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+          SIGNED_URL_SECRET: ${{ secrets.HANDS_SIGNED_URL_SECRET }}
+          RAFT_CLIENT_SECRET: ${{ secrets.HANDS_PREVIEW_RAFT_CLIENT_SECRET }}
+          ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          config=wrangler.hands.preview.jsonc
+          printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config "${config}"
+          printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config "${config}"
+          printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
+          printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
+
+      - name: Deploy preview Worker + admin assets
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec wrangler deploy --config wrangler.hands.preview.jsonc --containers-rollout immediate
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "### Hands preview"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Ref | \`${GITHUB_REF_NAME}\` |"
+            echo "| SHA | \`${GITHUB_SHA}\` |"
+            echo "| Preview URL | https://${PREVIEW_HOST} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Preview URL: https://${PREVIEW_HOST}"

--- a/worker/scripts/render-production-config.mjs
+++ b/worker/scripts/render-production-config.mjs
@@ -76,6 +76,25 @@ config.vars = {
   R2_BUCKET_NAME: r2.bucket_name,
 };
 
+// Preview mode: a throwaway `hands-worker-preview` on a single fixed host
+// preview.<business> for UI review (one branch previewed at a time — Raft apps
+// allow only one callback, so a fixed host keeps a single registered callback).
+// Reuses production D1/R2 (read-only review) + the same container/DO bindings,
+// and points origins at the preview host so Login-with-Raft resolves there. Uses
+// a dedicated preview Raft app (HANDS_PREVIEW_RAFT_CLIENT_ID + its secret) so the
+// production hands-4cc7a2 app's single callback is untouched.
+if (process.argv.includes("--preview")) {
+  const previewHost = `preview.${businessDomain}`;
+  config.name = "hands-worker-preview";
+  config.routes = [{ pattern: previewHost, custom_domain: true }];
+  config.vars.ENVIRONMENT = "preview";
+  config.vars.BUSINESS_ORIGIN = `https://${previewHost}`;
+  config.vars.DASHBOARD_ORIGIN = `https://${previewHost}`;
+  config.vars.CORS_ALLOWED_ORIGINS = `https://${previewHost},http://localhost:5173`;
+  config.vars.RAFT_CLIENT_ID = required("HANDS_PREVIEW_RAFT_CLIENT_ID");
+  console.log(`Preview config: ${config.name} on https://${previewHost}`);
+}
+
 mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
 console.log(`Rendered production Wrangler config: ${outputPath}`);


### PR DESCRIPTION
Dispatchable per-branch preview deploy to `preview.hands.build` (hands-worker-preview, prod D1/R2 read-only, dedicated 'quiver' preview Raft app so prod's single callback is untouched). Additive — the production deploy path (no `--preview`) is unchanged. Unblocks UI review for the raft-ui elegant rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786305663&installation_id=145465820&pr_number=233&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F233&signature=b2e4e701b24549b97b32aa0403da72b4e95d98db14ee5f3cc8208bce47e1354c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->