### PR TITLE
feat(feature-flags): general feature gate; delta offer per-device targeting

### DIFF
--- a/docs/feature-gate-design.md
+++ b/docs/feature-gate-design.md
@@ -1,0 +1,106 @@
+# Feature gate ("feature flags") — design
+
+A general, reusable **server-side feature gate**. A flag is **fail-safe OFF**:
+it is disabled unless a matching row explicitly enables it. Flags are evaluated
+per request, so a flag can target a single device (or cohort, or platform, or a
+percentage of devices) before an app-wide rollout.
+
+The first consumer is **delta-update offers** — so we can enable delta downloads
+for one test device, validate end-to-end, then widen the rollout.
+
+## Model
+
+Table `feature_flags` (migration `0042_feature_flags.sql`):
+
+| column             | type    | meaning                                                  |
+| ------------------ | ------- | -------------------------------------------------------- |
+| `id`               | TEXT PK | row id                                                   |
+| `app_id`           | TEXT    | nullable; `NULL` = **global default** for the key        |
+| `key`              | TEXT    | flag name, e.g. `delta_updates`                          |
+| `default_enabled`  | INTEGER | 0/1 — the fallback when no targeting rule matches        |
+| `rollout_percent`  | INTEGER | 0..100 — stable per-device percentage rollout            |
+| `allow_device_ids` | TEXT    | JSON array of device ids that are force-ON               |
+| `deny_device_ids`  | TEXT    | JSON array of device ids that are force-OFF              |
+| `allow_cohorts`    | TEXT    | JSON array of cohorts that are force-ON                  |
+| `platforms`        | TEXT    | JSON array; empty = all platforms, else an allow-list    |
+| `updated_at`       | INTEGER | last write (ms)                                          |
+| `updated_by`       | TEXT    | actor that last wrote                                    |
+
+`UNIQUE(app_id, key)`. A per-app row overrides the global (`app_id IS NULL`) row.
+
+The migration seeds one `delta_updates` row per app from the existing
+`apps.delta_updates_enabled` column, so behaviour before/after the migration is
+identical.
+
+## Evaluation precedence
+
+`isFeatureEnabled(db, key, { appId, deviceId?, cohort?, platform? })`
+(`worker/src/lib/feature_flags.ts`):
+
+1. Load the row for `(app_id = appId, key)`. If none, load the global row
+   (`app_id IS NULL, key`). If still none → **false** (fail-safe OFF).
+2. Evaluate the row — **first match wins**:
+   1. `deviceId ∈ deny_device_ids` → **false**
+   2. `deviceId ∈ allow_device_ids` → **true**
+   3. `cohort ∈ allow_cohorts` → **true**
+   4. `platforms` non-empty and `platform` not listed (or unknown) → **false**
+   5. `rollout_percent > 0` **and** we have a `deviceId`: stable bucket
+      `fnv1a32(key + ':' + deviceId) % 100 < rollout_percent` → **true**
+      (`>= 100` → always true). With no `deviceId`, rollout is skipped.
+   6. else → `default_enabled === 1`
+
+The rollout hash mirrors `rolloutBucket()` in `routes/public_v2.ts` (same FNV-1a
+32-bit hash), so a device keeps a stable bucket as the percentage climbs.
+
+The JSON array columns are parsed defensively (any parse error → `[]`), so a
+malformed row degrades to "no targeting" rather than throwing. `evaluateFlag()`
+is pure/synchronous and unit-testable in isolation.
+
+## Delta: generation vs. offer split
+
+Delta has **two** gates, deliberately separate:
+
+- **Generation** (`routes/delta.ts`, `routes/releases.ts`) stays gated by
+  `apps.delta_updates_enabled`. Generation happens at publish time and has **no
+  device context**, so a per-device flag makes no sense there.
+- **Offer** (`routes/public_v2.ts` `findDeltaPatch`) is gated by the
+  `delta_updates` feature flag. This is per request, so it *does* have a device
+  id + platform, enabling targeted rollout. When the gate is off, the update
+  response simply omits the `patch` field and the client downloads the full APK.
+
+So you can keep generating patches for an app (column ON) while only *offering*
+them to your allow-listed test device (flag `allow_device_ids = [deviceId]`).
+
+## Admin API
+
+- `GET /api/apps/:appId/feature-flags/:key` (viewer) — returns the flag row, or
+  a defaults object (`default_enabled: 0`, empty arrays) when none exists.
+- `PUT /api/apps/:appId/feature-flags/:key` (admin) — upserts. Body (all
+  optional; a partial PUT preserves untouched fields):
+  ```json
+  {
+    "default_enabled": true,
+    "rollout_percent": 25,
+    "allow_device_ids": ["device-123"],
+    "deny_device_ids": [],
+    "allow_cohorts": [],
+    "platforms": ["android"]
+  }
+  ```
+  `rollout_percent` must be an integer 0..100; the array fields must be arrays of
+  strings — otherwise `400`. Writes `updated_at` + `updated_by` and an
+  `app.feature_flag.update` audit log.
+
+## Recipe: enable delta for one test device
+
+1. Keep generating patches for the app (leave `apps.delta_updates_enabled = 1`
+   so publish produces delta assets).
+2. Point the flag at just your device:
+   ```
+   PUT /api/apps/<appId>/feature-flags/delta_updates
+   { "default_enabled": false, "allow_device_ids": ["<deviceId>"] }
+   ```
+   Only requests carrying `X-Hands-Device-Id: <deviceId>` (or `?device_id=`) get
+   the `patch` field; every other device gets the full APK.
+3. Validate the delta apply on that device, then widen: bump `rollout_percent`
+   (e.g. `25`, then `100`) or set `default_enabled: true`.

