### PR TITLE
feat(ohos): add AppGallery testing controls

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -776,6 +776,50 @@ export const verifyAgcCredentials = (appId: string) =>
     `/api/apps/${appId}/agc-credentials/verify`, { method: "POST", admin: true },
   );
 
+export interface AgcSubmission {
+  id: string;
+  app_id: string;
+  build_id: string;
+  provider: "appgallery";
+  lane: "invitation_test";
+  state: "uploading" | "processing" | "ready" | "testing_review" | "failed";
+  external_app_id: string | null;
+  external_version_id: string | null;
+  external_package_id: string | null;
+  error_message: string | null;
+  provider_state: Record<string, unknown>;
+  created_at: number;
+  updated_at: number;
+}
+
+export const getAgcBuildSubmission = (appId: string, buildId: string) =>
+  request<{ submission: AgcSubmission | null }>(
+    `/api/apps/${appId}/builds/${buildId}/agc-invitation-test`,
+    { admin: true },
+  );
+
+export const startAgcInvitationTest = (appId: string, buildId: string, packageName: string) =>
+  request<{ submission_id?: string; state?: string; submission?: AgcSubmission }>(
+    `/api/apps/${appId}/builds/${buildId}/agc-invitation-test`,
+    {
+      method: "POST",
+      admin: true,
+      body: JSON.stringify({ package_name: packageName }),
+    },
+  );
+
+export const getAgcSubmission = (appId: string, submissionId: string) =>
+  request<{ submission: AgcSubmission; events: Array<{ state: string; detail_json: string; created_at: number }> }>(
+    `/api/apps/${appId}/agc-submissions/${submissionId}`,
+    { admin: true },
+  );
+
+export const submitAgcInvitationTest = (appId: string, submissionId: string) =>
+  request<{ ok: boolean; submission_id: string; state: string }>(
+    `/api/apps/${appId}/agc-submissions/${submissionId}/submit`,
+    { method: "POST", admin: true },
+  );
+
 // ---------- TestFlight upload (Hands → Apple) ----------
 
 /** Apple's build-upload state is an object, not a bare string. */

--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -9,12 +9,16 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  getAgcBuildSubmission,
+  getAgcSubmission,
   getBuildAssetDownloadUrl,
   getBuild,
   listBuildAssets,
   listBuilds,
   listChannels,
   listProductTypes,
+  startAgcInvitationTest,
+  submitAgcInvitationTest,
   uploadBuildToTestflight,
   getTestflightUploadStatus,
   type Build,
@@ -167,6 +171,9 @@ export function Builds({ appId }: { appId: string }) {
               {b.product_type === "ios-ipa" && (
                 <TestflightUploadPanel appId={appId} build={b} />
               )}
+              {b.product_type === "ohos-app" && (
+                <AgcTestingPanel appId={appId} build={b} packageName={channel?.bundle_id ?? null} />
+              )}
               {isExpanded && <BuildAssetList appId={appId} buildId={b.id} />}
             </div>
           );
@@ -184,6 +191,88 @@ export function Builds({ appId }: { appId: string }) {
           }}
         />
       )}
