### PR TITLE
feat(ohos): expose AGC credential agent actions

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -802,6 +802,34 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "get-agc-credentials",
+        description:
+          "Get metadata for an OHOS app's encrypted AppGallery Connect credential. Never returns the client secret.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/agc-credentials" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
+        },
+      },
+      {
+        name: "set-agc-credentials",
+        description:
+          "Upload or rotate an OHOS app's AGC API client JSON. Requires app admin; the entire document is encrypted and secret fields are never returned.",
+        endpoint: { method: "PUT", path: "/api/apps/{app_id}/agc-credentials" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
+          credential_json: { type: "string", in: "body", required: true, description: "Contents of the AGC api_client JSON file." },
+        },
+      },
+      {
+        name: "verify-agc-credentials",
+        description:
+          "Test the stored AGC API client with an OAuth token exchange. Returns metadata and expiry only, never the access token.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/agc-credentials/verify" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
+        },
+      },
+      {
         name: "list-build-assets",
         description:
           "List every asset attached to a build, including installables, metadata, and symbols.",


### PR DESCRIPTION
Adds metadata-only get, encrypted credential upload, and token-without-token verification actions to the Hands Raft integration manifest.

Validation: Worker typecheck and route suite (99 tests).

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786350232&installation_id=145465820&pr_number=258&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F258&signature=2ef4ceddcafb8c705b7298f37f6d4a47e7b9219ab958a3cb093b41472e51b51e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->