### PR TITLE
chore(branding): drop Slock references from the SDKs

### DIFF
--- a/clients/android/docs/integration.md
+++ b/clients/android/docs/integration.md
@@ -1,6 +1,6 @@
 # Hands Android Client Integration
 
-A reference implementation showing Slock Android (or any Android app) how to
+A reference implementation showing an Android app how to
 check for the latest APK version hosted on a Hands server and trigger a
 download + install.
 
@@ -13,7 +13,7 @@ download + install.
 ```
 GET /public/v2/apps/{slug}/updates/check?channel=main&product_type=android-apk&current_version_code=42&platform=android&arch=arm64-v8a
 → 200 {
-    "app":         { "slug": "slock-android", "platform": "android" },
+    "app":         { "slug": "myapp-android", "platform": "android" },
     "channel":     "main",
     "current_version_code": 42,
     "update_available": true,

--- a/clients/android/src/main/kotlin/build/hands/update/HandsCrash.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsCrash.kt
@@ -31,8 +31,8 @@ import org.json.JSONObject
  * local files are removed on success. At most [MAX_STORED_CRASHES] recent
  * crashes are kept.
  *
- * This replaces the app-side SlockCrashReporter; app-specific context (e.g.
- * recent diagnostics) is injected via [extraContext].
+ * This replaces the app's previous in-process crash reporter; app-specific
+ * context (e.g. recent diagnostics) is injected via [extraContext].
  */
 object HandsCrash {
     private const val TAG = "HandsCrash"

--- a/clients/ohos/hands/src/main/ets/HandsCrashUploader.ets
+++ b/clients/ohos/hands/src/main/ets/HandsCrashUploader.ets
@@ -16,7 +16,7 @@ export interface CrashMeta {
 
 /**
  * Store-then-send crash reporting for OHOS (mirrors the Android SDK's
- * QuiverCrash): SlockOhosCrashReporter writes crash-<ts>.txt plus a
+ * HandsCrash): the crash reporter writes crash-<ts>.txt plus a
  * .meta.json sidecar at crash time; this uploader runs on the next launch,
  * submits each pending crash as a kind=crash Hands ticket (full log
  * attached, signature fields in metadata), and deletes local files on


### PR DESCRIPTION
Per @artin — it's Hands, not Slock. Renames the crash-reporter comments (Android `HandsCrash`, OHOS `HandsCrashUploader`) and the Android integration-doc example (wording + `slug`). No behaviour change.

Note: the `slock-agent-manifest` route/schema (worker) is intentionally NOT touched here — it's the Raft/Slock integration contract (`raft-agent-manifest` is the current name, `slock-` is a legacy alias); removing it needs a compat call. Internal design docs (handslog-spec, sdk-parity) still reference the Slock app as the motivating example — separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384206&installation_id=145465820&pr_number=278&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F278&signature=a0dacb57909ca68fc24b7998804a55a3c5d8d3db0b35dcfa3c82fc50fef4cd8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->