### PR TITLE
docs(agent): clarify integration and CLI auth

### DIFF
--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -5,36 +5,43 @@ and crash tickets** from the command line. For the broader auth model and
 release/share operations, see the [Agent Guide](/docs/agent-guide/); for the
 full command surface, the [CLI Reference](/docs/cli-reference/).
 
-## Why the CLI (and not `integration invoke`)
+## Choose the right auth surface
 
-Hands is a **Login-with-Raft HTTP API service**, not a manifest action
-service. So `raft integration invoke --service quiver --list-actions`
-returns **none** — that is expected, not a misconfiguration. Agents reach
-Hands two ways, both using a Bearer token from Raft Agent Login:
+Hands supports both Raft manifest actions and the local CLI, but their sessions
+are intentionally separate:
 
-- the **`@botiverse/hands-cli`** npm package (what this page covers), or
-- direct REST calls to `/api/*` (see the [Agent Guide](/docs/agent-guide/)).
+- `raft integration invoke` uses the session held by Raft Agent Login and is
+  the preferred surface for interactive agent/admin actions.
+- `@botiverse/hands-cli` requires an explicit Hands bearer/deploy token and is
+  the preferred surface for CI and repeatable release scripts.
 
-## 1. Get a token
+An integration login is not exported to the CLI through environment
+variables. Do not scrape cookies or callback handoffs to bridge the two.
 
-From any Raft-connected machine:
+## 1. Get a CLI token
 
-```bash
-raft integration login --service quiver
-# → prints a one-time "service callback handoff URL"
-curl -s "<that URL>"
-# → {"ok":true,"token_type":"Bearer","access_token":"…", …}
-```
-
-Export it for the CLI (both names work; `QUIVER_AUTH_TOKEN` takes precedence):
+For app-scoped automation, an admin can create a deploy token through the
+Hands console or the Raft integration:
 
 ```bash
-export QUIVER_BEARER_TOKEN=<access_token>
+raft integration login --service hands-4cc7a2
+raft integration invoke --service hands-4cc7a2 \
+  --action create-deploy-token \
+  --param app_id=<app-uuid> \
+  --data-json '{"name":"agent-cli","app_role":"publisher"}' \
+  --json
 ```
 
-The callback code is one-time — re-run the login for a fresh session. Your
-capabilities follow your Hands **org role**; `403` responses name the role
-required.
+Store the one-time raw token in a private secret manager, then export it for
+the CLI:
+
+```bash
+export HANDS_BEARER_TOKEN=<deploy-token>
+```
+
+Use a `viewer` token for read-only triage and `publisher` only when the script
+must upload or mutate releases. Revoke and replace any token whose initial
+secret-store write fails.
 
 ## 2. Run the CLI
 

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -18,29 +18,64 @@ Two options, by scope:
 From a Raft-connected machine:
 
 ```bash
-raft integration login --service quiver
-# → prints a one-time "service callback handoff URL"
-curl -s "<that URL>"
-# → {"ok":true,"token_type":"Bearer","access_token":"…","expires_at":…,"account":{…}}
+raft integration login --service hands-4cc7a2
+raft integration invoke --service hands-4cc7a2 --list-actions
+raft integration invoke --service hands-4cc7a2 --action list-apps
 ```
 
-Use the token as `Authorization: Bearer <access_token>` against `/api/*`, or
-export it for the CLI:
+Raft stores the Agent Login session inside the integration service and applies
+it when `integration invoke` calls a manifest action. It deliberately does
+**not** export that session as `HANDS_AUTH_TOKEN`, and `raft integration env`
+may report that the service is HTTP-actions-only. This is a security boundary,
+not a missing login.
 
-```bash
-export QUIVER_BEARER_TOKEN=<access_token>
-```
+Do not expect the local `hands` CLI to inherit an integration login. Use
+manifest actions for interactive admin work. Use a dedicated app deploy token
+for CLI/CI automation.
 
-Callback codes are one-time; re-run the login for a fresh session. Your
-capabilities follow your Hands org role — `403` responses name the required
-role (ask an org owner to adjust membership in Org settings).
+Your capabilities follow your Hands org role. A `403` response names the
+required role; ask an org owner to adjust membership in Org settings.
 
 ### Deploy tokens
 
-Created in an app's **Access** tab (or by an admin via API). App-scoped,
+Created in an app's **Settings -> Deploy Tokens** UI, by the CLI when it
+already has an admin bearer token, or by an admin Agent Login action:
+
+```bash
+raft integration invoke --service hands-4cc7a2 \
+  --action create-deploy-token \
+  --param app_id=<app-uuid> \
+  --data-json '{"name":"github-ci","app_role":"publisher"}' \
+  --json
+```
+
+The raw token is returned exactly once. Pipe it directly into the target CI
+secret store, then discard the response file. If storage fails, revoke that
+token id and mint a replacement; never leave an unused credential active.
+
+Deploy tokens are app-scoped,
 never expire unless revoked, attributed in audit logs as
 `deploy-token:<name>@<app>`. Prefer them for CI; prefer Agent Login for
 interactive agent operations.
+
+### Integration manifest URL contract
+
+Manifest action paths must be absolute, and URL resolution must produce the
+real API route. The robust Hands contract is:
+
+```json
+{
+  "execution": { "base_url": "https://hands.build" },
+  "endpoint": { "path": "/api/apps" }
+}
+```
+
+Do not combine `base_url: https://hands.build/api` with an action path that
+also starts with `/api`; manifest validation rejects the duplicated API base.
+Do not combine that nested base with `/apps` either: standard URL resolution
+resets the path to `https://hands.build/apps`, which serves the dashboard
+instead of the API. After changing a manifest, verify both
+`--list-actions` and one real JSON action response in production.
 
 ## Standard operations
 

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -33,7 +33,16 @@ If `HANDS_API` is unset, the CLI defaults to `https://hands.build`.
 Legacy `QUIVER_*` names still work: every variable is read as `HANDS_<name>`
 first, then `QUIVER_<name>`, so existing CI keeps working unchanged.
 
-Use app-scoped deploy tokens for CI. Mint them with `hands deploy-tokens create` (below) or in the app's Access page, choose the minimum role required, and store the raw token in your CI secret store.
+Use app-scoped deploy tokens for CI. Mint them with `hands deploy-tokens create`
+(below) or in the app's Settings page, choose the minimum role required, and
+store the raw token in your CI secret store.
+
+Raft Agent Login sessions are not exported to this CLI. `raft integration login`
+authenticates `raft integration invoke`; it does not populate
+`HANDS_AUTH_TOKEN`. An admin agent that needs to bootstrap CI should call the
+manifest `create-deploy-token` action, write the returned one-time token
+directly to the CI secret store, and then let the CLI consume that deploy
+token.
 
 ## Deploy Tokens
 


### PR DESCRIPTION
## Summary
- document that Raft Agent Login sessions stay inside `integration invoke` and are not exported to the local CLI
- document the admin manifest action → one-time deploy token → CI secret → CLI flow
- add lost-token cleanup guidance and the manifest base URL/action path contract
- replace stale callback-handoff instructions

## Validation
- `pnpm --filter @botiverse/hands-admin build`
- generated 10 public docs pages
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786341046&installation_id=145465820&pr_number=247&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F247&signature=e5e07c1b5b975d3e2569d05b59ac77818b77a094b92de83c486751868e3a459e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->