### PR TITLE
ci(hands): put R2 S3 credentials for direct-to-R2 downloads

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -132,6 +132,11 @@ jobs:
           RAFT_CLIENT_SECRET: ${{ secrets.HANDS_RAFT_CLIENT_SECRET }}
           ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
+          # Optional: R2 S3-API credentials enable direct-to-R2 presigned downloads
+          # (bandwidth bypasses the Worker). When unset, downloads fall back to the
+          # Worker-signed /public/r2 URL, so these are not required.
+          R2_S3_ACCESS_KEY_ID: ${{ secrets.R2_S3_ACCESS_KEY_ID }}
+          R2_S3_SECRET_ACCESS_KEY: ${{ secrets.R2_S3_SECRET_ACCESS_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -156,6 +161,13 @@ jobs:
           printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config "${config}"
           printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
+          # Optional R2 S3-API credentials (only put when configured).
+          if [[ -n "${R2_S3_ACCESS_KEY_ID:-}" ]]; then
+            printf '%s' "${R2_S3_ACCESS_KEY_ID}" | pnpm exec wrangler secret put R2_S3_ACCESS_KEY_ID --config "${config}"
+          fi
+          if [[ -n "${R2_S3_SECRET_ACCESS_KEY:-}" ]]; then
+            printf '%s' "${R2_S3_SECRET_ACCESS_KEY}" | pnpm exec wrangler secret put R2_S3_SECRET_ACCESS_KEY --config "${config}"
+          fi
 
       - name: Summary
         shell: bash


### PR DESCRIPTION
Adds R2_S3_ACCESS_KEY_ID + R2_S3_SECRET_ACCESS_KEY (new GitHub secrets, botiverse R2 API token) to the worker secret step, conditionally. When set, downloads presign directly against R2 (bypasses the Worker — for large APKs); otherwise they fall back to the Worker-signed URL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786350011&installation_id=145465820&pr_number=257&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F257&signature=e28c7b11c11e1d4167c869dfc4c90fd4acd5fdc6ebf04a5d3373fd525461bf15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->