### PR TITLE
feat(ohos): add encrypted AGC credential settings

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -131,6 +131,7 @@ jobs:
           SIGNED_URL_SECRET: ${{ secrets.HANDS_SIGNED_URL_SECRET }}
           RAFT_CLIENT_SECRET: ${{ secrets.HANDS_RAFT_CLIENT_SECRET }}
           ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
+          AGC_CRED_ENC_KEY: ${{ secrets.HANDS_AGC_CRED_ENC_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
         shell: bash
         run: |
@@ -147,6 +148,10 @@ jobs:
             echo "Missing GitHub secret HANDS_ASC_CRED_ENC_KEY." >&2
             exit 1
           fi
+          if [[ -z "${AGC_CRED_ENC_KEY:-}" ]]; then
+            echo "Missing GitHub secret HANDS_AGC_CRED_ENC_KEY." >&2
+            exit 1
+          fi
           if [[ -z "${R2_ACCOUNT_ID:-}" ]]; then
             echo "Missing GitHub secret CLOUDFLARE_BOTIVERSE_ACCOUNT_ID." >&2
             exit 1
@@ -155,6 +160,7 @@ jobs:
           printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config "${config}"
           printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config "${config}"
           printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
+          printf '%s' "${AGC_CRED_ENC_KEY}" | pnpm exec wrangler secret put AGC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
 
       - name: Summary

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -63,6 +63,7 @@ jobs:
           SIGNED_URL_SECRET: ${{ secrets.HANDS_SIGNED_URL_SECRET }}
           RAFT_CLIENT_SECRET: ${{ secrets.HANDS_PREVIEW_RAFT_CLIENT_SECRET }}
           ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
+          AGC_CRED_ENC_KEY: ${{ secrets.HANDS_AGC_CRED_ENC_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
         shell: bash
         run: |
@@ -71,6 +72,7 @@ jobs:
           printf '%s' "${SIGNED_URL_SECRET}" | pnpm exec wrangler secret put SIGNED_URL_SECRET --config "${config}"
           printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config "${config}"
           printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
+          printf '%s' "${AGC_CRED_ENC_KEY}" | pnpm exec wrangler secret put AGC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
 
       - name: Deploy preview Worker + admin assets

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -745,6 +745,35 @@ export const verifyAscCredentials = (appId: string, bundleId: string) =>
     body: JSON.stringify({ bundle_id: bundleId }),
   });
 
+// ---------- AppGallery Connect credentials (HarmonyOS) ----------
+
+export interface AgcCredentialsMeta {
+  id: string;
+  app_id: string;
+  credential_kind: "api_client";
+  developer_id: string;
+  project_id: string;
+  client_id: string;
+  configuration_version: string | null;
+  region: string | null;
+  credential_fingerprint: string;
+  created_by_actor: string | null;
+  created_at: number;
+  updated_at: number;
+}
+export const getAgcCredentials = (appId: string) =>
+  request<{ agc_credentials: AgcCredentialsMeta | null }>(`/api/apps/${appId}/agc-credentials`, { admin: true });
+export const setAgcCredentials = (appId: string, credential_json: string) =>
+  request<{ agc_credentials: AgcCredentialsMeta }>(`/api/apps/${appId}/agc-credentials`, {
+    method: "PUT", admin: true, body: JSON.stringify({ credential_json }),
+  });
+export const deleteAgcCredentials = (appId: string) =>
+  request<{ ok: boolean }>(`/api/apps/${appId}/agc-credentials`, { method: "DELETE", admin: true });
+export const verifyAgcCredentials = (appId: string) =>
+  request<{ ok: boolean; credential_kind?: string; developer_id?: string; project_id?: string; client_id?: string; region?: string | null; expires_in?: number; error?: string; status?: number }>(
+    `/api/apps/${appId}/agc-credentials/verify`, { method: "POST", admin: true },
+  );
+
 // ---------- TestFlight upload (Hands → Apple) ----------
 
 /** Apple's build-upload state is an object, not a bare string. */

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -50,6 +50,10 @@ import {
   setAscCredentials,
   deleteAscCredentials,
   verifyAscCredentials,
+  getAgcCredentials,
+  setAgcCredentials,
+  deleteAgcCredentials,
+  verifyAgcCredentials,
   getAppStoreReview,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
@@ -644,6 +648,62 @@ function TestFlightPanel({ appId }: { appId: string }) {
   );
 }
 
+function AppGalleryConnectPanel({ appId }: { appId: string }) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const query = useQuery({ queryKey: ["agc-credentials", appId], queryFn: () => getAgcCredentials(appId) });
+  const meta = query.data?.agc_credentials ?? null;
+  const [editing, setEditing] = useState(false);
+  const [credentialJson, setCredentialJson] = useState("");
+  const save = useMutation({
+    mutationFn: () => setAgcCredentials(appId, credentialJson),
+    onSuccess: () => { setCredentialJson(""); setEditing(false); qc.invalidateQueries({ queryKey: ["agc-credentials", appId] }); toast.show({ kind: "success", title: "AppGallery Connect credential saved" }); },
+    onError: (e) => toast.show({ kind: "error", title: "Save failed", description: (e as Error).message }),
+  });
+  const remove = useMutation({
+    mutationFn: () => deleteAgcCredentials(appId),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ["agc-credentials", appId] }); toast.show({ kind: "success", title: "AppGallery Connect credential removed" }); },
+    onError: (e) => toast.show({ kind: "error", title: "Remove failed", description: (e as Error).message }),
+  });
+  const test = useMutation({
+    mutationFn: () => verifyAgcCredentials(appId),
+    onSuccess: (r) => toast.show(r.ok
+      ? { kind: "success", title: "Connection OK", description: `AGC token exchange succeeded; expires in ${Math.round((r.expires_in ?? 0) / 3600)} hours.` }
+      : { kind: "error", title: "Verification failed", description: r.error ?? "Unknown AGC error" }),
+    onError: (e) => toast.show({ kind: "error", title: "Test failed", description: (e as Error).message }),
+  });
+  const showForm = editing || (!meta && !query.isLoading);
+  return (
+    <div className="border-t border-slate-100 pt-3">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium">AppGallery Connect</div>
+          <div className="text-xs text-slate-500">API client credential used for HarmonyOS testing and publishing. The uploaded JSON is encrypted and its client secret is never shown again.</div>
+          {meta && <div className="mt-1 text-xs space-y-0.5">
+            <div><span className="text-green-700 font-medium">Configured</span>{" · "}{meta.credential_kind}{" · updated "}{new Date(meta.updated_at).toISOString().slice(0, 10)}</div>
+            <div className="font-mono break-all">Developer {meta.developer_id} · Project {meta.project_id} · Client {meta.client_id}</div>
+            <div className="font-mono">Region {meta.region || "default"} · Fingerprint {meta.credential_fingerprint.slice(0, 12)}…</div>
+          </div>}
+        </div>
+        {meta && !editing && <div className="flex flex-wrap gap-2">
+          <Button variant="outline" disabled={test.isPending} onClick={() => test.mutate()}>{test.isPending ? "Testing…" : "Test connection"}</Button>
+          <Button variant="outline" onClick={() => setEditing(true)}>Replace credential</Button>
+          <Button variant="danger" disabled={remove.isPending} onClick={() => { if (window.confirm("Remove the AppGallery Connect credential? Publishing stops until a new credential is saved.")) remove.mutate(); }}>{remove.isPending ? "…" : "Remove"}</Button>
+        </div>}
+      </div>
+      {showForm && <div className="mt-3 p-3 border border-slate-200 rounded-md space-y-3">
+        <label className="block text-xs font-medium">AGC API client JSON</label>
+        <input type="file" accept=".json,application/json" onChange={(e) => { const file = e.target.files?.[0]; if (file) file.text().then(setCredentialJson, () => toast.show({ kind: "error", title: "Could not read the credential file" })); }} />
+        <div className="text-xs text-slate-500">Select the JSON downloaded from AppGallery Connect. The client secret is not displayed or returned by the API.</div>
+        <div className="flex gap-2">
+          <Button variant="primary" disabled={!credentialJson || save.isPending} onClick={() => save.mutate()}>{save.isPending ? "Saving…" : "Save credential"}</Button>
+          {meta && <Button variant="outline" onClick={() => { setCredentialJson(""); setEditing(false); }}>Cancel</Button>}
+        </div>
+      </div>}
+    </div>
+  );
+}
+
 // --- App Store review status (read-only) ---------------------------------
 
 type BadgeVariant = NonNullable<BadgeProps["variant"]>;
