### PR TITLE
fix(hands): ASC review — drop sparse fieldsets (invalid parameter)

### DIFF
--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -296,11 +296,14 @@ export async function getAppStoreVersions(
   creds: AscApiCredentials,
   ascAppId: string,
 ): Promise<AppStoreVersionSummary[]> {
+  // No sparse fieldset — ASC rejects some fields[...] selectors ("a given
+  // parameter is not allowed"); fetch the full resource and read what we need.
   const res = await ascRequest<{
     data: Array<{
       attributes?: {
         versionString?: string | null;
         appStoreState?: string | null;
+        appVersionState?: string | null;
         platform?: string | null;
         createdDate?: string | null;
       };
@@ -308,11 +311,13 @@ export async function getAppStoreVersions(
   }>(
     creds,
     "GET",
-    `/v1/apps/${ascAppId}/appStoreVersions?limit=5&fields[appStoreVersions]=versionString,appStoreState,platform,createdDate`,
+    `/v1/apps/${ascAppId}/appStoreVersions?limit=5`,
   );
   return (res.data ?? []).map((v) => ({
     versionString: v.attributes?.versionString ?? null,
-    appStoreState: v.attributes?.appStoreState ?? null,
+    // appStoreState is the classic field; newer API versions expose the same
+    // value as appVersionState — fall back so the badge still resolves.
+    appStoreState: v.attributes?.appStoreState ?? v.attributes?.appVersionState ?? null,
     platform: v.attributes?.platform ?? null,
     createdDate: v.attributes?.createdDate ?? null,
   }));
@@ -356,7 +361,7 @@ export async function getBetaReviewStates(
   }>(
     creds,
     "GET",
-    `/v1/apps/${ascAppId}/builds?limit=5&include=betaAppReviewSubmission&fields[builds]=version,processingState,uploadedDate&fields[betaAppReviewSubmissions]=betaReviewState`,
+    `/v1/apps/${ascAppId}/builds?limit=5&include=betaAppReviewSubmission`,
   );
 
   // Index the included betaAppReviewSubmissions by id so each build can look

--- a/worker/test/appstore_review.test.ts
+++ b/worker/test/appstore_review.test.ts
@@ -83,7 +83,9 @@ describe("getAppStoreVersions", () => {
     ]);
     const url = String(fetchMock.mock.calls[0]![0]);
     expect(url).toContain("/v1/apps/asc-app-1/appStoreVersions");
-    expect(url).toContain("fields[appStoreVersions]=versionString,appStoreState,platform,createdDate");
+    expect(url).toContain("limit=5");
+    // No sparse fieldset — ASC rejects some fields[...] selectors.
+    expect(url).not.toContain("fields[");
   });
 
   it("returns an empty array when the app has no versions", async () => {


### PR DESCRIPTION
App Store Connect returned `a given parameter is not allowed for this request` once a valid bundle id resolved — the `fields[...]` sparse fieldsets on the appStoreVersions/builds calls were rejected. Remove them (read attributes from the full resource; parsing unchanged) and add an `appVersionState` fallback for the review state. Worker 117 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786339086&installation_id=145465820&pr_number=240&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F240&signature=82558bf17ca89948910faac6716b2080d372c6adf2fbf473176f3f2b9405f66e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->