### PR TITLE
docs(android-sdk): bump to 0.11.0 (delta apply)

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
+    implementation("com.github.botiverse:hands:android-sdk-v0.11.0")
 }
 ```
 
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.2")
+    implementation("build.hands:hands-android-sdk:0.11.0")
 }
 ```
 
@@ -66,7 +66,7 @@ The server resolves release scope, rollout, version comparison, and APK asset se
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.10.2`). That publishes to
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.11.0`). That publishes to
 GitHub Packages (`build.hands:hands-android-sdk:<version>`) and, on the first
 request, builds the same version on JitPack
 (`com.github.botiverse:hands:android-sdk-v<version>`) — so both channels stay in

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.10.2")
+    implementation("com.github.botiverse:hands:android-sdk-v0.11.0")
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.10.2")
+    implementation("build.hands:hands-android-sdk:0.11.0")
 }
 ```
 


### PR DESCRIPTION
Version bump for the 0.11.0 release (client-side delta apply, #247). Delta stays dormant until an app opts in via server-side delta_updates_enabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384892&installation_id=145465820&pr_number=280&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F280&signature=3b5be862b8bfe9cf69eea93bdd8ff62ba31a90b55c805227434696724d5da517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->