### PR TITLE
fix(hands): build-asset download works Bearer-only (worker-signed URL)

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1057,6 +1057,22 @@ export const buildAssetDownloadUrl = (
 ) =>
   `${API_BASE}/api/apps/${encodeURIComponent(appId)}/builds/${encodeURIComponent(buildId)}/assets/${encodeURIComponent(assetId)}/download`;
 
+/**
+ * Fetch a browser-navigable signed download URL for a build asset. The raw
+ * /download endpoint is Bearer-gated, so a direct <a href> would 401 in the
+ * browser; this authenticated call returns a short-lived signed URL the browser
+ * can open directly.
+ */
+export const getBuildAssetDownloadUrl = (
+  appId: string,
+  buildId: string,
+  assetId: string,
+) =>
+  request<{ download_url: string }>(
+    `/api/apps/${appId}/builds/${buildId}/assets/${assetId}/download?presign=1`,
+    { admin: true },
+  );
+
 export const listReleases = (appId: string) =>
   request<{ releases: Release[] }>(`/api/apps/${appId}/releases`, { admin: true });
 

--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -9,7 +9,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  buildAssetDownloadUrl,
+  getBuildAssetDownloadUrl,
   getBuild,
   listBuildAssets,
   listBuilds,
@@ -318,6 +318,7 @@ function BuildStatusBadge({ status }: { status: string }) {
 }
 
 function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) {
+  const toast = useToast();
   const assets = useQuery({
     queryKey: ["build-assets", appId, buildId],
     queryFn: () => listBuildAssets(appId, buildId),
@@ -357,7 +358,22 @@ function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) 
                   <Button
                     variant="outline"
                     className="text-xs inline-flex"
-                    render={<a href={buildAssetDownloadUrl(appId, buildId, a.id)} />}
+                    onClick={async () => {
+                      try {
+                        const { download_url } = await getBuildAssetDownloadUrl(
+                          appId,
+                          buildId,
+                          a.id,
+                        );
+                        window.location.href = download_url;
+                      } catch (e) {
+                        toast.show({
+                          kind: "error",
+                          title: "Download failed",
+                          description: (e as Error).message,
+                        });
+                      }
+                    }}
                   >
                     Download
                   </Button>

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -1,6 +1,8 @@
 import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { presignR2DownloadUrl } from "../lib/r2_presign";
+import { generateSignedR2Url } from "./public_v2";
+import { requestOrigin } from "../lib/origin";
 import { emitWebhookEvent } from "./webhooks";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
@@ -521,17 +523,28 @@ export async function handleDownloadBuildAsset(c: Context<{ Bindings: Env }>) {
     contentDisposition,
   }, Number(c.env.R2_PRESIGNED_DOWNLOAD_TTL_SECONDS ?? c.env.SIGNED_URL_TTL_SECONDS ?? "3600"));
   if (c.req.query("presign") === "1") {
-    if (!directUrl) {
-      return c.json({ error: "presigned downloads are unavailable" }, 503);
-    }
     const objectHead = await c.env.APK_BUCKET.head(asset.r2_key);
     if (!objectHead) return c.json({ error: "object not found" }, 404);
+    // Prefer an S3-style presign when R2 S3 credentials are configured; otherwise
+    // fall back to the Worker-signed /public/r2 URL (HMAC over key+expiry with
+    // SIGNED_URL_SECRET — the same mechanism share-page downloads use). Both are
+    // browser-navigable without an Authorization header, so the console can hand
+    // a real download link to the browser even though the API is Bearer-only.
+    const ttl = Number(
+      c.env.R2_PRESIGNED_DOWNLOAD_TTL_SECONDS ?? c.env.SIGNED_URL_TTL_SECONDS ?? "3600",
+    );
+    const downloadUrl =
+      directUrl ?? (await generateSignedR2Url(c.env, asset.r2_key, ttl, requestOrigin(c)));
+    if (!downloadUrl) {
+      return c.json({ error: "presigned downloads are unavailable" }, 503);
+    }
+    // Presign just hands out a link; the download itself isn't counted here.
     return c.json({
       asset_id: asset.id,
       artifact_kind: asset.artifact_kind,
       filetype: asset.filetype,
       size_bytes: asset.size_bytes,
-      download_url: directUrl,
+      download_url: downloadUrl,
     });
   }
   if (directUrl) {


### PR DESCRIPTION
The console asset Download was a raw link to the Bearer-gated endpoint (401 on browser nav), and `?presign=1` used S3-presigning that needs unconfigured R2 S3 creds. Now `?presign=1` falls back to `generateSignedR2Url` (the worker-signed mechanism share downloads use), and the console fetches it with Bearer then navigates. 118 worker tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786348976&installation_id=145465820&pr_number=254&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F254&signature=1e54a2dfc4c2ea055e5e0962e128ea6bdeb657f0d6db4bfa083e4661abb37540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->