### PR TITLE
docs(android-sdk): document both JitPack and GitHub Packages

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -4,7 +4,11 @@ Android SDK for Hands server-side update checks and APK installation.
 
 ## Coordinates
 
-Pulled from JitPack — no token, no registry credentials.
+Two ways to consume the SDK. **JitPack needs no token** — prefer it unless you
+already have GitHub Packages set up. (GitHub Packages' Maven registry requires a
+`read:packages` token for every request, even though the package is public.)
+
+### JitPack (no token)
 
 ```kotlin
 repositories {
@@ -13,6 +17,24 @@ repositories {
 
 dependencies {
     implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
+}
+```
+
+### GitHub Packages (needs a `read:packages` token)
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/botiverse/hands")
+        credentials {
+            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation("build.hands:hands-android-sdk:0.10.2")
 }
 ```
 
@@ -44,7 +66,8 @@ The server resolves release scope, rollout, version comparison, and APK asset se
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.10.2`). JitPack builds
-that tag on the first request for it, so consumers can immediately pull
-`com.github.botiverse:hands:android-sdk-v<version>` — no publish step or token
-needed.
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.10.2`). That publishes to
+GitHub Packages (`build.hands:hands-android-sdk:<version>`) and, on the first
+request, builds the same version on JitPack
+(`com.github.botiverse:hands:android-sdk-v<version>`) — so both channels stay in
+sync from one tag. Or run the `Publish Android SDK` workflow manually.

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -6,7 +6,11 @@ feedback submission, and crash reporting.
 
 ## Install
 
-Pulled from JitPack — no token, no registry credentials.
+Consume the SDK from **JitPack (no token)** or from **GitHub Packages (needs a
+`read:packages` token)** — the GitHub Packages Maven registry requires a token on
+every request even for public packages, so JitPack is the simpler choice.
+
+### JitPack — no token
 
 ```kotlin
 // settings.gradle.kts or the module repositories block
@@ -16,6 +20,24 @@ repositories {
 
 dependencies {
     implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
+}
+```
+
+### GitHub Packages — needs a `read:packages` token
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/botiverse/hands")
+        credentials {
+            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation("build.hands:hands-android-sdk:0.10.2")
 }
 ```
 


### PR DESCRIPTION
Per artin — keep both consumption methods (more robust). JitPack (tokenless) + GitHub Packages (token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786381345&installation_id=145465820&pr_number=276&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F276&signature=42fb284607cb328102cbba0f2067cfb1f6be9ff601e0c31104b3e3de0b77ff5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->