### PR TITLE
fix(hands): ASC review TestFlight — drop unsupported include param

### DIFF
--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -340,47 +340,37 @@ export async function getBetaReviewStates(
   creds: AscApiCredentials,
   ascAppId: string,
 ): Promise<BetaReviewSummary[]> {
+  // ASC rejects `include` on /apps/{id}/builds ("The parameter 'include' can not
+  // be used with this request"), so fetch the builds first, then each build's
+  // beta review submission separately via its relationship endpoint.
   const res = await ascRequest<{
     data: Array<{
+      id: string;
       attributes?: {
         version?: string | null;
         processingState?: string | null;
         uploadedDate?: string | null;
       };
-      relationships?: {
-        betaAppReviewSubmission?: {
-          data?: { type: string; id: string } | null;
-        };
+    }>;
+  }>(creds, "GET", `/v1/apps/${ascAppId}/builds?limit=5`);
+
+  return Promise.all(
+    (res.data ?? []).map(async (b) => {
+      let betaReviewState: string | null = null;
+      try {
+        const sub = await ascRequest<{
+          data?: { attributes?: { betaReviewState?: string | null } } | null;
+        }>(creds, "GET", `/v1/builds/${b.id}/betaAppReviewSubmission`);
+        betaReviewState = sub.data?.attributes?.betaReviewState ?? null;
+      } catch {
+        // No beta review submission (internal-only builds) or inaccessible → null.
+      }
+      return {
+        version: b.attributes?.version ?? null,
+        processingState: b.attributes?.processingState ?? null,
+        uploadedDate: b.attributes?.uploadedDate ?? null,
+        betaReviewState,
       };
-    }>;
-    included?: Array<{
-      type: string;
-      id: string;
-      attributes?: { betaReviewState?: string | null };
-    }>;
-  }>(
-    creds,
-    "GET",
-    `/v1/apps/${ascAppId}/builds?limit=5&include=betaAppReviewSubmission`,
+    }),
   );
-
-  // Index the included betaAppReviewSubmissions by id so each build can look
-  // up its submission via the relationship pointer (JSON:API compound doc).
-  const submissions = new Map<string, string | null>();
-  for (const inc of res.included ?? []) {
-    if (inc.type === "betaAppReviewSubmissions") {
-      submissions.set(inc.id, inc.attributes?.betaReviewState ?? null);
-    }
-  }
-
-  return (res.data ?? []).map((b) => {
-    const rel = b.relationships?.betaAppReviewSubmission?.data;
-    const betaReviewState = rel ? submissions.get(rel.id) ?? null : null;
-    return {
-      version: b.attributes?.version ?? null,
-      processingState: b.attributes?.processingState ?? null,
-      uploadedDate: b.attributes?.uploadedDate ?? null,
-      betaReviewState,
-    };
-  });
 }

--- a/worker/test/appstore_review.test.ts
+++ b/worker/test/appstore_review.test.ts
@@ -96,38 +96,35 @@ describe("getAppStoreVersions", () => {
 });
 
 describe("getBetaReviewStates", () => {
-  it("joins each build to its included betaAppReviewSubmission state", async () => {
+  it("fetches builds then joins each build's beta review submission state", async () => {
     const creds = await generateTestCreds();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        jsonResponse({
-          data: [
-            {
-              type: "builds",
-              id: "b1",
-              attributes: {
-                version: "100",
-                processingState: "VALID",
-                uploadedDate: "2026-03-01T00:00:00Z",
-              },
-              relationships: {
-                betaAppReviewSubmission: {
-                  data: { type: "betaAppReviewSubmissions", id: "sub-1" },
-                },
-              },
+    // `include` is not allowed on /apps/{id}/builds; the submission is fetched
+    // per-build via /v1/builds/{id}/betaAppReviewSubmission.
+    const fetchMock = vi.fn(async (url: unknown) => {
+      if (String(url).includes("/betaAppReviewSubmission")) {
+        return jsonResponse({
+          data: {
+            type: "betaAppReviewSubmissions",
+            id: "sub-1",
+            attributes: { betaReviewState: "APPROVED" },
+          },
+        });
+      }
+      return jsonResponse({
+        data: [
+          {
+            type: "builds",
+            id: "b1",
+            attributes: {
+              version: "100",
+              processingState: "VALID",
+              uploadedDate: "2026-03-01T00:00:00Z",
             },
-          ],
-          included: [
-            {
-              type: "betaAppReviewSubmissions",
-              id: "sub-1",
-              attributes: { betaReviewState: "APPROVED" },
-            },
-          ],
-        }),
-      ),
-    );
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
     const builds = await getBetaReviewStates(creds, "asc-app-1");
     expect(builds).toEqual([
@@ -138,12 +135,22 @@ describe("getBetaReviewStates", () => {
         betaReviewState: "APPROVED",
       },
     ]);
+    const buildsUrl = String(fetchMock.mock.calls[0]![0]);
+    expect(buildsUrl).toContain("/v1/apps/asc-app-1/builds");
+    expect(buildsUrl).not.toContain("include");
+    expect(String(fetchMock.mock.calls[1]![0])).toContain(
+      "/v1/builds/b1/betaAppReviewSubmission",
+    );
   });
 
   it("yields betaReviewState null when a build has no beta review submission", async () => {
     const creds = await generateTestCreds();
-    const fetchMock = vi.fn(async (_url: unknown) =>
-      jsonResponse({
+    const fetchMock = vi.fn(async (url: unknown) => {
+      if (String(url).includes("/betaAppReviewSubmission")) {
+        // Internal-only build: relationship resolves to no data.
+        return jsonResponse({ data: null });
+      }
+      return jsonResponse({
         data: [
           {
             type: "builds",
@@ -153,13 +160,10 @@ describe("getBetaReviewStates", () => {
               processingState: "PROCESSING",
               uploadedDate: "2026-03-02T00:00:00Z",
             },
-            // No betaAppReviewSubmission relationship data (internal-only build).
-            relationships: { betaAppReviewSubmission: { data: null } },
           },
         ],
-        // No included array at all.
-      }),
-    );
+      });
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const builds = await getBetaReviewStates(creds, "asc-app-1");
@@ -171,8 +175,8 @@ describe("getBetaReviewStates", () => {
         betaReviewState: null,
       },
     ]);
-    const url = String(fetchMock.mock.calls[0]![0]);
-    expect(url).toContain("/v1/apps/asc-app-1/builds");
-    expect(url).toContain("include=betaAppReviewSubmission");
+    const buildsUrl = String(fetchMock.mock.calls[0]![0]);
+    expect(buildsUrl).toContain("/v1/apps/asc-app-1/builds");
+    expect(buildsUrl).not.toContain("include");
   });
 });


### PR DESCRIPTION
Diagnostic pinpointed it: ASC rejects `include` on `/apps/{id}/builds`. Fetch builds plain, then each build's beta review submission per-build. App Store versions already work. 117 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786341369&installation_id=145465820&pr_number=248&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F248&signature=e9c7674b2897f6061bef22fc5cc9ab6e2dfdf919e55f0bced4436d69ac029641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->