### PR TITLE
feat(ohos): end-to-end native crash symbolication (SDK capture + server, task #95)

### DIFF
--- a/clients/ohos/hands/changelog.md
+++ b/clients/ohos/hands/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.2
+
+- Native crashes now ship the full backtrace, not just a top-frame summary.
+  hiAppEvent delivers the symbolicatable stack (`#NN pc <off> <lib>.so(<buildId>)`)
+  only as on-device fault-log file paths; read those file contents (bounded,
+  best-effort) into the crash ticket so the server can symbolicate against the
+  build's uploaded `.so` symbols.
+
 ## 0.3.1
 
 - Fix native-crash signal formatting: hiAppEvent can deliver `signal` as a

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "Oranix",

--- a/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
@@ -6,6 +6,11 @@ import { HandsCrashUploader } from './HandsCrashUploader';
 
 const TAG: string = 'HandsFaultWatcher';
 const FAULT_LOG_MAX_CHARS: number = 180000;
+// Per-file / count caps for reading on-device fault-log files (the native
+// backtrace source). Kept well under FAULT_LOG_MAX_CHARS so the combined log
+// stays bounded after the final slice.
+const FAULT_FILE_MAX_CHARS: number = 120000;
+const FAULT_FILE_MAX_COUNT: number = 3;
 
 /**
  * System-level fault capture via hiAppEvent (the same channel Bugly-class
@@ -89,6 +94,11 @@ export class HandsFaultWatcher {
     const threads = params['threads'];
     const threadsText = threads === undefined ? '' : JSON.stringify(threads, null, 2);
     const externalLogs = HandsFaultWatcher.joinLines(params['external_log']);
+    // The full native backtrace (`#NN pc <off> <lib>.so(<buildId>)`) that the
+    // server needs to symbolicate lives in the on-device fault-log file(s),
+    // not in the hiAppEvent params — external_log only carries their paths.
+    // Read those file contents so the crash ticket actually ships the stack.
+    const externalFileContents = HandsFaultWatcher.readFaultFiles(params['external_log']);
 
     const lines: string[] = [
       'Hands OHOS fault log (hiAppEvent)',
@@ -110,6 +120,9 @@ export class HandsFaultWatcher {
     }
     if (externalLogs.length > 0) {
       lines.push('', '--- system fault log files (on device) ---', externalLogs);
+    }
+    if (externalFileContents.length > 0) {
+      lines.push('', '--- native backtrace (fault log file) ---', externalFileContents);
     }
     const crashLog = lines.join('\n').slice(0, FAULT_LOG_MAX_CHARS);
 
@@ -197,6 +210,36 @@ export class HandsFaultWatcher {
       return (value as Array<Object>).map((entry: Object): string => String(entry)).join('\n');
     }
     return String(value);
+  }
+
+  /**
+   * external_log carries paths to the system fault-log file(s), whose contents
+   * hold the full native backtrace. Read each (bounded, best-effort) so the
+   * symbolicatable stack ships with the ticket. Failures (missing file,
+   * permission) are swallowed — we still have the exception summary.
+   */
+  private static readFaultFiles(value: Object | undefined): string {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const paths: string[] = Array.isArray(value)
+      ? (value as Array<Object>).map((entry: Object): string => String(entry))
+      : [String(value)];
+    const blocks: string[] = [];
+    for (const path of paths) {
+      if (path.length === 0 || blocks.length >= FAULT_FILE_MAX_COUNT) {
+        continue;
+      }
+      try {
+        const content = fs.readTextSync(path, { offset: 0, length: FAULT_FILE_MAX_CHARS });
+        if (content.length > 0) {
+          blocks.push(`=== ${path} ===\n${content}`);
+        }
+      } catch (error) {
+        hilog.warn(0x0000, TAG, 'could not read fault file %{public}s: %{public}s', path, String(error));
+      }
+    }
+    return blocks.join('\n\n');
   }
 
   private static writeFaultLog(context: common.UIAbilityContext, crashLog: string): string {

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -98,10 +98,16 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   const slug = c.req.param("slug");
   if (!slug) return c.json({ error: "slug required" }, 400);
   const app = await c.env.DB.prepare(
-    "SELECT id, org_id, slug, client_key FROM apps WHERE slug = ?1 AND archived = 0",
+    "SELECT id, org_id, slug, client_key, platform FROM apps WHERE slug = ?1 AND archived = 0",
   )
     .bind(slug)
-    .first<{ id: string; org_id: string | null; slug: string; client_key: string | null }>();
+    .first<{
+      id: string;
+      org_id: string | null;
+      slug: string;
+      client_key: string | null;
+      platform: string | null;
+    }>();
   if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
 
   // Client-key gate (Sentry-DSN model): always required. Apps predating the
@@ -307,6 +313,21 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   if (kind === "crash" && nativeFrames.length > 0) {
     const run = () =>
       symbolicateNativeCrashTicket(c.env, app.id, ticketId, versionCode, nativeFrames);
+    try {
+      c.executionCtx.waitUntil(run());
+    } catch {
+      run().catch(() => {});
+    }
+  }
+
+  // OHOS crashes: the HarmonyOS SDK captures cppcrash/NativeCrash faults via
+  // hiAppEvent and uploads them as a text fault log (no structured
+  // crash_native_frames). Parse the debuggerd-style backtrace out of that log
+  // server-side into native frames, then reuse the native-symbols lane. Gated
+  // on platform so non-OHOS crashes don't pay for the extra log fetch.
+  if (kind === "crash" && app.platform === "ohos" && attachmentRows.length > 0) {
+    const logKey = attachmentRows[0]!.r2Key;
+    const run = () => symbolicateOhosCrashTicket(c.env, app.id, ticketId, versionCode, logKey);
     try {
       c.executionCtx.waitUntil(run());
     } catch {
@@ -724,6 +745,7 @@ export async function symbolicateNativeCrashTicket(
   ticketId: string,
   versionCode: number | null,
   frames: NativeFrame[],
+  publishHint: string = "quiver builds publish-android --symbols",
 ): Promise<void> {
   try {
     if (versionCode === null || frames.length === 0) return;
@@ -754,7 +776,7 @@ export async function symbolicateNativeCrashTicket(
       await appendComment(
         `Native crash could not be symbolicated: no 'native-symbols' build asset ` +
           `for version_code ${versionCode}${ids ? ` (crash BuildId: ${ids})` : ""}. ` +
-          `Publish the build with its unstripped .so archive (quiver builds publish-android --symbols).`,
+          `Publish the build with its unstripped .so archive (${publishHint}).`,
       );
       return;
     }
@@ -795,6 +817,127 @@ export async function symbolicateNativeCrashTicket(
   } catch (err) {
     console.error(
       `[symbolicate] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function ohosBasename(p: string): string {
+  const parts = p.split(/[\\/]/);
+  return parts[parts.length - 1] ?? "";
+}
+
+/**
+ * Parse OHOS/HarmonyOS native crash frames out of the fault log the OHOS SDK
+ * (HandsFaultWatcher) uploads. That log embeds the hiAppEvent `exception`,
+ * whose native backtrace shows up either as a debuggerd-style text stack
+ * (`#00 pc <offset> <path>.so(sym+off)(BuildId: <id>)`) or as structured JSON
+ * frames. Both are reduced to { index, offset, soname, build_id } — the exact
+ * shape the native-symbols lane feeds llvm-symbolizer — so OHOS reuses the
+ * Android native path unchanged (OHOS binaries are ARM64 ELF `.so`). The
+ * `.so`-relative program counter (`pc`) is the address llvm-symbolizer needs;
+ * a symbol-relative offset, when present, is display-only and ignored.
+ */
+export function parseOhosNativeFrames(logText: string): NativeFrame[] {
+  if (!logText) return [];
+  // hiAppEvent stacks often arrive JSON-stringified, so real newlines may be
+  // escaped as a literal backslash-n. Normalise so a line scan sees one frame
+  // per line and object regexes see clean field boundaries.
+  const normalized = logText
+    .replace(/\\r\\n|\\n|\\r/g, "\n")
+    .replace(/\r\n/g, "\n");
+
+  const frames: NativeFrame[] = [];
+  const seen = new Set<number>();
+
+  // Lane A — debuggerd-style text backtrace (the canonical HarmonyOS DFX form).
+  const frameRe = /#0*(\d+)\s+pc\s+([0-9a-fA-F]{1,16})\s+(\S+?\.so)\b/i;
+  const buildIdRe = /\bBuildId:\s*([0-9a-fA-F]{8,64})/i;
+  for (const rawLine of normalized.split("\n")) {
+    if (frames.length >= 256) break;
+    const line = rawLine.trim();
+    const m = frameRe.exec(line);
+    if (!m) continue;
+    const index = Number(m[1]);
+    if (!Number.isFinite(index) || seen.has(index)) continue;
+    const soname = ohosBasename(m[3]!);
+    if (!soname) continue;
+    const frame: NativeFrame = {
+      index,
+      offset: `0x${m[2]!.toLowerCase()}`,
+      soname: soname.slice(0, 200),
+    };
+    const bid = buildIdRe.exec(line);
+    if (bid) frame.build_id = bid[1]!.toLowerCase();
+    frames.push(frame);
+    seen.add(index);
+  }
+  if (frames.length > 0) return frames;
+
+  // Lane B — structured JSON frames: `"frames":[{"file":"…​.so","pc":"…"}]`.
+  // Map file->soname and the .so-relative pc (falling back to offset) into our
+  // shape. Field mapping validated against a real device sample (task #95).
+  const objRe = /\{[^{}]*?"file"\s*:\s*"([^"]*?\.so)"[^{}]*?\}/gi;
+  let om: RegExpExecArray | null;
+  let autoIndex = 0;
+  while ((om = objRe.exec(normalized)) !== null) {
+    if (frames.length >= 256) break;
+    const obj = om[0];
+    const soname = ohosBasename(om[1]!);
+    if (!soname) continue;
+    const pcM = /"pc"\s*:\s*"?(?:0x)?([0-9a-fA-F]{1,16})"?/i.exec(obj);
+    const offM = /"offset"\s*:\s*"?(?:0x)?([0-9a-fA-F]{1,16})"?/i.exec(obj);
+    const hex = pcM ? pcM[1]! : offM ? offM[1]! : "";
+    if (!hex) continue;
+    const idxM = /"index"\s*:\s*(\d+)/i.exec(obj);
+    const index = idxM ? Number(idxM[1]) : autoIndex;
+    const frame: NativeFrame = {
+      index,
+      offset: `0x${hex.toLowerCase()}`,
+      soname: soname.slice(0, 200),
+    };
+    const bidM = /"[bB]uild[_]?[iI]d"\s*:\s*"([0-9a-fA-F]{8,64})"/.exec(obj);
+    if (bidM) frame.build_id = bidM[1]!.toLowerCase();
+    frames.push(frame);
+    autoIndex++;
+  }
+  return frames;
+}
+
+/**
+ * OHOS native crash symbolication (server side, task #95). Reads the uploaded
+ * HarmonyOS fault log, extracts native frames, and hands them to the shared
+ * native-symbols lane — no OHOS-specific container work, since OHOS binaries
+ * are ARM64 ELF `.so` (same tooling as Android native). The `native-symbols`
+ * archive is what `publish-ohos --symbols` uploads.
+ */
+export async function symbolicateOhosCrashTicket(
+  env: Env,
+  appId: string,
+  ticketId: string,
+  versionCode: number | null,
+  logR2Key: string,
+): Promise<void> {
+  try {
+    if (versionCode === null) return;
+    const logObj = await env.APK_BUCKET.get(logR2Key);
+    if (!logObj) return;
+    const logText = await logObj.text();
+    // Only act on OHOS fault logs (HandsFaultWatcher writes this signature on
+    // the first line); ignore anything else routed here.
+    if (!logText.includes("Hands OHOS fault log")) return;
+    const frames = parseOhosNativeFrames(logText);
+    if (frames.length === 0) return;
+    await symbolicateNativeCrashTicket(
+      env,
+      appId,
+      ticketId,
+      versionCode,
+      frames,
+      "quiver builds publish-ohos --symbols",
+    );
+  } catch (err) {
+    console.error(
+      `[symbolicate-ohos] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -849,9 +849,22 @@ export function parseOhosNativeFrames(logText: string): NativeFrame[] {
   const frames: NativeFrame[] = [];
   const seen = new Set<number>();
 
-  // Lane A — debuggerd-style text backtrace (the canonical HarmonyOS DFX form).
-  const frameRe = /#0*(\d+)\s+pc\s+([0-9a-fA-F]{1,16})\s+(\S+?\.so)\b/i;
-  const buildIdRe = /\bBuildId:\s*([0-9a-fA-F]{8,64})/i;
+  // Lane A — `#NN pc <off> <path>.so …` text backtrace. Covers both the
+  // Kotlin/Native runtime form `… .so (0) [arm64-v8a::<buildid>]` (what our
+  // KMP libshared.so emits — validated against the Kuikly/Bugly OHOS format)
+  // and the HarmonyOS system cppcrash form `… .so(sym+off)(BuildId: <id>)`.
+  const frameRe = /#0*(\d+)\s+pc\s+([0-9a-fA-F]{1,16})\s+(\S+?\.so(?:\.\d+)?)\b/i;
+  // Build id appears in one of three forms across HarmonyOS backtrace sources:
+  //   `(BuildId: <hex>)`        — labeled (some system cppcrash dumps)
+  //   `.so(<hex>)`              — bare hex in parens after the lib (system
+  //                               faultlogger fault-log file form)
+  //   `[<arch>::<hex>]`         — Kotlin/Native runtime backtrace
+  // (a `(symbol+offset)` group is not pure hex, so it never matches these.)
+  const buildIdRes = [
+    /\bBuildId:\s*([0-9a-fA-F]{8,64})/i,
+    /\.so(?:\.\d+)?\(([0-9a-fA-F]{8,64})\)/i,
+    /\[[^\]]*::([0-9a-fA-F]{8,64})\]/,
+  ];
   for (const rawLine of normalized.split("\n")) {
     if (frames.length >= 256) break;
     const line = rawLine.trim();
@@ -866,8 +879,13 @@ export function parseOhosNativeFrames(logText: string): NativeFrame[] {
       offset: `0x${m[2]!.toLowerCase()}`,
       soname: soname.slice(0, 200),
     };
-    const bid = buildIdRe.exec(line);
-    if (bid) frame.build_id = bid[1]!.toLowerCase();
+    for (const re of buildIdRes) {
+      const bid = re.exec(line);
+      if (bid) {
+        frame.build_id = bid[1]!.toLowerCase();
+        break;
+      }
+    }
     frames.push(frame);
     seen.add(index);
   }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3975,6 +3975,100 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(comment.body).toContain("abcd1234");
   });
 
+  it("parseOhosNativeFrames extracts frames from a debuggerd-style HarmonyOS fault log", async () => {
+    const { parseOhosNativeFrames } = await import("../src/routes/feedback");
+    const log = [
+      "Hands OHOS fault log (hiAppEvent)",
+      "Event: APP_CRASH",
+      "Fault kind: CppCrash",
+      "",
+      "--- exception ---",
+      "Thread 0 crashed:",
+      "#00 pc 000000000004a1b8 /system/lib64/libc.so(abort+164)(BuildId: 1a2b3c4d5e6f7a8b)",
+      "#01 pc 0000000000012345 /data/storage/el1/bundle/entry/libs/arm64/libentry.so",
+      "#02 pc 00000000000067ff /data/app/libnative.so(doWork+31)(BuildId: aabbccddeeff0011)",
+    ].join("\n");
+    expect(parseOhosNativeFrames(log)).toEqual([
+      { index: 0, offset: "0x000000000004a1b8", soname: "libc.so", build_id: "1a2b3c4d5e6f7a8b" },
+      { index: 1, offset: "0x0000000000012345", soname: "libentry.so" },
+      { index: 2, offset: "0x00000000000067ff", soname: "libnative.so", build_id: "aabbccddeeff0011" },
+    ]);
+  });
+
+  it("parseOhosNativeFrames handles JSON-escaped newlines and structured frames", async () => {
+    const { parseOhosNativeFrames } = await import("../src/routes/feedback");
+    // Backtrace embedded as a JSON-stringified string (real newlines escaped).
+    const escaped =
+      "Hands OHOS fault log (hiAppEvent)\\n--- exception ---\\n" +
+      '{"stack":"#00 pc 000000000004a1b8 /system/lib64/libc.so(BuildId: 1a2b3c4d5e6f7a8b)"}';
+    expect(parseOhosNativeFrames(escaped)).toEqual([
+      { index: 0, offset: "0x000000000004a1b8", soname: "libc.so", build_id: "1a2b3c4d5e6f7a8b" },
+    ]);
+    // Structured JSON frames (no text backtrace): pc is the .so-relative address.
+    const structured =
+      "Hands OHOS fault log (hiAppEvent)\n--- exception ---\n" +
+      JSON.stringify({
+        message: "Segmentation fault",
+        frames: [
+          { index: 0, symbol: "abort", file: "/system/lib64/libc.so", pc: "4a1b8", offset: "164", buildId: "1a2b3c4d5e6f7a8b" },
+          { symbol: "", file: "/data/app/libentry.so", pc: "0x12345" },
+        ],
+      });
+    expect(parseOhosNativeFrames(structured)).toEqual([
+      { index: 0, offset: "0x4a1b8", soname: "libc.so", build_id: "1a2b3c4d5e6f7a8b" },
+      { index: 1, offset: "0x12345", soname: "libentry.so" },
+    ]);
+    expect(parseOhosNativeFrames("")).toEqual([]);
+    expect(parseOhosNativeFrames("no frames here")).toEqual([]);
+  });
+
+  it("symbolicateOhosCrashTicket parses the fault log and leaves a publish-ohos hint when symbols are missing", async () => {
+    const env = makeEnv();
+    const log =
+      "Hands OHOS fault log (hiAppEvent)\n--- exception ---\n" +
+      "#00 pc 000000000004a1b8 /data/app/libentry.so(BuildId: aabbccddeeff0011)";
+    env.APK_BUCKET = {
+      get: async (key: string) =>
+        key === "feedback/app-scope/tick-ohos/0-crash.log" ? { text: async () => log } : null,
+    } as any;
+    const { symbolicateOhosCrashTicket } = await import("../src/routes/feedback");
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?1, ?2, 'crash', 'open', 'ohos crash', '{}', ?3, ?4)`,
+    ).bind("tick-ohos", "app-scope", 1, 1).run();
+    await symbolicateOhosCrashTicket(
+      env as any,
+      "app-scope",
+      "tick-ohos",
+      1040000,
+      "feedback/app-scope/tick-ohos/0-crash.log",
+    );
+    const comment = (await env.DB.prepare(
+      "SELECT author_actor, body FROM feedback_comments WHERE ticket_id = ?1",
+    ).bind("tick-ohos").all()).results[0] as { author_actor: string; body: string };
+    expect(comment.author_actor).toBe("quiver-symbolicate");
+    expect(comment.body).toContain("native-symbols");
+    expect(comment.body).toContain("publish-ohos");
+    expect(comment.body).toContain("aabbccddeeff0011");
+  });
+
+  it("symbolicateOhosCrashTicket ignores non-OHOS logs", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = {
+      get: async () => ({ text: async () => "some android logcat, not an ohos fault log" }),
+    } as any;
+    const { symbolicateOhosCrashTicket } = await import("../src/routes/feedback");
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?1, ?2, 'crash', 'open', 'not ohos', '{}', ?3, ?4)`,
+    ).bind("tick-noop", "app-scope", 1, 1).run();
+    await symbolicateOhosCrashTicket(env as any, "app-scope", "tick-noop", 1040000, "any-key");
+    const rows = (await env.DB.prepare(
+      "SELECT id FROM feedback_comments WHERE ticket_id = ?1",
+    ).bind("tick-noop").all()).results;
+    expect(rows.length).toBe(0);
+  });
+
   it("parseBinaryImages/parseCrashFrames bound and shape-check SDK input", async () => {
     const { parseBinaryImages, parseCrashFrames } = await import("../src/routes/feedback");
     const images = parseBinaryImages(JSON.stringify([

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3995,6 +3995,34 @@ describe("quiver public API v2 — scope resolution", () => {
     ]);
   });
 
+  it("parseOhosNativeFrames handles the Kotlin/Native runtime backtrace (Kuikly/Bugly OHOS form)", async () => {
+    const { parseOhosNativeFrames } = await import("../src/routes/feedback");
+    // Real OHOS KN format: build id lives inside [arch::buildid], not (BuildId:).
+    const log = [
+      "Hands OHOS fault log (hiAppEvent)",
+      "--- exception ---",
+      "#00 pc 0000000000168f0b /data/storage/el1/bundle/libs/arm64/libshared.so (0) [arm64-v8a::914bbb25df0b98d1395de2ba65b9274b]",
+      "#01 pc 0000000000012345 /system/lib/ld-musl-aarch64.so.1 (0) [arm64-v8a::deadbeefcafe0011]",
+    ].join("\n");
+    expect(parseOhosNativeFrames(log)).toEqual([
+      { index: 0, offset: "0x0000000000168f0b", soname: "libshared.so", build_id: "914bbb25df0b98d1395de2ba65b9274b" },
+      { index: 1, offset: "0x0000000000012345", soname: "ld-musl-aarch64.so.1", build_id: "deadbeefcafe0011" },
+    ]);
+  });
+
+  it("parseOhosNativeFrames handles the system faultlogger form `.so(<buildid>)`", async () => {
+    const { parseOhosNativeFrames } = await import("../src/routes/feedback");
+    // hiAppEvent external_log fault-file form: bare hex build id in parens.
+    const log =
+      "Hands OHOS fault log (hiAppEvent)\n--- system fault log files (on device) ---\n" +
+      "#00 pc 0000000000006f98 /data/storage/el1/bundle/libs/arm64/libentry.so(996f532bb3d4b6a1a911675ec4a018291d3038c5)\n" +
+      "#01 pc 000000000004a1b8 /system/lib/ld-musl-aarch64.so.1(abort+164)";
+    expect(parseOhosNativeFrames(log)).toEqual([
+      { index: 0, offset: "0x0000000000006f98", soname: "libentry.so", build_id: "996f532bb3d4b6a1a911675ec4a018291d3038c5" },
+      { index: 1, offset: "0x000000000004a1b8", soname: "ld-musl-aarch64.so.1" },
+    ]);
+  });
+
   it("parseOhosNativeFrames handles JSON-escaped newlines and structured frames", async () => {
     const { parseOhosNativeFrames } = await import("../src/routes/feedback");
     // Backtrace embedded as a JSON-stringified string (real newlines escaped).


### PR DESCRIPTION
Completes OHOS/HarmonyOS native crash symbolication (**task #95**) end to end. Reverse-engineering Bugly's + Kuikly's OHOS crash reporting (per @artin) and inspecting real raft-ohos crash tickets surfaced the true shape of the problem.

## Findings
- OHOS binaries are ARM64 ELF `.so`, so the whole native symbolication lane (container `/symbolicate-native` → llvm-symbolizer, `native-symbols` asset from `publish-ohos --symbols`, `symbolicateNativeCrashTicket`) is reused **unchanged**.
- **The full symbolicatable backtrace was never reaching the server.** hiAppEvent delivers the native stack (`#NN pc <off> <lib>.so(<buildId>)`) only as *paths* to on-device fault-log files (`external_log`); the SDK stringified the paths, not the contents. The two real raft-ohos crashes carry only a `crash_top_frame` summary (`/system/lib/ld-musl-aarch64.so.1+216`), no stack, no attachment.
- Build id appears in **three** forms depending on source: `(BuildId: <hex>)`, `.so(<hex>)` (system faultlogger file), and `[<arch>::<hex>]` (Kotlin/Native runtime — what our `libshared.so` emits, confirmed against the Kuikly guide). The `.so`-relative `pc` is the llvm-symbolizer address.

## Changes
**SDK (OHOS 0.3.2)** — `HandsFaultWatcher` now reads the on-device fault-log file contents (bounded, best-effort) and ships the full backtrace in the crash ticket.

**Server** —
- `parseOhosNativeFrames()`: extracts `{ index, offset, soname, build_id }` from the fault log — handles all three build-id forms, `.so.N` versioned libs, debuggerd text, JSON-escaped newlines, and structured JSON frames.
- `symbolicateOhosCrashTicket()`: reads the log from R2, gates on the OHOS signature, feeds the shared native lane. Dispatch on `crash && app.platform==='ohos'`; missing-symbols hint → `publish-ohos --symbols`.

**Tests** — text / Kotlin-Native `[arch::buildid]` / system-faultlogger `.so(<buildid>)` / escaped / structured parsing, missing-symbols hint, non-OHOS no-op. 131 worker tests pass; `tsc` clean.

## Remaining before ready-for-review
End-to-end validation needs one fresh crash from **SDK 0.3.2** on a raft-ohos build published with `--symbols` (the two existing crashes predate the fault-capture SDK). Then flip out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
