### PR TITLE
chore(branding): Slock -> Raft (drop legacy manifest alias + docs)

### DIFF
--- a/docs/handslog-spec.md
+++ b/docs/handslog-spec.md
@@ -9,8 +9,8 @@ Hands already owns the **transport** side of client observability: crash and
 feedback ingest, attachments, `/metrics`, and (iOS) automatic bundling of a
 diagnostics zip onto crash tickets. What's missing is the **capture** side.
 
-Today every consumer rolls its own log writer — the Slock app ships a bespoke
-`slock-diagnostics.jsonl` writer (rotation, JSONL format, ring buffer) that only
+Today every consumer rolls its own log writer — the Raft app ships a bespoke
+`raft-diagnostics.jsonl` writer (rotation, JSONL format, ring buffer) that only
 it can use. Anyone else adopting Hands needs the same thing. HandsLog makes log
 capture a **first-class, generic capability built into the existing Hands
 SDKs**, so it flows straight into Hands's transport and closes the loop:
@@ -34,7 +34,7 @@ Two delivery surfaces for the **same** generic capability:
   desktop app. This is the track artin greenlit first (see Architecture below).
 - **Generic only** (see the "Hands stays generic" principle): HandsLog is a
   logging *primitive* — levels, structured fields, tags, rotation, ring buffer,
-  redaction. It does **not** encode any consumer's log semantics; Slock and
+  redaction. It does **not** encode any consumer's log semantics; Raft and
   others layer meaning on top.
 - **Out (P1)**: server-assisted distribution/collection and tag "染色" selective
   capture are later phases. This spec designs the P1 surface + the collection
@@ -76,11 +76,11 @@ contract everywhere.
 ## Concepts
 
 - **Entry** — one JSONL object per line. The shape is an explicit **superset of
-  the existing Slock diagnostics fields**, not a new schema, so current
+  the existing Raft diagnostics fields**, not a new schema, so current
   server/UI/human `grep` keeps working after migration:
   ```json
   {"ts":"2026-07-09T14:01:02.345+08:00","level":"info","event":"login_ok",
-   "tag":"auth","message":"login ok","fields":{"server":"slock-android"},
+   "tag":"auth","message":"login ok","fields":{"server":"raft-android"},
    "thread":"main","seq":123,"dropped":0,"truncated":false}
   ```
   `ts` (ISO-8601 with offset), `level`, **`event`** (distinct machine key — kept
@@ -103,7 +103,7 @@ contract everywhere.
 Support **both** schemes, configurable, because the tradeoff is real:
 
 - `rotate: "size"` — `hands-<name>.jsonl`, `.1`, `.2`, … (fixed file count,
-  simple). This is what `slock-diagnostics` does today.
+  simple). This is what `raft-diagnostics` does today.
 - `rotate: "daily"` — `hands-<name>-YYYY-MM-DD.jsonl` (one file per calendar
   day). Trivially correlates to a crash timestamp and to age-based retention;
   costs more files if the app launches many times a day.
@@ -145,25 +145,25 @@ Hands.log.snapshot() -> [entries]     // ring buffer, for crash-time capture
 - **Format** — JSONL stays the shape the server already parses from the
   diagnostics zip, so no server change is needed for P1.
 
-## Migration (slock-diagnostics → HandsLog)
+## Migration (raft-diagnostics → HandsLog)
 
-The Slock app's `slock-diagnostics` writer (KMP, task #101) is replaced by
+The Raft app's `raft-diagnostics` writer (KMP, task #101) is replaced by
 `Hands.log`. Three hard constraints (from KMP review) protect the existing
 crash/feedback evidence chain during migration:
 
 1. **Superset entry shape, `event` preserved.** The JSONL fields above are a
