### PR TITLE
fix(ohos): accept AGC project client credentials

### DIFF
--- a/worker/src/lib/agc_credentials.ts
+++ b/worker/src/lib/agc_credentials.ts
@@ -38,7 +38,9 @@ export function parseAgcCredential(input: string | unknown): AgcApiClientCredent
   }
   const obj = value as Record<string, unknown>;
   const type = requiredString(obj.type, "type");
-  if (type !== "api_client") throw new Error(`unsupported AGC credential type: ${type}`);
+  if (type !== "api_client" && type !== "project_client_id") {
+    throw new Error(`unsupported AGC credential type: ${type}`);
+  }
   const credential: AgcApiClientCredential = {
     type,
     developer_id: requiredString(obj.developer_id, "developer_id"),

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -8,6 +8,12 @@ describe("AGC credentials", () => {
   it("parses the real api_client shape without dropping metadata", () => {
     expect(parseAgcCredential(raw)).toMatchObject({ type: "api_client", client_id: "client", region: "CN" });
   });
+  it("accepts Huawei's project_client_id discriminator", () => {
+    expect(parseAgcCredential(raw.replace("api_client", "project_client_id"))).toMatchObject({
+      type: "project_client_id",
+      client_id: "client",
+    });
+  });
   it("rejects malformed and unsupported credentials", () => {
     expect(() => parseAgcCredential("not json")).toThrow(/valid JSON/);
     expect(() => parseAgcCredential({ type: "service_account" })).toThrow(/unsupported/);


### PR DESCRIPTION
Accepts Huawei credential JSON with the official `project_client_id` type while retaining normalized encrypted API-client storage.

Validation: Worker typecheck and 7 AGC tests.

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786350420&installation_id=145465820&pr_number=259&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F259&signature=92520c4f74773e3966ed06d2a3c4d0c3bc2f70fb67d363dc54ebd23ea2bf123d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->