### PR TITLE
fix(admin): authenticate build asset downloads

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1057,6 +1057,47 @@ export const buildAssetDownloadUrl = (
 ) =>
   `${API_BASE}/api/apps/${encodeURIComponent(appId)}/builds/${encodeURIComponent(buildId)}/assets/${encodeURIComponent(assetId)}/download`;
 
+function filenameFromContentDisposition(value: string | null): string | null {
+  if (!value) return null;
+  const encoded = /filename\*=UTF-8''([^;]+)/i.exec(value)?.[1];
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded);
+    } catch {
+      // Fall through to the plain filename when the server value is malformed.
+    }
+  }
+  return /filename="([^"]+)"/i.exec(value)?.[1] ?? null;
+}
+
+export const downloadBuildAsset = async (
+  appId: string,
+  buildId: string,
+  assetId: string,
+  fallbackFilename: string,
+): Promise<void> => {
+  const headers = new Headers();
+  addAuthHeader(headers);
+  const activeOrgId = getActiveOrgId();
+  if (activeOrgId) headers.set("x-hands-org-id", activeOrgId);
+
+  const res = await fetch(buildAssetDownloadUrl(appId, buildId, assetId), { headers });
+  if (!res.ok) {
+    throw new ApiError(res.status, await readErrorBody(res), `asset download failed ${res.status}`);
+  }
+
+  const blobUrl = URL.createObjectURL(await res.blob());
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = blobUrl;
+    anchor.download = filenameFromContentDisposition(res.headers.get("content-disposition"))
+      ?? fallbackFilename;
+    anchor.click();
+  } finally {
+    URL.revokeObjectURL(blobUrl);
+  }
+};
+
 export const listReleases = (appId: string) =>
   request<{ releases: Release[] }>(`/api/apps/${appId}/releases`, { admin: true });
 

--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -9,7 +9,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  buildAssetDownloadUrl,
+  downloadBuildAsset,
   getBuild,
   listBuildAssets,
   listBuilds,
@@ -318,10 +318,26 @@ function BuildStatusBadge({ status }: { status: string }) {
 }
 
 function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) {
+  const toast = useToast();
   const assets = useQuery({
     queryKey: ["build-assets", appId, buildId],
     queryFn: () => listBuildAssets(appId, buildId),
     enabled: !!appId && !!buildId,
+  });
+  const download = useMutation({
+    mutationFn: (asset: BuildAsset) =>
+      downloadBuildAsset(
+        appId,
+        buildId,
+        asset.id,
+        `hands-${asset.platform}-${asset.artifact_kind}.${asset.filetype}`,
+      ),
+    onError: (error) =>
+      toast.show({
+        kind: "error",
+        title: "Download failed",
+        description: (error as Error).message,
+      }),
   });
   return (
     <div className="mt-2 pt-2 border-t border-slate-100 text-xs">
@@ -357,9 +373,12 @@ function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) 
                   <Button
                     variant="outline"
                     className="text-xs inline-flex"
-                    render={<a href={buildAssetDownloadUrl(appId, buildId, a.id)} />}
+                    disabled={download.isPending}
+                    onClick={() => download.mutate(a)}
                   >
-                    Download
+                    {download.isPending && download.variables?.id === a.id
+                      ? "Downloading…"
+                      : "Download"}
                   </Button>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- replace the Builds page's legacy direct download anchor with the same bearer-authenticated fetch flow used by feedback attachments
- preserve server-provided Content-Disposition filenames with a safe fallback
- show per-row download progress and surface authorization/download errors

## Root cause
The bearer-session migration in af3c7d2 moved normal API calls, uploads, SSE, and feedback attachments off the browser session cookie, but the build asset button still used a plain anchor navigation. Top-level navigation cannot attach the Hands JWT stored in localStorage, so the protected download route returned 401 after cookie removal. No bearer or client key is placed in the URL.

## Validation
- pnpm --dir admin typecheck
- pnpm --dir admin build
- git diff --check
- production Agent Login can list the reported build assets; the same direct unauthenticated URL reproduces the authorization boundary

Signed-off-by: KMP-专家 <fa88c6a8-85f2-4127-8995-c7167f9e00e9@raft.local>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786348943&installation_id=145465820&pr_number=253&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F253&signature=d0f9666e99b8101c5fd41486f85afc390b2398a5209c8e39c300352b318f5a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->