+    </div>
+  );
+}
+
+function AgcTestingPanel({ appId, build, packageName }: { appId: string; build: Build; packageName: string | null }) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const existing = useQuery({
+    queryKey: ["agc-build-submission", appId, build.id],
+    queryFn: () => getAgcBuildSubmission(appId, build.id),
+  });
+  const upload = useMutation({
+    mutationFn: () => startAgcInvitationTest(appId, build.id, packageName!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agc-build-submission", appId, build.id] });
+      toast.show({ kind: "success", title: "Uploaded to AppGallery testing", description: "Huawei is compiling the App Pack." });
+    },
+    onError: (e) => toast.show({ kind: "error", title: "AppGallery upload failed", description: (e as Error).message }),
+  });
+  const submissionId = upload.data?.submission_id ?? upload.data?.submission?.id ?? existing.data?.submission?.id ?? null;
+  const status = useQuery({
+    queryKey: ["agc-submission", appId, submissionId],
+    queryFn: () => getAgcSubmission(appId, submissionId!),
+    enabled: submissionId != null,
+    refetchInterval: (q) => {
+      const state = q.state.data?.submission.state;
+      return state === "uploading" || state === "processing" ? 5000 : false;
+    },
+  });
+  const submission = status.data?.submission ?? upload.data?.submission ?? existing.data?.submission ?? null;
+  const submit = useMutation({
+    mutationFn: () => submitAgcInvitationTest(appId, submission!.id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agc-submission", appId, submission?.id] });
+      qc.invalidateQueries({ queryKey: ["agc-build-submission", appId, build.id] });
+      toast.show({ kind: "success", title: "Submitted for invitation testing review" });
+    },
+    onError: (e) => toast.show({ kind: "error", title: "Review submission failed", description: (e as Error).message }),
+  });
+  const state = submission?.state;
+  const stateClass = state === "failed" ? "text-red-700" : state === "ready" || state === "testing_review" ? "text-green-700" : "text-blue-700";
+
+  return (
+    <div className="mt-2 pt-2 border-t border-slate-100">
+      <div className="flex items-center gap-2 flex-wrap text-xs">
+        <span className="badge-gray">AppGallery testing</span>
+        {!submission || state === "failed" ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="outline"
+                  className="py-1! px-2! text-xs!"
+                  disabled={upload.isPending || build.status !== "succeeded" || !packageName}
+                  onClick={() => upload.mutate()}
+                >
+                  {upload.isPending ? "Uploading…" : state === "failed" ? "Retry upload" : "Upload to AppGallery testing"}
+                </Button>
+              }
+            />
+            <TooltipContent>
+              {!packageName ? "Set the channel bundle ID first" : build.status !== "succeeded" ? "Build must be succeeded" : "Upload the signed .app and create an invitation-test version"}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+        {state === "ready" && (
+          <Button
+            variant="primary"
+            className="py-1! px-2! text-xs!"
+            disabled={submit.isPending}
+            onClick={() => {
+              if (window.confirm("Submit this AppGallery invitation-test version for review?")) submit.mutate();
+            }}
+          >
+            {submit.isPending ? "Submitting…" : "Submit testing review"}
+          </Button>
+        )}
+        {state && <span className={`font-medium ${stateClass}`}>{state === "processing" ? "Huawei processing…" : state.replaceAll("_", " ")}</span>}
+      </div>
+      {submission?.error_message && <p className="mt-1 text-xs text-red-700">{submission.error_message}</p>}
+      {state === "ready" && <p className="mt-1 text-xs text-slate-500">Package compiled and bound. Review submission remains a separate confirmation.</p>}
+      {state === "testing_review" && <p className="mt-1 text-xs text-green-700">Submitted to AppGallery invitation testing review.</p>}
     </div>
   );
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -32,7 +32,7 @@ import {
   handleSetAgcCredentials,
   handleVerifyAgcCredentials,
 } from "./routes/agc_credentials";
