### PR TITLE
feat(releases): hide a release from public history (reversible)

### DIFF
--- a/migrations/sql/0041_release_hidden.sql
+++ b/migrations/sql/0041_release_hidden.sql
@@ -1,0 +1,5 @@
+-- Hide a release from the public history / release-notes surfaces without
+-- deleting it. Superseded and cancelled releases can't be deleted (they are
+-- part of the real release chain), but junk/duplicate old entries should not
+-- clutter the public changelog. This flag is reversible.
+ALTER TABLE releases ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;

--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -110,7 +110,7 @@ const HISTORY_SQL = `
   FROM releases r
   JOIN builds b ON b.id = r.build_id
   JOIN channels ch ON ch.id = r.channel_id
-  WHERE r.app_id = ?1 AND r.status IN ('active', 'superseded')
+  WHERE r.app_id = ?1 AND r.hidden = 0 AND r.status IN ('active', 'superseded')
   ORDER BY b.version_code DESC, released_at DESC
   LIMIT 50`;
 
@@ -131,7 +131,7 @@ const NOTES_SQL = `
   FROM releases r
   JOIN builds b ON b.id = r.build_id
   JOIN channels ch ON ch.id = r.channel_id
-  WHERE r.app_id = ?1 AND (
+  WHERE r.app_id = ?1 AND r.hidden = 0 AND (
     r.status IN ('active', 'superseded')
     OR (r.status = 'draft' AND b.version_code = ?2)
   )
@@ -261,7 +261,7 @@ export async function handlePublicAppHistoryDownload(
   const asset = await c.env.DB.prepare(
     `SELECT ba.r2_key FROM releases r
      JOIN build_assets ba ON ba.build_id = r.build_id
-     WHERE r.app_id = ?1 AND r.id = ?2 AND r.status IN ('active', 'superseded')
+     WHERE r.app_id = ?1 AND r.id = ?2 AND r.hidden = 0 AND r.status IN ('active', 'superseded')
        AND ba.artifact_kind = 'installable'
      ORDER BY ba.created_at LIMIT 1`,
   )

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -38,6 +38,10 @@ interface ReleaseUpdateInput {
   availability_at?: number | null;
   provenance_json?: unknown;
   scopes?: ReleaseScopeInput[];
+  // Hide/show this release on the public history + release-notes surfaces
+  // without deleting it. Editable even on locked (superseded/cancelled)
+  // releases so junk/duplicate old entries can be cleaned from the changelog.
+  hidden?: boolean;
 }
 
 interface ReleaseRow {
@@ -233,21 +237,20 @@ async function updateReleaseFields(
   actor: string,
 ): Promise<ReleaseRow> {
   if (release.status === "cancelled" || release.status === "superseded") {
-    // Locked releases: allow editing only the changelog (display text, e.g.
-    // reformatting an old version's release notes), never the fields with live
-    // rollout/scope/availability semantics.
-    const onlyChangelog =
-      (input.changelog !== undefined ||
-        input.release_notes !== undefined) &&
-      input.should_force_update === undefined &&
-      input.rollout_cohort_count === undefined &&
-      input.rollout_target_cohorts_json === undefined &&
-      input.availability_at === undefined &&
-      input.provenance_json === undefined &&
-      input.scopes === undefined;
-    if (!onlyChangelog) {
+    // Locked releases: allow editing only display/visibility fields — the
+    // changelog (e.g. reformatting an old version's notes) and `hidden` (clean
+    // junk/duplicate entries out of the public history) — never the fields with
+    // live rollout/scope/availability semantics.
+    const editsLiveFields =
+      input.should_force_update !== undefined ||
+      input.rollout_cohort_count !== undefined ||
+      input.rollout_target_cohorts_json !== undefined ||
+      input.availability_at !== undefined ||
+      input.provenance_json !== undefined ||
+      input.scopes !== undefined;
+    if (editsLiveFields) {
       throw new Error(
-        `cannot update ${release.status} release (only the changelog may be edited)`,
+        `cannot update ${release.status} release (only the changelog and visibility may be edited)`,
       );
     }
   }
@@ -284,6 +287,10 @@ async function updateReleaseFields(
   if (input.provenance_json !== undefined) {
     sets.push(`provenance_json = ?${binds.length + 1}`);
     binds.push(jsonString(input.provenance_json));
+  }
+  if (input.hidden !== undefined) {
+    sets.push(`hidden = ?${binds.length + 1}`);
+    binds.push(input.hidden ? 1 : 0);
   }
 
   const statements: D1PreparedStatement[] = [];

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -210,6 +210,7 @@ function makeMockDb() {
       should_force_update INTEGER NOT NULL DEFAULT 0,
       changelog TEXT,
       provenance_json TEXT NOT NULL DEFAULT '{}',
+      hidden INTEGER NOT NULL DEFAULT 0,
       created_by TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,


### PR DESCRIPTION
Superseded/cancelled releases can't be deleted, so junk/duplicate old entries (e.g. a duplicate empty-changelog 1.0.0 + an old 1.0/build-1 test) had no way to be cleaned from the public changelog. Adds a reversible `hidden` flag on releases: migration + `hidden = 0` filter on the public history/release-notes/download surfaces + `handleUpdateRelease` accepts `hidden` (allowed on locked releases as a display/visibility field). 140 worker tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786378427&installation_id=145465820&pr_number=272&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F272&signature=8549e33adfdb350cc090fe1e59123ea4730b43b30734bbaeed2c1ef841edd2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->