### PR TITLE
fix(worker): guard requestedLang query accessor (fixes #235 test breakage)

### DIFF
--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -639,7 +639,10 @@ export function resolveChangelog(raw: string | null, lang: string | null): strin
 }
 
 export function requestedLang(c: Context<{ Bindings: Env }>): string | null {
-  const explicit = c.req.query("lang") ?? c.req.header("X-Hands-Lang") ?? c.req.header("X-Quiver-Lang");
+  // `query` is guarded because requestedLang is now called from several public
+  // handlers (share/history) whose contexts may not expose the query accessor.
+  const fromQuery = typeof c.req.query === "function" ? c.req.query("lang") : null;
+  const explicit = fromQuery ?? c.req.header("X-Hands-Lang") ?? c.req.header("X-Quiver-Lang");
   if (explicit) return explicit;
   const accept = c.req.header("accept-language");
   if (!accept) return null;


### PR DESCRIPTION
PR #235 made the share handler call `requestedLang(c)`, which reads `c.req.query`; some share-flow contexts/test mocks don't expose it, breaking 6 worker tests and blocking the prod deploy's `run_checks` gate. Guard the query read (prod Hono always has query, so behavior is unchanged there). All 113 worker tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786317294&installation_id=145465820&pr_number=236&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F236&signature=e18096292bb792cbc8fd7a9d7dbdee6e494b171dc2945192778fc5b801e8639b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->