### PR TITLE
feat(delta): client-side delta APK apply (SDK) + server opt-in gate (task #247)

### DIFF
--- a/clients/android/.gitignore
+++ b/clients/android/.gitignore
@@ -1,3 +1,9 @@
 .gradle/
-build/
+# Anchored so this only ignores the Gradle output dir, NOT the `build/hands`
+# Java package directory under src/main/kotlin.
+/build/
+# The Kotlin sources live in a `build.hands` package -> a literal `build/`
+# directory under src. Re-include it so the repo-root `build/` ignore rule
+# does not silently drop SDK source files (e.g. update/internal/*).
+!src/main/kotlin/build/
 local.properties

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     api("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("androidx.core:core-ktx:1.13.1")
+    // Delta (incremental) APK apply. Maintained fork of Google's Play-Store
+    // file-by-file engine; the CLI/CI side generates patches with the SAME jar.
+    implementation("com.eidu:archive-patcher:3.0.0")
 }
 
 afterEvaluate {

--- a/clients/android/src/main/AndroidManifest.xml
+++ b/clients/android/src/main/AndroidManifest.xml
@@ -1,4 +1,22 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <application>
+        <!--
+          Grants the system package installer read access to a locally
+          reconstructed (delta-applied) APK sitting in the host app's cacheDir.
+          Authority is namespaced with `.hands.` so it never collides with a
+          host app that already declares its own FileProvider.
+        -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.hands.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/hands_file_paths" />
+        </provider>
+    </application>
 </manifest>

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -4,12 +4,14 @@ import android.app.DownloadManager
 import android.content.Context
 import android.content.IntentFilter
 import build.hands.update.installer.ApkInstaller
+import build.hands.update.internal.DeltaUpdater
 import build.hands.update.internal.HandsClient
 import build.hands.update.models.UpdateCheckResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * High-level entry point for "check if there's a new version on the quiver
@@ -56,6 +58,15 @@ class UpdateChecker(
     private val client: HandsClient = HandsClient(baseUrl),
     private val installer: ApkInstaller = ApkInstaller(context),
     private val deviceId: String? = null,
+    /** Master switch for client-side delta (incremental) update apply. */
+    private val deltaApplyEnabled: Boolean = true,
+    private val deltaUpdater: DeltaUpdater = DeltaUpdater(
+        context = context,
+        installedVersionCode = installedVersionCode,
+        httpClient = HandsClient.defaultClient(),
+        installer = installer,
+        deltaApplyEnabled = deltaApplyEnabled,
+    ),
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -103,8 +114,21 @@ class UpdateChecker(
         }
     }
 
-    private fun installUpdate(response: UpdateCheckResponse) {
+    private suspend fun installUpdate(response: UpdateCheckResponse) {
         val (latest, asset) = response.requireUpdate() ?: return
+
+        // Prefer the incremental (delta) path when the server offered a patch.
+        // DeltaUpdater does blocking IO + a CPU-heavy patch apply and never
+        // throws: it returns false for any failure/verification miss, and we
+        // fall through to the unchanged full-APK download below.
+        val patch = response.patch
+        if (patch != null) {
+            val applied = withContext(Dispatchers.IO) {
+                deltaUpdater.tryApplyAndInstall(patch, asset, latest, appSlug)
+            }
+            if (applied) return
+        }
+
         val downloadId = installer.downloadAndInstall(
             downloadUrl = asset.download_url,
             fileName = "quiver-${appSlug}-${latest.version_code}.apk",

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import java.io.File
 
 /**
@@ -79,6 +80,28 @@ class ApkInstaller(private val context: Context) {
                 triggerInstall(ctx ?: context, dm, id)
             }
         }
+    }
+
+    /**
+     * Trigger the system install prompt for an APK that already lives on disk
+     * (e.g. one reconstructed locally by the delta updater), rather than one
+     * fetched via DownloadManager.
+     *
+     * The file is expected to sit in the host app's private cacheDir; it is
+     * shared with the installer through the SDK's FileProvider (authority
+     * `${'$'}{applicationId}.hands.fileprovider`, declared in the SDK manifest)
+     * so no world-readable storage is needed.
+     */
+    fun installLocalApk(file: File) {
+        val authority = "${context.packageName}.hands.fileprovider"
+        val apkUri = FileProvider.getUriForFile(context, authority, file)
+
+        val install = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(apkUri, "application/vnd.android.package-archive")
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+        }
+        context.startActivity(install)
     }
 
     private fun triggerInstall(ctx: Context, dm: DownloadManager, downloadId: Long) {

--- a/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
@@ -158,10 +158,10 @@ class DeltaUpdater(
 
     /**
      * Feature flag. Defaults to the constructor value, but a JVM system property
-     * `SLOCK_DELTA_APPLY=false` force-disables it (kill switch for field ops).
+     * `HANDS_DELTA_APPLY=false` force-disables it (kill switch for field ops).
      */
     private fun deltaEnabled(): Boolean {
-        val override = System.getProperty("SLOCK_DELTA_APPLY")
+        val override = System.getProperty("HANDS_DELTA_APPLY")
         if (override != null) return !override.equals("false", ignoreCase = true)
         return deltaApplyEnabled
     }

--- a/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
@@ -1,0 +1,338 @@
+package build.hands.update.internal
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import build.hands.update.installer.ApkInstaller
+import build.hands.update.models.LatestUpdate
+import build.hands.update.models.Patch
+import build.hands.update.models.UpdateAsset
+import com.google.archivepatcher.applier.FileByFileV1DeltaApplier
+import com.google.archivepatcher.shared.DefaultDeflater
+import com.google.archivepatcher.shared.IDeflater
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.security.MessageDigest
+import java.util.function.BiFunction
+import java.util.zip.GZIPInputStream
+
+/**
+ * Applies a server-offered incremental (delta) APK update on-device and, only
+ * after it passes every safety check, hands the reconstructed APK to the system
+ * installer.
+ *
+ * This is intentionally a dedicated, self-contained class (not folded into
+ * [build.hands.update.UpdateChecker]) because it does something security
+ * sensitive: it reconstructs an installable binary from an untrusted patch and
+ * then installs it. Every path that could produce an APK that is not a
+ * byte-identical, same-signer successor of the running app must fail closed.
+ *
+ * Guarantees:
+ *  - It NEVER throws. Any failure (flag off, bad offer, network, gunzip, patch
+ *    apply, or a failed verification) is caught, logged, temp files are deleted,
+ *    and it returns `false` so the caller falls back to the full-APK download.
+ *  - It only installs a reconstructed APK when ALL of these hold:
+ *      1. sha256(reconstructed) == patch.target_sha256 (constant-time compare),
+ *      2. the APK's package == this app and its versionCode >= the installed one,
+ *      3. the APK's signing certificate(s) exactly match the installed app's.
+ *
+ * The apply + signature/package checks require a real device/PackageManager and
+ * the archive-patcher engine, so they are validated on-device, not by JVM unit
+ * tests. The pure helpers ([isGzipped], [toHex], [constantTimeEquals]) are unit
+ * testable in isolation.
+ */
+class DeltaUpdater(
+    private val context: Context,
+    private val installedVersionCode: Long,
+    private val httpClient: OkHttpClient,
+    private val installer: ApkInstaller,
+    private val deltaApplyEnabled: Boolean = true,
+) {
+
+    /**
+     * Attempt to apply [patch] on top of the installed base APK and install the
+     * result.
+     *
+     * @return `true` if a verified reconstructed APK was handed to the installer
+     *         (caller should stop); `false` for ANY failure (caller must fall
+     *         back to the full download). Never throws.
+     */
+    fun tryApplyAndInstall(
+        patch: Patch,
+        asset: UpdateAsset,
+        latest: LatestUpdate,
+        appSlug: String,
+    ): Boolean {
+        if (!deltaEnabled()) {
+            log("delta_fallback reason=flag_off")
+            return false
+        }
+        if (!validateOffer(patch)) {
+            log("delta_fallback reason=validate")
+            return false
+        }
+        // Non-null and non-blank, per validateOffer.
+        val expectedSha = patch.target_sha256!!
+
+        val baseFile = File(context.applicationInfo.sourceDir)
+        if (!baseFile.isFile) {
+            log("delta_fallback reason=validate")
+            return false
+        }
+
+        val stamp = System.nanoTime()
+        val patchFile = File(context.cacheDir, "hands-delta-${latest.version_code}-$stamp.patch")
+        val reconstructed =
+            File(context.cacheDir, "hands-delta-$appSlug-${latest.version_code}-$stamp.apk")
+        var installed = false
+        try {
+            // 1. Download the patch bytes into a private temp file.
+            try {
+                downloadTo(patch.download_url, patchFile)
+            } catch (e: Throwable) {
+                log("delta_fallback reason=download err=${e.message}")
+                return false
+            }
+
+            // 2. Open the delta stream, gunzipping first when the algorithm asks
+            //    for it. A corrupt gzip header surfaces here as `gunzip`.
+            val deltaStream: InputStream = try {
+                openDeltaStream(patchFile, isGzipped(patch.algorithm))
+            } catch (e: Throwable) {
+                log("delta_fallback reason=gunzip err=${e.message}")
+                return false
+            }
+
+            // 3. Apply the patch onto the base APK. A mid-stream gunzip fault or
+            //    any patch error surfaces here as `apply`.
+            try {
+                deltaStream.use { stream ->
+                    reconstructed.outputStream().buffered().use { out ->
+                        // Use cacheDir as the applier's scratch dir explicitly
+                        // rather than relying on java.io.tmpdir.
+                        FileByFileV1DeltaApplier(context.cacheDir, deflaterFactory())
+                            .applyDelta(baseFile, stream, out)
+                    }
+                }
+            } catch (e: Throwable) {
+                log("delta_fallback reason=apply err=${e.message}")
+                return false
+            }
+
+            // 4a. Content integrity: sha256 must equal the offered target.
+            val actualSha = sha256Hex(reconstructed)
+            if (!constantTimeEquals(actualSha, expectedSha.lowercase())) {
+                log("delta_fallback reason=sha_mismatch")
+                return false
+            }
+
+            // 4b/4c. Package identity, version, and signer-cert equality.
+            val reason = verifyReconstructedApk(reconstructed)
+            if (reason != null) {
+                log("delta_fallback reason=$reason")
+                return false
+            }
+
+            // 5. Install the verified reconstructed APK.
+            installer.installLocalApk(reconstructed)
+            installed = true
+            log("delta_applied bytes_saved=${asset.size_bytes - patch.size_bytes}")
+            return true
+        } catch (e: Throwable) {
+            // Belt-and-suspenders: nothing above should escape, but never throw.
+            log("delta_fallback reason=apply err=${e.message}")
+            return false
+        } finally {
+            // The patch is never needed once applied. The reconstructed APK is
+            // kept ONLY on the success path — the system installer reads it via
+            // the content URI after we return; deleting it would break install.
+            safeDelete(patchFile)
+            if (!installed) safeDelete(reconstructed)
+        }
+    }
+
+    /**
+     * Feature flag. Defaults to the constructor value, but a JVM system property
+     * `SLOCK_DELTA_APPLY=false` force-disables it (kill switch for field ops).
+     */
+    private fun deltaEnabled(): Boolean {
+        val override = System.getProperty("SLOCK_DELTA_APPLY")
+        if (override != null) return !override.equals("false", ignoreCase = true)
+        return deltaApplyEnabled
+    }
+
+    /**
+     * Cheap, non-cryptographic offer sanity checks. The real trust anchors are
+     * the post-apply verifications; this just avoids wasted work.
+     */
+    private fun validateOffer(patch: Patch): Boolean {
+        if (patch.from_version_code != installedVersionCode) return false
+        if (!patch.algorithm.startsWith("archive-patcher-v1")) return false
+        if (patch.target_sha256.isNullOrBlank()) return false
+        return true
+    }
+
+    private fun downloadTo(url: String, dest: File) {
+        val request = Request.Builder()
+            .url(url)
+            .header("accept", "application/octet-stream")
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("HTTP ${response.code}")
+            }
+            val body = response.body ?: throw IOException("empty response body")
+            dest.outputStream().use { out ->
+                body.byteStream().use { input -> input.copyTo(out) }
+            }
+        }
+    }
+
+    private fun openDeltaStream(patchFile: File, gzipped: Boolean): InputStream {
+        val raw = patchFile.inputStream().buffered()
+        return if (gzipped) {
+            try {
+                GZIPInputStream(raw)
+            } catch (e: Throwable) {
+                raw.close()
+                throw e
+            }
+        } else {
+            raw
+        }
+    }
+
+    /**
+     * Verifies the reconstructed APK is a legitimate successor of the running
+     * app. Returns `null` when everything checks out, or a short fallback reason
+     * (`pkg_mismatch` / `signer_mismatch`) otherwise.
+     */
+    @Suppress("DEPRECATION")
+    private fun verifyReconstructedApk(file: File): String? {
+        val pm = context.packageManager
+        val usesSigningInfo = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+        val flags = if (usesSigningInfo) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            PackageManager.GET_SIGNATURES
+        }
+
+        val archiveInfo = pm.getPackageArchiveInfo(file.path, flags) ?: return "pkg_mismatch"
+        // Point the parsed ApplicationInfo at the archive so signatures resolve
+        // on pre-P devices (where getPackageArchiveInfo leaves sourceDir null).
+        archiveInfo.applicationInfo?.apply {
+            sourceDir = file.path
+            publicSourceDir = file.path
+        }
+
+        if (archiveInfo.packageName != context.packageName) return "pkg_mismatch"
+        val archiveVersionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            archiveInfo.longVersionCode
+        } else {
+            archiveInfo.versionCode.toLong()
+        }
+        if (archiveVersionCode < installedVersionCode) return "pkg_mismatch"
+
+        val installedInfo = try {
+            pm.getPackageInfo(context.packageName, flags)
+        } catch (e: Exception) {
+            return "signer_mismatch"
+        }
+
+        val archiveCerts = signingCerts(archiveInfo) ?: return "signer_mismatch"
+        val installedCerts = signingCerts(installedInfo) ?: return "signer_mismatch"
+        if (archiveCerts != installedCerts) return "signer_mismatch"
+        return null
+    }
+
+    /**
+     * The set of signing certificates (hex-encoded DER) for [info], or `null` if
+     * none could be read. On API 28+ we read the modern `signingInfo`; on
+     * 24–27 the legacy `signatures` array.
+     */
+    @Suppress("DEPRECATION")
+    private fun signingCerts(info: PackageInfo?): Set<String>? {
+        info ?: return null
+        val raw: Array<out android.content.pm.Signature>? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val signingInfo = info.signingInfo ?: return null
+                if (signingInfo.hasMultipleSigners()) {
+                    signingInfo.apkContentsSigners
+                } else {
+                    signingInfo.signingCertificateHistory
+                }
+            } else {
+                info.signatures
+            }
+        val set = raw?.mapNotNull { it?.toByteArray()?.let(::toHex) }?.toSet()
+        return set?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun sha256Hex(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(8192)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return toHex(digest.digest())
+    }
+
+    private fun log(message: String) {
+        Log.i(TAG, message)
+    }
+
+    companion object {
+        private const val TAG = "HandsDelta"
+
+        private val HEX = "0123456789abcdef".toCharArray()
+
+        /** The `+gzip` suffix means the patch bytes are gzip-wrapped. */
+        internal fun isGzipped(algorithm: String): Boolean = algorithm.endsWith("+gzip")
+
+        /** Same deflater factory the generator (CLI/CI) used; must match byte-for-byte. */
+        internal fun deflaterFactory(): BiFunction<Int, Boolean, IDeflater> =
+            BiFunction { level, nowrap -> DefaultDeflater(level, nowrap) }
+
+        /** Lowercase hex encoding. */
+        internal fun toHex(bytes: ByteArray): String {
+            val out = CharArray(bytes.size * 2)
+            for (i in bytes.indices) {
+                val v = bytes[i].toInt() and 0xFF
+                out[i * 2] = HEX[v ushr 4]
+                out[i * 2 + 1] = HEX[v and 0x0F]
+            }
+            return String(out)
+        }
+
+        /**
+         * Length-and-content constant-time comparison of two hex strings. Both
+         * are compared as-is (callers pass already-lowercased values); guards the
+         * sha256 check against timing side channels.
+         */
+        internal fun constantTimeEquals(a: String, b: String): Boolean {
+            if (a.length != b.length) return false
+            var diff = 0
+            for (i in a.indices) {
+                diff = diff or (a[i].code xor b[i].code)
+            }
+            return diff == 0
+        }
+
+        private fun safeDelete(file: File) {
+            try {
+                if (file.exists()) file.delete()
+            } catch (_: Throwable) {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/clients/android/src/main/kotlin/build/hands/update/models/Version.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/models/Version.kt
@@ -19,6 +19,7 @@ data class UpdateCheckResponse(
     val latest: LatestUpdate? = null,
     val asset: UpdateAsset? = null,
     val scoped: ScopedRelease? = null,
+    val patch: Patch? = null,
     val expires_in: Int? = null,
     val checked_at: Long? = null,
 ) {
@@ -50,6 +51,31 @@ data class UpdateAsset(
     val size_bytes: Long,
     val signature: String? = null,
     val download_url: String,
+)
+
+/**
+ * Optional incremental-update offer. When present, the client MAY reconstruct
+ * the target APK by applying [download_url]'s binary patch on top of the
+ * currently-installed base APK, instead of downloading the full asset.
+ *
+ * Purely an optimization: the client falls back to the full download whenever
+ * the patch is missing, disabled, invalid, or fails any safety verification.
+ *
+ *  - [from_version_code] MUST equal the installed version_code (the patch is
+ *    built against that exact base APK).
+ *  - [algorithm] identifies the delta engine; today `archive-patcher-v1` or
+ *    `archive-patcher-v1+gzip` (the `+gzip` suffix means the patch bytes are
+ *    gzip-wrapped and must be gunzipped before applying).
+ *  - [target_sha256] is the SHA-256 (hex) of the full TARGET APK; the client
+ *    verifies the reconstructed file against it before installing.
+ */
+@Serializable
+data class Patch(
+    val from_version_code: Long,
+    val algorithm: String,
+    val download_url: String,
+    val size_bytes: Long,
+    val target_sha256: String? = null,
 )
 
 @Serializable

--- a/clients/android/src/main/res/xml/hands_file_paths.xml
+++ b/clients/android/src/main/res/xml/hands_file_paths.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Exposes the host app's internal cacheDir (Context.getCacheDir()) to the
+  FileProvider declared in AndroidManifest.xml. The delta updater writes the
+  reconstructed APK here and shares it with the system installer via a
+  content:// URI + FLAG_GRANT_READ_URI_PERMISSION.
+-->
+<paths>
+    <cache-path
+        name="hands_delta_cache"
+        path="." />
+</paths>

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -495,6 +495,19 @@ async function findDeltaPatch(
   size_bytes: number;
   target_sha256: string | null;
 } | null> {
+  // Server-side kill switch: only offer deltas when the app has opted in
+  // (delta_updates_enabled — the same per-app flag that gates delta generation).
+  // When off, no `patch` field is returned at all, so the client never sees or
+  // downloads an incremental — it just gets the full APK.
+  const app = await c.env.DB.prepare(
+    `SELECT a.delta_updates_enabled AS delta_updates_enabled
+     FROM builds b JOIN apps a ON a.id = b.app_id
+     WHERE b.id = ?1`,
+  )
+    .bind(args.buildId)
+    .first<{ delta_updates_enabled: number }>();
+  if (!app || app.delta_updates_enabled !== 1) return null;
+
   const row = await c.env.DB.prepare(
     `SELECT r2_key, size_bytes, arch,
             json_extract(metadata_json, '$.algorithm') AS algorithm,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3297,6 +3297,16 @@ describe("quiver public API v2 — scope resolution", () => {
         }),
       );
 
+    // Kill switch: delta is off by default → no patch offered even though one
+    // exists and applies. Client just gets the full APK.
+    const gatedOff = await responseJson<any>(await call("10"));
+    expect(gatedOff.update_available).toBe(true);
+    expect(gatedOff.patch).toBeUndefined();
+
+    // Opt the app into delta updates.
+    await env.DB.prepare("UPDATE apps SET delta_updates_enabled = 1 WHERE id = ?1")
+      .bind("app-scope").run();
+
     // Client on 10 → patch offered with target hash + signed URL.
     const offered = await responseJson<any>(await call("10"));
     expect(offered.patch).toMatchObject({


### PR DESCRIPTION
Implements client-side delta (incremental) APK update **apply** in the Hands Android SDK (task #247), plus the server-side opt-in gate. Security-sensitive (reconstructs + installs an APK), so it fails closed everywhere.

## Client (Hands Android SDK)
New `DeltaUpdater` (dedicated, not folded into UpdateChecker):
- download patch → gunzip when `algorithm` ends with `+gzip` → `archive-patcher` `FileByFileV1DeltaApplier` (same `DefaultDeflater(level,nowrap)` factory as the server generator; **applier API verified against the com.eidu:archive-patcher:3.0.0 jar via javap**) applied against the installed APK (`applicationInfo.sourceDir`), scratch in cacheDir;
- **verify before install**: sha256 == `target_sha256` (constant-time), package == this app + versionCode ≥ installed, and **signing certificate(s) exactly match the installed app** (GET_SIGNING_CERTIFICATES on 28+, GET_SIGNATURES on 24–27);
- **any** failure → return false → UpdateChecker falls back to the full download; never throws; temp files cleaned in finally;
- install via a namespaced FileProvider (`${applicationId}.hands.fileprovider`); feature flag `SLOCK_DELTA_APPLY`.
- Adds `Patch` model + `patch` field; minimal UpdateChecker wiring (delta runs on Dispatchers.IO). Fixes `clients/android/.gitignore` (bare `build/` was ignoring the `build/hands/` source package).

## Server
`/updates/check` gates the delta offer on the existing per-app `delta_updates_enabled` flag: when off (default), **no `patch` field is returned at all** — clients only ever get the full APK. Authoritative kill switch (per @artin). Toggle via the existing `PATCH /api/apps/:appId` (`delta_updates_enabled`).

## Verification
- **Client compiles**: JitPack `compileReleaseKotlin` → `BUILD SUCCESSFUL` (archive-patcher dep resolves, all code compiles).
- **Server**: 140 worker tests pass (incl. a new "off by default → no patch" assertion); `tsc` clean.
- **Still needed before the 0.11.0 SDK release**: on-device end-to-end validation (real delta install: same-signer verify passes, sha match, install succeeds; and the failure/fallback paths). The apply + signature checks can't be JVM-unit-tested.

Security-sensitive — requesting review before merge + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786383571&installation_id=145465820&pr_number=277&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F277&signature=34864e9b91b02b48b68e6a9a7b02dcab66868993956a9e9e270d5b82294a0e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->