### PR TITLE
fix(hands): ASC review — independent surfaces + error detail

### DIFF
--- a/worker/src/routes/appstore_review.ts
+++ b/worker/src/routes/appstore_review.ts
@@ -17,6 +17,7 @@ import type { Context } from "hono";
 import type { AdminEnv } from "../middleware/auth";
 import { getAscCredentials } from "../lib/asc_credentials";
 import {
+  AscApiError,
   getAppStoreVersions,
   getBetaReviewStates,
   resolveAscAppId,
@@ -74,7 +75,10 @@ export async function handleAppStoreReview(c: AdminContext) {
         error: `no App Store Connect app record for bundle id ${bundleId}`,
       });
     }
-    const [appStoreVersions, testflightBuilds] = await Promise.all([
+    // Fetch the two review surfaces independently: a failure on one (e.g. an ASC
+    // parameter rejection on builds) still shows the other. Surface the ASC error
+    // detail, which names the offending parameter, not just the generic title.
+    const [versionsR, buildsR] = await Promise.allSettled([
       getAppStoreVersions(creds, ascAppId),
       getBetaReviewStates(creds, ascAppId),
     ]);
@@ -83,13 +87,25 @@ export async function handleAppStoreReview(c: AdminContext) {
       applicable: true,
       bundle_id: bundleId,
       asc_app_id: ascAppId,
-      app_store_versions: appStoreVersions,
-      testflight_builds: testflightBuilds,
+      app_store_versions: versionsR.status === "fulfilled" ? versionsR.value : [],
+      testflight_builds: buildsR.status === "fulfilled" ? buildsR.value : [],
+      app_store_versions_error:
+        versionsR.status === "rejected" ? ascErrorText(versionsR.reason) : null,
+      testflight_builds_error:
+        buildsR.status === "rejected" ? ascErrorText(buildsR.reason) : null,
     });
   } catch (e) {
     return c.json({
       configured: true,
-      error: e instanceof Error ? e.message : String(e),
+      bundle_id: bundleId,
+      error: ascErrorText(e),
     });
   }
+}
+
+function ascErrorText(e: unknown): string {
+  if (e instanceof AscApiError) {
+    return e.detail ? `${e.message} — ${e.detail}` : e.message;
+  }
+  return e instanceof Error ? e.message : String(e);
 }


### PR DESCRIPTION
Fetch versions/builds independently (partial success) and surface the ASC error detail that names the bad parameter. 117 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786340732&installation_id=145465820&pr_number=246&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F246&signature=d746a408d2553de9e82c0c1f1d6cd534cd276e9802bb17d995dd6016c8266369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->