### PR TITLE
fix(hands): App Store review uses main-channel bundle id + config hint

### DIFF
--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -747,15 +747,37 @@ function AppStoreReviewPanel({ appId }: { appId: string; app: App }) {
           </EmptyState>
         ) : data?.bundle_id === null ? (
           <EmptyState>
-            <EmptyStateTitle>No iOS bundle ID</EmptyStateTitle>
+            <EmptyStateTitle>No App Store bundle ID configured</EmptyStateTitle>
             <EmptyStateDescription>
-              Set a bundle ID on one of this app's channels to resolve its App
-              Store Connect record.
+              Set the production App Store bundle ID on the{" "}
+              <a
+                href={`/apps/${appId}/channels`}
+                className="underline font-medium"
+              >
+                main channel
+              </a>{" "}
+              (Channels tab). Only the main channel's bundle ID is used —
+              preview/nightly channels are ignored, so their beta bundle IDs won't
+              be picked up here.
             </EmptyStateDescription>
           </EmptyState>
         ) : data?.error ? (
           <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
             Could not load review status from App Store Connect: {data.error}
+            {data.bundle_id && (
+              <div className="mt-1">
+                Bundle ID{" "}
+                <span className="font-mono">{data.bundle_id}</span> is set on the
+                main channel. If it doesn't match your App Store app, update it in{" "}
+                <a
+                  href={`/apps/${appId}/channels`}
+                  className="underline font-medium"
+                >
+                  Channels
+                </a>
+                .
+              </div>
+            )}
           </div>
         ) : (
           <div className="space-y-4">

--- a/worker/src/routes/appstore_review.ts
+++ b/worker/src/routes/appstore_review.ts
@@ -44,22 +44,24 @@ export async function handleAppStoreReview(c: AdminContext) {
   const creds = await getAscCredentials(c.env.DB, encKey, appId);
   if (!creds) return c.json({ configured: false });
 
-  // Resolve the iOS bundle id from this app's channels. Prefer the "main"
-  // channel; otherwise take the earliest-created channel that carries one.
+  // Use the production ("main") channel's bundle id — the App Store record is the
+  // production app. We deliberately do NOT fall back to preview/nightly channels:
+  // those carry beta bundle ids (e.g. foo.preview) that are not real App Store
+  // records, and silently guessing one is misleading. If main has no bundle id,
+  // report that it needs configuring rather than inventing one.
   const bundleRow = await c.env.DB.prepare(
-    `SELECT bundle_id FROM channels
-     WHERE app_id = ?1 AND bundle_id IS NOT NULL AND bundle_id != ''
-     ORDER BY CASE WHEN slug = 'main' THEN 0 ELSE 1 END, created_at ASC
-     LIMIT 1`,
+    `SELECT bundle_id FROM channels WHERE app_id = ?1 AND slug = 'main' LIMIT 1`,
   )
     .bind(appId)
-    .first<{ bundle_id: string }>();
-  const bundleId = bundleRow?.bundle_id ?? null;
+    .first<{ bundle_id: string | null }>();
+  const bundleId = (bundleRow?.bundle_id ?? "").trim() || null;
   if (!bundleId) {
     return c.json({
       configured: true,
+      applicable: true,
       bundle_id: null,
-      error: "no iOS bundle id on any channel",
+      needs_bundle_id: true,
+      error: "No App Store bundle id is set on the main channel.",
     });
   }
 


### PR DESCRIPTION
Follow-up to #237. Two issues from review:

1. The panel auto-picked a bundle id from any channel, so with an empty main channel it fell to a preview channel's beta bundle id (`raft-ios.preview`) — not a real App Store record. Now it uses **only the main channel's bundle id**; if unset it returns `needs_bundle_id` instead of guessing.
2. Added clear hints telling the user where to set/fix it: the empty state and the ASC-error state both link to the **Channels** tab (set the production bundle id on the main channel).

Worker 117 tests pass; admin tsc+build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786338560&installation_id=145465820&pr_number=238&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F238&signature=0a98ca8c8b9dd7fc3f0b184abb0627c4398228282f69bba95ca9d4cf9d8e9ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->