@@ -1075,6 +1135,7 @@ export function AppSettings({ appId }: { appId: string }) {
 
         {/* TestFlight upload credentials — iOS apps only */}
         {app.platform === "ios" && <TestFlightPanel appId={appId} />}
+        {app.platform === "ohos" && <AppGalleryConnectPanel appId={appId} />}
 
         {/* Default release channel picker */}
         <DefaultChannelPicker appId={appId} app={app} isOrgAdmin={isOrgAdmin} />

--- a/docs/ohos-appgallery-connect-design.md
+++ b/docs/ohos-appgallery-connect-design.md
@@ -21,7 +21,8 @@ and local package validation. Hands receives the signed `.app`, standalone
 
 AppGallery Connect currently exposes APIs for:
 
-- developer-level Service Account authentication using PS256 JWTs;
+- AGC API client authentication using OAuth client credentials, with
+  developer-level Service Account/PS256 support reserved as a future credential kind;
 - HarmonyOS `.app` upload, including large/multipart uploads and SHA-256;
 - package binding and asynchronous compile/parse status;
 - invitation testing and public testing, including groups, members, invite
@@ -51,7 +52,7 @@ in a separate table and encryption domain.
 |---|---|
 | `id`, `app_id` | One active credential set per Hands app. |
 | `service_account_id`, `key_id` | Non-secret identifiers shown in Settings. |
-| `credential_ciphertext_b64`, `credential_iv_b64` | Entire Service Account credential JSON encrypted with AES-GCM. |
+| `credential_ciphertext_b64`, `credential_iv_b64` | Entire AGC credential JSON encrypted with AES-GCM. |
 | `credential_fingerprint` | SHA-256 fingerprint for rotation/audit, never the private key. |
 | `created_by_actor`, `created_at`, `updated_at` | Audit ownership. |
 
@@ -66,7 +67,7 @@ Settings actions:
 - `PUT /api/apps/:appId/agc-credentials`
 - `GET /api/apps/:appId/agc-credentials`
 - `DELETE /api/apps/:appId/agc-credentials`
-- `POST /api/apps/:appId/agc-credentials/test`
+- `POST /api/apps/:appId/agc-credentials/verify`
 
 The connection test mints a short-lived JWT and performs a read-only app
 lookup for the configured `main` channel bundle name.
@@ -127,7 +128,7 @@ workflow instance id on `market_submissions`.
 
 Steps must be individually retryable:
 
-1. load encrypted credentials and mint a PS256 JWT;
+1. load encrypted credentials and exchange the API client secret for an OAuth access token;
 2. resolve the manually created AGC app by bundle name;
 3. request the short-lived upload URL;
 4. stream the `.app` from R2, using multipart upload when required;
@@ -139,7 +140,7 @@ Steps must be individually retryable:
 10. submit and poll review/release state until terminal or long-term waiting;
 11. update Hands status, operation progress, and audit events.
 
-Refresh the Service Account JWT before expiry. A five-minute upload URL must
+Refresh the OAuth access token before expiry. A five-minute upload URL must
 be reacquired if upload has not started or a retry crosses its validity
 window. Provider `429` and `5xx` responses are retryable; validation, policy,
 and permission errors require user action.
@@ -218,7 +219,7 @@ Hands draft. Market submit remains a separate reviewed action.
 ### P0A: foundation
 
 - migration for encrypted AGC credentials, market submissions, and events;
-- Service Account JWT client and read-only connection test;
+- API client OAuth exchange and read-only connection test;
 - AppGallery page with credential configuration and app/bundle resolution;
 - provider-neutral operation kinds and status polling.
 
@@ -245,7 +246,7 @@ Hands draft. Market submit remains a separate reviewed action.
 
 - repeated trigger with the same idempotency key creates one AGC submission;
 - Worker restart/redeploy does not lose upload/parse/review progress;
-- raw Service Account credentials never appear in API responses or logs;
+- raw AGC credentials and access tokens never appear in API responses or logs;
 - a signed Hands `.app` is uploaded without buffering the whole file in D1;
 - parse polling handles success, Huawei validation failure, timeout, and retry;
 - testing and production submission require separate explicit approval;

--- a/migrations/sql/0038_app_agc_credentials.sql
+++ b/migrations/sql/0038_app_agc_credentials.sql
@@ -1,0 +1,16 @@
+CREATE TABLE app_agc_credentials (
+  id TEXT PRIMARY KEY,
+  app_id TEXT NOT NULL UNIQUE REFERENCES apps(id) ON DELETE CASCADE,
+  credential_kind TEXT NOT NULL CHECK (credential_kind IN ('api_client')),
+  developer_id TEXT NOT NULL,
+  project_id TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  configuration_version TEXT,
+  region TEXT,
+  credential_fingerprint TEXT NOT NULL,
+  credential_ciphertext_b64 TEXT NOT NULL,
+  credential_iv_b64 TEXT NOT NULL,
+  created_by_actor TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -26,6 +26,8 @@ declare global {
     // AES-GCM key material for encrypting per-app App Store Connect .p8 keys
     // (see lib/asc_credentials.ts). Set via `wrangler secret put ASC_CRED_ENC_KEY`.
     ASC_CRED_ENC_KEY?: string;
+    /** AES-GCM root secret for per-app AppGallery Connect credential JSON. */
+    AGC_CRED_ENC_KEY?: string;
     RAFT_ALLOWED_SERVER_IDS?: string;
     RAFT_ALLOWED_SERVER_SLUGS?: string;
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,12 @@ import {
   handleRaftCallback,
 } from "./routes/auth";
 import {
+  handleDeleteAgcCredentials,
+  handleGetAgcCredentials,
+  handleSetAgcCredentials,
+  handleVerifyAgcCredentials,
+} from "./routes/agc_credentials";
+import {
   handleListApps,
   handleCreateApp,
   handleGetApp,
@@ -791,6 +797,11 @@ admin.get("/api/apps/:appId/testflight-uploads/:buildUploadId", requireAppRole("
 admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
+// AppGallery Connect API client credentials for OHOS publishing.
+admin.get("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleGetAgcCredentials);
+admin.put("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleSetAgcCredentials);
+admin.delete("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleDeleteAgcCredentials);
+admin.post("/api/apps/:appId/agc-credentials/verify", requireAppRole("admin"), handleVerifyAgcCredentials);
 admin.post(
   "/api/apps/:appId/builds/:buildId/generate-delta-patches",
   requireAppRole("publisher"),

--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -1,0 +1,21 @@
+import type { AgcApiClientCredential } from "./agc_credentials";
+
+export class AgcApiError extends Error {
+  constructor(public status: number, message: string) { super(message); }
+}
+
+export async function exchangeAgcApiClientToken(credential: AgcApiClientCredential, fetchImpl: typeof fetch = fetch) {
+  const response = await fetchImpl("https://connect-api.cloud.huawei.com/api/oauth2/v1/token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client_id: credential.client_id, client_secret: credential.client_secret, grant_type: "client_credentials" }),
+  });
+  let body: unknown;
+  try { body = await response.json(); } catch { body = null; }
+  if (!response.ok) throw new AgcApiError(response.status, "AGC rejected the API client credentials");
+  const obj = body as Record<string, unknown> | null;
+  if (!obj || typeof obj.access_token !== "string" || !obj.access_token || typeof obj.expires_in !== "number") {
+    throw new AgcApiError(502, "AGC returned a malformed token response");
+  }
+  return { access_token: obj.access_token, expires_in: obj.expires_in };
+}

--- a/worker/src/lib/agc_credentials.ts
+++ b/worker/src/lib/agc_credentials.ts
@@ -1,0 +1,115 @@
+export type AgcApiClientCredential = {
+  type: string;
+  developer_id: string;
+  project_id: string;
+  client_id: string;
+  client_secret: string;
+  configuration_version?: string;
+  region?: string;
+};
+
+export type AgcCredentialsMeta = {
+  id: string;
+  app_id: string;
+  credential_kind: "api_client";
+  developer_id: string;
+  project_id: string;
+  client_id: string;
+  configuration_version: string | null;
+  region: string | null;
+  credential_fingerprint: string;
+  created_by_actor: string;
+  created_at: number;
+  updated_at: number;
+};
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${name} is required`);
+  return value.trim();
+}
+
+export function parseAgcCredential(input: string | unknown): AgcApiClientCredential {
+  let value: unknown = input;
+  if (typeof input === "string") {
+    try { value = JSON.parse(input); } catch { throw new Error("credential_json must contain valid JSON"); }
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("credential_json must be a JSON object");
+  }
+  const obj = value as Record<string, unknown>;
+  const type = requiredString(obj.type, "type");
+  if (type !== "api_client") throw new Error(`unsupported AGC credential type: ${type}`);
+  const credential: AgcApiClientCredential = {
+    type,
+    developer_id: requiredString(obj.developer_id, "developer_id"),
+    project_id: requiredString(obj.project_id, "project_id"),
+    client_id: requiredString(obj.client_id, "client_id"),
+    client_secret: requiredString(obj.client_secret, "client_secret"),
+  };
+  if (typeof obj.configuration_version === "string") credential.configuration_version = obj.configuration_version.trim();
+  if (typeof obj.region === "string") credential.region = obj.region.trim();
+  return credential;
+}
+
+function b64Encode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+function b64Decode(value: string): Uint8Array {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+async function keyFor(secret: string): Promise<CryptoKey> {
+  if (!secret) throw new Error("AGC_CRED_ENC_KEY is not configured");
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+export async function encryptAgcCredential(value: string, secret: string) {
+  const key = await keyFor(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, new TextEncoder().encode(value));
+  return { ciphertext_b64: b64Encode(new Uint8Array(ciphertext)), iv_b64: b64Encode(iv) };
+}
+export async function decryptAgcCredential(ciphertext: string, iv: string, secret: string) {
+  const plaintext = await crypto.subtle.decrypt({ name: "AES-GCM", iv: b64Decode(iv) }, await keyFor(secret), b64Decode(ciphertext));
+  return new TextDecoder().decode(plaintext);
+}
+export async function fingerprintAgcCredential(value: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)));
+  return Array.from(digest, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function storeAgcCredentials(db: D1Database, encKey: string, args: { app_id: string; credential: AgcApiClientCredential; actor: string }) {
+  const canonical = JSON.stringify(args.credential);
+  const encrypted = await encryptAgcCredential(canonical, encKey);
+  const fingerprint = await fingerprintAgcCredential(canonical);
+  const now = Date.now();
+  await db.prepare(`INSERT INTO app_agc_credentials
+    (id, app_id, credential_kind, developer_id, project_id, client_id, configuration_version, region,
+     credential_fingerprint, credential_ciphertext_b64, credential_iv_b64, created_by_actor, created_at, updated_at)
+    VALUES (?1, ?2, 'api_client', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)
+    ON CONFLICT(app_id) DO UPDATE SET credential_kind='api_client', developer_id=excluded.developer_id,
+      project_id=excluded.project_id, client_id=excluded.client_id, configuration_version=excluded.configuration_version,
+      region=excluded.region, credential_fingerprint=excluded.credential_fingerprint,
+      credential_ciphertext_b64=excluded.credential_ciphertext_b64, credential_iv_b64=excluded.credential_iv_b64,
+      updated_at=excluded.updated_at`)
+    .bind(crypto.randomUUID(), args.app_id, args.credential.developer_id, args.credential.project_id,
+      args.credential.client_id, args.credential.configuration_version ?? null, args.credential.region ?? null,
+      fingerprint, encrypted.ciphertext_b64, encrypted.iv_b64, args.actor, now).run();
+  return (await getAgcCredentialsMeta(db, args.app_id))!;
+}
+export async function getAgcCredentialsMeta(db: D1Database, appId: string) {
+  return (await db.prepare(`SELECT id, app_id, credential_kind, developer_id, project_id, client_id,
+    configuration_version, region, credential_fingerprint, created_by_actor, created_at, updated_at
+    FROM app_agc_credentials WHERE app_id=?1`).bind(appId).first<AgcCredentialsMeta>()) ?? null;
+}
+export async function getAgcCredentials(db: D1Database, encKey: string, appId: string) {
+  const row = await db.prepare(`SELECT credential_ciphertext_b64, credential_iv_b64 FROM app_agc_credentials WHERE app_id=?1`)
+    .bind(appId).first<{ credential_ciphertext_b64: string; credential_iv_b64: string }>();
+  if (!row) return null;
+  return parseAgcCredential(await decryptAgcCredential(row.credential_ciphertext_b64, row.credential_iv_b64, encKey));
+}
+export async function deleteAgcCredentials(db: D1Database, appId: string) {
+  await db.prepare("DELETE FROM app_agc_credentials WHERE app_id=?1").bind(appId).run();
+}

--- a/worker/src/routes/agc_credentials.ts
+++ b/worker/src/routes/agc_credentials.ts
@@ -1,0 +1,52 @@
+import type { Context } from "hono";
+import { currentActor, type AdminEnv } from "../middleware/auth";
+import { insertAuditLog } from "../lib/permissions";
+import { deleteAgcCredentials, getAgcCredentials, getAgcCredentialsMeta, parseAgcCredential, storeAgcCredentials } from "../lib/agc_credentials";
+import { AgcApiError, exchangeAgcApiClientToken } from "../lib/agc_api";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+async function requireOhosApp(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const app = await c.env.DB.prepare("SELECT platform FROM apps WHERE id=?1").bind(appId).first<{ platform: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+  if (app.platform !== "ohos") return c.json({ error: "AppGallery Connect credentials are only available for OHOS apps" }, 400);
+  return null;
+}
+export async function handleGetAgcCredentials(c: AdminContext) {
+  const invalid = await requireOhosApp(c); if (invalid) return invalid;
+  return c.json({ agc_credentials: await getAgcCredentialsMeta(c.env.DB, c.req.param("appId") ?? "") });
+}
+export async function handleSetAgcCredentials(c: AdminContext) {
+  const invalid = await requireOhosApp(c); if (invalid) return invalid;
+  if (!c.env.AGC_CRED_ENC_KEY) return c.json({ error: "server is missing AGC_CRED_ENC_KEY; cannot store credentials" }, 500);
+  const body = await c.req.json().catch(() => ({})) as { credential_json?: unknown };
+  let credential;
+  try { credential = parseAgcCredential(body.credential_json); } catch (e) { return c.json({ error: (e as Error).message }, 400); }
+  const appId = c.req.param("appId") ?? "";
+  const meta = await storeAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, { app_id: appId, credential, actor: currentActor(c) });
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.set", payload: { credential_kind: meta.credential_kind, client_id: meta.client_id, project_id: meta.project_id }, created_at: meta.updated_at });
+  return c.json({ agc_credentials: meta });
+}
+export async function handleDeleteAgcCredentials(c: AdminContext) {
+  const invalid = await requireOhosApp(c); if (invalid) return invalid;
+  const appId = c.req.param("appId") ?? "";
+  await deleteAgcCredentials(c.env.DB, appId);
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.delete", payload: {} });
+  return c.json({ ok: true });
+}
+export async function handleVerifyAgcCredentials(c: AdminContext) {
+  const invalid = await requireOhosApp(c); if (invalid) return invalid;
+  if (!c.env.AGC_CRED_ENC_KEY) return c.json({ error: "server is missing AGC_CRED_ENC_KEY" }, 500);
+  const appId = c.req.param("appId") ?? "";
+  const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, appId);
+  if (!credential) return c.json({ error: "no AGC credentials configured for this app" }, 404);
+  try {
+    const token = await exchangeAgcApiClientToken(credential);
+    await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: "api_client", ok: true } });
+    return c.json({ ok: true, credential_kind: "api_client", developer_id: credential.developer_id, project_id: credential.project_id, client_id: credential.client_id, region: credential.region ?? null, expires_in: token.expires_in });
+  } catch (e) {
+    await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: "api_client", ok: false } });
+    if (e instanceof AgcApiError) return c.json({ ok: false, error: e.message, status: e.status }, 502);
+    throw e;
+  }
+}

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { decryptAgcCredential, encryptAgcCredential, fingerprintAgcCredential, parseAgcCredential } from "../src/lib/agc_credentials";
+import { AgcApiError, exchangeAgcApiClientToken } from "../src/lib/agc_api";
+
+const raw = JSON.stringify({ type: "api_client", developer_id: "dev", project_id: "project", client_id: "client", client_secret: "secret", configuration_version: "1.0", region: "CN" });
+
+describe("AGC credentials", () => {
+  it("parses the real api_client shape without dropping metadata", () => {
+    expect(parseAgcCredential(raw)).toMatchObject({ type: "api_client", client_id: "client", region: "CN" });
+  });
+  it("rejects malformed and unsupported credentials", () => {
+    expect(() => parseAgcCredential("not json")).toThrow(/valid JSON/);
+    expect(() => parseAgcCredential({ type: "service_account" })).toThrow(/unsupported/);
+    expect(() => parseAgcCredential({ type: "api_client" })).toThrow(/developer_id/);
+  });
+  it("encrypts, decrypts, fingerprints, and uses fresh IVs", async () => {
+    const a = await encryptAgcCredential(raw, "root-secret");
+    const b = await encryptAgcCredential(raw, "root-secret");
+    expect(a.iv_b64).not.toBe(b.iv_b64);
+    expect(await decryptAgcCredential(a.ciphertext_b64, a.iv_b64, "root-secret")).toBe(raw);
+    expect(await fingerprintAgcCredential(raw)).toMatch(/^[a-f0-9]{64}$/);
+    await expect(decryptAgcCredential(a.ciphertext_b64, a.iv_b64, "wrong")).rejects.toThrow();
+    await expect(encryptAgcCredential(raw, "")).rejects.toThrow(/AGC_CRED_ENC_KEY/);
+  });
+});
+
+describe("AGC token exchange", () => {
+  const credential = parseAgcCredential(raw);
+  it("returns the token internally and expiry on success", async () => {
+    let requestBody = "";
+    const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestBody = String(init?.body ?? "");
+      return new Response(JSON.stringify({ access_token: "token", expires_in: 172799 }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    await expect(exchangeAgcApiClientToken(credential, mockFetch as typeof fetch)).resolves.toEqual({ access_token: "token", expires_in: 172799 });
+    expect(JSON.parse(requestBody)).toEqual({ client_id: "client", client_secret: "secret", grant_type: "client_credentials" });
+  });
+  it("redacts provider errors", async () => {
+    const mockFetch = vi.fn(async () => new Response(JSON.stringify({ error: "contains provider details" }), { status: 401 }));
+    await expect(exchangeAgcApiClientToken(credential, mockFetch as typeof fetch)).rejects.toEqual(expect.objectContaining<Partial<AgcApiError>>({ status: 401, message: "AGC rejected the API client credentials" }));
+  });
+  it("rejects malformed success responses", async () => {
+    const mockFetch = vi.fn(async () => new Response(JSON.stringify({ expires_in: 10 }), { status: 200 }));
+    await expect(exchangeAgcApiClientToken(credential, mockFetch as typeof fetch)).rejects.toThrow(/malformed/);
+  });
+});


### PR DESCRIPTION
## Summary
- add OHOS-only AppGallery Connect credential upload, metadata, rotation, deletion, and connection verification
- encrypt the full AGC api_client JSON with a dedicated Worker secret and never return the client secret or access token
- add migration, OAuth token exchange, audit entries, Admin Settings UI, deployment secret wiring, and focused tests

## Validation
- Worker typecheck
- Worker tests: 124 passed
- Admin production build
- git diff --check

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786349654&installation_id=145465820&pr_number=256&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F256&signature=64d84f2013bf8151be072540380d1b949f907e6f0766c5eab6056ea77e9a3653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->