### PR TITLE
fix(auth): open the canonical dashboard origin

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -68,7 +68,6 @@ import {
   getAuthMe,
   listApps,
   listOrgs,
-  loginUrl,
   logout,
   type AuthAccount,
 } from "./lib/api";
@@ -901,9 +900,8 @@ function CliCallback({ token }: { token: string }) {
   );
 }
 
-function dashboardHref(account?: AuthAccount): string {
-  if (account) return "/apps";
-  return loginUrl("/apps");
+function dashboardHref(): string {
+  return "/api/auth/dashboard?return=%2Fapps";
 }
 
 function PublicLanding({ account }: { account?: AuthAccount }) {
@@ -932,7 +930,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
             >
               API explorer
             </a>
-            <Button variant="primary" render={<a href={dashboardHref(account)} />}>
+            <Button variant="primary" render={<a href={dashboardHref()} />}>
               <RaftIcon className="h-5 w-5" />
               {account ? "Open dashboard" : "Login"}
             </Button>
@@ -971,7 +969,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
                 ))}
               </div>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                <Button variant="primary" size="lg" render={<a href={dashboardHref(account)} />}>
+                <Button variant="primary" size="lg" render={<a href={dashboardHref()} />}>
                   <RaftIcon className="h-5 w-5" />
                   {account ? "Open dashboard" : "Login with Raft"}
                 </Button>

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -20,6 +20,7 @@ import {
   handleAgentManifest,
   handleAgentHelp,
   handleAuthConfig,
+  handleDashboardRedirect,
   handleAuthLogin,
   handleAuthLogout,
   handleAuthMe,
@@ -484,6 +485,7 @@ app.get("/docs.md", handlePublicDocs);
 app.get("/docs/*", handlePublicDocs);
 
 app.get("/api/auth/config", handleAuthConfig);
+app.get("/api/auth/dashboard", handleDashboardRedirect);
 app.get("/api/auth/login", handleAuthLogin);
 app.get("/login/raft/callback", handleRaftCallback);
 app.get("/api/auth/me", handleAuthMe);

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -521,6 +521,13 @@ export async function handleAuthConfig(c: Context<{ Bindings: Env }>) {
   });
 }
 
+export async function handleDashboardRedirect(c: Context<{ Bindings: Env }>) {
+  const rawReturn = c.req.query("return");
+  const returnPath = normalizeReturnPath(rawReturn);
+  const origin = dashboardOrigin(c.env, () => appOrigin(c));
+  return c.redirect(`${origin}${returnPath}`, 302);
+}
+
 export async function handleAuthMe(c: Context<{ Bindings: Env }>) {
   const authHeader = c.req.header("authorization");
   const bearerToken = authHeader?.startsWith("Bearer ")

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
 import { handleCreateApp, handleListApps } from "../src/routes/apps";
-import { createSignedJwt, handleAuthLogin, handleAuthMe } from "../src/routes/auth";
+import { createSignedJwt, handleAuthLogin, handleAuthMe, handleDashboardRedirect } from "../src/routes/auth";
 import { handleListOrgs } from "../src/routes/orgs";
 
 // ---------- Test harness ----------
@@ -1386,6 +1386,33 @@ describe("quiver route handlers — SQL smoke", () => {
 });
 
 describe("auth origin handling", () => {
+  it("opens the configured dashboard origin without restarting OAuth", async () => {
+    const env = makeMockEnv();
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/dashboard", handleDashboardRedirect);
+
+    const res = await app.request(
+      "https://business.example/api/auth/dashboard?return=%2Fapps",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://dashboard.example/apps");
+  });
+
+  it("sanitizes unsafe dashboard return paths", async () => {
+    const env = makeMockEnv();
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/dashboard", handleDashboardRedirect);
+    const res = await app.request(
+      "https://business.example/api/auth/dashboard?return=https%3A%2F%2Fevil.example",
+      {},
+      env as any,
+    );
+    expect(res.headers.get("location")).toBe("https://dashboard.example/");
+  });
+
   it("issues signed JWT-shaped Hands access tokens with scoped claims", async () => {
     const env = makeMockEnv();
     (env as any).SIGNED_URL_SECRET = "jwt-test-secret";


### PR DESCRIPTION
## Summary
- make business-site Open dashboard resolve through the configured `DASHBOARD_ORIGIN`
- land on `app.hands.build/apps`, where the existing origin-scoped Hands JWT is available
- sanitize the return path and avoid restarting OAuth for already-signed-in dashboard users

## Validation
- Worker typecheck
- route suite: 101 passed
- Admin production build
- git diff --check

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786354289&installation_id=145465820&pr_number=261&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F261&signature=fe62a85b7150b10acdc10dddd22b0b5c9e67f0df68501c5c766899cf6c163209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->