### PR TITLE
feat(ohos): support AGC service accounts

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -750,10 +750,12 @@ export const verifyAscCredentials = (appId: string, bundleId: string) =>
 export interface AgcCredentialsMeta {
   id: string;
   app_id: string;
-  credential_kind: "api_client";
-  developer_id: string;
-  project_id: string;
-  client_id: string;
+  credential_kind: "api_client" | "service_account";
+  developer_id: string | null;
+  project_id: string | null;
+  client_id: string | null;
+  key_id: string | null;
+  sub_account: string | null;
   configuration_version: string | null;
   region: string | null;
   credential_fingerprint: string;
@@ -770,7 +772,7 @@ export const setAgcCredentials = (appId: string, credential_json: string) =>
 export const deleteAgcCredentials = (appId: string) =>
   request<{ ok: boolean }>(`/api/apps/${appId}/agc-credentials`, { method: "DELETE", admin: true });
 export const verifyAgcCredentials = (appId: string) =>
-  request<{ ok: boolean; credential_kind?: string; developer_id?: string; project_id?: string; client_id?: string; region?: string | null; expires_in?: number; error?: string; status?: number }>(
+  request<{ ok: boolean; credential_kind?: string; developer_id?: string; project_id?: string; client_id?: string; key_id?: string; sub_account?: string; region?: string | null; expires_in?: number; error?: string; status?: number }>(
     `/api/apps/${appId}/agc-credentials/verify`, { method: "POST", admin: true },
   );
 

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -668,7 +668,7 @@ function AppGalleryConnectPanel({ appId }: { appId: string }) {
   const test = useMutation({
     mutationFn: () => verifyAgcCredentials(appId),
     onSuccess: (r) => toast.show(r.ok
-      ? { kind: "success", title: "Connection OK", description: `AGC token exchange succeeded; expires in ${Math.round((r.expires_in ?? 0) / 3600)} hours.` }
+      ? { kind: "success", title: "Connection OK", description: `${r.credential_kind === "service_account" ? "Service Account JWT signing" : "AGC token exchange"} succeeded; credential expires in ${Math.round((r.expires_in ?? 0) / 3600)} hours.` }
       : { kind: "error", title: "Verification failed", description: r.error ?? "Unknown AGC error" }),
     onError: (e) => toast.show({ kind: "error", title: "Test failed", description: (e as Error).message }),
   });
@@ -678,10 +678,14 @@ function AppGalleryConnectPanel({ appId }: { appId: string }) {
       <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium">AppGallery Connect</div>
-          <div className="text-xs text-slate-500">API client credential used for HarmonyOS testing and publishing. The uploaded JSON is encrypted and its client secret is never shown again.</div>
+          <div className="text-xs text-slate-500">Service Account or legacy API client credential used for HarmonyOS testing and publishing. The uploaded JSON is encrypted and private material is never shown again.</div>
           {meta && <div className="mt-1 text-xs space-y-0.5">
             <div><span className="text-green-700 font-medium">Configured</span>{" · "}{meta.credential_kind}{" · updated "}{new Date(meta.updated_at).toISOString().slice(0, 10)}</div>
-            <div className="font-mono break-all">Developer {meta.developer_id} · Project {meta.project_id} · Client {meta.client_id}</div>
+            {meta.credential_kind === "service_account" ? (
+              <div className="font-mono break-all">Sub-account {meta.sub_account} · Key {meta.key_id} · Project {meta.project_id || "default"}</div>
+            ) : (
+              <div className="font-mono break-all">Developer {meta.developer_id} · Project {meta.project_id} · Client {meta.client_id}</div>
+            )}
             <div className="font-mono">Region {meta.region || "default"} · Fingerprint {meta.credential_fingerprint.slice(0, 12)}…</div>
           </div>}
         </div>
@@ -692,9 +696,9 @@ function AppGalleryConnectPanel({ appId }: { appId: string }) {
         </div>}
       </div>
       {showForm && <div className="mt-3 p-3 border border-slate-200 rounded-md space-y-3">
-        <label className="block text-xs font-medium">AGC API client JSON</label>
+        <label className="block text-xs font-medium">AGC Service Account private JSON</label>
         <input type="file" accept=".json,application/json" onChange={(e) => { const file = e.target.files?.[0]; if (file) file.text().then(setCredentialJson, () => toast.show({ kind: "error", title: "Could not read the credential file" })); }} />
-        <div className="text-xs text-slate-500">Select the JSON downloaded from AppGallery Connect. The client secret is not displayed or returned by the API.</div>
+        <div className="text-xs text-slate-500">Select the private JSON downloaded from AppGallery Connect. Service Account is recommended; legacy API client JSON remains supported during migration.</div>
         <div className="flex gap-2">
           <Button variant="primary" disabled={!credentialJson || save.isPending} onClick={() => save.mutate()}>{save.isPending ? "Saving…" : "Save credential"}</Button>
           {meta && <Button variant="outline" onClick={() => { setCredentialJson(""); setEditing(false); }}>Cancel</Button>}

--- a/docs/ohos-appgallery-connect-design.md
+++ b/docs/ohos-appgallery-connect-design.md
@@ -21,8 +21,8 @@ and local package validation. Hands receives the signed `.app`, standalone
 
 AppGallery Connect currently exposes APIs for:
 
-- AGC API client authentication using OAuth client credentials, with
-  developer-level Service Account/PS256 support reserved as a future credential kind;
+- developer-level Service Account authentication using one-hour PS256 JWTs,
+  with legacy API client OAuth authentication retained for migration;
 - HarmonyOS `.app` upload, including large/multipart uploads and SHA-256;
 - package binding and asynchronous compile/parse status;
 - invitation testing and public testing, including groups, members, invite
@@ -51,7 +51,7 @@ in a separate table and encryption domain.
 | Column | Purpose |
 |---|---|
 | `id`, `app_id` | One active credential set per Hands app. |
-| `service_account_id`, `key_id` | Non-secret identifiers shown in Settings. |
+| `credential_kind`, `developer_id`, `project_id`, `client_id`, `key_id`, `sub_account` | Non-secret identifiers shown in Settings for Service Accounts or legacy API clients. |
 | `credential_ciphertext_b64`, `credential_iv_b64` | Entire AGC credential JSON encrypted with AES-GCM. |
 | `credential_fingerprint` | SHA-256 fingerprint for rotation/audit, never the private key. |
 | `created_by_actor`, `created_at`, `updated_at` | Audit ownership. |
@@ -69,8 +69,10 @@ Settings actions:
 - `DELETE /api/apps/:appId/agc-credentials`
 - `POST /api/apps/:appId/agc-credentials/verify`
 
-The connection test mints a short-lived JWT and performs a read-only app
-lookup for the configured `main` channel bundle name.
+The connection test validates Service Account PKCS#8 key import and PS256 JWT
+signing, or exchanges the legacy API client secret for an OAuth access token.
+The first app lookup/upload then verifies provider-side Publishing/Testing
+permissions without exposing the JWT or access token.
 
 ## Persistent market model
 
@@ -128,7 +130,8 @@ workflow instance id on `market_submissions`.
 
 Steps must be individually retryable:
 
-1. load encrypted credentials and exchange the API client secret for an OAuth access token;
+1. load encrypted credentials and mint a one-hour Service Account PS256 JWT,
+   or exchange a legacy API client secret for an OAuth access token;
 2. resolve the manually created AGC app by bundle name;
 3. request the short-lived upload URL;
 4. stream the `.app` from R2, using multipart upload when required;
@@ -219,7 +222,8 @@ Hands draft. Market submit remains a separate reviewed action.
 ### P0A: foundation
 
 - migration for encrypted AGC credentials, market submissions, and events;
-- API client OAuth exchange and read-only connection test;
+- Service Account PS256 JWT auth, legacy API client OAuth compatibility, and
+  credential validation;
 - AppGallery page with credential configuration and app/bundle resolution;
 - provider-neutral operation kinds and status polling.
 

--- a/migrations/sql/0040_agc_service_accounts.sql
+++ b/migrations/sql/0040_agc_service_accounts.sql
@@ -1,0 +1,33 @@
+ALTER TABLE app_agc_credentials RENAME TO app_agc_credentials_api_client;
+
+CREATE TABLE app_agc_credentials (
+  id TEXT PRIMARY KEY,
+  app_id TEXT NOT NULL UNIQUE REFERENCES apps(id) ON DELETE CASCADE,
+  credential_kind TEXT NOT NULL CHECK (credential_kind IN ('api_client', 'service_account')),
+  developer_id TEXT,
+  project_id TEXT,
+  client_id TEXT,
+  key_id TEXT,
+  sub_account TEXT,
+  configuration_version TEXT,
+  region TEXT,
+  credential_fingerprint TEXT NOT NULL,
+  credential_ciphertext_b64 TEXT NOT NULL,
+  credential_iv_b64 TEXT NOT NULL,
+  created_by_actor TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+INSERT INTO app_agc_credentials
+  (id, app_id, credential_kind, developer_id, project_id, client_id,
+   configuration_version, region, credential_fingerprint,
+   credential_ciphertext_b64, credential_iv_b64, created_by_actor,
+   created_at, updated_at)
+SELECT id, app_id, credential_kind, developer_id, project_id, client_id,
+       configuration_version, region, credential_fingerprint,
+       credential_ciphertext_b64, credential_iv_b64, created_by_actor,
+       created_at, updated_at
+FROM app_agc_credentials_api_client;
+
+DROP TABLE app_agc_credentials_api_client;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -800,7 +800,7 @@ admin.get("/api/apps/:appId/testflight-uploads/:buildUploadId", requireAppRole("
 admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
-// AppGallery Connect API client credentials for OHOS publishing.
+// AppGallery Connect Service Account and legacy API client credentials for OHOS publishing.
 admin.get("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleGetAgcCredentials);
 admin.put("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleSetAgcCredentials);
 admin.delete("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleDeleteAgcCredentials);

--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -1,4 +1,5 @@
-import type { AgcApiClientCredential } from "./agc_credentials";
+import { importPKCS8, SignJWT } from "jose";
+import type { AgcApiClientCredential, AgcServiceAccountCredential } from "./agc_credentials";
 
 export class AgcApiError extends Error {
   constructor(public status: number, message: string) { super(message); }
@@ -20,11 +21,22 @@ export async function exchangeAgcApiClientToken(credential: AgcApiClientCredenti
   return { access_token: obj.access_token, expires_in: obj.expires_in };
 }
 
-type AgcAuth = { clientId: string; accessToken: string };
+export async function createAgcServiceAccountJwt(credential: AgcServiceAccountCredential, nowSeconds = Math.floor(Date.now() / 1000)) {
+  const key = await importPKCS8(credential.private_key, "PS256");
+  return new SignJWT({})
+    .setProtectedHeader({ alg: "PS256", typ: "JWT", kid: credential.key_id })
+    .setIssuer(credential.sub_account)
+    .setAudience("https://oauth-login.cloud.huawei.com/oauth2/v3/token")
+    .setIssuedAt(nowSeconds)
+    .setExpirationTime(nowSeconds + 3600)
+    .sign(key);
+}
+
+export type AgcAuth = { clientId?: string; accessToken: string };
 async function agcJson(auth: AgcAuth, path: string, init: RequestInit = {}, fetchImpl: typeof fetch = fetch) {
   const response = await fetchImpl(`https://connect-api.cloud.huawei.com${path}`, {
     ...init,
-    headers: { "content-type": "application/json", client_id: auth.clientId, authorization: `Bearer ${auth.accessToken}`, ...(init.headers ?? {}) },
+    headers: { "content-type": "application/json", ...(auth.clientId ? { client_id: auth.clientId } : {}), authorization: `Bearer ${auth.accessToken}`, ...(init.headers ?? {}) },
   });
   const body = await response.json().catch(() => null) as any;
   const providerCode = body?.ret?.code ?? body?.rtnCode;

--- a/worker/src/lib/agc_credentials.ts
+++ b/worker/src/lib/agc_credentials.ts
@@ -7,14 +7,28 @@ export type AgcApiClientCredential = {
   configuration_version?: string;
   region?: string;
 };
+export type AgcServiceAccountCredential = {
+  credential_kind: "service_account";
+  project_id?: string;
+  key_id: string;
+  private_key: string;
+  sub_account: string;
+  token_uri: string;
+  auth_uri?: string;
+  auth_provider_cert_uri?: string;
+  client_cert_uri?: string;
+};
+export type AgcCredential = AgcApiClientCredential | AgcServiceAccountCredential;
 
 export type AgcCredentialsMeta = {
   id: string;
   app_id: string;
-  credential_kind: "api_client";
-  developer_id: string;
-  project_id: string;
-  client_id: string;
+  credential_kind: "api_client" | "service_account";
+  developer_id: string | null;
+  project_id: string | null;
+  client_id: string | null;
+  key_id: string | null;
+  sub_account: string | null;
   configuration_version: string | null;
   region: string | null;
   credential_fingerprint: string;
@@ -28,7 +42,7 @@ function requiredString(value: unknown, name: string): string {
   return value.trim();
 }
 
-export function parseAgcCredential(input: string | unknown): AgcApiClientCredential {
+export function parseAgcCredential(input: string | unknown): AgcCredential {
   let value: unknown = input;
   if (typeof input === "string") {
     try { value = JSON.parse(input); } catch { throw new Error("credential_json must contain valid JSON"); }
@@ -37,6 +51,22 @@ export function parseAgcCredential(input: string | unknown): AgcApiClientCredent
     throw new Error("credential_json must be a JSON object");
   }
   const obj = value as Record<string, unknown>;
+  if (typeof obj.key_id === "string" || typeof obj.private_key === "string" || typeof obj.sub_account === "string") {
+    const privateKey = requiredString(obj.private_key, "private_key");
+    if (!privateKey.includes("BEGIN PRIVATE KEY")) throw new Error("private_key must be a PKCS#8 PEM private key");
+    const credential: AgcServiceAccountCredential = {
+      credential_kind: "service_account",
+      key_id: requiredString(obj.key_id, "key_id"),
+      private_key: privateKey,
+      sub_account: requiredString(obj.sub_account, "sub_account"),
+      token_uri: typeof obj.token_uri === "string" && obj.token_uri.trim() ? obj.token_uri.trim() : "https://oauth-login.cloud.huawei.com/oauth2/v3/token",
+    };
+    if (typeof obj.project_id === "string") credential.project_id = obj.project_id.trim();
+    if (typeof obj.auth_uri === "string") credential.auth_uri = obj.auth_uri.trim();
+    if (typeof obj.auth_provider_cert_uri === "string") credential.auth_provider_cert_uri = obj.auth_provider_cert_uri.trim();
+    if (typeof obj.client_cert_uri === "string") credential.client_cert_uri = obj.client_cert_uri.trim();
+    return credential;
+  }
   const type = requiredString(obj.type, "type");
   if (type !== "api_client" && type !== "project_client_id") {
     throw new Error(`unsupported AGC credential type: ${type}`);
@@ -82,27 +112,33 @@ export async function fingerprintAgcCredential(value: string): Promise<string> {
   return Array.from(digest, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-export async function storeAgcCredentials(db: D1Database, encKey: string, args: { app_id: string; credential: AgcApiClientCredential; actor: string }) {
+export function agcCredentialKind(value: AgcCredential): "api_client" | "service_account" {
+  return "credential_kind" in value ? value.credential_kind : "api_client";
+}
+export async function storeAgcCredentials(db: D1Database, encKey: string, args: { app_id: string; credential: AgcCredential; actor: string }) {
   const canonical = JSON.stringify(args.credential);
   const encrypted = await encryptAgcCredential(canonical, encKey);
   const fingerprint = await fingerprintAgcCredential(canonical);
   const now = Date.now();
+  const kind = agcCredentialKind(args.credential);
+  const api = kind === "api_client" ? args.credential as AgcApiClientCredential : null;
+  const service = kind === "service_account" ? args.credential as AgcServiceAccountCredential : null;
   await db.prepare(`INSERT INTO app_agc_credentials
-    (id, app_id, credential_kind, developer_id, project_id, client_id, configuration_version, region,
+    (id, app_id, credential_kind, developer_id, project_id, client_id, key_id, sub_account, configuration_version, region,
      credential_fingerprint, credential_ciphertext_b64, credential_iv_b64, created_by_actor, created_at, updated_at)
-    VALUES (?1, ?2, 'api_client', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)
-    ON CONFLICT(app_id) DO UPDATE SET credential_kind='api_client', developer_id=excluded.developer_id,
-      project_id=excluded.project_id, client_id=excluded.client_id, configuration_version=excluded.configuration_version,
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
+    ON CONFLICT(app_id) DO UPDATE SET credential_kind=excluded.credential_kind, developer_id=excluded.developer_id,
+      project_id=excluded.project_id, client_id=excluded.client_id, key_id=excluded.key_id, sub_account=excluded.sub_account, configuration_version=excluded.configuration_version,
       region=excluded.region, credential_fingerprint=excluded.credential_fingerprint,
       credential_ciphertext_b64=excluded.credential_ciphertext_b64, credential_iv_b64=excluded.credential_iv_b64,
       updated_at=excluded.updated_at`)
-    .bind(crypto.randomUUID(), args.app_id, args.credential.developer_id, args.credential.project_id,
-      args.credential.client_id, args.credential.configuration_version ?? null, args.credential.region ?? null,
+    .bind(crypto.randomUUID(), args.app_id, kind, api?.developer_id ?? null, api?.project_id ?? service?.project_id ?? null,
+      api?.client_id ?? null, service?.key_id ?? null, service?.sub_account ?? null, api?.configuration_version ?? null, api?.region ?? null,
       fingerprint, encrypted.ciphertext_b64, encrypted.iv_b64, args.actor, now).run();
   return (await getAgcCredentialsMeta(db, args.app_id))!;
 }
 export async function getAgcCredentialsMeta(db: D1Database, appId: string) {
-  return (await db.prepare(`SELECT id, app_id, credential_kind, developer_id, project_id, client_id,
+  return (await db.prepare(`SELECT id, app_id, credential_kind, developer_id, project_id, client_id, key_id, sub_account,
     configuration_version, region, credential_fingerprint, created_by_actor, created_at, updated_at
     FROM app_agc_credentials WHERE app_id=?1`).bind(appId).first<AgcCredentialsMeta>()) ?? null;
 }

--- a/worker/src/routes/agc_credentials.ts
+++ b/worker/src/routes/agc_credentials.ts
@@ -1,8 +1,8 @@
 import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { insertAuditLog } from "../lib/permissions";
-import { deleteAgcCredentials, getAgcCredentials, getAgcCredentialsMeta, parseAgcCredential, storeAgcCredentials } from "../lib/agc_credentials";
-import { AgcApiError, exchangeAgcApiClientToken } from "../lib/agc_api";
+import { agcCredentialKind, deleteAgcCredentials, getAgcCredentials, getAgcCredentialsMeta, parseAgcCredential, storeAgcCredentials, type AgcApiClientCredential, type AgcServiceAccountCredential } from "../lib/agc_credentials";
+import { AgcApiError, createAgcServiceAccountJwt, exchangeAgcApiClientToken } from "../lib/agc_api";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 async function requireOhosApp(c: AdminContext) {
@@ -24,7 +24,7 @@ export async function handleSetAgcCredentials(c: AdminContext) {
   try { credential = parseAgcCredential(body.credential_json); } catch (e) { return c.json({ error: (e as Error).message }, 400); }
   const appId = c.req.param("appId") ?? "";
   const meta = await storeAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, { app_id: appId, credential, actor: currentActor(c) });
-  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.set", payload: { credential_kind: meta.credential_kind, client_id: meta.client_id, project_id: meta.project_id }, created_at: meta.updated_at });
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.set", payload: { credential_kind: meta.credential_kind, client_id: meta.client_id, key_id: meta.key_id, project_id: meta.project_id }, created_at: meta.updated_at });
   return c.json({ agc_credentials: meta });
 }
 export async function handleDeleteAgcCredentials(c: AdminContext) {
@@ -41,11 +41,19 @@ export async function handleVerifyAgcCredentials(c: AdminContext) {
   const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, appId);
   if (!credential) return c.json({ error: "no AGC credentials configured for this app" }, 404);
   try {
-    const token = await exchangeAgcApiClientToken(credential);
-    await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: "api_client", ok: true } });
-    return c.json({ ok: true, credential_kind: "api_client", developer_id: credential.developer_id, project_id: credential.project_id, client_id: credential.client_id, region: credential.region ?? null, expires_in: token.expires_in });
+    const kind = agcCredentialKind(credential);
+    if (kind === "service_account") {
+      const service = credential as AgcServiceAccountCredential;
+      await createAgcServiceAccountJwt(service);
+      await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: kind, ok: true } });
+      return c.json({ ok: true, credential_kind: kind, project_id: service.project_id ?? null, key_id: service.key_id, sub_account: service.sub_account, expires_in: 3600 });
+    }
+    const api = credential as AgcApiClientCredential;
+    const token = await exchangeAgcApiClientToken(api);
+    await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: kind, ok: true } });
+    return c.json({ ok: true, credential_kind: kind, developer_id: api.developer_id, project_id: api.project_id, client_id: api.client_id, region: api.region ?? null, expires_in: token.expires_in });
   } catch (e) {
-    await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: "api_client", ok: false } });
+    await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_credentials.verify", payload: { credential_kind: agcCredentialKind(credential), ok: false } });
     if (e instanceof AgcApiError) return c.json({ ok: false, error: e.message, status: e.status }, 502);
     throw e;
   }

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -1,8 +1,8 @@
 import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { insertAuditLog } from "../lib/permissions";
-import { getAgcCredentials } from "../lib/agc_credentials";
-import { addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, exchangeAgcApiClientToken, getAgcCompileStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion, uploadAgcObject } from "../lib/agc_api";
+import { agcCredentialKind, getAgcCredentials, type AgcApiClientCredential, type AgcServiceAccountCredential } from "../lib/agc_credentials";
+import { addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion, uploadAgcObject } from "../lib/agc_api";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 type Submission = { id: string; app_id: string; build_id: string; state: string; external_app_id: string; external_version_id: string; external_package_id: string; provider_state_json: string; error_message: string | null; created_at: number; updated_at: number };
@@ -10,8 +10,12 @@ async function auth(c: AdminContext) {
   if (!c.env.AGC_CRED_ENC_KEY) throw new Error("server is missing AGC_CRED_ENC_KEY");
   const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, c.req.param("appId") ?? "");
   if (!credential) throw new Error("no AGC credentials configured for this app");
-  const token = await exchangeAgcApiClientToken(credential);
-  return { clientId: credential.client_id, accessToken: token.access_token };
+  if (agcCredentialKind(credential) === "service_account") {
+    return { accessToken: await createAgcServiceAccountJwt(credential as AgcServiceAccountCredential) };
+  }
+  const api = credential as AgcApiClientCredential;
+  const token = await exchangeAgcApiClientToken(api);
+  return { clientId: api.client_id, accessToken: token.access_token };
 }
 async function event(db: D1Database, submissionId: string, state: string, detail: object = {}) {
   const now = Date.now();

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -811,7 +811,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "get-agc-credentials",
         description:
-          "Get metadata for an OHOS app's encrypted AppGallery Connect credential. Never returns the client secret.",
+          "Get metadata for an OHOS app's encrypted AppGallery Connect Service Account or legacy API client credential. Never returns private credential material.",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/agc-credentials" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
@@ -820,17 +820,17 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "set-agc-credentials",
         description:
-          "Upload or rotate an OHOS app's AGC API client JSON. Requires app admin; the entire document is encrypted and secret fields are never returned.",
+          "Upload or rotate an OHOS app's AGC Service Account private JSON or legacy API client JSON. Requires app admin; the entire document is encrypted and secret fields are never returned.",
         endpoint: { method: "PUT", path: "/api/apps/{app_id}/agc-credentials" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
-          credential_json: { type: "string", in: "body", required: true, description: "Contents of the AGC api_client JSON file." },
+          credential_json: { type: "string", in: "body", required: true, description: "Contents of the AGC Service Account private JSON or legacy api_client JSON file." },
         },
       },
       {
         name: "verify-agc-credentials",
         description:
-          "Test the stored AGC API client with an OAuth token exchange. Returns metadata and expiry only, never the access token.",
+          "Validate the stored AGC credential by signing a Service Account PS256 JWT or exchanging a legacy API client token. Returns metadata and expiry only, never the token.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/agc-credentials/verify" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { decryptAgcCredential, encryptAgcCredential, fingerprintAgcCredential, parseAgcCredential } from "../src/lib/agc_credentials";
-import { AgcApiError, addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, exchangeAgcApiClientToken, getAgcCompileStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion } from "../src/lib/agc_api";
+import { decodeProtectedHeader, exportPKCS8, generateKeyPair, jwtVerify } from "jose";
+import { decryptAgcCredential, encryptAgcCredential, fingerprintAgcCredential, parseAgcCredential, type AgcApiClientCredential } from "../src/lib/agc_credentials";
+import { AgcApiError, addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion } from "../src/lib/agc_api";
 
 const raw = JSON.stringify({ type: "api_client", developer_id: "dev", project_id: "project", client_id: "client", client_secret: "secret", configuration_version: "1.0", region: "CN" });
 
@@ -14,10 +15,28 @@ describe("AGC credentials", () => {
       client_id: "client",
     });
   });
+  it("parses Huawei service account private JSON", async () => {
+    const { privateKey } = await generateKeyPair("PS256", { extractable: true });
+    const credential = parseAgcCredential({
+      project_id: "project",
+      key_id: "key-1",
+      private_key: await exportPKCS8(privateKey),
+      sub_account: "service@example.com",
+      token_uri: "https://oauth-login.cloud.huawei.com/oauth2/v3/token",
+    });
+    expect(credential).toMatchObject({
+      credential_kind: "service_account",
+      project_id: "project",
+      key_id: "key-1",
+      sub_account: "service@example.com",
+    });
+  });
   it("rejects malformed and unsupported credentials", () => {
     expect(() => parseAgcCredential("not json")).toThrow(/valid JSON/);
     expect(() => parseAgcCredential({ type: "service_account" })).toThrow(/unsupported/);
     expect(() => parseAgcCredential({ type: "api_client" })).toThrow(/developer_id/);
+    expect(() => parseAgcCredential({ key_id: "key-1", sub_account: "service@example.com" })).toThrow(/private_key/);
+    expect(() => parseAgcCredential({ key_id: "key-1", sub_account: "service@example.com", private_key: "not a key" })).toThrow(/PKCS#8/);
   });
   it("encrypts, decrypts, fingerprints, and uses fresh IVs", async () => {
     const a = await encryptAgcCredential(raw, "root-secret");
@@ -71,10 +90,44 @@ describe("AGC invitation testing API", () => {
     const mockFetch = vi.fn(async () => new Response(JSON.stringify({ ret: { code: 204144688, msg: "invalid package" } }), { status: 200 }));
     await expect(resolveAgcAppId(auth, "build.raft.mobile", mockFetch as typeof fetch)).rejects.toThrow("invalid package (HTTP 200, code 204144688)");
   });
+  it("omits the legacy client_id header for service account auth", async () => {
+    let headers = new Headers();
+    const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      headers = new Headers(init?.headers);
+      return new Response(JSON.stringify({ ret: { code: 0 }, appids: [{ key: "build.raft.mobile", value: "agc-app" }] }), { status: 200 });
+    });
+    await resolveAgcAppId({ accessToken: "service-jwt" }, "build.raft.mobile", mockFetch as typeof fetch);
+    expect(headers.get("authorization")).toBe("Bearer service-jwt");
+    expect(headers.has("client_id")).toBe(false);
+  });
+});
+
+describe("AGC service account JWT", () => {
+  it("creates the official one-hour PS256 assertion", async () => {
+    const { privateKey, publicKey } = await generateKeyPair("PS256", { extractable: true });
+    const now = 1_750_000_000;
+    const jwt = await createAgcServiceAccountJwt({
+      credential_kind: "service_account",
+      key_id: "key-1",
+      private_key: await exportPKCS8(privateKey),
+      sub_account: "service@example.com",
+      token_uri: "https://oauth-login.cloud.huawei.com/oauth2/v3/token",
+    }, now);
+
+    expect(decodeProtectedHeader(jwt)).toMatchObject({ alg: "PS256", typ: "JWT", kid: "key-1" });
+    const { payload } = await jwtVerify(jwt, publicKey, {
+      algorithms: ["PS256"],
+      issuer: "service@example.com",
+      audience: "https://oauth-login.cloud.huawei.com/oauth2/v3/token",
+      currentDate: new Date(now * 1000),
+    });
+    expect(payload.iat).toBe(now);
+    expect(payload.exp).toBe(now + 3600);
+  });
 });
 
 describe("AGC token exchange", () => {
-  const credential = parseAgcCredential(raw);
+  const credential = parseAgcCredential(raw) as AgcApiClientCredential;
   it("returns the token internally and expiry on success", async () => {
     let requestBody = "";
     const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary
- accept and encrypt Huawei Service Account private JSON while retaining legacy API client compatibility
- generate one-hour PS256 bearer JWTs and omit the legacy client_id header for Publishing/Testing APIs
- expose credential-kind metadata in Settings and Raft integration actions
- migrate existing AGC credential rows without decrypting or rewriting stored secrets

## Validation
- worker typecheck
- worker tests: 140 passed
- admin production build
- focused Service Account parsing/JWT/header tests
- SQLite migration smoke preserving an existing API client row
- git diff --check

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786358134&installation_id=145465820&pr_number=264&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F264&signature=03e910e44d92939e4e15ef2ec711e2702dac552bebe39f670915e2122c422308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->