### PR TITLE
docs(android-sdk): document JitPack (tokenless) consumption; bump 0.10.2

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -4,6 +4,24 @@ Android SDK for Hands server-side update checks and APK installation.
 
 ## Coordinates
 
+Two ways to consume the SDK. **JitPack needs no token** — prefer it unless you
+already have GitHub Packages set up. (GitHub Packages' Maven registry requires a
+`read:packages` token for every request, even though the package is public.)
+
+### JitPack (no token)
+
+```kotlin
+repositories {
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencies {
+    implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
+}
+```
+
+### GitHub Packages (needs a `read:packages` token)
+
 ```kotlin
 repositories {
     maven {
@@ -16,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.1")
+    implementation("build.hands:hands-android-sdk:0.10.2")
 }
 ```
 
@@ -53,7 +71,10 @@ Publish to GitHub Packages:
 ```bash
 cd clients/android
 GITHUB_ACTOR=<github-user> GITHUB_TOKEN=<token-with-packages-write> \
-  gradle publish -PVERSION_NAME=0.10.1
+  gradle publish -PVERSION_NAME=0.10.2
 ```
 
-In CI, use the `Publish Android SDK` workflow and a version such as `0.10.1`.
+In CI, push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.10.2`) — that
+publishes to GitHub Packages and, on first request, builds the same version on
+JitPack (`com.github.botiverse:hands:android-sdk-v<version>`). Or run the
+`Publish Android SDK` workflow manually with a version input.

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -6,10 +6,26 @@ feedback submission, and crash reporting.
 
 ## Install
 
-The SDK is published to GitHub Packages.
+Consume the SDK from **JitPack (no token)** or from **GitHub Packages (needs a
+`read:packages` token)** — the GitHub Packages Maven registry requires a token on
+every request even for public packages, so JitPack is the simpler choice.
+
+### JitPack — no token
 
 ```kotlin
 // settings.gradle.kts or the module repositories block
+repositories {
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencies {
+    implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
+}
+```
+
+### GitHub Packages — needs a `read:packages` token
+
+```kotlin
 repositories {
     maven {
         url = uri("https://maven.pkg.github.com/botiverse/hands")
@@ -21,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.1")
+    implementation("build.hands:hands-android-sdk:0.10.2")
 }
 ```
 


### PR DESCRIPTION
Adds JitPack (tokenless) alongside GitHub Packages in the Android SDK README + public docs, and bumps to 0.10.2. Prep for the `android-sdk-v0.10.2` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786380140&installation_id=145465820&pr_number=274&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F274&signature=0785e1b954b5a0ae02c2391a216daa8ed92419e04bb0ff94e2411abea502f488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->