-   strict superset of today's `slock-diagnostics` (`ts/level/event/tag/message/
+   strict superset of today's `raft-diagnostics` (`ts/level/event/tag/message/
    thread/seq/dropped/truncated`). `event` stays a distinct field — do not fold
    it into `tag` — or `event=…` grep/filters regress.
 2. **Filename-agnostic attach.** Do not assume the server keys off filenames.
    P1 defaults to `hands-<name>-YYYY-MM-DD.jsonl`, but the crash/feedback
    attach must keep a compatibility entry: **either** `currentFiles()` also
-   returns a legacy `slock-diagnostics*.jsonl` alias/manifest, **or** the server
+   returns a legacy `raft-diagnostics*.jsonl` alias/manifest, **or** the server
    is confirmed to parse by JSONL *content*, not filename. Pin this in the spec —
    it's the most likely "zip has files but nobody can see them" break.
-3. **Slock-side adapter, not a rewrite.** Slock keeps its call sites and red
+3. **Raft-side adapter, not a rewrite.** Raft keeps its call sites and red
    lines (app-owned logs only; never read system logcat/hilog; redact sensitive
-   fields first) behind a thin `SlockDiagnosticsSink → Hands.log` adapter.
+   fields first) behind a thin `RaftDiagnosticsSink → Hands.log` adapter.
    HandsLog owns only disk/rotation/ring/`currentFiles`/`snapshot`. This keeps
    P1 a minimal swap instead of touching business call sites on all three
    platforms at once.
@@ -216,7 +216,7 @@ Node / desktop track (artin greenlit, thread #Hands:c526b5e1):
 Mobile track (original P1/P2, unchanged):
 
 - **Mobile P1** — core capture inside the mobile SDKs + wire into the existing
-  crash-diagnostics attach; migrate `slock-diagnostics` via the adapter above.
+  crash-diagnostics attach; migrate `raft-diagnostics` via the adapter above.
   **iOS + Android must-do**; OHOS same batch if its SDK writes to disk reliably,
   else interface-placeholder + wire attach right after.
 - **Mobile P2** — the same server-assisted distribution/collection + 染色, built

--- a/docs/public/agent-cli-feedback.md
+++ b/docs/public/agent-cli-feedback.md
@@ -140,7 +140,7 @@ with the CLI (accepts a slug and a short/prefix ticket id):
 
 ```bash
 hands feedback download-attachment raft-android 389d855b <attachmentId>
