### PR TITLE
fix(admin): make the sidebar collapse button clickable/interactive

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -191,7 +191,7 @@ function Header({ account }: { account: AuthAccount }) {
               render={
                 <button
                   type="button"
-                  className="icon-button hidden h-8 w-8 md:flex"
+                  className="hidden h-8 w-8 cursor-pointer items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-950 md:flex"
                   onClick={() => setCollapsed(true)}
                   aria-label="Collapse sidebar"
                 >


### PR DESCRIPTION
artin reported the sidebar collapse button felt unclickable. Root cause: it used an undefined `icon-button` CSS class (defined nowhere — a raft-ui-migration leftover), so it had no `cursor-pointer`, no hover feedback, and no icon centering → a dead-looking control. Styled it as a proper icon button matching the (working) expand button. Admin build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786370969&installation_id=145465820&pr_number=270&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F270&signature=1c9996c0e2d46cf2b23d891f7675c1f0af6964cf8f99cda05700404829f41321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->