### PR TITLE
feat(cli): publish OHOS app and HAP assets

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -152,6 +152,34 @@ For raw CI drafts, a single `--changelog-file ./changelog.txt` is still valid.
 For reviewed notes, prefer repeatable `lang=file` entries such as
 `--changelog-file zh=zh.md --changelog-file en=en.md`.
 
+## Publish HarmonyOS / OHOS
+
+Use `builds publish-ohos` after CI has assembled and signed the App Pack. The
+command stores both distribution paths on one build: `.app` for AppGallery and
+the standalone signed `.hap` for user sideloading.
+
+```bash
+hands builds publish-ohos raft-ohos \
+  --app ./raft-ohos-1.0.0-1000000.app \
+  --hap ./raft-ohos-entry-1.0.0-1000000.hap \
+  --symbols ./ohos-symbols-1.0.0-1000000.tar.gz \
+  --metadata ./ohos-release-metadata.json \
+  --channel main \
+  --version-name 1.0.0 \
+  --version-code 1000000 \
+  --source-commit "$GITHUB_SHA" \
+  --ci-provider github-actions \
+  --ci-run-id "$GITHUB_RUN_ID" \
+  --ci-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+  --draft
+```
+
+Both `.app` and `.hap` are installable assets with distinct file types and
+distribution metadata. Public update consumers can request `filetype=app` or
+`filetype=hap`; authenticated build views expose both files individually.
+Signing certificates, profiles, P12 files, and passwords remain in CI and are
+never uploaded to Hands.
+
 ## Publish Electron (generic provider)
 
 Hands can host Electron apps that use `electron-updater` with the generic

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -85,6 +85,31 @@ support artifact for symbolication. TestFlight processing status can be written
 back through metadata/status follow-ups, but the release should still remain
 `draft` until changelog review is complete.
 
+For HarmonyOS/OHOS, CI signs the HAPs inside the App Pack, verifies each HAP,
+and exports both the signed `.app` and a standalone signed `.hap`. Publish both
+files to one draft build so AppGallery submission and user sideloading consume
+the exact same verified release:
+
+```sh
+hands builds publish-ohos raft-ohos \
+  --channel main \
+  --version-name 1.0.0 \
+  --version-code 1000000 \
+  --app build/raft-ohos-1.0.0-1000000.app \
+  --hap build/raft-ohos-entry-1.0.0-1000000.hap \
+  --symbols build/ohos-symbols-1.0.0-1000000.tar.gz \
+  --metadata build/ohos-release-metadata.json \
+  --changelog-file ./changelog.txt \
+  --source-commit "$GITHUB_SHA" \
+  --ci-provider github-actions \
+  --ci-run-id "$GITHUB_RUN_ID" \
+  --ci-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+  --draft
+```
+
+Hands records `.app` as the AppGallery installable and `.hap` as the sideload
+installable. Signing material stays in the mobile CI secret boundary.
+
 If CI already has reviewed localized release notes, use repeatable
 `lang=file` entries instead of the raw plain changelog:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,8 @@ Hands CLI — manage apps, builds, releases from the terminal.
 
 Status: **alpha**. The npm package is public as `@botiverse/hands-cli`; v1 ships
 `login`, `logout`, `whoami`, `apps list/get`, `builds list/get`, and
-`builds publish-android`. Other commands listed in `docs/cli-reference.md` land
+`builds publish-android`, `builds publish-ios`, `builds publish-ohos`, and
+`builds publish-electron`. Other commands listed in `docs/cli-reference.md` land
 incrementally as backend endpoints become available.
 
 ## Install

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -166,6 +166,16 @@ describe("iOS build helper contract", () => {
   });
 });
 
