### PR TITLE
fix(ohos): preserve AGC provider errors

### DIFF
--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -29,7 +29,9 @@ async function agcJson(auth: AgcAuth, path: string, init: RequestInit = {}, fetc
   const body = await response.json().catch(() => null) as any;
   const providerCode = body?.ret?.code ?? body?.rtnCode;
   if (!response.ok || (providerCode !== undefined && String(providerCode) !== "0")) {
-    throw new AgcApiError(response.status, body?.ret?.msg || body?.rtnDesc || "AGC API request failed");
+    const providerMessage = body?.ret?.msg || body?.rtnDesc || body?.error_description || body?.error;
+    const suffix = providerCode !== undefined ? `, code ${String(providerCode)}` : "";
+    throw new AgcApiError(response.status, `${providerMessage || "AGC API request failed"} (HTTP ${response.status}${suffix})`);
   }
   return body;
 }

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -31,7 +31,8 @@ export async function handleStartAgcInvitationTest(c: AdminContext) {
     WHERE b.id=?1 AND b.app_id=?2 AND ba.platform='ohos' AND ba.filetype='app'`).bind(buildId, appId).first<{ r2_key: string; file_hash: string; size_bytes: number; filetype: string }>();
   if (!row) return c.json({ error: "signed OHOS .app asset not found for build" }, 404);
   const existing = await c.env.DB.prepare("SELECT * FROM market_submissions WHERE idempotency_key=?1").bind(`agc-invitation:${buildId}`).first<Submission>();
-  if (existing) return c.json({ submission: existing });
+  if (existing && existing.state !== "failed") return c.json({ submission: existing });
+  if (existing) await c.env.DB.prepare("DELETE FROM market_submissions WHERE id=?1").bind(existing.id).run();
   const id = crypto.randomUUID(); const now = Date.now();
   await c.env.DB.prepare(`INSERT INTO market_submissions (id,app_id,build_id,provider,lane,state,idempotency_key,created_by_actor,created_at,updated_at)
     VALUES (?1,?2,?3,'appgallery','invitation_test','uploading',?4,?5,?6,?6)`).bind(id, appId, buildId, `agc-invitation:${buildId}`, currentActor(c), now).run();

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -69,7 +69,7 @@ describe("AGC invitation testing API", () => {
   });
   it("rejects provider business errors even on HTTP 200", async () => {
     const mockFetch = vi.fn(async () => new Response(JSON.stringify({ ret: { code: 204144688, msg: "invalid package" } }), { status: 200 }));
-    await expect(resolveAgcAppId(auth, "build.raft.mobile", mockFetch as typeof fetch)).rejects.toThrow("invalid package");
+    await expect(resolveAgcAppId(auth, "build.raft.mobile", mockFetch as typeof fetch)).rejects.toThrow("invalid package (HTTP 200, code 204144688)");
   });
 });
 


### PR DESCRIPTION
Keeps redacted HTTP/business codes in AGC operation failures and allows an idempotent retry after a failed draft preparation.

Validation: Worker typecheck and 11 AGC tests.

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786357014&installation_id=145465820&pr_number=263&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F263&signature=edef3b5f835d7c6014a15e211e2c7583fe1330ba883453775e7910513756941d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->