### PR TITLE
feat(worker): localize share + history public pages (zh/en)

### DIFF
--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -6,7 +6,70 @@
 import type { Context } from "hono";
 import { requestOrigin } from "../lib/origin";
 import { parseReleaseNotes } from "../lib/release_notes";
-import { generateSignedR2Url, resolveChangelog, changelogToHtml } from "./public_v2";
+import { generateSignedR2Url, resolveChangelog, changelogToHtml, requestedLang } from "./public_v2";
+
+// UI-chrome localization (task: localize surrounding chrome, not just the
+// changelog). Detection reuses requestedLang() (Accept-Language / ?lang=);
+// anything that isn't Chinese falls back to English.
+type HistoryStrings = {
+  htmlLang: string;
+  versionsSuffix: string; // page <title>: "{app} — {suffix}"
+  versionHistory: string; // header sub-line
+  build: string; // "build {code}"
+  latest: string; // history-page badge
+  download: string; // download link
+  noVersions: string; // empty state
+  releaseNotesSuffix: string; // release-notes <title> suffix
+  whatsNewIn: (name: string) => string; // release-notes h1
+  releaseNotes: string; // release-notes sub-line
+  draft: string; // badge
+  current: string; // badge
+  latestBadge: string; // badge
+  noNotesForVersion: string; // per-version empty notes
+  noNotesYet: string; // page empty state
+};
+
+const HISTORY_I18N: { en: HistoryStrings; zh: HistoryStrings } = {
+  en: {
+    htmlLang: "en",
+    versionsSuffix: "Versions",
+    versionHistory: "version history",
+    build: "build",
+    latest: "latest",
+    download: "Download",
+    noVersions: "No published versions yet.",
+    releaseNotesSuffix: "Release Notes",
+    whatsNewIn: (name) => `What's new in ${name}`,
+    releaseNotes: "Release notes",
+    draft: "Draft",
+    current: "Current",
+    latestBadge: "Latest",
+    noNotesForVersion: "No release notes for this version.",
+    noNotesYet: "No release notes yet.",
+  },
+  zh: {
+    htmlLang: "zh",
+    versionsSuffix: "版本",
+    versionHistory: "版本历史",
+    build: "构建",
+    latest: "最新",
+    download: "下载",
+    noVersions: "暂无已发布的版本。",
+    releaseNotesSuffix: "更新日志",
+    whatsNewIn: (name) => `${name} 新功能`,
+    releaseNotes: "更新日志",
+    draft: "草稿",
+    current: "当前",
+    latestBadge: "最新",
+    noNotesForVersion: "此版本暂无更新说明。",
+    noNotesYet: "暂无更新说明。",
+  },
+};
+
+function historyStrings(c: Context<{ Bindings: Env }>): HistoryStrings {
+  const lang = (requestedLang(c) ?? "").toLowerCase();
+  return lang.startsWith("zh") ? HISTORY_I18N.zh : HISTORY_I18N.en;
+}
 
 type HistoryRow = {
   release_id: string;
@@ -87,7 +150,7 @@ export async function handlePublicAppHistory(c: Context<{ Bindings: Env }>) {
     .all<HistoryRow>();
   const lang =
     (c.req.header("accept-language") ?? "").split(",")[0]?.trim().split(";")[0] ?? null;
-  return new Response(renderHistoryPage(app, results, lang), {
+  return new Response(renderHistoryPage(app, results, lang, historyStrings(c)), {
     headers: { "content-type": "text/html; charset=utf-8" },
   });
 }
@@ -138,7 +201,7 @@ export async function handlePublicReleaseNotes(c: Context<{ Bindings: Env }>) {
     null;
 
   return new Response(
-    renderReleaseNotesPage(app, visible, requestedCode, lang),
+    renderReleaseNotesPage(app, visible, requestedCode, lang, historyStrings(c)),
     { headers: { "content-type": "text/html; charset=utf-8" } },
   );
 }
@@ -232,6 +295,7 @@ function renderHistoryPage(
   app: { slug: string; name: string; platform: string; icon_r2_key: string | null },
   rows: HistoryRow[],
   lang: string | null,
+  t: HistoryStrings,
 ): string {
   const items = rows
     .map((row) => {
@@ -241,11 +305,11 @@ function renderHistoryPage(
       <div class="head">
         <div>
           <strong>${esc(row.version_name)}</strong>
-          <span class="meta">build ${row.version_code} · ${esc(row.channel_slug)}</span>
-          ${row.release_status === "active" ? '<span class="badge">latest</span>' : ""}
+          <span class="meta">${t.build} ${row.version_code} · ${esc(row.channel_slug)}</span>
+          ${row.release_status === "active" ? `<span class="badge">${t.latest}</span>` : ""}
         </div>
         <a class="dl" href="/apps/${esc(app.slug)}/history/${esc(row.release_id)}/download">
-          Download${row.size_bytes ? ` · ${formatSize(row.size_bytes)}` : ""}
+          ${t.download}${row.size_bytes ? ` · ${formatSize(row.size_bytes)}` : ""}
         </a>
       </div>
       <div class="date" data-ts="${row.released_at}"></div>
@@ -255,11 +319,11 @@ function renderHistoryPage(
     .join("\n");
 
   return `<!doctype html>
-<html lang="en">
+<html lang="${t.htmlLang}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${esc(app.name)} — Versions</title>
+  <title>${esc(app.name)} — ${t.versionsSuffix}</title>
   <style>
     :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     body { margin: 0; background: #f5f5f2; color: #1e1f22; }
@@ -294,10 +358,10 @@ function renderHistoryPage(
       ${app.icon_r2_key ? `<img src="/public/apps/${esc(app.slug)}/icon" alt="" width="56" height="56">` : ""}
       <div>
         <h1>${esc(app.name)}</h1>
-        <div class="sub">${esc(app.platform)} · version history</div>
+        <div class="sub">${esc(app.platform)} · ${t.versionHistory}</div>
       </div>
     </header>
-    ${rows.length === 0 ? '<p class="sub">No published versions yet.</p>' : `<ul>${items}</ul>`}
+    ${rows.length === 0 ? `<p class="sub">${t.noVersions}</p>` : `<ul>${items}</ul>`}
   </main>
   <script>
     document.querySelectorAll(".date").forEach((el) => {
@@ -317,6 +381,7 @@ function renderReleaseNotesPage(
   rows: HistoryRow[],
   requestedCode: number | null,
   lang: string | null,
+  t: HistoryStrings,
 ): string {
   const items = rows
     .map((row) => {
@@ -325,11 +390,11 @@ function renderReleaseNotesPage(
       const isDraft = row.release_status === "draft";
       const isLatest = row.release_status === "active";
       const badge = isDraft
-        ? '<span class="badge draft">Draft</span>'
+        ? `<span class="badge draft">${t.draft}</span>`
         : featured
-          ? '<span class="badge you">Current</span>'
+          ? `<span class="badge you">${t.current}</span>`
           : isLatest
-            ? '<span class="badge latest">Latest</span>'
+            ? `<span class="badge latest">${t.latestBadge}</span>`
             : "";
       return `
     <li class="entry${featured ? " featured" : ""}" id="v${row.version_code}">
@@ -338,7 +403,7 @@ function renderReleaseNotesPage(
         <div class="head">
           <div class="title">
             <strong>${esc(row.version_name)}</strong>
-            <span class="meta">build ${row.version_code}</span>
+            <span class="meta">${t.build} ${row.version_code}</span>
             ${badge}
           </div>
           <span class="date" data-ts="${row.released_at}"></span>
@@ -346,7 +411,7 @@ function renderReleaseNotesPage(
         ${
           changelog
             ? `<div class="notes">${changelogToHtml(changelog)}</div>`
-            : '<div class="notes muted">No release notes for this version.</div>'
+            : `<div class="notes muted">${t.noNotesForVersion}</div>`
         }
       </div>
     </li>`;
@@ -354,11 +419,11 @@ function renderReleaseNotesPage(
     .join("\n");
 
   return `<!doctype html>
-<html lang="en">
+<html lang="${t.htmlLang}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${esc(app.name)} — Release Notes</title>
+  <title>${esc(app.name)} — ${t.releaseNotesSuffix}</title>
   <style>
     :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --accent: #176f5d; }
     html { background: #f5f5f2; }
@@ -404,10 +469,10 @@ function renderReleaseNotesPage(
 <body>
   <main>
     <header>
-      <h1>What's new in ${esc(app.name)}</h1>
-      <div class="sub">Release notes</div>
+      <h1>${t.whatsNewIn(esc(app.name))}</h1>
+      <div class="sub">${t.releaseNotes}</div>
     </header>
-    ${rows.length === 0 ? '<p class="empty">No release notes yet.</p>' : `<ul>${items}</ul>`}
+    ${rows.length === 0 ? `<p class="empty">${t.noNotesYet}</p>` : `<ul>${items}</ul>`}
   </main>
   <script>
     document.querySelectorAll(".date").forEach((el) => {

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -638,7 +638,7 @@ export function resolveChangelog(raw: string | null, lang: string | null): strin
   return resolveReleaseNote(raw, lang);
 }
 
-function requestedLang(c: Context<{ Bindings: Env }>): string | null {
+export function requestedLang(c: Context<{ Bindings: Env }>): string | null {
   const explicit = c.req.query("lang") ?? c.req.header("X-Hands-Lang") ?? c.req.header("X-Quiver-Lang");
   if (explicit) return explicit;
   const accept = c.req.header("accept-language");

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -2,7 +2,98 @@ import type { Context } from "hono";
 import qrcode from "qrcode-generator";
 import { requestOrigin } from "../lib/origin";
 import { currentActor, type AdminEnv } from "../middleware/auth";
-import { generateSignedR2Url, resolveChangelog , changelogToHtml } from "./public_v2";
+import { generateSignedR2Url, resolveChangelog , changelogToHtml, requestedLang } from "./public_v2";
+
+// UI-chrome localization for the public share/password/error pages. Detection
+// reuses requestedLang() (Accept-Language / ?lang=); anything not Chinese falls
+// back to English. The changelog itself is still localized separately via
+// resolveChangelog().
+type ShareStrings = {
+  htmlLang: string;
+  preRelease: string; // draft tag
+  build: string; // "build {code}"
+  packageLabel: string;
+  versionLabel: string;
+  artifactLabel: string;
+  platformLabel: string;
+  checksumLabel: string;
+  expiresLabel: string;
+  statsLabel: string;
+  visitors: string;
+  views: string;
+  downloaders: string;
+  downloads: string;
+  downloadApk: string;
+  scanHint: string;
+  passwordRequired: string; // password page title + heading
+  wrongPassword: string;
+  passwordProtected: string;
+  passwordPlaceholder: string;
+  unlock: string;
+  shareUnavailable: string; // error page title + heading
+  errMissingToken: string;
+  errUnavailable: string;
+};
+
+const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
+  en: {
+    htmlLang: "en",
+    preRelease: "Pre-release",
+    build: "build",
+    packageLabel: "Package",
+    versionLabel: "Version",
+    artifactLabel: "Artifact",
+    platformLabel: "Platform",
+    checksumLabel: "Checksum",
+    expiresLabel: "Expires",
+    statsLabel: "Stats",
+    visitors: "visitors",
+    views: "views",
+    downloaders: "downloaders",
+    downloads: "downloads",
+    downloadApk: "Download APK",
+    scanHint: "Scan to open on your phone",
+    passwordRequired: "Password required",
+    wrongPassword: "Wrong password. Try again.",
+    passwordProtected: "This download is password protected.",
+    passwordPlaceholder: "Password",
+    unlock: "Unlock",
+    shareUnavailable: "Share unavailable",
+    errMissingToken: "Missing share token",
+    errUnavailable: "This share link is expired, revoked, or unavailable.",
+  },
+  zh: {
+    htmlLang: "zh",
+    preRelease: "预发布",
+    build: "构建",
+    packageLabel: "包名",
+    versionLabel: "版本",
+    artifactLabel: "安装包",
+    platformLabel: "平台",
+    checksumLabel: "校验和",
+    expiresLabel: "过期时间",
+    statsLabel: "统计",
+    visitors: "访客数",
+    views: "浏览次数",
+    downloaders: "下载人数",
+    downloads: "下载次数",
+    downloadApk: "下载 APK",
+    scanHint: "扫码在手机上打开",
+    passwordRequired: "需要密码",
+    wrongPassword: "密码错误，请重试。",
+    passwordProtected: "此下载受密码保护。",
+    passwordPlaceholder: "密码",
+    unlock: "解锁",
+    shareUnavailable: "分享不可用",
+    errMissingToken: "缺少分享令牌",
+    errUnavailable: "此分享链接已过期、被撤销或不可用。",
+  },
+};
+
+function shareStrings(c: Context<{ Bindings: Env }>): ShareStrings {
+  const lang = (requestedLang(c) ?? "").toLowerCase();
+  return lang.startsWith("zh") ? SHARE_I18N.zh : SHARE_I18N.en;
+}
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -309,18 +400,19 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
 }
 
 export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
+  const t = shareStrings(c);
   const token = c.req.param("token");
-  if (!token) return htmlResponse(renderErrorPage("Missing share token"), 400);
+  if (!token) return htmlResponse(renderErrorPage(t, t.errMissingToken), 400);
 
   const row = await findActiveShare(c.env.DB, token);
 
   if (!row) {
-    return htmlResponse(renderErrorPage("This share link is expired, revoked, or unavailable."), 404);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
   }
 
   if (row.password_hash && !(await hasValidUnlockCookie(c, row))) {
     await recordShareEvent(c, row.share_id, "view");
-    return htmlResponse(renderPasswordPage(token, false));
+    return htmlResponse(renderPasswordPage(t, token, false));
   }
 
   await recordShareEvent(c, row.share_id, "view");
@@ -330,16 +422,17 @@ export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
   const shareUrl = new URL(`/share/${token}`, origin).toString();
   const lang = (c.req.header("accept-language") ?? "").split(",")[0]?.trim().split(";")[0] ?? null;
   const localized = { ...row, changelog: resolveChangelog(row.changelog, lang) };
-  return htmlResponse(renderSharePage(localized, stats, downloadUrl, shareUrl, token));
+  return htmlResponse(renderSharePage(t, localized, stats, downloadUrl, shareUrl, token));
 }
 
 export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: Env }>) {
+  const t = shareStrings(c);
   const token = c.req.param("token");
-  if (!token) return htmlResponse(renderErrorPage("Missing share token"), 400);
+  if (!token) return htmlResponse(renderErrorPage(t, t.errMissingToken), 400);
 
   const row = await findActiveShare(c.env.DB, token);
   if (!row) {
-    return htmlResponse(renderErrorPage("This share link is expired, revoked, or unavailable."), 404);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
   }
 
   if (row.password_hash && !(await hasValidUnlockCookie(c, row))) {
@@ -370,11 +463,12 @@ export async function handlePublicReleaseShareIcon(c: Context<{ Bindings: Env }>
 }
 
 export async function handlePublicReleaseShareUnlock(c: Context<{ Bindings: Env }>) {
+  const t = shareStrings(c);
   const token = c.req.param("token");
-  if (!token) return htmlResponse(renderErrorPage("Missing share token"), 400);
+  if (!token) return htmlResponse(renderErrorPage(t, t.errMissingToken), 400);
   const row = await findActiveShare(c.env.DB, token);
   if (!row) {
-    return htmlResponse(renderErrorPage("This share link is expired, revoked, or unavailable."), 404);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
   }
   if (!row.password_hash) return c.redirect(`/share/${token}`, 302);
 
@@ -396,7 +490,7 @@ export async function handlePublicReleaseShareUnlock(c: Context<{ Bindings: Env 
         row.release_id,
       )
       .run();
-    return htmlResponse(renderPasswordPage(token, true), 401);
+    return htmlResponse(renderPasswordPage(t, token, true), 401);
   }
 
   const proof = await shareUnlockProof(row, currentDayBucket());
@@ -618,6 +712,7 @@ function htmlResponse(html: string, status = 200): Response {
 }
 
 function renderSharePage(
+  t: ShareStrings,
   row: SharePageRow,
   stats: ShareStats,
   downloadUrl: string,
@@ -628,7 +723,7 @@ function renderSharePage(
   const expiresIso = new Date(row.expires_at).toISOString();
   const qrSvg = renderShareQrSvg(shareUrl);
   return `<!doctype html>
-<html lang="en">
+<html lang="${t.htmlLang}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -675,30 +770,30 @@ function renderSharePage(
       <div>
         <h1>${escapeHtml(row.app_name || row.app_slug)}${
           row.release_status === "draft"
-            ? ' <span class="draft-tag">Pre-release</span>'
+            ? ` <span class="draft-tag">${t.preRelease}</span>`
             : ""
         }</h1>
-        <p>${escapeHtml(row.version_name)} · build ${row.version_code} · ${escapeHtml(row.channel_slug)}</p>
+        <p>${escapeHtml(row.version_name)} · ${t.build} ${row.version_code} · ${escapeHtml(row.channel_slug)}</p>
       </div>
     </div>
     <dl>
-      <dt>Package</dt><dd>${escapeHtml(row.package_id || row.app_slug)}</dd>
-      <dt>Version</dt><dd>${escapeHtml(row.version_name)} (${row.version_code})</dd>
-      <dt>Artifact</dt><dd>${escapeHtml(row.filetype.toUpperCase())} · ${formatBytes(row.size_bytes)}</dd>
-      <dt>Platform</dt><dd>${escapeHtml([row.platform, row.arch, row.variant].filter(Boolean).join(" / "))}</dd>
-      <dt>Checksum</dt><dd>${escapeHtml(row.file_hash)}</dd>
-      <dt>Expires</dt><dd><time id="expires-at" datetime="${escapeAttribute(expiresIso)}" data-expires-at="${row.expires_at}">${escapeHtml(expiresIso)}</time></dd>
-      <dt>Stats</dt>
+      <dt>${t.packageLabel}</dt><dd>${escapeHtml(row.package_id || row.app_slug)}</dd>
+      <dt>${t.versionLabel}</dt><dd>${escapeHtml(row.version_name)} (${row.version_code})</dd>
+      <dt>${t.artifactLabel}</dt><dd>${escapeHtml(row.filetype.toUpperCase())} · ${formatBytes(row.size_bytes)}</dd>
+      <dt>${t.platformLabel}</dt><dd>${escapeHtml([row.platform, row.arch, row.variant].filter(Boolean).join(" / "))}</dd>
+      <dt>${t.checksumLabel}</dt><dd>${escapeHtml(row.file_hash)}</dd>
+      <dt>${t.expiresLabel}</dt><dd><time id="expires-at" datetime="${escapeAttribute(expiresIso)}" data-expires-at="${row.expires_at}">${escapeHtml(expiresIso)}</time></dd>
+      <dt>${t.statsLabel}</dt>
       <dd class="stats">
-        <span class="stat"><strong>${stats.unique_view_count}</strong><span>visitors</span></span>
-        <span class="stat"><strong>${stats.view_count}</strong><span>views</span></span>
-        <span class="stat"><strong>${stats.unique_download_count}</strong><span>downloaders</span></span>
-        <span class="stat"><strong>${stats.download_count}</strong><span>downloads</span></span>
+        <span class="stat"><strong>${stats.unique_view_count}</strong><span>${t.visitors}</span></span>
+        <span class="stat"><strong>${stats.view_count}</strong><span>${t.views}</span></span>
+        <span class="stat"><strong>${stats.unique_download_count}</strong><span>${t.downloaders}</span></span>
+        <span class="stat"><strong>${stats.download_count}</strong><span>${t.downloads}</span></span>
       </dd>
     </dl>
     <div class="get-it">
-      <a class="download" href="${escapeAttribute(downloadUrl)}">Download APK</a>
-      <div class="qr">${qrSvg}<span>Scan to open on your phone</span></div>
+      <a class="download" href="${escapeAttribute(downloadUrl)}">${t.downloadApk}</a>
+      <div class="qr">${qrSvg}<span>${t.scanHint}</span></div>
     </div>
     ${row.changelog ? `<div class="notes">${changelogToHtml(row.changelog)}</div>` : ""}
   </main>
@@ -730,13 +825,13 @@ function renderShareQrSvg(url: string): string {
   return qr.createSvgTag({ cellSize: 4, margin: 0, scalable: true });
 }
 
-function renderPasswordPage(token: string, failed: boolean): string {
+function renderPasswordPage(t: ShareStrings, token: string, failed: boolean): string {
   return `<!doctype html>
-<html lang="en">
+<html lang="${t.htmlLang}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Password required</title>
+  <title>${t.passwordRequired}</title>
   <style>
     :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f5f5f2; color: #1e1f22; }
@@ -755,24 +850,24 @@ function renderPasswordPage(token: string, failed: boolean): string {
 </head>
 <body>
   <main>
-    <h1>Password required</h1>
-    <p>${failed ? '<span class="error">Wrong password. Try again.</span>' : "This download is password protected."}</p>
+    <h1>${t.passwordRequired}</h1>
+    <p>${failed ? `<span class="error">${t.wrongPassword}</span>` : t.passwordProtected}</p>
     <form method="post" action="/share/${escapeAttribute(encodeURIComponent(token))}/unlock">
-      <input type="password" name="password" placeholder="Password" autofocus autocomplete="off" required>
-      <button type="submit">Unlock</button>
+      <input type="password" name="password" placeholder="${escapeAttribute(t.passwordPlaceholder)}" autofocus autocomplete="off" required>
+      <button type="submit">${t.unlock}</button>
     </form>
   </main>
 </body>
 </html>`;
 }
 
-function renderErrorPage(message: string): string {
+function renderErrorPage(t: ShareStrings, message: string): string {
   return `<!doctype html>
-<html lang="en">
+<html lang="${t.htmlLang}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Share unavailable</title>
+  <title>${t.shareUnavailable}</title>
   <style>
     :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f5f5f2; color: #1e1f22; }
@@ -789,7 +884,7 @@ function renderErrorPage(message: string): string {
 <body>
   <main>
     <div class="badge" aria-hidden="true">🔗</div>
-    <h1>Share unavailable</h1>
+    <h1>${t.shareUnavailable}</h1>
     <p>${escapeHtml(message)}</p>
   </main>
 </body>


### PR DESCRIPTION
The public **share page** and **release history page** localized only the changelog; their surrounding UI chrome (headings, `Download`, `Latest`, `Version`, `What's new`, password/error pages, etc.) was hardcoded English.

Adds a small zh/en string dictionary selected by the existing `requestedLang()` Accept-Language helper (now exported from `public_v2.ts`) and threads it through `history.ts` + `shares.ts`. Changelog resolution is unchanged. `<html lang>` now follows the selected UI language.

Requested by artin after the 1.4.0 release (changelog was bilingual but page chrome wasn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786317098&installation_id=145465820&pr_number=235&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F235&signature=77842a14040e800f6bfdf429a5759dfa58313567279a70afcbdf487976773647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->