+describe("OHOS build helper contract", () => {
+  it("preserves the App Pack, HAP, symbols, and metadata asset types", async () => {
+    const { inferOhosFiletype } = await import("../src/commands/builds.js");
+    expect(inferOhosFiletype("build/Raft.app")).toBe("app");
+    expect(inferOhosFiletype("build/entry-default-signed.hap")).toBe("hap");
+    expect(inferOhosFiletype("build/ohos-symbols.tar.gz")).toBe("symbols.tar.gz");
+    expect(inferOhosFiletype("build/ohos-release-metadata.json")).toBe("metadata.json");
+  });
+});
+
 describe("build publish changelog options", () => {
   it("supports repeatable lang=file changelogs", async () => {
     const dir = mkdtempSync(join(tmpdir(), "quiver-changelog-"));

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -598,6 +598,209 @@ export function registerBuildCommands(program: Command): void {
     );
 
   builds
+    .command("publish-ohos <appIdOrSlug>")
+    .description(
+      "Create an OHOS build/release and upload the signed AppGallery .app plus a standalone signed .hap for sideloading.",
+    )
+    .requiredOption("--app <path>", "Signed App Pack (.app) for AppGallery submission.")
+    .requiredOption("--hap <path>", "Standalone signed HAP (.hap) for user sideloading.")
+    .requiredOption("--version-name <name>", "OHOS versionName.")
+    .requiredOption("--version-code <code>", "OHOS versionCode.")
+    .option("--channel <slug>", "Hands channel slug.", "main")
+    .option("--release-type <type>", "Release type metadata.", "stable")
+    .option("--product-type <type>", "Product type metadata.", "ohos-app")
+    .option("--symbols <path>", "Native symbols/source maps archive.")
+    .option("--metadata <path>", "OHOS release metadata JSON support artifact.")
+    .option(
+      "--changelog <text>",
+      "Inline changelog. Repeatable with lang=text for multiple languages.",
+      collect,
+      [],
+    )
+    .option(
+      "--changelog-file <path>",
+      "Read changelog from file. Repeatable with lang=path, e.g. --changelog-file zh=zh.md --changelog-file en=en.md.",
+      collect,
+      [],
+    )
+    .option("--source-commit <sha>", "Source commit SHA.")
+    .option("--source-branch <branch>", "Source branch.")
+    .option("--build-time <iso>", "Build time. Defaults to now.")
+    .option("--ci-provider <name>", "CI provider name.")
+    .option("--ci-run-id <id>", "CI run id.")
+    .option("--ci-url <url>", "CI run URL.")
+    .option("--force-update", "Mark release as force update.", false)
+    .option("--draft", "Create draft release instead of active.", false)
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        opts: {
+          app: string;
+          hap: string;
+          versionName: string;
+          versionCode: string;
+          channel: string;
+          releaseType: string;
+          productType: string;
+          symbols?: string;
+          metadata?: string;
+          changelog?: string[];
+          changelogFile?: string[];
+          sourceCommit?: string;
+          sourceBranch?: string;
+          buildTime?: string;
+          ciProvider?: string;
+          ciRunId?: string;
+          ciUrl?: string;
+          forceUpdate?: boolean;
+          draft?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        const appId = await resolveAppId(appIdOrSlug);
+        const channelId = await resolveChannelId(appId, opts.channel);
+        const versionCode = Number(opts.versionCode);
+        if (!Number.isFinite(versionCode) || versionCode < 0) {
+          throw new Error("--version-code must be a non-negative number");
+        }
+        for (const file of [opts.app, opts.hap, opts.symbols, opts.metadata].filter(Boolean) as string[]) {
+          if (!existsSync(file)) throw new Error(`missing file: ${file}`);
+        }
+        if (inferOhosFiletype(opts.app) !== "app") {
+          throw new Error("--app must point to an .app file");
+        }
+        if (inferOhosFiletype(opts.hap) !== "hap") {
+          throw new Error("--hap must point to a .hap file");
+        }
+
+        const changelog = parseChangelogOptions(opts);
+        const metadataJson = opts.metadata
+          ? JSON.parse(readFileSync(opts.metadata, "utf8"))
+          : {};
+        const provenance = {
+          source_commit: opts.sourceCommit ?? null,
+          source_branch: opts.sourceBranch ?? null,
+          build_time: opts.buildTime ?? new Date().toISOString(),
+          ci_provider: opts.ciProvider ?? null,
+          ci_run_id: opts.ciRunId ?? null,
+          ci_url: opts.ciUrl ?? null,
+        };
+
+        const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
+          method: "POST",
+          body: {
+            channel_id: channelId,
+            product_type: opts.productType,
+            release_type: opts.releaseType,
+            version_name: opts.versionName,
+            version_code: versionCode,
+            changelog,
+            source: "cli",
+            status: "succeeded",
+            build_metadata_json: {
+              ...metadataJson,
+              ohos: {
+                app: basename(opts.app),
+                hap: basename(opts.hap),
+                signed: true,
+                signing_owner: "ci",
+              },
+            },
+            provenance_json: provenance,
+            should_force_update: Boolean(opts.forceUpdate),
+          },
+        });
+
+        const assets = [];
+        assets.push(
+          await uploadAndRegisterAsset(appId, build.id, opts.app, {
+            artifact_kind: "installable",
+            platform: "ohos",
+            arch: null,
+            variant: "appgallery",
+            filetype: "app",
+            metadata_json: {
+              filename: basename(opts.app),
+              signed: true,
+              distribution: "appgallery",
+            },
+          }),
+        );
+        assets.push(
+          await uploadAndRegisterAsset(appId, build.id, opts.hap, {
+            artifact_kind: "installable",
+            platform: "ohos",
+            arch: null,
+            variant: "sideload",
+            filetype: "hap",
+            metadata_json: {
+              filename: basename(opts.hap),
+              signed: true,
+              distribution: "sideload",
+            },
+          }),
+        );
+        if (opts.symbols) {
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, opts.symbols, {
+              artifact_kind: "native-symbols",
+              platform: "ohos",
+              arch: null,
+              filetype: inferOhosFiletype(opts.symbols),
+              metadata_json: { filename: basename(opts.symbols) },
+            }),
+          );
+        }
+        if (opts.metadata) {
+          assets.push(
+            await uploadAndRegisterAsset(appId, build.id, opts.metadata, {
+              artifact_kind: "metadata-file",
+              platform: "ohos",
+              arch: null,
+              filetype: inferOhosFiletype(opts.metadata),
+              metadata_json: { filename: basename(opts.metadata) },
+            }),
+          );
+        }
+
+        const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
+          method: "POST",
+          body: {
+            build_id: build.id,
+            channel_id: channelId,
+            product_type: opts.productType,
+            release_type: opts.releaseType,
+            status: opts.draft ? "draft" : "active",
+            changelog,
+            should_force_update: Boolean(opts.forceUpdate),
+            provenance_json: provenance,
+            scopes: [{ scope_type: "full", scope_value: "all" }],
+          },
+        });
+
+        const result = {
+          app_id: appId,
+          build_id: build.id,
+          release_id: release.id,
+          channel: opts.channel,
+          version_name: opts.versionName,
+          version_code: versionCode,
+          assets,
+        };
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(`Published OHOS release ${opts.versionName} (${versionCode})`);
+        console.log(`  build:   ${build.id}`);
+        console.log(`  release: ${release.id}`);
+        console.log(`  channel: ${opts.channel}`);
+        console.log(`  assets:  ${assets.map((a) => `${a.artifact_kind}:${a.filetype}`).join(", ")}`);
+      },
+    );
+
+  builds
     .command("publish-electron <appIdOrSlug>")
     .description("Create an Electron generic-provider build/release and upload electron-builder output.")
     .requiredOption("--version-name <name>", "Electron app version.")
@@ -879,6 +1082,13 @@ async function uploadAndRegisterAsset(
     file_hash: uploaded.file_hash,
     size_bytes: uploaded.size_bytes,
   };
+}
+
+export function inferOhosFiletype(path: string): string {
+  const name = basename(path).toLowerCase();
+  if (name.endsWith(".tar.gz")) return "symbols.tar.gz";
+  if (name.endsWith(".json")) return "metadata.json";
+  return extname(name).replace(/^\./, "") || "bin";
 }
 
 const ARCHIVE_PATCHER_VERSION = "3.0.0";


### PR DESCRIPTION
## Summary
- add `hands builds publish-ohos` for one signed AppGallery `.app` plus a standalone signed `.hap`
- register both files as distinct OHOS installable assets on the same draft-capable build
- support symbols, metadata, provenance, and localized changelogs
- document the draft-first OHOS release flow and bump the CLI to 0.5.5

## Validation
- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli test` (13 tests)
- `pnpm --filter @botiverse/hands-cli build`
- `node packages/cli/dist/index.js builds publish-ohos --help`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786338848&installation_id=145465820&pr_number=239&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F239&signature=594a3125b3e81d329d2069bc96e42a76dc2970ea3ccfd24d49fd7bf941aff6d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->