### PR TITLE
fix(ohos): separate build upload from testing

### DIFF
--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -206,7 +206,7 @@ function AgcTestingPanel({ appId, build, packageName }: { appId: string; build: 
     mutationFn: () => startAgcInvitationTest(appId, build.id, packageName!),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agc-build-submission", appId, build.id] });
-      toast.show({ kind: "success", title: "Uploaded to AppGallery testing", description: "Huawei is compiling the App Pack." });
+      toast.show({ kind: "success", title: "Build uploaded to AppGallery", description: "Huawei is compiling the App Pack. Testing has not been submitted." });
     },
     onError: (e) => toast.show({ kind: "error", title: "AppGallery upload failed", description: (e as Error).message }),
   });
@@ -226,7 +226,7 @@ function AgcTestingPanel({ appId, build, packageName }: { appId: string; build: 
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agc-submission", appId, submission?.id] });
       qc.invalidateQueries({ queryKey: ["agc-build-submission", appId, build.id] });
-      toast.show({ kind: "success", title: "Submitted for invitation testing review" });
+      toast.show({ kind: "success", title: "Submitted to invitation testing" });
     },
     onError: (e) => toast.show({ kind: "error", title: "Review submission failed", description: (e as Error).message }),
   });
@@ -236,7 +236,7 @@ function AgcTestingPanel({ appId, build, packageName }: { appId: string; build: 
   return (
     <div className="mt-2 pt-2 border-t border-slate-100">
       <div className="flex items-center gap-2 flex-wrap text-xs">
-        <span className="badge-gray">AppGallery testing</span>
+        <span className="badge-gray">AppGallery</span>
         {!submission || state === "failed" ? (
           <Tooltip>
             <TooltipTrigger
@@ -247,12 +247,12 @@ function AgcTestingPanel({ appId, build, packageName }: { appId: string; build: 
                   disabled={upload.isPending || build.status !== "succeeded" || !packageName}
                   onClick={() => upload.mutate()}
                 >
-                  {upload.isPending ? "Uploading…" : state === "failed" ? "Retry upload" : "Upload to AppGallery testing"}
+                  {upload.isPending ? "Uploading build…" : state === "failed" ? "Retry build upload" : "Upload build to AppGallery"}
                 </Button>
               }
             />
             <TooltipContent>
-              {!packageName ? "Set the channel bundle ID first" : build.status !== "succeeded" ? "Build must be succeeded" : "Upload the signed .app and create an invitation-test version"}
+              {!packageName ? "Set the channel bundle ID first" : build.status !== "succeeded" ? "Build must be succeeded" : "Upload the signed .app and wait for Huawei build processing"}
             </TooltipContent>
           </Tooltip>
         ) : null}
@@ -262,17 +262,17 @@ function AgcTestingPanel({ appId, build, packageName }: { appId: string; build: 
             className="py-1! px-2! text-xs!"
             disabled={submit.isPending}
             onClick={() => {
-              if (window.confirm("Submit this AppGallery invitation-test version for review?")) submit.mutate();
+              if (window.confirm("Submit this uploaded build to AppGallery invitation testing?")) submit.mutate();
             }}
           >
-            {submit.isPending ? "Submitting…" : "Submit testing review"}
+            {submit.isPending ? "Submitting…" : "Submit to invitation testing"}
           </Button>
         )}
-        {state && <span className={`font-medium ${stateClass}`}>{state === "processing" ? "Huawei processing…" : state.replaceAll("_", " ")}</span>}
+        {state && <span className={`font-medium ${stateClass}`}>{state === "processing" ? "Huawei processing build…" : state === "ready" ? "Build uploaded" : state.replaceAll("_", " ")}</span>}
       </div>
       {submission?.error_message && <p className="mt-1 text-xs text-red-700">{submission.error_message}</p>}
-      {state === "ready" && <p className="mt-1 text-xs text-slate-500">Package compiled and bound. Review submission remains a separate confirmation.</p>}
-      {state === "testing_review" && <p className="mt-1 text-xs text-green-700">Submitted to AppGallery invitation testing review.</p>}
+      {state === "ready" && <p className="mt-1 text-xs text-slate-500">Build compiled and ready. Invitation testing has not been submitted.</p>}
+      {state === "testing_review" && <p className="mt-1 text-xs text-green-700">Build submitted to AppGallery invitation testing review.</p>}
     </div>
   );
 }

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -838,7 +838,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "start-agc-invitation-test",
-        description: "Upload a signed OHOS App Pack from a Hands build to a new AGC invitation-test version. Creates a draft operation and does not submit review.",
+        description: "Upload a signed OHOS App Pack from a Hands build and wait for Huawei package processing. Creates an unsubmitted draft version; it does not enter testing or submit review.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/builds/{build_id}/agc-invitation-test" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
@@ -859,7 +859,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "submit-agc-invitation-test",
-        description: "Explicitly submit a ready AGC invitation-test version for review. This is the human approval gate.",
+        description: "Explicitly submit a previously uploaded, ready build to AGC invitation testing review. This is the human approval gate.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/agc-submissions/{submission_id}/submit" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },


### PR DESCRIPTION
## Summary
- present AppGallery delivery as two explicit user actions
- first upload and process the signed build without implying testing was submitted
- only show the separate invitation-testing submission after the build is ready
- align agent action descriptions with the same build-first contract

## Validation
- worker typecheck
- admin production build
- git diff --check

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786361452&installation_id=145465820&pr_number=266&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F266&signature=1a9ec13d84e9de189bd42e3864717281663a3f49008d2a410e540c5f0959e486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->