-# → Saved 445539 bytes to slock-feedback-....zip   (use -o to choose the path)
+# → Saved 445539 bytes to raft-feedback-....zip   (use -o to choose the path)
 ```
 
 Hands saves the **raw bytes as-is** — it does not unzip or interpret the

--- a/docs/sdk-parity/deep-product-surface.md
+++ b/docs/sdk-parity/deep-product-surface.md
@@ -10,7 +10,7 @@ AI 能力。
 
 **总立场**:Sentry 的告警/集成体系本质是"把信号推给人,再让人去各个工具里
 操作"。Hands 的差异化是 **agent-native**:信号直接进到 AI agent 的工作环境
-(CLI/API,Raft/Slock 聊天即席),由 agent 完成分诊甚至修复。所以很多领域
+(CLI/API,Raft 聊天即席),由 agent 完成分诊甚至修复。所以很多领域
 我们不该抄 Sentry 的"人肉 UI",而是补齐**信号生成层**(规则、阈值、聚合),
 把"消费层"留给 agent。
 
@@ -72,7 +72,7 @@ Sentry 2025 年底把告警重构为 **Alerts + Monitors** 双层模型
 - **可后置**:Prophet 级异常检测。自托管、单租户、数据量小,先做
   "7 天同时段均值 × 系数"的轻量基线即可覆盖 80% 场景;Sentry 也是先有
   固定阈值多年后才补异常检测。
-- **不追**:Uptime/Cron monitors——不是崩溃平台的本职,Slock 生态另有位置。
+- **不追**:Uptime/Cron monitors——不是崩溃平台的本职,Raft 生态另有位置。
 
 ---
 
@@ -106,7 +106,7 @@ Sentry 2025 年底把告警重构为 **Alerts + Monitors** 双层模型
 
 - 无任何 chat-ops 集成;无 issue tracker 同步;无 VCS 集成(无 commit
   追踪、无 suspect commit、无栈帧链接)。
-- 但:**Raft/Slock 聊天平台是我们的原生栖息地**。Sentry 花大力气把自己
+- 但:**Raft 聊天平台是我们的原生栖息地**。Sentry 花大力气把自己
   "嵌进" Slack;我们的 agent 本来就活在 Raft 对话里,通过 CLI/API 直接
   读写 crash 组和 feedback 工单——"在聊天里 resolve" 对我们不是集成,
   是本体。
@@ -118,7 +118,7 @@ Sentry 2025 年底把告警重构为 **Alerts + Monitors** 双层模型
   **更进一步**:Sentry 在 Slack 里只有固定按钮 + 刚起步的 Seer Agent,
   我们频道里坐着的是全功能 agent,能查符号化栈、翻设备分布、改状态、
   开工单、甚至提修复 PR——这是我们**领先而非追赶**的一域,应最优先做实。
-  (参照 slock-agent-manifest 的 actions[] 模式暴露可调用动作。)
+  (参照 raft-agent-manifest 的 actions[] 模式暴露可调用动作。)
 - **关键:suspect commit(轻量版)**。这是 Sentry VCS 集成里对分诊增益
   最大的一项,而且对 agent 消费尤其有价值:agent 拿到"疑似引入提交 +
   作者"后可以直接去读 diff。最小实现:上传 release 时带 commit SHA
@@ -274,7 +274,7 @@ Sentry 2025 年底把告警重构为 **Alerts + Monitors** 双层模型
 ### Hands 现状
 
 - 平台自身无内置 AI,但**架构即 AI**:agent 经 CLI/API 对 crash 组、
-  符号化栈、设备/版本分布、feedback 工单有全量读写权,在 Slock/Raft
+  符号化栈、设备/版本分布、feedback 工单有全量读写权,在 Raft
   里即席完成 Seer 的全部用例(总结、根因、修复 PR、问答)——且用户
   自带模型和 agent,无 add-on 计费、无数据出域。
 
@@ -289,7 +289,7 @@ Sentry 2025 年底把告警重构为 **Alerts + Monitors** 双层模型
   栈-仓库链接(根因分析的原料)。Seer 强是因为 Sentry 给它喂了这些
   结构化输入;我们要喂给用户自己的 agent。
 - **可后置**:文档层面的 agent 引导(MCP 清单 / actions[] 声明已有
-  方向,见 slock-agent-manifest 备忘)。
+  方向,见 raft-agent-manifest 备忘)。
 
 ---
 

--- a/docs/sdk-parity/ios.md
+++ b/docs/sdk-parity/ios.md
@@ -4,7 +4,7 @@ Source: `clients/ios/Sources/Hands` (Objective-C — no Swift files, which is
 why naive `*.swift` searches miss it). Podspec v0.1.4, iOS 14.1+, zero deps.
 
 **Version drift (P1.6):** podspec `0.1.4` vs `kHandsSDKVersion = 0.1.5`.
-**Rename in flight (P1.6):** the Slock mobile app still consumes the old
+**Rename in flight (P1.6):** the Raft mobile app still consumes the old
 `Quiver` pod name pinned to an old git commit (Podfile.lock `Quiver (0.1.4)`)
 and calls `Quiver`-prefixed symbols via reflection.
 
@@ -26,7 +26,7 @@ and calls `Quiver`-prefixed symbols via reflection.
 - **Device analytics** — 24h-throttled `reportDevice` ping.
 - **Diagnostics provider** — `setDiagnosticsProvider:` lets the host attach
   log files at crash-upload time. The mobile app feeds its own
-  `slock-diagnostics.jsonl` (512 KB × 4 rotation) — a self-built substitute
+  `raft-diagnostics.jsonl` (512 KB × 4 rotation) — a self-built substitute
   for the missing breadcrumb layer.
 
 ## Absent (→ roadmap)

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -378,7 +378,6 @@ app.use(
 
 // Public — health check (no auth)
 app.get("/health", handleHealth);
-app.get("/.well-known/slock-agent-manifest.json", handleAgentManifest);
 app.get("/.well-known/raft-agent-manifest.json", handleAgentManifest);
 app.get("/openapi.json", (c) => c.json({
   ...openApiDocument,

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -747,7 +747,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
   // current action list (a stale cached copy makes schema changes invisible).
   c.header("Cache-Control", "no-store");
   return c.json({
-    schema: "slock-agent-manifest.v0",
+    schema: "raft-agent-manifest.v0",
     service: c.env.RAFT_CLIENT_ID || "quiver",
     docs_url: `${origin}/`,
     execution: {


### PR DESCRIPTION
Per @artin (all daemons upgraded to raft-agent-manifest). Removes the legacy `/.well-known/slock-agent-manifest.json` alias (raft- stays), renames the manifest `schema` to `raft-agent-manifest.v0`, and sweeps Slock→Raft across the design docs. Worker tsc + 140 tests pass. Repo is now Slock-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384425&installation_id=145465820&pr_number=279&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F279&signature=eb84e20d0177176125bb87d12c47aea5bb13a0866221fb7ab06d46af777ee251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->