--- a/migrations/sql/0042_feature_flags.sql
+++ b/migrations/sql/0042_feature_flags.sql
@@ -1,0 +1,28 @@
+-- General server-side feature-gate ("feature flags") system. A reusable,
+-- fail-safe-OFF gate evaluated per request with per-device targeting. The first
+-- consumer is delta-update *offers* (routes/public_v2.ts findDeltaPatch), so we
+-- can enable delta for one test device before an app-wide rollout. Note: delta
+-- *generation* stays gated by apps.delta_updates_enabled (routes/delta.ts) —
+-- generation has no device context. See docs/feature-gate-design.md.
+--
+-- A row with app_id = NULL is the global default for a key; a row with a
+-- concrete app_id overrides it for that app. Uniqueness is on (app_id, key).
+CREATE TABLE feature_flags (
+  id TEXT PRIMARY KEY,
+  app_id TEXT,                 -- nullable: NULL = global default row
+  key TEXT NOT NULL,           -- e.g. 'delta_updates'
+  default_enabled INTEGER NOT NULL DEFAULT 0,
+  rollout_percent INTEGER NOT NULL DEFAULT 0,   -- 0..100
+  allow_device_ids TEXT NOT NULL DEFAULT '[]',  -- JSON array of device_id strings
+  deny_device_ids TEXT NOT NULL DEFAULT '[]',   -- JSON array
+  allow_cohorts TEXT NOT NULL DEFAULT '[]',     -- JSON array (optional dimension)
+  platforms TEXT NOT NULL DEFAULT '[]',         -- JSON array; empty = all platforms
+  updated_at INTEGER NOT NULL,
+  updated_by TEXT,
+  FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX idx_feature_flags_app_key ON feature_flags(app_id, key);
+-- Seed delta_updates from the existing per-app column so current behaviour is
+-- preserved: apps that already opted into delta keep offering it.
+INSERT INTO feature_flags (id, app_id, key, default_enabled, updated_at)
+SELECT lower(hex(randomblob(16))), id, 'delta_updates', delta_updates_enabled, 0 FROM apps;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -44,6 +44,8 @@ import {
   handlePublicAppIcon,
   handleGetClientKey,
   handleRotateClientKey,
+  handleGetFeatureFlag,
+  handleUpdateFeatureFlag,
 } from "./routes/apps";
 import {
   handlePublicListChannels,
@@ -599,6 +601,8 @@ admin.get("/api/apps/:appId", requireAppRole("viewer"), handleGetApp);
 admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);
 admin.post("/api/apps/:appId/purge", requireAppRole("admin"), handlePurgeApp);
+admin.get("/api/apps/:appId/feature-flags/:key", requireAppRole("viewer"), handleGetFeatureFlag);
+admin.put("/api/apps/:appId/feature-flags/:key", requireAppRole("admin"), handleUpdateFeatureFlag);
 
 admin.get("/api/apps/:appId/builds", requireAppRole("viewer"), handleListBuilds);
 admin.post("/api/apps/:appId/builds", requireAppRole("publisher"), handleCreateBuild);

--- a/worker/src/lib/feature_flags.ts
+++ b/worker/src/lib/feature_flags.ts
@@ -1,0 +1,136 @@
+/**
+ * Server-side feature gate ("feature flags").
+ *
+ * A reusable, fail-safe-OFF gate: the flag is OFF unless a matching row says
+ * otherwise. Evaluated per request so a flag can target a single device before
+ * an app-wide rollout. The first consumer is delta-update *offers*
+ * (routes/public_v2.ts findDeltaPatch). See docs/feature-gate-design.md.
+ *
+ * Kept dependency-free and pure (evaluateFlag) so it is trivially unit-testable.
+ */
+
+/**
+ * The subset of a feature_flags row needed to evaluate a gate. The JSON array
+ * columns are the raw stored strings; they are parsed defensively at eval time.
+ */
+export interface FeatureFlagRow {
+  default_enabled: number;
+  rollout_percent: number;
+  allow_device_ids: string;
+  deny_device_ids: string;
+  allow_cohorts: string;
+  platforms: string;
+}
+
+export interface FeatureContext {
+  appId: string;
+  deviceId?: string | null;
+  cohort?: string | null;
+  platform?: string | null;
+}
+
+/**
+ * Stable 32-bit FNV-1a hash. Mirrors rolloutBucket() in routes/public_v2.ts so
+ * a device keeps the same bucket for a given flag while the rollout climbs.
+ * Kept local so this module stays pure and dependency-free.
+ */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/** Parse a JSON array-of-strings column defensively; any error → []. */
+function parseStringArray(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Evaluate a loaded flag row against a context. Pure & synchronous. First match
+ * wins:
+ *  1. device in deny list        → false
+ *  2. device in allow list       → true
+ *  3. cohort in allow_cohorts    → true
+ *  4. platforms set & no match   → false
+ *  5. rollout_percent > 0 (needs a device id; stable per-device bucket) → maybe
+ *  6. else default_enabled === 1
+ */
+export function evaluateFlag(
+  row: FeatureFlagRow,
+  key: string,
+  ctx: FeatureContext,
+): boolean {
+  const deviceId = ctx.deviceId ?? null;
+
+  // 1. explicit deny by device.
+  if (deviceId && parseStringArray(row.deny_device_ids).includes(deviceId)) {
+    return false;
+  }
+  // 2. explicit allow by device.
+  if (deviceId && parseStringArray(row.allow_device_ids).includes(deviceId)) {
+    return true;
+  }
+  // 3. allow by cohort.
+  if (ctx.cohort && parseStringArray(row.allow_cohorts).includes(ctx.cohort)) {
+    return true;
+  }
+  // 4. platform restriction: when platforms is non-empty, a client whose
+  //    platform is unknown or not listed is gated out.
+  const platforms = parseStringArray(row.platforms);
+  if (platforms.length > 0 && (!ctx.platform || !platforms.includes(ctx.platform))) {
+    return false;
+  }
+  // 5. percentage rollout — only applies when we have a device id to bucket on.
+  const rollout = row.rollout_percent;
+  if (rollout > 0 && deviceId) {
+    if (rollout >= 100) return true;
+    if (fnv1a32(`${key}:${deviceId}`) % 100 < rollout) return true;
+  }
+  // 6. default.
+  return row.default_enabled === 1;
+}
+
+const LOAD_FLAG_SQL = `SELECT default_enabled, rollout_percent, allow_device_ids,
+       deny_device_ids, allow_cohorts, platforms
+  FROM feature_flags WHERE key = ?1 AND app_id IS ?2`;
+
+/**
+ * Load the flag row for (app_id, key), falling back to the global row
+ * (app_id IS NULL, key). Returns null when neither exists.
+ */
+async function loadFlag(
+  db: D1Database,
+  key: string,
+  appId: string,
+): Promise<FeatureFlagRow | null> {
+  const perApp = await db
+    .prepare(LOAD_FLAG_SQL)
+    .bind(key, appId)
+    .first<FeatureFlagRow>();
+  if (perApp) return perApp;
+  return db.prepare(LOAD_FLAG_SQL).bind(key, null).first<FeatureFlagRow>();
+}
+
+/**
+ * True when `key` is enabled for the given context. Missing row or any parse
+ * error → false (fail-safe OFF).
+ */
+export async function isFeatureEnabled(
+  db: D1Database,
+  key: string,
+  ctx: FeatureContext,
+): Promise<boolean> {
+  const row = await loadFlag(db, key, ctx.appId);
+  if (!row) return false; // fail-safe OFF.
+  return evaluateFlag(row, key, ctx);
+}

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -348,6 +348,177 @@ export async function handleUpdateApp(c: AdminContext) {
   return c.json({ ok: true });
 }
 
+/** Defaults returned when an app has no explicit feature_flags row for a key. */
+const FEATURE_FLAG_DEFAULTS = {
+  default_enabled: 0,
+  rollout_percent: 0,
+  allow_device_ids: "[]",
+  deny_device_ids: "[]",
+  allow_cohorts: "[]",
+  platforms: "[]",
+};
+
+/** GET /api/apps/:appId/feature-flags/:key — read a feature flag (viewer). */
+export async function handleGetFeatureFlag(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const key = c.req.param("key") ?? "";
+  const app = await c.env.DB.prepare("SELECT id FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string }>();
+  if (!app) return c.json({ error: "not found" }, 404);
+  const row = await c.env.DB.prepare(
+    `SELECT id, app_id, key, default_enabled, rollout_percent, allow_device_ids,
+            deny_device_ids, allow_cohorts, platforms, updated_at, updated_by
+     FROM feature_flags WHERE app_id = ?1 AND key = ?2`,
+  )
+    .bind(appId, key)
+    .first();
+  if (!row) {
+    return c.json({
+      app_id: appId,
+      key,
+      ...FEATURE_FLAG_DEFAULTS,
+      updated_at: null,
+      updated_by: null,
+    });
+  }
+  return c.json(row);
+}
+
+/** PUT /api/apps/:appId/feature-flags/:key — upsert a feature flag (admin). */
+export async function handleUpdateFeatureFlag(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const key = c.req.param("key") ?? "";
+  const body = (await c.req.json().catch(() => ({}))) as {
+    default_enabled?: boolean;
+    rollout_percent?: number;
+    allow_device_ids?: string[];
+    deny_device_ids?: string[];
+    allow_cohorts?: string[];
+    platforms?: string[];
+  };
+  // Confirm app exists.
+  const existing = await c.env.DB.prepare("SELECT id FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string }>();
+  if (!existing) return c.json({ error: "not found" }, 404);
+
+  const isStringArray = (v: unknown): v is string[] =>
+    Array.isArray(v) && v.every((x) => typeof x === "string");
+
+  if (body.rollout_percent !== undefined) {
+    if (
+      typeof body.rollout_percent !== "number" ||
+      !Number.isInteger(body.rollout_percent) ||
+      body.rollout_percent < 0 ||
+      body.rollout_percent > 100
+    ) {
+      return c.json({ error: "rollout_percent must be an integer 0..100" }, 400);
+    }
+  }
+  const arrayFields = [
+    "allow_device_ids",
+    "deny_device_ids",
+    "allow_cohorts",
+    "platforms",
+  ] as const;
+  for (const field of arrayFields) {
+    if (body[field] !== undefined && !isStringArray(body[field])) {
+      return c.json({ error: `${field} must be an array of strings` }, 400);
+    }
+  }
+
+  // Load the current row (if any) so a partial PUT preserves the other fields.
+  const current = await c.env.DB.prepare(
+    `SELECT default_enabled, rollout_percent, allow_device_ids, deny_device_ids,
+            allow_cohorts, platforms
+     FROM feature_flags WHERE app_id = ?1 AND key = ?2`,
+  )
+    .bind(appId, key)
+    .first<{
+      default_enabled: number;
+      rollout_percent: number;
+      allow_device_ids: string;
+      deny_device_ids: string;
+      allow_cohorts: string;
+      platforms: string;
+    }>();
+
+  const defaultEnabled =
+    body.default_enabled !== undefined
+      ? body.default_enabled
+        ? 1
+        : 0
+      : current?.default_enabled ?? 0;
+  const rolloutPercent =
+    body.rollout_percent !== undefined
+      ? body.rollout_percent
+      : current?.rollout_percent ?? 0;
+  const allowDeviceIds =
+    body.allow_device_ids !== undefined
+      ? JSON.stringify(body.allow_device_ids)
+      : current?.allow_device_ids ?? "[]";
+  const denyDeviceIds =
+    body.deny_device_ids !== undefined
+      ? JSON.stringify(body.deny_device_ids)
+      : current?.deny_device_ids ?? "[]";
+  const allowCohorts =
+    body.allow_cohorts !== undefined
+      ? JSON.stringify(body.allow_cohorts)
+      : current?.allow_cohorts ?? "[]";
+  const platforms =
+    body.platforms !== undefined
+      ? JSON.stringify(body.platforms)
+      : current?.platforms ?? "[]";
+  const now = Date.now();
+  const actor = currentActor(c);
+
+  await c.env.DB.prepare(
+    `INSERT INTO feature_flags
+       (id, app_id, key, default_enabled, rollout_percent, allow_device_ids,
+        deny_device_ids, allow_cohorts, platforms, updated_at, updated_by)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+     ON CONFLICT(app_id, key) DO UPDATE SET
+       default_enabled = excluded.default_enabled,
+       rollout_percent = excluded.rollout_percent,
+       allow_device_ids = excluded.allow_device_ids,
+       deny_device_ids = excluded.deny_device_ids,
+       allow_cohorts = excluded.allow_cohorts,
+       platforms = excluded.platforms,
+       updated_at = excluded.updated_at,
+       updated_by = excluded.updated_by`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      appId,
+      key,
+      defaultEnabled,
+      rolloutPercent,
+      allowDeviceIds,
+      denyDeviceIds,
+      allowCohorts,
+      platforms,
+      now,
+      actor,
+    )
+    .run();
+
+  await c.env.DB.prepare(
+    "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+  )
+    .bind(
+      crypto.randomUUID(),
+      appId,
+      "app.feature_flag.update",
+      actor,
+      JSON.stringify({ key, ...body }),
+      now,
+    )
+    .run();
+
+  return c.json({ ok: true });
+}
+
 const APP_ICON_MAX_BYTES = 1024 * 1024;
 
 /** PUT /api/apps/:appId/icon — upload a PNG/WebP app icon (<=1MB). */

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -21,6 +21,7 @@ import type { Context } from "hono";
 import { requestOrigin } from "../lib/origin";
 import { presignR2DownloadUrl } from "../lib/r2_presign";
 import { parseReleaseNotes, resolveReleaseNote, type ReleaseNotes } from "../lib/release_notes";
+import { isFeatureEnabled } from "../lib/feature_flags";
 
 interface ScopedResolution {
   release_id: string;
@@ -436,6 +437,8 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
   // a patch to the latest build for its arch, and that patch is meaningfully
   // smaller than the full APK, offer it. The full `asset` stays the fallback;
   // old SDKs ignore the extra `patch` field. See docs/delta-download-design.md.
+  const deviceId =
+    c.req.header("X-Hands-Device-Id") ?? c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
   const patch =
     currentVersionCode > 0
       ? await findDeltaPatch(c, {
@@ -445,6 +448,8 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
           fullSizeBytes: asset.size_bytes,
           origin: publicRequestOrigin(c),
           ttl: latest.expires_in,
+          deviceId,
+          platform: requestedPlatform,
         })
       : null;
 
@@ -487,6 +492,8 @@ async function findDeltaPatch(
     fullSizeBytes: number;
     origin: string;
     ttl: number;
+    deviceId: string | null;
+    platform: string | null;
   },
 ): Promise<{
   from_version_code: number;
@@ -495,18 +502,26 @@ async function findDeltaPatch(
   size_bytes: number;
   target_sha256: string | null;
 } | null> {
-  // Server-side kill switch: only offer deltas when the app has opted in
-  // (delta_updates_enabled — the same per-app flag that gates delta generation).
-  // When off, no `patch` field is returned at all, so the client never sees or
-  // downloads an incremental — it just gets the full APK.
+  // Server-side feature gate for the delta *offer*: only offer deltas when the
+  // `delta_updates` feature flag is enabled for this app + device. This allows
+  // per-device targeting (enable delta for one test device before an app-wide
+  // rollout). Delta *generation* stays gated by apps.delta_updates_enabled
+  // (routes/delta.ts) — generation has no device context. When the gate is off,
+  // no `patch` field is returned at all, so the client just gets the full APK.
   const app = await c.env.DB.prepare(
-    `SELECT a.delta_updates_enabled AS delta_updates_enabled
+    `SELECT a.id AS app_id
      FROM builds b JOIN apps a ON a.id = b.app_id
      WHERE b.id = ?1`,
   )
     .bind(args.buildId)
-    .first<{ delta_updates_enabled: number }>();
-  if (!app || app.delta_updates_enabled !== 1) return null;
+    .first<{ app_id: string }>();
+  if (!app) return null;
+  const enabled = await isFeatureEnabled(c.env.DB, "delta_updates", {
+    appId: app.app_id,
+    deviceId: args.deviceId,
+    platform: args.platform,
+  });
+  if (!enabled) return null;
 
   const row = await c.env.DB.prepare(
     `SELECT r2_key, size_bytes, arch,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -100,6 +100,21 @@ function makeMockDb() {
       archived_at INTEGER, created_at INTEGER NOT NULL, icon_r2_key TEXT, public_history INTEGER NOT NULL DEFAULT 0, client_key TEXT,
       delta_updates_enabled INTEGER NOT NULL DEFAULT 0
     );
+    CREATE TABLE feature_flags (
+      id TEXT PRIMARY KEY,
+      app_id TEXT,
+      key TEXT NOT NULL,
+      default_enabled INTEGER NOT NULL DEFAULT 0,
+      rollout_percent INTEGER NOT NULL DEFAULT 0,
+      allow_device_ids TEXT NOT NULL DEFAULT '[]',
+      deny_device_ids TEXT NOT NULL DEFAULT '[]',
+      allow_cohorts TEXT NOT NULL DEFAULT '[]',
+      platforms TEXT NOT NULL DEFAULT '[]',
+      updated_at INTEGER NOT NULL,
+      updated_by TEXT,
+      FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
+    );
+    CREATE UNIQUE INDEX idx_feature_flags_app_key ON feature_flags(app_id, key);
     CREATE TABLE channels (
       id TEXT PRIMARY KEY, app_id TEXT NOT NULL, slug TEXT NOT NULL,
       name TEXT NOT NULL, bundle_id TEXT, password TEXT, git_url TEXT,
@@ -3303,9 +3318,12 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(gatedOff.update_available).toBe(true);
     expect(gatedOff.patch).toBeUndefined();
 
-    // Opt the app into delta updates.
-    await env.DB.prepare("UPDATE apps SET delta_updates_enabled = 1 WHERE id = ?1")
-      .bind("app-scope").run();
+    // Opt the app into delta updates via the feature flag (the delta *offer*
+    // is now gated by the `delta_updates` feature flag, not apps.delta_updates_enabled).
+    await env.DB.prepare(
+      `INSERT INTO feature_flags (id, app_id, key, default_enabled, updated_at)
+       VALUES ('ff-delta-existing', 'app-scope', 'delta_updates', 1, ?1)`,
+    ).bind(Date.now()).run();
 
     // Client on 10 → patch offered with target hash + signed URL.
     const offered = await responseJson<any>(await call("10"));
@@ -3334,6 +3352,90 @@ describe("quiver public API v2 — scope resolution", () => {
     });
     const bigPatch = await responseJson<any>(await call("5"));
     expect(bigPatch.patch).toBeUndefined();
+  });
+
+  it("delta offer respects the delta_updates feature flag (default off/on, per-device allow/deny)", async () => {
+    const env = makeEnv();
+    const { handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    await seedRelease(env, "rel-ff", "build-ff", [["full", "all"]], {
+      versionCode: 20,
+      versionName: "1.0.20",
+    });
+    await seedAsset(env, "build-ff", "asset-ff-full", { arch: "arm64-v8a", sizeBytes: 1000 });
+    await seedAsset(env, "build-ff", "asset-ff-patch", {
+      artifactKind: "delta-patch",
+      arch: "arm64-v8a",
+      filetype: "patch",
+      sizeBytes: 200,
+      r2Key: "apps/app-scope/patch-ff-10-20.patch",
+      metadata: {
+        from_version_code: 10,
+        to_version_code: 20,
+        algorithm: "archive-patcher-v1",
+        target_sha256: "cafef00d",
+      },
+    });
+
+    const call = (deviceId: string) =>
+      handlePublicV2UpdateCheck(
+        makePublicContext(env, {
+          channel: "production",
+          product_type: "android-apk",
+          current_version_code: "10",
+          platform: "android",
+          arch: "arm64-v8a",
+          device_id: deviceId,
+        }),
+      );
+
+    // Replace the (single) delta_updates flag row with a fresh config.
+    const setFlag = async (opts: {
+      default_enabled?: number;
+      allow?: string[];
+      deny?: string[];
+    }) => {
+      await env.DB.prepare(
+        "DELETE FROM feature_flags WHERE app_id = ?1 AND key = 'delta_updates'",
+      )
+        .bind("app-scope")
+        .run();
+      await env.DB.prepare(
+        `INSERT INTO feature_flags
+           (id, app_id, key, default_enabled, allow_device_ids, deny_device_ids, updated_at)
+         VALUES ('ff-delta', 'app-scope', 'delta_updates', ?1, ?2, ?3, ?4)`,
+      )
+        .bind(
+          opts.default_enabled ?? 0,
+          JSON.stringify(opts.allow ?? []),
+          JSON.stringify(opts.deny ?? []),
+          Date.now(),
+        )
+        .run();
+    };
+
+    // (a) No flag row → fail-safe OFF → delta not offered.
+    const none = await responseJson<any>(await call("dev-a"));
+    expect(none.update_available).toBe(true);
+    expect(none.patch).toBeUndefined();
+
+    // (b) default_enabled = 1 → offered.
+    await setFlag({ default_enabled: 1 });
+    const on = await responseJson<any>(await call("dev-a"));
+    expect(on.patch).toMatchObject({ from_version_code: 10, size_bytes: 200 });
+
+    // (c) default off but allow_device_ids contains dev-a → offered ONLY for dev-a.
+    await setFlag({ default_enabled: 0, allow: ["dev-a"] });
+    const allowed = await responseJson<any>(await call("dev-a"));
+    expect(allowed.patch).toMatchObject({ from_version_code: 10 });
+    const otherDevice = await responseJson<any>(await call("dev-b"));
+    expect(otherDevice.patch).toBeUndefined();
+
+    // (d) deny overrides default-on: dev-a denied, dev-b still offered.
+    await setFlag({ default_enabled: 1, deny: ["dev-a"] });
+    const denied = await responseJson<any>(await call("dev-a"));
+    expect(denied.patch).toBeUndefined();
+    const notDenied = await responseJson<any>(await call("dev-b"));
+    expect(notDenied.patch).toMatchObject({ from_version_code: 10 });
   });
 
   it("public R2 download serves active release assets with a valid signature", async () => {


### PR DESCRIPTION
General server-side feature gate (feature_flags + isFeatureEnabled, fail-safe OFF). First use: delta *offer* gating so delta can be enabled for a single test device (allow_device_ids) or a % rollout before app-wide. Generation stays on delta_updates_enabled. Migration seeds delta_updates from the existing column. Admin GET/PUT /api/apps/:appId/feature-flags/:key. Design doc included. 141 worker tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786389063&installation_id=145465820&pr_number=281&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F281&signature=a081704b40e14977525a4ec22c565e8bd8f0f40d363627eb2673a3e661556ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->