### PR TITLE
fix(admin): hide TestFlight outside iOS

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -715,7 +715,12 @@ function AuditRoute() {
 
 function TestflightRoute() {
   const { appId } = useParams();
+  const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
+  const app = apps.data?.apps.find((candidate) => candidate.id === appId);
   if (!appId) return null;
+  if (app && app.platform !== "ios") {
+    return <Navigate to={`/apps/${appId}/builds`} replace />;
+  }
   return <Testflight key={appId} appId={appId} />;
 }
 
@@ -1356,7 +1361,7 @@ const APP_NAV_SECTIONS: Array<{
       { to: "channels", label: "Channels", icon: Radio },
       { to: "releases", label: "Releases", icon: Rocket },
       { to: "builds", label: "Builds", icon: Package },
-      { to: "testflight", label: "TestFlight", icon: Plane },
+      { to: "testflight", label: "TestFlight", icon: Plane, platform: "ios" },
       { to: "appstore", label: "App Store", icon: Store, platform: "ios" },
       { to: "shares", label: "Shares", icon: Share2 },
     ],


### PR DESCRIPTION
## Summary
- mark TestFlight navigation as iOS-only on desktop and mobile
- redirect direct non-iOS TestFlight URLs back to the app Builds page
- keep AppGallery as the only market workflow exposed for OHOS apps

## Validation
- admin production build
- git diff --check

Signed-off-by: 林舟 <codex-android-devops@mail.build>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786361723&installation_id=145465820&pr_number=268&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F268&signature=29d7023d9e8bba14dff9f2791f431c3935bf1bef4d6ca46c2eaf04c8bc580071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->