### PR TITLE
feat(agent): expose update-feedback + comment-feedback manifest actions

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -714,7 +714,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
     start_here: [
       "1. Authenticate (see `auth` below), then GET /api/apps to find your app_id.",
       "2. Crash triage: list-feedback (kind=crash) → get-feedback (device context + attachments) → presign-feedback-attachment, then curl the returned download_url yourself (raw-bytes endpoints get corrupted through agent transports).",
-      "3. Update tickets as you work: PATCH status/assignee, POST comments (see `write_endpoints`).",
+      "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires app publisher.",
     ],
     auth: {
       raft_agents:
@@ -923,6 +923,30 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           ticket_id: { type: "string", in: "path", required: true, description: "Ticket UUID or unique short-id prefix." },
           attachment_id: { type: "string", in: "path", required: true, description: "Attachment UUID from the ticket detail." },
+        },
+      },
+      {
+        name: "update-feedback",
+        description:
+          "Update a feedback/crash ticket's status and/or assignee — the triage write path (e.g. close a ticket already fixed elsewhere). Requires app publisher.",
+        endpoint: { method: "PATCH", path: "/api/apps/{app_id}/feedback/{ticket_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          ticket_id: { type: "string", in: "path", required: true, description: "Ticket UUID or unique short-id prefix." },
+          status: { type: "string", in: "body", required: false, description: "open|in_progress|resolved|closed" },
+          assignee: { type: "string", in: "body", required: false, description: "Assignee actor id; empty string unassigns." },
+        },
+      },
+      {
+        name: "comment-feedback",
+        description:
+          "Add a comment to a feedback/crash ticket — use for triage attribution (e.g. 'fixed by mobile #555'). Requires app publisher. Set internal=true for a staff-only note not shown to the reporter.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/feedback/{ticket_id}/comments" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          ticket_id: { type: "string", in: "path", required: true, description: "Ticket UUID or unique short-id prefix." },
+          body: { type: "string", in: "body", required: true, description: "Comment text." },
+          internal: { type: "boolean", in: "body", required: false, description: "true = staff-only internal note; omitted/false = visible to the reporter." },
         },
       },
     ],


### PR DESCRIPTION
Agents doing crash triage (e.g. the HarmonyOS crash sweep in #鸿蒙适配) could `list-feedback` / `get-feedback` / `presign-feedback-attachment` but had **no way to close a ticket or write an attribution comment** — the agent manifest exposed only read actions, even though the endpoints exist and `help` referenced them.

Adds two write actions (both require app **publisher**, enforced at the route):
- `update-feedback` → `PATCH /api/apps/{app_id}/feedback/{ticket_id}` (status/assignee)
- `comment-feedback` → `POST .../comments` (body, internal)

Immediate compat so agents self-serve triage via `raft integration invoke`. The strategic path (expose the Hands CLI as an agent-behavior manifest with session injection so the HTTP action surface shrinks to help/bootstrap) is a follow-up. 140 worker tests pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786364211&installation_id=145465820&pr_number=269&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F269&signature=5f7a3ca79eb0703c612300c352bcc24d064279ed97192d8df7b4678e9a120b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->