### PR TITLE
feat(hands): App Store review status panel (task #135)

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -784,6 +784,47 @@ export const getTestflightUploadStatus = (appId: string, buildUploadId: string) 
     uploaded_at: string | null;
   }>(`/api/apps/${appId}/testflight-uploads/${buildUploadId}`, { admin: true });
 
+// ---------- App Store review status (read-only) ----------
+
+export interface AppStoreVersionSummary {
+  versionString: string | null;
+  appStoreState: string | null;
+  platform: string | null;
+  createdDate: string | null;
+}
+
+export interface BetaReviewSummary {
+  version: string | null;
+  processingState: string | null;
+  uploadedDate: string | null;
+  betaReviewState: string | null;
+}
+
+/**
+ * Read-only App Store / TestFlight review status for an iOS app. The worker
+ * returns one of a few shapes; the optional fields distinguish them:
+ *  - { applicable: false }                          → non-iOS, hide the panel
+ *  - { configured: false }                          → no ASC credentials
+ *  - { configured: true, bundle_id: null, error }   → no iOS bundle id
+ *  - { configured: true, error }                    → Apple/ASC call failed
+ *  - { configured: true, applicable: true, … }      → data present
+ */
+export interface AppStoreReview {
+  applicable?: boolean;
+  configured?: boolean;
+  platform?: string;
+  bundle_id?: string | null;
+  asc_app_id?: string;
+  app_store_versions?: AppStoreVersionSummary[];
+  testflight_builds?: BetaReviewSummary[];
+  error?: string;
+}
+
+export const getAppStoreReview = (appId: string) =>
+  request<AppStoreReview>(`/api/apps/${appId}/appstore-review`, {
+    admin: true,
+  });
+
 export const listAppDeployTokens = (appId: string) =>
   request<{ deploy_tokens: AppDeployToken[] }>(
     `/api/apps/${appId}/deploy-tokens`,

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -19,7 +19,10 @@ import {
   DialogFooter,
   EmptyState,
   EmptyStateTitle,
+  EmptyStateDescription,
   Skeleton,
+  Badge,
+  type BadgeProps,
 } from "raft-ui";
 import { DeviceAnalytics } from "../components/DeviceAnalytics";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -47,6 +50,7 @@ import {
   setAscCredentials,
   deleteAscCredentials,
   verifyAscCredentials,
+  getAppStoreReview,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
@@ -640,6 +644,194 @@ function TestFlightPanel({ appId }: { appId: string }) {
   );
 }
 
+// --- App Store review status (read-only) ---------------------------------
+
+type BadgeVariant = NonNullable<BadgeProps["variant"]>;
+
+/** Map an appStoreState enum to a Badge variant + a human label. */
+function appStoreStateBadge(state: string | null): {
+  variant: BadgeVariant;
+  label: string;
+} {
+  switch (state) {
+    case "READY_FOR_SALE":
+      return { variant: "success", label: "Ready for sale" };
+    case "IN_REVIEW":
+      return { variant: "information", label: "In review" };
+    case "WAITING_FOR_REVIEW":
+      return { variant: "warning", label: "Waiting for review" };
+    case "PENDING_DEVELOPER_RELEASE":
+      return { variant: "accent", label: "Pending developer release" };
+    case "PENDING_APPLE_RELEASE":
+      return { variant: "accent", label: "Pending Apple release" };
+    case "PREPARE_FOR_SUBMISSION":
+      return { variant: "muted", label: "Preparing" };
+    case "REJECTED":
+      return { variant: "danger", label: "Rejected" };
+    case "METADATA_REJECTED":
+      return { variant: "danger", label: "Metadata rejected" };
+    case "DEVELOPER_REJECTED":
+      return { variant: "danger", label: "Developer rejected" };
+    default:
+      // Unknown/other states (e.g. PROCESSING_FOR_APP_STORE): show verbatim.
+      return {
+        variant: "muted",
+        label: state ? state.replace(/_/g, " ").toLowerCase() : "Unknown",
+      };
+  }
+}
+
+/** Map a TestFlight betaReviewState to a Badge variant + label. */
+function betaReviewStateBadge(state: string | null): {
+  variant: BadgeVariant;
+  label: string;
+} {
+  switch (state) {
+    case "APPROVED":
+      return { variant: "success", label: "Approved" };
+    case "IN_REVIEW":
+      return { variant: "information", label: "In review" };
+    case "WAITING_FOR_REVIEW":
+      return { variant: "warning", label: "Waiting for review" };
+    case "REJECTED":
+      return { variant: "danger", label: "Rejected" };
+    default:
+      return { variant: "muted", label: "No beta review" };
+  }
+}
+
+function AppStoreReviewPanel({ appId }: { appId: string; app: App }) {
+  // Non-iOS apps never render this panel — the parent guards on
+  // app.platform === "ios" (mirrors the worker's applicable:false response).
+  const review = useQuery({
+    queryKey: ["appstore-review", appId],
+    queryFn: () => getAppStoreReview(appId),
+  });
+
+  const data = review.data;
+  const versions = data?.app_store_versions ?? [];
+  const builds = data?.testflight_builds ?? [];
+  const current = versions[0];
+  const currentBadge = current ? appStoreStateBadge(current.appStoreState) : null;
+
+  return (
+    <div className="border-t border-slate-100 pt-3">
+      <div className="flex items-center gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <div className="text-sm font-medium">App Store review status</div>
+            {currentBadge && (
+              <Badge variant={currentBadge.variant}>{currentBadge.label}</Badge>
+            )}
+          </div>
+          <div className="text-xs text-slate-500">
+            Live review state of this app's recent App Store versions and
+            TestFlight builds, from App Store Connect. Read-only.
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3">
+        {review.isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        ) : data?.configured === false ? (
+          <EmptyState>
+            <EmptyStateTitle>App Store Connect not configured</EmptyStateTitle>
+            <EmptyStateDescription>
+              Add ASC credentials in the TestFlight settings above to see review
+              status.
+            </EmptyStateDescription>
+          </EmptyState>
+        ) : data?.bundle_id === null ? (
+          <EmptyState>
+            <EmptyStateTitle>No iOS bundle ID</EmptyStateTitle>
+            <EmptyStateDescription>
+              Set a bundle ID on one of this app's channels to resolve its App
+              Store Connect record.
+            </EmptyStateDescription>
+          </EmptyState>
+        ) : data?.error ? (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            Could not load review status from App Store Connect: {data.error}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <div className="text-xs font-medium text-slate-600 mb-1">
+                Recent App Store versions
+              </div>
+              {versions.length === 0 ? (
+                <div className="text-xs text-slate-400">
+                  No App Store versions yet.
+                </div>
+              ) : (
+                <ul className="space-y-1">
+                  {versions.map((v, i) => {
+                    const b = appStoreStateBadge(v.appStoreState);
+                    return (
+                      <li
+                        key={`${v.versionString}-${i}`}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <span className="font-mono">
+                          {v.versionString ?? "—"}
+                        </span>
+                        <Badge variant={b.variant}>{b.label}</Badge>
+                        {(v.appStoreState === "REJECTED" ||
+                          v.appStoreState === "METADATA_REJECTED" ||
+                          v.appStoreState === "DEVELOPER_REJECTED") && (
+                          <span className="text-xs text-slate-400">
+                            (see App Store Connect for the rejection details)
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            <div>
+              <div className="text-xs font-medium text-slate-600 mb-1">
+                Recent TestFlight builds — beta review
+              </div>
+              {builds.length === 0 ? (
+                <div className="text-xs text-slate-400">
+                  No builds on App Store Connect yet.
+                </div>
+              ) : (
+                <ul className="space-y-1">
+                  {builds.map((bld, i) => {
+                    const b = betaReviewStateBadge(bld.betaReviewState);
+                    return (
+                      <li
+                        key={`${bld.version}-${i}`}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <span className="font-mono">{bld.version ?? "—"}</span>
+                        <Badge variant={b.variant}>{b.label}</Badge>
+                        {bld.processingState &&
+                          bld.processingState !== "VALID" && (
+                            <span className="text-xs text-slate-400">
+                              {bld.processingState.toLowerCase()}
+                            </span>
+                          )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function PublicHistoryToggle({ appId, app }: { appId: string; app: App }) {
   const toast = useToast();
   const qc = useQueryClient();
@@ -861,6 +1053,9 @@ export function AppSettings({ appId }: { appId: string }) {
 
         {/* TestFlight upload credentials — iOS apps only */}
         {app.platform === "ios" && <TestFlightPanel appId={appId} />}
+
+        {/* App Store review status (read-only) — iOS apps only */}
+        {app.platform === "ios" && <AppStoreReviewPanel appId={appId} app={app} />}
 
         {/* Default release channel picker */}
         <DefaultChannelPicker appId={appId} app={app} isOrgAdmin={isOrgAdmin} />

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -93,6 +93,7 @@ import {
   handleTestflightUpload,
   handleTestflightUploadStatus,
 } from "./routes/testflight";
+import { handleAppStoreReview } from "./routes/appstore_review";
 import { handleGenerateDeltaPatches, handleDeltaSources } from "./routes/delta";
 import { handleUploadApk } from "./routes/upload";
 import {
@@ -787,6 +788,7 @@ admin.get("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleGet
 admin.post("/api/apps/:appId/asc-credentials/verify", requireAppRole("admin"), handleVerifyAscCredentials);
 admin.post("/api/apps/:appId/builds/:buildId/testflight-upload", requireAppRole("admin"), handleTestflightUpload);
 admin.get("/api/apps/:appId/testflight-uploads/:buildUploadId", requireAppRole("viewer"), handleTestflightUploadStatus);
+admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
 admin.post(

--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -275,3 +275,107 @@ export async function getBuildUpload(
   );
   return res.data;
 }
+
+// ---------- App Store review status (read-only) ----------
+
+/**
+ * A version's App Store review lifecycle state, e.g. PREPARE_FOR_SUBMISSION,
+ * WAITING_FOR_REVIEW, IN_REVIEW, PENDING_DEVELOPER_RELEASE,
+ * PENDING_APPLE_RELEASE, READY_FOR_SALE, REJECTED, METADATA_REJECTED,
+ * DEVELOPER_REJECTED, … (Apple keeps adding to this enum; keep it a string).
+ */
+export interface AppStoreVersionSummary {
+  versionString: string | null;
+  appStoreState: string | null;
+  platform: string | null;
+  createdDate: string | null;
+}
+
+/** Recent App Store versions with their review state (newest first, per Apple). */
+export async function getAppStoreVersions(
+  creds: AscApiCredentials,
+  ascAppId: string,
+): Promise<AppStoreVersionSummary[]> {
+  const res = await ascRequest<{
+    data: Array<{
+      attributes?: {
+        versionString?: string | null;
+        appStoreState?: string | null;
+        platform?: string | null;
+        createdDate?: string | null;
+      };
+    }>;
+  }>(
+    creds,
+    "GET",
+    `/v1/apps/${ascAppId}/appStoreVersions?limit=5&fields[appStoreVersions]=versionString,appStoreState,platform,createdDate`,
+  );
+  return (res.data ?? []).map((v) => ({
+    versionString: v.attributes?.versionString ?? null,
+    appStoreState: v.attributes?.appStoreState ?? null,
+    platform: v.attributes?.platform ?? null,
+    createdDate: v.attributes?.createdDate ?? null,
+  }));
+}
+
+/**
+ * A build's TestFlight beta-review state. betaReviewState is
+ * WAITING_FOR_REVIEW / IN_REVIEW / APPROVED / REJECTED, or null when the
+ * build has no beta review submission (e.g. internal-only builds).
+ */
+export interface BetaReviewSummary {
+  version: string | null;
+  processingState: string | null;
+  uploadedDate: string | null;
+  betaReviewState: string | null;
+}
+
+/** Recent builds joined to their betaAppReviewSubmission state (newest first). */
+export async function getBetaReviewStates(
+  creds: AscApiCredentials,
+  ascAppId: string,
+): Promise<BetaReviewSummary[]> {
+  const res = await ascRequest<{
+    data: Array<{
+      attributes?: {
+        version?: string | null;
+        processingState?: string | null;
+        uploadedDate?: string | null;
+      };
+      relationships?: {
+        betaAppReviewSubmission?: {
+          data?: { type: string; id: string } | null;
+        };
+      };
+    }>;
+    included?: Array<{
+      type: string;
+      id: string;
+      attributes?: { betaReviewState?: string | null };
+    }>;
+  }>(
+    creds,
+    "GET",
+    `/v1/apps/${ascAppId}/builds?limit=5&include=betaAppReviewSubmission&fields[builds]=version,processingState,uploadedDate&fields[betaAppReviewSubmissions]=betaReviewState`,
+  );
+
+  // Index the included betaAppReviewSubmissions by id so each build can look
+  // up its submission via the relationship pointer (JSON:API compound doc).
+  const submissions = new Map<string, string | null>();
+  for (const inc of res.included ?? []) {
+    if (inc.type === "betaAppReviewSubmissions") {
+      submissions.set(inc.id, inc.attributes?.betaReviewState ?? null);
+    }
+  }
+
+  return (res.data ?? []).map((b) => {
+    const rel = b.relationships?.betaAppReviewSubmission?.data;
+    const betaReviewState = rel ? submissions.get(rel.id) ?? null : null;
+    return {
+      version: b.attributes?.version ?? null,
+      processingState: b.attributes?.processingState ?? null,
+      uploadedDate: b.attributes?.uploadedDate ?? null,
+      betaReviewState,
+    };
+  });
+}

--- a/worker/src/routes/appstore_review.ts
+++ b/worker/src/routes/appstore_review.ts
@@ -1,0 +1,93 @@
+/**
+ * App Store review status (read-only).
+ *
+ * GET /api/apps/:appId/appstore-review
+ *   Surfaces the App Store review state of this iOS app's recent versions and
+ *   the TestFlight beta-review state of its recent builds, straight from App
+ *   Store Connect. Read-only — it never touches the release/publish flow.
+ *
+ *   Reuses the TestFlight ASC integration end-to-end: same encrypted
+ *   credentials, same bundle-id → ASC app resolution. iOS-only; other
+ *   platforms get { applicable: false } so the admin can skip the panel.
+ *
+ *   Apple hiccups never 500 this endpoint — they come back as
+ *   { configured: true, error } with a 200 so the panel can show the message.
+ */
+import type { Context } from "hono";
+import type { AdminEnv } from "../middleware/auth";
+import { getAscCredentials } from "../lib/asc_credentials";
+import {
+  getAppStoreVersions,
+  getBetaReviewStates,
+  resolveAscAppId,
+} from "../lib/asc_api";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+export async function handleAppStoreReview(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const encKey = c.env.ASC_CRED_ENC_KEY;
+  if (!encKey) return c.json({ error: "server is missing ASC_CRED_ENC_KEY" }, 500);
+
+  const app = await c.env.DB.prepare(
+    "SELECT platform FROM apps WHERE id = ?1",
+  )
+    .bind(appId)
+    .first<{ platform: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+
+  // The App Store review panel only applies to iOS apps.
+  if (app.platform !== "ios") {
+    return c.json({ platform: app.platform, applicable: false });
+  }
+
+  const creds = await getAscCredentials(c.env.DB, encKey, appId);
+  if (!creds) return c.json({ configured: false });
+
+  // Resolve the iOS bundle id from this app's channels. Prefer the "main"
+  // channel; otherwise take the earliest-created channel that carries one.
+  const bundleRow = await c.env.DB.prepare(
+    `SELECT bundle_id FROM channels
+     WHERE app_id = ?1 AND bundle_id IS NOT NULL AND bundle_id != ''
+     ORDER BY CASE WHEN slug = 'main' THEN 0 ELSE 1 END, created_at ASC
+     LIMIT 1`,
+  )
+    .bind(appId)
+    .first<{ bundle_id: string }>();
+  const bundleId = bundleRow?.bundle_id ?? null;
+  if (!bundleId) {
+    return c.json({
+      configured: true,
+      bundle_id: null,
+      error: "no iOS bundle id on any channel",
+    });
+  }
+
+  try {
+    const ascAppId = await resolveAscAppId(creds, bundleId);
+    if (!ascAppId) {
+      return c.json({
+        configured: true,
+        bundle_id: bundleId,
+        error: `no App Store Connect app record for bundle id ${bundleId}`,
+      });
+    }
+    const [appStoreVersions, testflightBuilds] = await Promise.all([
+      getAppStoreVersions(creds, ascAppId),
+      getBetaReviewStates(creds, ascAppId),
+    ]);
+    return c.json({
+      configured: true,
+      applicable: true,
+      bundle_id: bundleId,
+      asc_app_id: ascAppId,
+      app_store_versions: appStoreVersions,
+      testflight_builds: testflightBuilds,
+    });
+  } catch (e) {
+    return c.json({
+      configured: true,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+}

--- a/worker/test/appstore_review.test.ts
+++ b/worker/test/appstore_review.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for the read-only App Store review helpers: the JSON:API
+ * response shapes must map to the flat summaries the panel consumes —
+ * including a rejected version state and the build→betaAppReviewSubmission
+ * join (present, and absent → null).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  getAppStoreVersions,
+  getBetaReviewStates,
+  type AscApiCredentials,
+} from "../src/lib/asc_api";
+
+async function generateTestCreds(): Promise<AscApiCredentials> {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(
+    (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer,
+  );
+  let bin = "";
+  for (const b of pkcs8) bin += String.fromCharCode(b);
+  const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(bin)}\n-----END PRIVATE KEY-----`;
+  return { key_id: "TESTKEY123", issuer_id: "issuer-uuid-1234", p8: pem };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getAppStoreVersions", () => {
+  it("maps appStoreVersions attributes to flat summaries and requests the right endpoint", async () => {
+    const creds = await generateTestCreds();
+    const fetchMock = vi.fn(async (_url: unknown) =>
+      jsonResponse({
+        data: [
+          {
+            type: "appStoreVersions",
+            id: "v1",
+            attributes: {
+              versionString: "2.0.0",
+              appStoreState: "READY_FOR_SALE",
+              platform: "IOS",
+              createdDate: "2026-01-01T00:00:00Z",
+            },
+          },
+          {
+            type: "appStoreVersions",
+            id: "v2",
+            attributes: {
+              versionString: "2.1.0",
+              appStoreState: "METADATA_REJECTED",
+              platform: "IOS",
+              createdDate: "2026-02-01T00:00:00Z",
+            },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const versions = await getAppStoreVersions(creds, "asc-app-1");
+    expect(versions).toEqual([
+      {
+        versionString: "2.0.0",
+        appStoreState: "READY_FOR_SALE",
+        platform: "IOS",
+        createdDate: "2026-01-01T00:00:00Z",
+      },
+      {
+        versionString: "2.1.0",
+        appStoreState: "METADATA_REJECTED",
+        platform: "IOS",
+        createdDate: "2026-02-01T00:00:00Z",
+      },
+    ]);
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toContain("/v1/apps/asc-app-1/appStoreVersions");
+    expect(url).toContain("fields[appStoreVersions]=versionString,appStoreState,platform,createdDate");
+  });
+
+  it("returns an empty array when the app has no versions", async () => {
+    const creds = await generateTestCreds();
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ data: [] })));
+    expect(await getAppStoreVersions(creds, "asc-app-1")).toEqual([]);
+  });
+});
+
+describe("getBetaReviewStates", () => {
+  it("joins each build to its included betaAppReviewSubmission state", async () => {
+    const creds = await generateTestCreds();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: [
+            {
+              type: "builds",
+              id: "b1",
+              attributes: {
+                version: "100",
+                processingState: "VALID",
+                uploadedDate: "2026-03-01T00:00:00Z",
+              },
+              relationships: {
+                betaAppReviewSubmission: {
+                  data: { type: "betaAppReviewSubmissions", id: "sub-1" },
+                },
+              },
+            },
+          ],
+          included: [
+            {
+              type: "betaAppReviewSubmissions",
+              id: "sub-1",
+              attributes: { betaReviewState: "APPROVED" },
+            },
+          ],
+        }),
+      ),
+    );
+
+    const builds = await getBetaReviewStates(creds, "asc-app-1");
+    expect(builds).toEqual([
+      {
+        version: "100",
+        processingState: "VALID",
+        uploadedDate: "2026-03-01T00:00:00Z",
+        betaReviewState: "APPROVED",
+      },
+    ]);
+  });
+
+  it("yields betaReviewState null when a build has no beta review submission", async () => {
+    const creds = await generateTestCreds();
+    const fetchMock = vi.fn(async (_url: unknown) =>
+      jsonResponse({
+        data: [
+          {
+            type: "builds",
+            id: "b2",
+            attributes: {
+              version: "101",
+              processingState: "PROCESSING",
+              uploadedDate: "2026-03-02T00:00:00Z",
+            },
+            // No betaAppReviewSubmission relationship data (internal-only build).
+            relationships: { betaAppReviewSubmission: { data: null } },
+          },
+        ],
+        // No included array at all.
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const builds = await getBetaReviewStates(creds, "asc-app-1");
+    expect(builds).toEqual([
+      {
+        version: "101",
+        processingState: "PROCESSING",
+        uploadedDate: "2026-03-02T00:00:00Z",
+        betaReviewState: null,
+      },
+    ]);
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toContain("/v1/apps/asc-app-1/builds");
+    expect(url).toContain("include=betaAppReviewSubmission");
+  });
+});


### PR DESCRIPTION
Read-only App Store Connect **review status** for iOS apps, reusing the existing ASC credentials/client (no new auth, no release-flow changes).

**Worker:** `getAppStoreVersions` + `getBetaReviewStates` in `asc_api.ts`; new `GET /api/apps/:appId/appstore-review` (viewer) resolving the iOS bundle id from channels → ASC app → both review surfaces. Graceful states (non-iOS / no-creds / no-bundle / ASC-error) all 200. +4 worker tests (117 total pass).

**Admin:** an elegant `AppStoreReviewPanel` in AppDetail (iOS-only) — a prominent current-version status Badge, recent App Store versions (version + `appStoreState` badge), and recent builds' TestFlight beta review states. Rejection surfaced as the state (Apple's read API exposes no reason text).

State→badge mapping: READY_FOR_SALE→success, IN_REVIEW→information, WAITING_FOR_REVIEW→warning, PENDING_*→accent, REJECTED/METADATA_REJECTED/DEVELOPER_REJECTED→danger.

Branch is based on the raft-ui elegant pilot so the panel uses the elegant components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786333567&installation_id=145465820&pr_number=237&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F237&signature=65c24d2b99a647583eeafb5be6384c5fadf9dff65ded6783106c14575be58b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->