### PR TITLE
fix(admin): debounce build-asset Download (per-asset single-flight)

### DIFF
--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -319,6 +319,10 @@ function BuildStatusBadge({ status }: { status: string }) {
 
 function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) {
   const toast = useToast();
+  // Per-asset in-flight guard: a Download stays disabled ("Preparing…") from the
+  // presign request until the browser navigation fires, so double-clicks don't
+  // send a second presign / open a second download. Other assets are unaffected.
+  const [downloading, setDownloading] = useState<ReadonlySet<string>>(new Set());
   const assets = useQuery({
     queryKey: ["build-assets", appId, buildId],
     queryFn: () => listBuildAssets(appId, buildId),
@@ -358,7 +362,11 @@ function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) 
                   <Button
                     variant="outline"
                     className="text-xs inline-flex"
+                    loading={downloading.has(a.id)}
+                    disabled={downloading.has(a.id)}
                     onClick={async () => {
+                      if (downloading.has(a.id)) return;
+                      setDownloading((s) => new Set(s).add(a.id));
                       try {
                         const { download_url } = await getBuildAssetDownloadUrl(
                           appId,
@@ -371,6 +379,12 @@ function BuildAssetList({ appId, buildId }: { appId: string; buildId: string }) 
                           kind: "error",
                           title: "Download failed",
                           description: (e as Error).message,
+                        });
+                      } finally {
+                        setDownloading((s) => {
+                          const next = new Set(s);
+                          next.delete(a.id);
+                          return next;
                         });
                       }
                     }}


### PR DESCRIPTION
Per feedback (artin + @KMP-专家): guard the Download button against repeated clicks — disable + loading from presign until navigation fires, per-asset (Set) so other assets download independently. Errors still toast.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786349443&installation_id=145465820&pr_number=255&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F255&signature=de61ef9275c155137c50be057bf19d982befd4d54b46f20c6b8897a01ae6b4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->