### PR TITLE
fix(release): make OHOS publish output reliable

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
+import { Command } from "commander";
 import fixturePolicy from "./fixtures/collect-policy.json";
 
 describe("config round-trip", () => {
@@ -173,6 +174,14 @@ describe("OHOS build helper contract", () => {
     expect(inferOhosFiletype("build/entry-default-signed.hap")).toBe("hap");
     expect(inferOhosFiletype("build/ohos-symbols.tar.gz")).toBe("symbols.tar.gz");
     expect(inferOhosFiletype("build/ohos-release-metadata.json")).toBe("metadata.json");
+  });
+
+  it("honors the root --json flag for nested build commands", async () => {
+    const { shouldOutputJson } = await import("../src/commands/builds.js");
+    const program = new Command().option("--json", "JSON output", false);
+    program.parse(["node", "hands", "--json"]);
+    expect(shouldOutputJson(program, false)).toBe(true);
+    expect(shouldOutputJson(new Command(), true)).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -48,6 +48,10 @@ function collect(value: string, previous: string[]): string[] {
   return previous.concat(value);
 }
 
+export function shouldOutputJson(program: Command, localJson?: boolean): boolean {
+  return Boolean(localJson || program.opts<{ json?: boolean }>().json);
+}
+
 export function parseChangelogOptions(opts: {
   changelog?: string | string[];
   changelogFile?: string | string[];
@@ -104,7 +108,7 @@ export function registerBuildCommands(program: Command): void {
           `/api/apps/${id}/builds`,
           { query: { limit: opts.limit } },
         );
-        if (opts.json) {
+        if (shouldOutputJson(program, opts.json)) {
           console.log(JSON.stringify(res, null, 2));
           return;
         }
@@ -133,7 +137,7 @@ export function registerBuildCommands(program: Command): void {
       ) => {
         const id = await resolveAppId(appIdOrSlug);
         const build = await apiRequest<BuildRow>(`/api/apps/${id}/builds/${buildId}`);
-        if (opts.json) {
+        if (shouldOutputJson(program, opts.json)) {
           console.log(JSON.stringify(build, null, 2));
           return;
         }
@@ -386,7 +390,7 @@ export function registerBuildCommands(program: Command): void {
           version_code: versionCode,
           assets,
         };
-        if (opts.json) {
+        if (shouldOutputJson(program, opts.json)) {
           console.log(JSON.stringify(result, null, 2));
           return;
         }
@@ -579,7 +583,7 @@ export function registerBuildCommands(program: Command): void {
           version_code: versionCode,
           assets,
         };
-        if (opts.json) {
+        if (shouldOutputJson(program, opts.json)) {
           console.log(JSON.stringify(result, null, 2));
           return;
         }
@@ -788,7 +792,7 @@ export function registerBuildCommands(program: Command): void {
           version_code: versionCode,
           assets,
         };
-        if (opts.json) {
+        if (shouldOutputJson(program, opts.json)) {
           console.log(JSON.stringify(result, null, 2));
           return;
         }
@@ -1001,7 +1005,7 @@ export function registerBuildCommands(program: Command): void {
           version_code: versionCode,
           assets,
         };
-        if (opts.json) {
+        if (shouldOutputJson(program, opts.json)) {
           console.log(JSON.stringify(result, null, 2));
           return;
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.3")
+  .version("0.5.6")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -802,6 +802,30 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "list-build-assets",
+        description:
+          "List every asset attached to a build, including installables, metadata, and symbols.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/builds/{build_id}/assets" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Build UUID." },
+        },
+      },
+      {
+        name: "presign-build-asset",
+        description:
+          "Return a short-lived direct download URL for an authenticated build asset. Fetch the returned URL outside the integration transport for binary verification.",
+        endpoint: {
+          method: "GET",
+          path: "/api/apps/{app_id}/builds/{build_id}/assets/{asset_id}/download?presign=1",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Build UUID." },
+          asset_id: { type: "string", in: "path", required: true, description: "Build asset UUID." },
+        },
+      },
+      {
         name: "list-feedback",
         description:
           "List feedback/crash tickets for an app, newest first. Optional status/kind filters.",

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -520,6 +520,20 @@ export async function handleDownloadBuildAsset(c: Context<{ Bindings: Env }>) {
     filetype: asset.filetype,
     contentDisposition,
   }, Number(c.env.R2_PRESIGNED_DOWNLOAD_TTL_SECONDS ?? c.env.SIGNED_URL_TTL_SECONDS ?? "3600"));
+  if (c.req.query("presign") === "1") {
+    if (!directUrl) {
+      return c.json({ error: "presigned downloads are unavailable" }, 503);
+    }
+    const objectHead = await c.env.APK_BUCKET.head(asset.r2_key);
+    if (!objectHead) return c.json({ error: "object not found" }, 404);
+    return c.json({
+      asset_id: asset.id,
+      artifact_kind: asset.artifact_kind,
+      filetype: asset.filetype,
+      size_bytes: asset.size_bytes,
+      download_url: directUrl,
+    });
+  }
   if (directUrl) {
     const objectHead = await c.env.APK_BUCKET.head(asset.r2_key);
     if (!objectHead) return c.json({ error: "object not found" }, 404);

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2460,6 +2460,7 @@ describe("quiver public API v2 — scope resolution", () => {
     env: MockEnv,
     buildId: string,
     assetId: string,
+    query: Record<string, string | undefined> = {},
   ) {
     return {
       env,
@@ -2472,6 +2473,7 @@ describe("quiver public API v2 — scope resolution", () => {
               : name === "assetId"
                 ? assetId
                 : "",
+        query: (name: string) => query[name],
       },
       json: (data: unknown, status = 200) =>
         new Response(JSON.stringify(data), {
@@ -3594,6 +3596,44 @@ describe("quiver public API v2 — scope resolution", () => {
       .bind("asset-direct-metadata")
       .first() as { download_count: number } | null;
     expect(row?.download_count).toBe(1);
+  });
+
+  it("authenticated build asset presign returns JSON without counting a download", async () => {
+    const env = makeEnv();
+    configureR2Presign(env);
+    const { handleDownloadBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-presign-metadata", "build-presign-metadata", [["full", "all"]], {
+      versionCode: 13,
+      versionName: "1.0.13",
+    });
+    await seedAsset(env, "build-presign-metadata", "asset-presign-metadata", {
+      artifactKind: "metadata-file",
+      filetype: "json",
+      sizeBytes: 14,
+    });
+    const key = "apps/app-scope/asset-presign-metadata.apk";
+    env.APK_BUCKET = {
+      head: async (requestedKey: string) =>
+        requestedKey === key ? { httpEtag: '"asset-presign-metadata"' } : null,
+    };
+
+    const response = await handleDownloadBuildAsset(
+      makeBuildAssetDownloadContext(
+        env,
+        "build-presign-metadata",
+        "asset-presign-metadata",
+        { presign: "1" },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await responseJson<any>(response);
+    expect(body.asset_id).toBe("asset-presign-metadata");
+    expect(body.download_url).toContain("cloudflarestorage.com");
+    const row = await env.DB.prepare("SELECT download_count FROM build_assets WHERE id = ?")
+      .bind("asset-presign-metadata")
+      .first() as { download_count: number } | null;
+    expect(row?.download_count).toBe(0);
   });
 
   it("creates public release shares with hashed tokens only", async () => {


### PR DESCRIPTION
## Summary
- honor root `--json` for nested build commands, including `publish-ohos`
- bump Hands CLI to 0.5.6 and align the reported CLI version
- add admin manifest actions to list build assets and request short-lived direct download URLs
- add `?presign=1` JSON support without incrementing download counters

## Validation
- Hands Node build
- CLI 14 tests + build
- Worker 118 tests
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786342609&installation_id=145465820&pr_number=249&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F249&signature=259799dae8ad03f1526f1327c7656cc730ee3246e4e9973f71baccaed740dd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->