### PR TITLE
docs: credit Sentry + clean up wording/consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,6 @@ Workflows:
 
 ## Credits
 
-Reference feature set inspired by [Zealot (tryzealot/zealot)](https://github.com/tryzealot/zealot).
+Reference feature set inspired by [Zealot (tryzealot/zealot)](https://github.com/tryzealot/zealot)
+and [Sentry](https://sentry.io/) — whose DSN model informs the client-key (app-identifier)
+and crash-reporting design.

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -90,7 +90,7 @@ Use share pages for human review and manual testing. Use the public update API f
 
 ## Feedback
 
-The Feedback tab is a lightweight ticket system for reports submitted from the app (via the SDK's `HandsFeedback` or the public feedback endpoint). Each ticket carries the message, contact, app version, device context (including the rollout device id), and up to three attachments.
+The Feedback tab is a lightweight ticket system for reports submitted from the app (via the SDK's `HandsFeedback` or the public feedback endpoint). Each ticket carries the message, contact, app version, device context (including the rollout device id), and up to nine attachments.
 
 - Tickets are shareable pages (`/apps/<id>/feedback/<ticket>`).
 - Triage with statuses (`open → in_progress → resolved/closed`), an assignee (Assign to me / edit / unassign), and a comment trail.

--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -129,7 +129,7 @@ stack is appended as an internal comment — visible in `feedback show`. To
 aggregate by signature across a fleet, call the API directly:
 
 ```bash
-curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+curl -s -H "Authorization: Bearer $HANDS_BEARER_TOKEN" \
   https://hands.build/api/apps/<appId>/feedback/crash-groups
 ```
 
@@ -156,16 +156,16 @@ The same downloads and ticket detail can also be fetched directly via REST
 APP_ID="$(hands apps get "$APP" --json \
   | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 
-curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+curl -s -H "Authorization: Bearer $HANDS_BEARER_TOKEN" \
   "https://hands.build/api/apps/$APP_ID/feedback/$TICKET_ID"                       # ticket detail
-curl -s -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+curl -s -H "Authorization: Bearer $HANDS_BEARER_TOKEN" \
   "https://hands.build/api/apps/$APP_ID/feedback/$TICKET_ID/attachments/<attachmentId>" \
   -o diagnostics.zip                                                                     # raw attachment
 ```
 
 ## Other environment knobs
 
-- `QUIVER_API` — point the CLI at a non-production Worker (defaults to the
+- `HANDS_API` — point the CLI at a non-production Worker (defaults to the
   production origin).
 - `--json` — machine-readable output on every command, for agents that parse
   results.

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -53,15 +53,15 @@ The raw token is returned exactly once. Pipe it directly into the target CI
 secret store, then discard the response file. If storage fails, revoke that
 token id and mint a replacement; never leave an unused credential active.
 
-Deploy tokens are app-scoped,
-never expire unless revoked, attributed in audit logs as
+Deploy tokens are app-scoped, never expire unless revoked, and are
+attributed in audit logs as
 `deploy-token:<name>@<app>`. Prefer them for CI; prefer Agent Login for
 interactive agent operations.
 
 ### Integration manifest URL contract
 
 Manifest action paths must be absolute, and URL resolution must produce the
-real API route. The robust Hands contract is:
+real API route. The correct Hands contract is:
 
 ```json
 {
@@ -137,7 +137,7 @@ The share URL is printed once; tokens are stored hashed.
 ```bash
 # create (API; CLI covers list/get)
 curl -X POST https://hands.build/api/apps \
-  -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+  -H "Authorization: Bearer $HANDS_BEARER_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"slug":"my-app","name":"My App","platform":"android"}'
 ```
@@ -148,9 +148,9 @@ product types, and get a **client key** (`qk_…`) that clients must send as
 `X-Quiver-Client-Key` header is still accepted):
 
 ```bash
-curl -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+curl -H "Authorization: Bearer $HANDS_BEARER_TOKEN" \
   https://hands.build/api/apps/<appId>/client-key          # read
-curl -X POST -H "Authorization: Bearer $QUIVER_BEARER_TOKEN" \
+curl -X POST -H "Authorization: Bearer $HANDS_BEARER_TOKEN" \
   https://hands.build/api/apps/<appId>/rotate-client-key   # (re)generate
 ```
 

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -291,7 +291,7 @@ role for read, publisher for changes):
 ```bash
 hands feedback list raft-android --status open --kind crash
 hands feedback show raft-android <ticket-id>
-hands feedback update raft-android <ticket-id> --status in_progress --assignee cc-quiver-owner
+hands feedback update raft-android <ticket-id> --status in_progress --assignee me
 hands feedback comment raft-android <ticket-id> "已复现，修复中"
 hands feedback update raft-android <ticket-id> --status resolved
 ```

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -174,7 +174,7 @@ GET /electron/:appSlug/:channel/:installerFile.blockmap
 ```
 
 Hands serves these from the active `electron-installer` release on that
-channel. Phase 1 intentionally hosts electron-builder's generated files
+channel. Hands intentionally hosts electron-builder's generated files
 as-is: upload `latest*.yml`, installers, and `.blockmap` files as build
 assets. Use `artifact_kind = electron-metadata` for `latest*.yml`; use the
 original filename in `variant` or `metadata_json.filename` so relative URLs


### PR DESCRIPTION
Per artin: add Sentry to the README Credits and review the docs.

- **README Credits**: add Sentry (its DSN model informs the client-key / crash-reporting design; the SDK docs already reference it).
- **Docs cleanup** (conservative): env-var names in examples → canonical `HANDS_*` (legacy `QUIVER_*` still accepted), fix awkward/AI-ish phrasing, drop internal 'Phase 1' jargon from a public reference, neutral example assignee, and fix a stale attachment limit (admin guide said 3; server `MAX_ATTACH=9` and the other docs say 9).

Legacy `X-Quiver-*` headers / `QUIVER_*` back-compat / the Quiver deploy path were intentionally left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786344680&installation_id=145465820&pr_number=251&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F251&signature=dd3bd42d5055be49d526be0da940e127f1494eb7e14bc5388c8dbc3395c06d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->