### PR TITLE
fix(agent): expose admin deploy token creation

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -760,24 +760,33 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         name: "help",
         description:
           "Start here — how to authenticate, what each action does, common crash/feedback flows, and docs links.",
-        endpoint: { method: "GET", path: "/api/agent/help" },
+        endpoint: { method: "GET", path: "/agent/help" },
       },
       {
         name: "list-orgs",
         description:
           "List every organization the current Raft identity can access across linked servers, including role and server identity.",
-        endpoint: { method: "GET", path: "/api/orgs" },
+        endpoint: { method: "GET", path: "/orgs" },
       },
       {
         name: "list-apps",
         description: "List apps the caller can access.",
-        endpoint: { method: "GET", path: "/api/apps" },
+        endpoint: { method: "GET", path: "/apps" },
+      },
+      {
+        name: "create-deploy-token",
+        description:
+          "Create an app-scoped deploy token. Requires app admin. The raw token is returned exactly once; store it immediately in a secret manager and never post it to a public channel.",
+        endpoint: { method: "POST", path: "/apps/{app_id}/deploy-tokens" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+        },
       },
       {
         name: "list-feedback",
         description:
           "List feedback/crash tickets for an app, newest first. Optional status/kind filters.",
-        endpoint: { method: "GET", path: "/api/apps/{app_id}/feedback" },
+        endpoint: { method: "GET", path: "/apps/{app_id}/feedback" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           status: { type: "string", in: "query", required: false, description: "open|in_progress|resolved|closed" },
@@ -788,7 +797,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         name: "get-feedback",
         description:
           "Get a feedback/crash ticket with device context, attachments, and comments. ticket_id may be a full UUID or a unique short-id prefix.",
-        endpoint: { method: "GET", path: "/api/apps/{app_id}/feedback/{ticket_id}" },
+        endpoint: { method: "GET", path: "/apps/{app_id}/feedback/{ticket_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           ticket_id: { type: "string", in: "path", required: true, description: "Ticket UUID or unique short-id prefix." },
@@ -800,7 +809,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           "Get a short-lived signed download URL for a feedback attachment. USE THIS for binaries (zips, images): fetch the returned download_url yourself with curl/wget — invoking a raw-bytes endpoint through an agent transport corrupts binary data.",
         endpoint: {
           method: "GET",
-          path: "/api/apps/{app_id}/feedback/{ticket_id}/attachments/{attachment_id}?presign=1",
+          path: "/apps/{app_id}/feedback/{ticket_id}/attachments/{attachment_id}?presign=1",
         },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },


### PR DESCRIPTION
## Summary
- fix manifest action paths so they are correctly relative to the `/api` execution base
- expose the existing app-admin deploy-token creation endpoint as a Raft integration action
- preserve the existing one-time-token and audit-log behavior

## Validation
- `pnpm --filter @botiverse/hands-worker test` (117 tests)
- Worker typecheck is deferred to CI because `worker-configuration.d.ts` is generated from production GitHub Variables
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786340043&installation_id=145465820&pr_number=241&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F241&signature=770fdad520a0d7cb57c32f9e2b24cb08ec3ea25b02dff5c0114258e98baba2db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->