### PR TITLE
feat(rbac): right-size two over-privileged endpoints + permissions reference

### DIFF
--- a/docs/feature-gate-design.md
+++ b/docs/feature-gate-design.md
@@ -75,7 +75,7 @@ them to your allow-listed test device (flag `allow_device_ids = [deviceId]`).
 
 - `GET /api/apps/:appId/feature-flags/:key` (viewer) — returns the flag row, or
   a defaults object (`default_enabled: 0`, empty arrays) when none exists.
-- `PUT /api/apps/:appId/feature-flags/:key` (admin) — upserts. Body (all
+- `PUT /api/apps/:appId/feature-flags/:key` (publisher) — upserts. Body (all
   optional; a partial PUT preserves untouched fields):
   ```json
   {

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -123,6 +123,8 @@ The Access page controls who can see or publish an app.
 
 Deploy tokens are app-scoped bearer tokens. Create them for automation instead of reusing a human browser session. Copy the token when it is created; Hands only shows the raw token once. Each token records who created it, and actions performed with it are attributed as `deploy-token:<name>@<app>` in audit logs and release provenance.
 
+Roles range from `viewer` (read) through `member` (collaborate — e.g. triage feedback), `publisher` (ship builds/releases), to `admin` (configure, manage members, hold secrets). See the [permissions reference](../rbac-permissions.md) for the full role model and the endpoint→role matrix.
+
 ## Common Issues
 
 ### No update is found

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -121,6 +121,11 @@ Crash tickets carry a grouping signature and, when the build's
 `mapping.txt` was uploaded, an auto-retraced stack in the comments.
 `GET /api/apps/:id/feedback/crash-groups` aggregates by signature.
 
+Triage is a **member-level** operation: reading tickets needs `viewer`, and
+updating status/assignee or adding comments needs org **member** (or an app
+`publisher` — e.g. a publisher deploy token). See the
+[permissions reference](../rbac-permissions.md) for the full role matrix.
+
 ### Share links
 
 ```bash

--- a/docs/rbac-permissions.md
+++ b/docs/rbac-permissions.md
@@ -1,0 +1,88 @@
+# Hands RBAC — roles & permissions reference
+
+Hands uses **role-based access control** (RBAC) with two role scopes: an
+**organization** role and a per-**app** role. Every admin API endpoint declares
+the minimum role required; the public (client) update/download/feedback-submit
+API is separate and needs no admin role.
+
+## Roles
+
+**Org roles** (rank low→high): `viewer` < `member` < `admin` < `owner`
+**App roles** (rank low→high): `viewer` < `publisher` < `admin`
+
+- **viewer** — read-only: browse apps, builds, releases, analytics, feedback.
+- **member** — a collaborating team member: everything viewer can do, plus
+  member-level writes (today: feedback triage).
+- **publisher** (app) — ships: create builds/assets, publish/roll out/roll back
+  releases, manage share links, toggle rollout/feature flags.
+- **admin** — configures and secures: app settings, channels & types, member and
+  server-grant management, deploy tokens, client keys, store credentials, and
+  destructive actions (archive/purge/delete).
+- **owner** (org) — org superuser.
+
+## How a role is resolved
+
+For an app request, `ensureAppRole` grants access if **either** bar is met:
+
+- the caller's **org** role is high enough, **or**
+- their explicit **app** role is high enough.
+
+Org role overrides app role, so an org admin/owner implicitly has admin on every
+app in the org. The default org bar is `viewer` for read endpoints and `admin`
+for write endpoints — except endpoints that opt into a lower org bar:
+
+- **Feedback triage** (`requireFeedbackTriageRole`) uses org bar **member** (or
+  app `publisher`). So any org member can triage; a bare read-only viewer cannot.
+
+**Deploy tokens** carry only an app role (`viewer` or `publisher`) and no org
+role, so a token uses the app-role bar directly — e.g. a `publisher` token can
+triage feedback, a `viewer` token can only read it.
+
+## Endpoint → minimum role
+
+Reads (`GET`/list/stream/download/analytics) are `viewer` unless noted.
+
+| Area | Write endpoints | Min role |
+| --- | --- | --- |
+| **Feedback triage** | `PATCH feedback/:id`, `POST feedback/:id/comments` | **member** (or app publisher) |
+| **App create** | `POST /api/apps` | org member |
+| **APK parse** | `POST /api/parse-apk` | org member |
+| **Builds** | `POST builds`, `PATCH builds/:id`, `POST builds/:id/assets`, `POST upload` | publisher |
+| **Releases** | `POST/PATCH/DELETE releases`, `publish`, `rollback`, `bump-rollout`, `force-update` | publisher |
+| **Release shares** | `POST/PATCH/DELETE releases/:id/shares` | publisher |
+| **Rollout / feature flags** | `PUT feature-flags/:key` | publisher |
+| **Operations** | `POST operations/:id/retry` | publisher |
+| **App config** | `PATCH app`, `POST/PATCH/DELETE channels`, `product-types`, `release-types` | admin |
+| **App icon** | `PUT icon` | publisher |
+| **Membership & access** | `POST/PATCH/DELETE members`, `server-grants`, `deploy-tokens` | admin |
+| **Secrets** | `client-key`, `rotate-client-key`, `asc-credentials`, `agc-credentials` (get/put/verify/submit) | admin |
+| **Destructive** | `POST archive`, `POST purge`, `DELETE builds/:id`, `DELETE operations/:id` | admin |
+
+Reads gated above viewer (sensitive metadata): `GET deploy-tokens`,
+`GET client-key`, `GET asc-credentials`, `GET agc-credentials`,
+`GET agc-submissions/:id` require **admin**.
+
+## 403 responses are machine-readable
+
+A denied call returns the required and current role plus a `next_action` and a
+`manage_url` pointing at where an admin grants the role — act on it, don't just
+fail:
+
+```json
+{
+  "error": "insufficient_app_role",
+  "code": "INSUFFICIENT_APP_ROLE",
+  "required_role": "publisher",
+  "current_role": "viewer",
+  "next_action": "...ask an admin to grant you the 'publisher' role on this app (Access → Members).",
+  "manage_url": "https://app.hands.build/apps/{appId}/settings"
+}
+```
+
+## Changing an operation's required role
+
+Route guards live in `worker/src/index.ts` (`requireAppRole("<role>")`,
+`requireOrgRole(...)`, or a purpose-built guard like
+`requireFeedbackTriageRole()`); the role helpers and `ensureAppRole` live in
+`worker/src/lib/permissions.ts`. When you change a bar, update this table, the
+handler doc comment, and any agent/admin guide that names the role.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -603,7 +603,9 @@ admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);
 admin.post("/api/apps/:appId/purge", requireAppRole("admin"), handlePurgeApp);
 admin.get("/api/apps/:appId/feature-flags/:key", requireAppRole("viewer"), handleGetFeatureFlag);
