### PR TITLE
fix(admin): drop the footer inside the authenticated console

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -1249,54 +1249,6 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
           }
         />
       </Routes>
-      <footer className="bg-white border-t border-slate-200 py-4 mt-8">
-        <div className="max-w-5xl mx-auto px-4 text-xs text-slate-500 flex items-center justify-between">
-          <span>
-            Hands — a{" "}
-            <a
-              href="https://botiverse.dev/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-slate-600 hover:text-slate-900"
-            >
-              Botiverse
-            </a>{" "}
-            product
-          </span>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="outline"
-                  className="py-1! px-2! text-xs! inline-flex items-center gap-1.5"
-                  render={
-                    <a
-                      href="https://github.com/oranix-io/hands"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    />
-                  }
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    className="w-3.5 h-3.5"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  GitHub
-                </Button>
-              }
-            />
-            <TooltipContent>View Hands source on GitHub</TooltipContent>
-          </Tooltip>
-        </div>
-      </footer>
       </div>
     </div>
   );


### PR DESCRIPTION
artin: the "Hands — a Botiverse product" footer was showing at the bottom of the **console** (the signed-in dashboard), which hurts the working UX.

Keep the footer only on the public marketing landing (`PublicLanding`); remove it from the authenticated app shell (`AuthenticatedApp`). No other change. Admin `tsc` + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786361647&installation_id=145465820&pr_number=267&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F267&signature=f3e7693b726913b917dfb0e033a66b2ab812e9811e763d8b0189a834f22b10b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->