-import { handleGetAgcSubmission, handleStartAgcInvitationTest, handleSubmitAgcInvitationTest } from "./routes/agc_testing";
+import { handleGetAgcBuildSubmission, handleGetAgcSubmission, handleStartAgcInvitationTest, handleSubmitAgcInvitationTest } from "./routes/agc_testing";
 import {
   handleListApps,
   handleCreateApp,
@@ -805,6 +805,7 @@ admin.get("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleGet
 admin.put("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleSetAgcCredentials);
 admin.delete("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleDeleteAgcCredentials);
 admin.post("/api/apps/:appId/agc-credentials/verify", requireAppRole("admin"), handleVerifyAgcCredentials);
+admin.get("/api/apps/:appId/builds/:buildId/agc-invitation-test", requireAppRole("admin"), handleGetAgcBuildSubmission);
 admin.post("/api/apps/:appId/builds/:buildId/agc-invitation-test", requireAppRole("admin"), handleStartAgcInvitationTest);
 admin.get("/api/apps/:appId/agc-submissions/:submissionId", requireAppRole("admin"), handleGetAgcSubmission);
 admin.post("/api/apps/:appId/agc-submissions/:submissionId/submit", requireAppRole("admin"), handleSubmitAgcInvitationTest);

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -6,6 +6,9 @@ import { addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, crea
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 type Submission = { id: string; app_id: string; build_id: string; state: string; external_app_id: string; external_version_id: string; external_package_id: string; provider_state_json: string; error_message: string | null; created_at: number; updated_at: number };
+function publicSubmission(sub: Submission) {
+  return { ...sub, provider_state: JSON.parse(sub.provider_state_json || "{}"), provider_state_json: undefined };
+}
 async function auth(c: AdminContext) {
   if (!c.env.AGC_CRED_ENC_KEY) throw new Error("server is missing AGC_CRED_ENC_KEY");
   const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, c.req.param("appId") ?? "");
@@ -35,7 +38,7 @@ export async function handleStartAgcInvitationTest(c: AdminContext) {
     WHERE b.id=?1 AND b.app_id=?2 AND ba.platform='ohos' AND ba.filetype='app'`).bind(buildId, appId).first<{ r2_key: string; file_hash: string; size_bytes: number; filetype: string }>();
   if (!row) return c.json({ error: "signed OHOS .app asset not found for build" }, 404);
   const existing = await c.env.DB.prepare("SELECT * FROM market_submissions WHERE idempotency_key=?1").bind(`agc-invitation:${buildId}`).first<Submission>();
-  if (existing && existing.state !== "failed") return c.json({ submission: existing });
+  if (existing && existing.state !== "failed") return c.json({ submission: publicSubmission(existing) });
   if (existing) await c.env.DB.prepare("DELETE FROM market_submissions WHERE id=?1").bind(existing.id).run();
   const id = crypto.randomUUID(); const now = Date.now();
   await c.env.DB.prepare(`INSERT INTO market_submissions (id,app_id,build_id,provider,lane,state,idempotency_key,created_by_actor,created_at,updated_at)
@@ -60,6 +63,14 @@ export async function handleStartAgcInvitationTest(c: AdminContext) {
     return c.json({ error: (e as Error).message, submission_id: id }, 502);
   }
 }
+export async function handleGetAgcBuildSubmission(c: AdminContext) {
+  const sub = await c.env.DB.prepare(`SELECT * FROM market_submissions
+    WHERE app_id=?1 AND build_id=?2 AND provider='appgallery' AND lane='invitation_test'
+    ORDER BY created_at DESC LIMIT 1`)
+    .bind(c.req.param("appId") ?? "", c.req.param("buildId") ?? "")
+    .first<Submission>();
+  return c.json({ submission: sub ? publicSubmission(sub) : null });
+}
 export async function handleGetAgcSubmission(c: AdminContext) {
   const id = c.req.param("submissionId") ?? "";
   const sub = await c.env.DB.prepare("SELECT * FROM market_submissions WHERE id=?1 AND app_id=?2").bind(id, c.req.param("appId") ?? "").first<Submission>();
@@ -72,7 +83,7 @@ export async function handleGetAgcSubmission(c: AdminContext) {
     }
   }
   const events = await c.env.DB.prepare("SELECT state, detail_json, created_at FROM market_submission_events WHERE submission_id=?1 ORDER BY created_at").bind(id).all();
-  return c.json({ submission: { ...sub, provider_state: JSON.parse(sub.provider_state_json || "{}"), provider_state_json: undefined }, events: events.results });
+  return c.json({ submission: publicSubmission(sub), events: events.results });
 }
 export async function handleSubmitAgcInvitationTest(c: AdminContext) {
   const id = c.req.param("submissionId") ?? ""; const appId = c.req.param("appId") ?? "";


### PR DESCRIPTION
## Summary
- show AppGallery invitation-testing controls directly on OHOS builds
- reuse existing idempotent submissions and poll Huawei package compilation state
- keep testing review behind a separate explicit confirmation
- add a read-only per-build submission lookup endpoint for page reloads

## Validation
- worker typecheck
- worker tests: 140 passed
- admin production build
- git diff --check

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786359467&installation_id=145465820&pr_number=265&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F265&signature=6c095de1c0135defc7af0310860901fd5b9267b539ded965aaba37f1f41f8a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->