### PR TITLE
ci(jitpack): tokenless Android SDK consumption via JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,7 +3,14 @@
 # read:packages token. JitPack builds the subdirectory module and publishes it
 # to the local Maven repo; it then serves it as
 #   com.github.botiverse.hands:hands-android-sdk:<tag>
+#
+# The module targets AGP 8.7.3 / Kotlin 2.0.21, which need Gradle 8.x — JitPack's
+# system Gradle is far older, and the module ships no wrapper, so install a
+# modern Gradle via SDKMAN first.
 jdk:
   - openjdk17
+before_install:
+  - sdk install gradle 8.10.2 < /dev/null
+  - sdk default gradle 8.10.2 < /dev/null
 install:
   - cd clients/android && gradle --no-daemon -PVERSION_NAME=$VERSION publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,9 @@
+# JitPack build config for the Hands Android SDK (clients/android).
+# Lets consumers pull the SDK from https://jitpack.io without a GitHub Packages
+# read:packages token. JitPack builds the subdirectory module and publishes it
+# to the local Maven repo; it then serves it as
+#   com.github.botiverse.hands:hands-android-sdk:<tag>
+jdk:
+  - openjdk17
+install:
+  - cd clients/android && gradle --no-daemon -PVERSION_NAME=$VERSION publishToMavenLocal


### PR DESCRIPTION
Lets teams pull the Hands Android SDK from JitPack **without a GitHub Packages read:packages token**. Adds `jitpack.yml` (installs Gradle 8.10.2 via SDKMAN — the module targets AGP 8.7.3 and ships no wrapper — then builds `clients/android` + `publishToMavenLocal`).

Verified with a real JitPack build (commit 606f0819): `BUILD SUCCESSFUL`, incl. the native NDK/CMake build; AAR produced. JitPack serves it as **`com.github.botiverse:hands:<version>`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786379252&installation_id=145465820&pr_number=273&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F273&signature=e8edb3b7f6bd20e4cd30155cc60c5387ff08331823ade47345de3f3d0393791f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->