### PR TITLE
feat(feedback): let org members triage feedback (status + comments)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -174,6 +174,7 @@ import {
 import {
   requireAppRole,
   requireCurrentOrgRole,
+  requireFeedbackTriageRole,
   requireOrgRole,
 } from "./lib/permissions";
 import { openApiDocument } from "./openapi";
@@ -643,8 +644,8 @@ admin.get("/api/apps/:appId/analytics/devices/:deviceId", requireAppRole("viewer
 admin.get("/api/apps/:appId/release-health", requireAppRole("viewer"), handleReleaseHealth);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
-admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRole("publisher"), handleUpdateFeedback);
-admin.post("/api/apps/:appId/feedback/:ticketId/comments", requireAppRole("publisher"), handleAddFeedbackComment);
+admin.patch("/api/apps/:appId/feedback/:ticketId", requireFeedbackTriageRole(), handleUpdateFeedback);
+admin.post("/api/apps/:appId/feedback/:ticketId/comments", requireFeedbackTriageRole(), handleAddFeedbackComment);
 admin.get("/api/apps/:appId/feedback/:ticketId/attachments/:attachmentId", requireAppRole("viewer"), handleDownloadFeedbackAttachment);
 admin.get("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("viewer"), handleListReleaseShares);
 admin.post("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("publisher"), handleCreateReleaseShare);

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -209,7 +209,12 @@ export async function ensureOrgRole(c: AdminContext, orgId: string, minimum: Org
   return { ok: true as const, role };
 }
 
-export async function ensureAppRole(c: AdminContext, appId: string, minimum: AppRole) {
+export async function ensureAppRole(
+  c: AdminContext,
+  appId: string,
+  minimum: AppRole,
+  opts?: { orgMinimum?: OrgRole },
+) {
   if (devTokenBypass(c)) return { ok: true as const, app_role: "admin" as AppRole, org_role: "owner" as OrgRole };
   const deployToken = currentDeployToken(c);
   if (deployToken) {
@@ -257,10 +262,11 @@ export async function ensureAppRole(c: AdminContext, appId: string, minimum: App
     };
   }
   const role = await getEffectiveRole(c.env.DB, account.id, { appId });
-  const orgAllows =
-    minimum === "viewer"
-      ? isOrgAtLeast(role.org_role, "viewer")
-      : isOrgAtLeast(role.org_role, "admin");
+  // Default org bar: a plain app action needs org admin (or the app-role
+  // fallback below); a viewer action only needs org viewer. Callers can lower
+  // the org bar via opts.orgMinimum (e.g. feedback triage → org member).
+  const orgMinimum = opts?.orgMinimum ?? (minimum === "viewer" ? "viewer" : "admin");
+  const orgAllows = isOrgAtLeast(role.org_role, orgMinimum);
   const appAllows = isAppAtLeast(role.app_role, minimum);
   if (!orgAllows && !appAllows) {
     return {
@@ -310,6 +316,22 @@ export function requireAppRole(minimum: AppRole): MiddlewareHandler<RoleContext>
     const appId = c.req.param("appId");
     if (!appId) return c.json({ error: "missing appId" }, 400);
     const allowed = await ensureAppRole(c, appId, minimum);
+    if (!allowed.ok) return allowed.response;
+    await next();
+  };
+}
+
+/**
+ * Feedback triage (update status/assignee, add comments) is a member-level
+ * operation: any org member — not just app publishers/admins — can triage an
+ * app's feedback tickets. Existing app publishers/admins still pass via the
+ * app-role fallback; bare viewers (read-only) still cannot write.
+ */
+export function requireFeedbackTriageRole(): MiddlewareHandler<RoleContext> {
+  return async (c, next) => {
+    const appId = c.req.param("appId");
+    if (!appId) return c.json({ error: "missing appId" }, 400);
+    const allowed = await ensureAppRole(c, appId, "publisher", { orgMinimum: "member" });
     if (!allowed.ok) return allowed.response;
     await next();
   };

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -714,7 +714,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
     start_here: [
       "1. Authenticate (see `auth` below), then GET /api/apps to find your app_id.",
       "2. Crash triage: list-feedback (kind=crash) → get-feedback (device context + attachments) → presign-feedback-attachment, then curl the returned download_url yourself (raw-bytes endpoints get corrupted through agent transports).",
-      "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires app publisher.",
+      "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
     ],
     auth: {
       raft_agents:
@@ -928,7 +928,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "update-feedback",
         description:
-          "Update a feedback/crash ticket's status and/or assignee — the triage write path (e.g. close a ticket already fixed elsewhere). Requires app publisher.",
+          "Update a feedback/crash ticket's status and/or assignee — the triage write path (e.g. close a ticket already fixed elsewhere). Requires org member (or app publisher).",
         endpoint: { method: "PATCH", path: "/api/apps/{app_id}/feedback/{ticket_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
@@ -940,7 +940,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "comment-feedback",
         description:
-          "Add a comment to a feedback/crash ticket — use for triage attribution (e.g. 'fixed by mobile #555'). Requires app publisher. Set internal=true for a staff-only note not shown to the reporter.",
+          "Add a comment to a feedback/crash ticket — use for triage attribution (e.g. 'fixed by mobile #555'). Requires org member (or app publisher). Set internal=true for a staff-only note not shown to the reporter.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/feedback/{ticket_id}/comments" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -20,7 +20,8 @@ import Database from "better-sqlite3";
 import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
-import { requireCurrentOrgRole } from "../src/lib/permissions";
+import { requireCurrentOrgRole, requireFeedbackTriageRole } from "../src/lib/permissions";
+import { handleUpdateFeedback, handleAddFeedbackComment } from "../src/routes/feedback";
 import {
   httpsRedirectUrl,
   isSecureRequest,
@@ -844,6 +845,135 @@ describe("quiver route handlers — SQL smoke", () => {
       .bind("member-app")
       .all();
     expect(seededChannels.results.map((row: any) => row.slug)).toEqual(["main", "nightly", "preview"]);
+  });
+
+  it("lets org members triage feedback (update status + comment) while viewers cannot", async () => {
+    const now = Date.now();
+    const memberToken = "fb-member-token";
+    const viewerToken = "fb-viewer-token";
+    const ticketId = "11111111-2222-4333-8444-555555555555";
+
+    await env.DB
+      .prepare(
+        `INSERT INTO organizations
+         (id, slug, name, external_provider, external_id, created_at, archived)
+         VALUES (?, ?, ?, 'raft', ?, ?, 0)`,
+      )
+      .bind("raft_fb", "fb-org", "FB Org", "fb-server", now)
+      .run();
+
+    await env.DB
+      .prepare(
+        "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .bind("fb-app", "raft_fb", "fb-app", "FB App", "android", now)
+      .run();
+
+    await env.DB
+      .prepare(
+        `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+         VALUES (?, ?, 'crash', 'open', ?, '{}', ?, ?)`,
+      )
+      .bind(ticketId, "fb-app", "boom", now, now)
+      .run();
+
+    for (const account of [
+      { id: "fb-member-agent", subject: "fb-member-sub", role: "member", token: memberToken },
+      { id: "fb-viewer-agent", subject: "fb-viewer-sub", role: "viewer", token: viewerToken },
+    ]) {
+      await env.DB
+        .prepare(
+          `INSERT INTO raft_accounts
+           (id, provider, provider_subject, server_id, server_slug, principal_type,
+            server_role, username, display_name, avatar_url, raw_profile,
+            created_at, updated_at, last_login_at)
+           VALUES (?, 'raft', ?, 'fb-server', 'fb-org', 'agent',
+                   NULL, ?, ?, NULL, '{}', ?, ?, ?)`,
+        )
+        .bind(account.id, account.subject, account.id, account.id, now, now, now)
+        .run();
+      await env.DB
+        .prepare(
+          "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(`orgmem-${account.id}`, "raft_fb", account.id, account.role, now)
+        .run();
+      await env.DB
+        .prepare(
+          "INSERT INTO raft_sessions (id, account_id, token_hash, created_at, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+          `session-${account.id}`,
+          account.id,
+          createHash("sha256").update(account.token).digest("hex"),
+          now,
+          now + 60_000,
+          now,
+        )
+        .run();
+    }
+
+    const testApp = new Hono<{ Bindings: Env }>();
+    testApp.use("*", authMiddleware as any);
+    testApp.patch(
+      "/api/apps/:appId/feedback/:ticketId",
+      requireFeedbackTriageRole() as any,
+      handleUpdateFeedback as any,
+    );
+    testApp.post(
+      "/api/apps/:appId/feedback/:ticketId/comments",
+      requireFeedbackTriageRole() as any,
+      handleAddFeedbackComment as any,
+    );
+
+    // Org viewer (read-only) cannot triage.
+    const viewerResponse = await testApp.request(
+      `https://quiver-worker.test/api/apps/fb-app/feedback/${ticketId}`,
+      {
+        method: "PATCH",
+        headers: { authorization: `Bearer ${viewerToken}`, "content-type": "application/json" },
+        body: JSON.stringify({ status: "resolved" }),
+      },
+      env as any,
+    );
+    expect(viewerResponse.status).toBe(403);
+
+    // Org member (no explicit app role) can change status...
+    const memberStatus = await testApp.request(
+      `https://quiver-worker.test/api/apps/fb-app/feedback/${ticketId}`,
+      {
+        method: "PATCH",
+        headers: { authorization: `Bearer ${memberToken}`, "content-type": "application/json" },
+        body: JSON.stringify({ status: "resolved" }),
+      },
+      env as any,
+    );
+    expect(memberStatus.status).toBe(200);
+    await expect(memberStatus.json()).resolves.toMatchObject({ id: ticketId, status: "resolved" });
+
+    // ...and add an attribution comment.
+    const memberComment = await testApp.request(
+      `https://quiver-worker.test/api/apps/fb-app/feedback/${ticketId}/comments`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${memberToken}`, "content-type": "application/json" },
+        body: JSON.stringify({ body: "fixed by mobile #999", internal: true }),
+      },
+      env as any,
+    );
+    expect(memberComment.status).toBe(201);
+
+    const ticket = (await env.DB
+      .prepare("SELECT status FROM feedback_tickets WHERE id = ?")
+      .bind(ticketId)
+      .first()) as { status: string } | null;
+    expect(ticket?.status).toBe("resolved");
+    const comment = (await env.DB
+      .prepare("SELECT body, internal FROM feedback_comments WHERE ticket_id = ?")
+      .bind(ticketId)
+      .first()) as { body: string; internal: number } | null;
+    expect(comment?.body).toBe("fixed by mobile #999");
+    expect(comment?.internal).toBe(1);
   });
 
   it("uses a validated selected-org header for org-scoped app requests", async () => {


### PR DESCRIPTION
## What
Feedback triage — `update-feedback` (status/assignee) and `comment-feedback` — previously required **app publisher**. Org **members** (the org_role most agents have) hit HTTP 403 and could not mark tickets `in_progress`, close them, or add attribution comments. That blocks the "whoever handles it marks it" triage discipline artin asked for.

## Change
- New `requireFeedbackTriageRole()` middleware with bar = **org ≥ member OR app ≥ publisher**.
  - Existing app publishers/admins still pass (app-role fallback).
  - Bare read-only viewers still cannot write.
- Implemented by generalizing `ensureAppRole(...)` with an optional `orgMinimum` override; default behavior for every other route is unchanged.
- Pointed the two feedback routes at the new middleware.
- Updated the `raft-agent-manifest` action descriptions (`update-feedback` / `comment-feedback`) from "Requires app publisher" → "Requires org member (or app publisher)".

## Test
- New integration test: an org member (no explicit app role) can PATCH status + POST an attribution comment; an org viewer gets 403.
- `tsc --noEmit` clean; full worker suite **142 passed**.

## Why
Unblocks the KMP agents' task #46/#47/#48 feedback audits so they self-serve (no cross-app proxying, no per-agent publisher grants). Per @artin: "关 feedback 权限就 member 就行 / 你先修复服务端吧".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786439519&installation_id=145465820&pr_number=282&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F282&signature=615c096ab4eebd969fb4b91bec300b101728d490726e0fa1ce9da7bfd32ab4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->