### PR TITLE
feat(admin): landing — light platform chips + Botiverse footer

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -962,9 +962,12 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
                   Client platforms:
                 </span>
                 {["Android", "iOS", "HarmonyOS", "Electron"].map((p) => (
-                  <Badge key={p} variant="muted">
+                  <span
+                    key={p}
+                    className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-medium text-slate-600"
+                  >
                     {p}
-                  </Badge>
+                  </span>
                 ))}
               </div>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
@@ -1223,7 +1226,9 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
       </Routes>
       <footer className="bg-white border-t border-slate-200 py-4 mt-8">
         <div className="max-w-5xl mx-auto px-4 text-xs text-slate-500 flex items-center justify-between">
-          <span>Hands - Login with Raft</span>
+          <span>
+            Hands — <span className="font-medium text-slate-600">a Botiverse product</span>
+          </span>
           <Tooltip>
             <TooltipTrigger
               render={

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -1069,6 +1069,33 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
           </div>
         </section>
       </main>
+      <footer className="border-t border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-2 px-4 py-6 text-xs text-slate-500 sm:flex-row">
+          <span>
+            Hands — a{" "}
+            <a
+              href="https://botiverse.dev/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-slate-600 hover:text-slate-900"
+            >
+              Botiverse
+            </a>{" "}
+            product
+          </span>
+          <div className="flex items-center gap-4">
+            <a href="/docs" className="hover:text-slate-700">Docs</a>
+            <a
+              href="https://github.com/oranix-io/hands"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-slate-700"
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 }
@@ -1227,7 +1254,16 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
       <footer className="bg-white border-t border-slate-200 py-4 mt-8">
         <div className="max-w-5xl mx-auto px-4 text-xs text-slate-500 flex items-center justify-between">
           <span>
-            Hands — <span className="font-medium text-slate-600">a Botiverse product</span>
+            Hands — a{" "}
+            <a
+              href="https://botiverse.dev/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-slate-600 hover:text-slate-900"
+            >
+              Botiverse
+            </a>{" "}
+            product
           </span>
           <Tooltip>
             <TooltipTrigger


### PR DESCRIPTION
Refine the Client-platforms tags to light outline chips, and add a footer with 'Hands — a Botiverse product' (Botiverse links to https://botiverse.dev/) to the public landing (and the console footer). Approved by artin on preview.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786344414&installation_id=145465820&pr_number=250&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F250&signature=bef58c766b278765f899a160d617c1f0c5a5158bb8d7faa631501567d1254f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->