### PR TITLE
docs(android-sdk): JitPack only, drop GitHub Packages

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -4,11 +4,7 @@ Android SDK for Hands server-side update checks and APK installation.
 
 ## Coordinates
 
-Two ways to consume the SDK. **JitPack needs no token** — prefer it unless you
-already have GitHub Packages set up. (GitHub Packages' Maven registry requires a
-`read:packages` token for every request, even though the package is public.)
-
-### JitPack (no token)
+Pulled from JitPack — no token, no registry credentials.
 
 ```kotlin
 repositories {
@@ -17,24 +13,6 @@ repositories {
 
 dependencies {
     implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
-}
-```
-
-### GitHub Packages (needs a `read:packages` token)
-
-```kotlin
-repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/botiverse/hands")
-        credentials {
-            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
-        }
-    }
-}
-
-dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.2")
 }
 ```
 
@@ -64,17 +42,9 @@ GET /public/v2/apps/{slug}/updates/check
 
 The server resolves release scope, rollout, version comparison, and APK asset selection.
 
-## Publish
+## Release
 
-Publish to GitHub Packages:
-
-```bash
-cd clients/android
-GITHUB_ACTOR=<github-user> GITHUB_TOKEN=<token-with-packages-write> \
-  gradle publish -PVERSION_NAME=0.10.2
-```
-
-In CI, push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.10.2`) — that
-publishes to GitHub Packages and, on first request, builds the same version on
-JitPack (`com.github.botiverse:hands:android-sdk-v<version>`). Or run the
-`Publish Android SDK` workflow manually with a version input.
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.10.2`). JitPack builds
+that tag on the first request for it, so consumers can immediately pull
+`com.github.botiverse:hands:android-sdk-v<version>` — no publish step or token
+needed.

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -6,11 +6,7 @@ feedback submission, and crash reporting.
 
 ## Install
 
-Consume the SDK from **JitPack (no token)** or from **GitHub Packages (needs a
-`read:packages` token)** — the GitHub Packages Maven registry requires a token on
-every request even for public packages, so JitPack is the simpler choice.
-
-### JitPack — no token
+Pulled from JitPack — no token, no registry credentials.
 
 ```kotlin
 // settings.gradle.kts or the module repositories block
@@ -20,24 +16,6 @@ repositories {
 
 dependencies {
     implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
-}
-```
-
-### GitHub Packages — needs a `read:packages` token
-
-```kotlin
-repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/botiverse/hands")
-        credentials {
-            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
-        }
-    }
-}
-
-dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.2")
 }
 ```
 


### PR DESCRIPTION
Per artin — document only the tokenless JitPack path; remove the GitHub Packages consumption block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786380428&installation_id=145465820&pr_number=275&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F275&signature=77bf79276dbc3b7920efbcee6a8239a55d1d3c569f857489832fcd8b349edf76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->