-admin.put("/api/apps/:appId/feature-flags/:key", requireAppRole("admin"), handleUpdateFeatureFlag);
+// Feature flags are rollout controls (like bump-rollout / force-update), so they
+// sit at the publisher (ship) tier rather than admin.
+admin.put("/api/apps/:appId/feature-flags/:key", requireAppRole("publisher"), handleUpdateFeatureFlag);
 
 admin.get("/api/apps/:appId/builds", requireAppRole("viewer"), handleListBuilds);
 admin.post("/api/apps/:appId/builds", requireAppRole("publisher"), handleCreateBuild);
@@ -818,7 +820,8 @@ admin.post(
   requireAppRole("publisher"),
   handleGenerateDeltaPatches,
 );
-admin.get("/api/apps/:appId/delta-sources", requireAppRole("publisher"), handleDeltaSources);
+// delta-sources is a read-only listing; align it with every other GET at viewer.
+admin.get("/api/apps/:appId/delta-sources", requireAppRole("viewer"), handleDeltaSources);
 
 app.route("/", admin);
 

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -385,7 +385,7 @@ export async function handleGetFeatureFlag(c: AdminContext) {
   return c.json(row);
 }
 
-/** PUT /api/apps/:appId/feature-flags/:key — upsert a feature flag (admin). */
+/** PUT /api/apps/:appId/feature-flags/:key — upsert a feature flag (publisher). */
 export async function handleUpdateFeatureFlag(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const key = c.req.param("key") ?? "";

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -20,7 +20,7 @@ import Database from "better-sqlite3";
 import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
-import { requireCurrentOrgRole, requireFeedbackTriageRole } from "../src/lib/permissions";
+import { requireAppRole, requireCurrentOrgRole, requireFeedbackTriageRole } from "../src/lib/permissions";
 import { handleUpdateFeedback, handleAddFeedbackComment } from "../src/routes/feedback";
 import {
   httpsRedirectUrl,
@@ -28,7 +28,7 @@ import {
   requestOrigin,
 } from "../src/lib/origin";
 import { openApiDocument } from "../src/openapi";
-import { handleCreateApp, handleListApps } from "../src/routes/apps";
+import { handleCreateApp, handleListApps, handleUpdateFeatureFlag } from "../src/routes/apps";
 import { createSignedJwt, handleAuthLogin, handleAuthMe, handleDashboardRedirect } from "../src/routes/auth";
 import { handleListOrgs } from "../src/routes/orgs";
 
@@ -974,6 +974,105 @@ describe("quiver route handlers — SQL smoke", () => {
       .first()) as { body: string; internal: number } | null;
     expect(comment?.body).toBe("fixed by mobile #999");
     expect(comment?.internal).toBe(1);
+  });
+
+  it("lets an app publisher set feature flags (was admin-only) but denies plain members", async () => {
+    const now = Date.now();
+    const publisherToken = "ff-pub-token";
+    const memberToken = "ff-member-token";
+
+    await env.DB
+      .prepare(
+        `INSERT INTO organizations
+         (id, slug, name, external_provider, external_id, created_at, archived)
+         VALUES (?, ?, ?, 'raft', ?, ?, 0)`,
+      )
+      .bind("raft_ff", "ff-org", "FF Org", "ff-server", now)
+      .run();
+    await env.DB
+      .prepare(
+        "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .bind("ff-app", "raft_ff", "ff-app", "FF App", "android", now)
+      .run();
+
+    // publisher = org viewer + explicit app publisher; member = org member, no app role.
+    const accounts = [
+      { id: "ff-pub", subject: "ff-pub-sub", org: "viewer", app: "publisher", token: publisherToken },
+      { id: "ff-mem", subject: "ff-mem-sub", org: "member", app: null as string | null, token: memberToken },
+    ];
+    for (const a of accounts) {
+      await env.DB
+        .prepare(
+          `INSERT INTO raft_accounts
+           (id, provider, provider_subject, server_id, server_slug, principal_type,
+            server_role, username, display_name, avatar_url, raw_profile,
+            created_at, updated_at, last_login_at)
+           VALUES (?, 'raft', ?, 'ff-server', 'ff-org', 'agent',
+                   NULL, ?, ?, NULL, '{}', ?, ?, ?)`,
+        )
+        .bind(a.id, a.subject, a.id, a.id, now, now, now)
+        .run();
+      await env.DB
+        .prepare(
+          "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(`om-${a.id}`, "raft_ff", a.id, a.org, now)
+        .run();
+      if (a.app) {
+        await env.DB
+          .prepare(
+            "INSERT INTO app_members (id, app_id, account_id, app_role, joined_at) VALUES (?, ?, ?, ?, ?)",
+          )
+          .bind(`am-${a.id}`, "ff-app", a.id, a.app, now)
+          .run();
+      }
+      await env.DB
+        .prepare(
+          "INSERT INTO raft_sessions (id, account_id, token_hash, created_at, expires_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(
+          `s-${a.id}`,
+          a.id,
+          createHash("sha256").update(a.token).digest("hex"),
+          now,
+          now + 60_000,
+          now,
+        )
+        .run();
+    }
+
+    const testApp = new Hono<{ Bindings: Env }>();
+    testApp.use("*", authMiddleware as any);
+    testApp.put(
+      "/api/apps/:appId/feature-flags/:key",
+      requireAppRole("publisher") as any,
+      handleUpdateFeatureFlag as any,
+    );
+
+    // Plain org member (no app role) is below the publisher bar → 403.
+    const memberResponse = await testApp.request(
+      "https://quiver-worker.test/api/apps/ff-app/feature-flags/delta_updates",
+      {
+        method: "PUT",
+        headers: { authorization: `Bearer ${memberToken}`, "content-type": "application/json" },
+        body: JSON.stringify({ rollout_percent: 25 }),
+      },
+      env as any,
+    );
+    expect(memberResponse.status).toBe(403);
+
+    // App publisher can now toggle the flag (previously required admin).
+    const publisherResponse = await testApp.request(
+      "https://quiver-worker.test/api/apps/ff-app/feature-flags/delta_updates",
+      {
+        method: "PUT",
+        headers: { authorization: `Bearer ${publisherToken}`, "content-type": "application/json" },
+        body: JSON.stringify({ rollout_percent: 25 }),
+      },
+      env as any,
+    );
+    expect(publisherResponse.status).toBe(200);
   });
 
   it("uses a validated selected-org header for org-scoped app requests", async () => {


### PR DESCRIPTION
## What
Follow-up to the feedback-triage relaxation (#282): an audit of the role-per-endpoint policy (RBAC) found two endpoints gated higher than their sensitivity warrants. artin approved both.

## Changes
1. **`GET /delta-sources`: publisher → viewer** — it's a read-only listing; every other GET is viewer. Consistency fix.
2. **`PUT /feature-flags/:key`: admin → publisher** — feature flags are rollout controls, same category as `bump-rollout` / `force-update` (publisher); admin was stricter than the sibling release controls.

Everything genuinely sensitive is unchanged: releases / publish / rollback / upload / shares = **publisher**; app config, membership, server-grants, deploy-tokens, client-key, asc/agc credentials, archive/purge/delete = **admin**.

## Docs (artin: "相关文档都要一起更新")
- **New `docs/rbac-permissions.md`** — authoritative role model (org + app roles, resolution rules, deploy tokens) + endpoint→minimum-role matrix, linked from the admin & agent guides.
- Updated `feature-gate-design.md` + the handler doc comment (admin→publisher).

## Test
- New authz test: an app **publisher** can `PUT` feature-flags (previously admin-only), a plain org **member** gets 403.
- `tsc --noEmit` clean; full worker suite **143 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786440866&installation_id=145465820&pr_number=283&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F283&signature=35b035892186962f4970591faf153c0882e97230150348ce7ed1dfffb24022bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->