### PR TITLE
feat(feedback): productize crash symbolication — first-class field + one-click re-run (#136)

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1414,6 +1414,9 @@ export interface FeedbackDetail {
     arch: string | null;
     locale: string | null;
     metadata_json: string;
+    symbolication_status: string | null;
+    symbolicated_stack: string | null;
+    symbolicated_at: number | null;
   };
   attachments: Array<{
     id: string;
@@ -1456,6 +1459,14 @@ export const listFeedback = (
 
 export const getFeedback = (appId: string, ticketId: string) =>
   request<FeedbackDetail>(`/api/apps/${appId}/feedback/${ticketId}`, { admin: true });
+
+export const resymbolicateFeedback = (appId: string, ticketId: string) =>
+  request<{
+    id: string;
+    symbolication_status: string | null;
+    symbolicated_stack: string | null;
+    symbolicated_at: number | null;
+  }>(`/api/apps/${appId}/feedback/${ticketId}/symbolicate`, { method: "POST", admin: true });
 
 export const updateFeedbackTicket = (
   appId: string,

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -8,6 +8,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   addFeedbackComment,
+  resymbolicateFeedback,
   downloadFeedbackAttachment,
   getAuthMe,
   getFeedback,
@@ -564,6 +565,19 @@ export function FeedbackTicketPage({
       toast.show({ kind: "error", title: "Comment failed", description: (e as Error).message }),
   });
 
+  const resymbolicate = useMutation({
+    mutationFn: () => resymbolicateFeedback(appId, ticketId),
+    onSuccess: (r) => {
+      invalidate();
+      toast.show({
+        kind: r.symbolication_status === "symbolicated" ? "success" : "info",
+        title: `Symbolication: ${r.symbolication_status ?? "done"}`,
+      });
+    },
+    onError: (e) =>
+      toast.show({ kind: "error", title: "Symbolicate failed", description: (e as Error).message }),
+  });
+
   const t = detail.data?.ticket;
   const myName = me.data?.account?.display_name ?? null;
 
@@ -778,17 +792,46 @@ export function FeedbackTicketPage({
               const log = detail.data!.attachments.find(
                 (a) => (a.content_type?.startsWith("text/") ?? false) || /\.txt$/i.test(a.filename),
               );
-              const deobfuscated = detail.data!.comments.find(
-                (cm) => cm.author_actor === "quiver-retrace" || cm.author_actor === "quiver-symbolicate",
-              )?.body;
-              return log ? (
-                <CrashLogView
-                  appId={appId}
-                  ticketId={ticketId}
-                  attachmentId={log.id}
-                  deobfuscated={deobfuscated}
-                />
-              ) : null;
+              const symStatus = t.symbolication_status;
+              const symStack = t.symbolicated_stack ?? undefined;
+              const badgeClass =
+                symStatus === "symbolicated"
+                  ? "bg-green-100 text-green-700"
+                  : symStatus === "no_symbols"
+                    ? "bg-amber-100 text-amber-700"
+                    : symStatus === "failed"
+                      ? "bg-red-100 text-red-700"
+                      : "bg-slate-100 text-slate-600";
+              return (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="font-medium">Symbolication</span>
+                    <span className={`rounded px-1.5 py-0.5 text-xs ${badgeClass}`}>
+                      {symStatus ?? "not run"}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={resymbolicate.isPending}
+                      onClick={() => resymbolicate.mutate()}
+                    >
+                      {resymbolicate.isPending ? "Symbolicating…" : "Re-run"}
+                    </Button>
+                  </div>
+                  {log ? (
+                    <CrashLogView
+                      appId={appId}
+                      ticketId={ticketId}
+                      attachmentId={log.id}
+                      deobfuscated={symStack}
+                    />
+                  ) : symStack ? (
+                    <pre className="overflow-x-auto whitespace-pre-wrap rounded border border-slate-200 bg-slate-50 p-3 text-xs">
+                      {symStack}
+                    </pre>
+                  ) : null}
+                </div>
+              );
             })()}
 
           {detail.data!.attachments.length > 0 && (

--- a/migrations/sql/0043_feedback_symbolication.sql
+++ b/migrations/sql/0043_feedback_symbolication.sql
@@ -1,0 +1,13 @@
+-- Productize crash symbolication (#136): promote the symbolicated stack from an
+-- async internal comment to first-class, queryable fields on the crash ticket.
+--   symbolication_status: null (not yet run) | pending | symbolicated |
+--     no_symbols (missing symbol asset — operator-actionable) | unsymbolicated
+--     (container returned nothing) | failed | not_applicable (no native frames).
+--   symbolicated_stack: the resolved stack text when symbolicated, or the
+--     operator-actionable guidance when no_symbols.
+--   symbolicated_at: epoch ms of the last symbolication run.
+-- This lets the detail panel render the stack directly and a one-click re-run
+-- endpoint recompute it, instead of scanning synthetic comments.
+ALTER TABLE feedback_tickets ADD COLUMN symbolication_status TEXT;
+ALTER TABLE feedback_tickets ADD COLUMN symbolicated_stack TEXT;
+ALTER TABLE feedback_tickets ADD COLUMN symbolicated_at INTEGER;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -75,6 +75,7 @@ import {
   handleGetFeedback,
   handleUpdateFeedback,
   handleAddFeedbackComment,
+  handleResymbolicateFeedback,
   handleDownloadFeedbackAttachment,
   handleListCrashGroups,
   handleFeedbackStats,
@@ -648,6 +649,7 @@ admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedb
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireFeedbackTriageRole(), handleUpdateFeedback);
 admin.post("/api/apps/:appId/feedback/:ticketId/comments", requireFeedbackTriageRole(), handleAddFeedbackComment);
+admin.post("/api/apps/:appId/feedback/:ticketId/symbolicate", requireFeedbackTriageRole(), handleResymbolicateFeedback);
 admin.get("/api/apps/:appId/feedback/:ticketId/attachments/:attachmentId", requireAppRole("viewer"), handleDownloadFeedbackAttachment);
 admin.get("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("viewer"), handleListReleaseShares);
 admin.post("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("publisher"), handleCreateReleaseShare);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -296,51 +296,20 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   ];
   await c.env.DB.batch(statements);
 
-  // Crash tickets: deobfuscate the stack in the background using the
-  // proguard-mapping asset stored for this version_code.
-  if (kind === "crash" && attachmentRows.length > 0) {
-    const logKey = attachmentRows[0]!.r2Key;
-    const run = () => retraceCrashTicket(c.env, app.id, ticketId, versionCode, logKey);
-    try {
-      c.executionCtx.waitUntil(run());
-    } catch {
-      run().catch(() => {});
-    }
-  }
-
-  // Native crashes: symbolicate frames against the native-symbols asset.
-  const nativeFrames = parseNativeFrames(metadata["crash_native_frames"]);
-  if (kind === "crash" && nativeFrames.length > 0) {
+  // Crash tickets: symbolicate in the background (retrace / native / OHOS / dSYM
+  // lanes) and record the result on the ticket's symbolicated_stack /
+  // symbolication_status fields. See dispatchSymbolication.
+  if (kind === "crash") {
+    const logKey = attachmentRows.length > 0 ? attachmentRows[0]!.r2Key : null;
     const run = () =>
-      symbolicateNativeCrashTicket(c.env, app.id, ticketId, versionCode, nativeFrames);
-    try {
-      c.executionCtx.waitUntil(run());
-    } catch {
-      run().catch(() => {});
-    }
-  }
-
-  // OHOS crashes: the HarmonyOS SDK captures cppcrash/NativeCrash faults via
-  // hiAppEvent and uploads them as a text fault log (no structured
-  // crash_native_frames). Parse the debuggerd-style backtrace out of that log
-  // server-side into native frames, then reuse the native-symbols lane. Gated
-  // on platform so non-OHOS crashes don't pay for the extra log fetch.
-  if (kind === "crash" && app.platform === "ohos" && attachmentRows.length > 0) {
-    const logKey = attachmentRows[0]!.r2Key;
-    const run = () => symbolicateOhosCrashTicket(c.env, app.id, ticketId, versionCode, logKey);
-    try {
-      c.executionCtx.waitUntil(run());
-    } catch {
-      run().catch(() => {});
-    }
-  }
-
-  // iOS crashes: symbolicate frames against the dSYM asset.
-  const dsymImages = parseBinaryImages(metadata["crash_binary_images"]);
-  const dsymFrames = parseCrashFrames(metadata["crash_frames"]);
-  if (kind === "crash" && dsymImages.length > 0 && dsymFrames.length > 0) {
-    const run = () =>
-      symbolicateDsymCrashTicket(c.env, app.id, ticketId, versionCode, dsymImages, dsymFrames);
+      dispatchSymbolication(
+        c.env,
+        { id: app.id, platform: app.platform },
+        ticketId,
+        versionCode,
+        metadata,
+        logKey,
+      );
     try {
       c.executionCtx.waitUntil(run());
     } catch {
@@ -623,6 +592,76 @@ function crashSignature(metadata: Record<string, unknown>): string | null {
   return `${exc || "UnknownException"}@${normFrame}`.slice(0, 300);
 }
 
+export type SymbolicationStatus =
+  | "pending"
+  | "symbolicated"
+  | "no_symbols"
+  | "unsymbolicated"
+  | "failed"
+  | "not_applicable";
+
+// Higher rank wins when several lanes touch one ticket (e.g. an Android crash
+// with both a Java stack and native frames): a real symbolicated stack must
+// never be downgraded to "no_symbols".
+const SYMBOLICATION_RANK: Record<SymbolicationStatus, number> = {
+  pending: 0,
+  not_applicable: 1,
+  failed: 2,
+  unsymbolicated: 3,
+  no_symbols: 4,
+  symbolicated: 5,
+};
+
+/** Clear a ticket's symbolication fields before a fresh run (ingest or re-run). */
+export async function resetSymbolication(env: Env, ticketId: string): Promise<void> {
+  const now = Date.now();
+  await env.DB.prepare(
+    `UPDATE feedback_tickets
+     SET symbolication_status = 'pending', symbolicated_stack = NULL,
+         symbolicated_at = ?1, updated_at = ?2
+     WHERE id = ?3`,
+  )
+    .bind(now, now, ticketId)
+    .run();
+}
+
+/**
+ * Persist one lane's symbolication result on the ticket — the first-class
+ * replacement for the old synthetic `quiver-symbolicate` comments (#136).
+ * Appends the labeled block to `symbolicated_stack` (lanes run sequentially, so
+ * this read-modify-write is race-free) and raises `symbolication_status` to the
+ * best result seen so far.
+ */
+export async function appendSymbolication(
+  env: Env,
+  ticketId: string,
+  label: string,
+  status: SymbolicationStatus,
+  text: string | null,
+): Promise<void> {
+  const now = Date.now();
+  const row = await env.DB.prepare(
+    "SELECT symbolicated_stack, symbolication_status FROM feedback_tickets WHERE id = ?1",
+  )
+    .bind(ticketId)
+    .first<{ symbolicated_stack: string | null; symbolication_status: string | null }>();
+  if (!row) return;
+  const prev = (row.symbolication_status as SymbolicationStatus | null) ?? "pending";
+  const nextStatus = SYMBOLICATION_RANK[status] >= SYMBOLICATION_RANK[prev] ? status : prev;
+  let stack = row.symbolicated_stack;
+  if (text && text.trim()) {
+    const block = `[${label}]\n${text.trim()}`;
+    stack = (stack ? `${stack}\n\n${block}` : block).slice(0, 40_000);
+  }
+  await env.DB.prepare(
+    `UPDATE feedback_tickets
+     SET symbolication_status = ?1, symbolicated_stack = ?2, symbolicated_at = ?3, updated_at = ?4
+     WHERE id = ?5`,
+  )
+    .bind(nextStatus, stack, now, now, ticketId)
+    .run();
+}
+
 /**
  * Best-effort deobfuscation: find the proguard-mapping build asset for the
  * crash's version_code, fetch the crash log, run the container retrace tool,
@@ -646,7 +685,17 @@ export async function retraceCrashTicket(
     )
       .bind(appId, versionCode)
       .first<{ r2_key: string }>();
-    if (!mapping) return;
+    if (!mapping) {
+      await appendSymbolication(
+        env,
+        ticketId,
+        "android-r8",
+        "no_symbols",
+        `No proguard-mapping asset for version_code ${versionCode}. ` +
+          "Publish the build with its R8 mapping (quiver builds publish-android --mapping).",
+      );
+      return;
+    }
 
     const [mappingObj, logObj] = await Promise.all([
       env.APK_BUCKET.get(mapping.r2_key),
@@ -671,19 +720,13 @@ export async function retraceCrashTicket(
     const { retraced } = (await res.json()) as { retraced?: string };
     if (!retraced || !retraced.trim()) return;
 
-    const body =
-      "Deobfuscated stack trace (auto-retraced from build mapping):\n\n" +
-      retraced.trim().slice(0, 20_000);
-    await env.DB.batch([
-      env.DB.prepare(
-        `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
-         VALUES (?1, ?2, 'quiver-retrace', ?3, 1, ?4)`,
-      ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
-      env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
-        Date.now(),
-        ticketId,
-      ),
-    ]);
+    await appendSymbolication(
+      env,
+      ticketId,
+      "android-r8",
+      "symbolicated",
+      retraced.trim().slice(0, 20_000),
+    );
   } catch (err) {
     console.error(
       `[retrace] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -749,18 +792,6 @@ export async function symbolicateNativeCrashTicket(
 ): Promise<void> {
   try {
     if (versionCode === null || frames.length === 0) return;
-    const appendComment = async (body: string) => {
-      await env.DB.batch([
-        env.DB.prepare(
-          `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
-           VALUES (?1, ?2, 'quiver-symbolicate', ?3, 1, ?4)`,
-        ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
-        env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
-          Date.now(),
-          ticketId,
-        ),
-      ]);
-    };
 
     const symbols = await env.DB.prepare(
       `SELECT ba.r2_key FROM build_assets ba
@@ -773,9 +804,13 @@ export async function symbolicateNativeCrashTicket(
       .first<{ r2_key: string }>();
     if (!symbols) {
       const ids = [...new Set(frames.map((f) => f.build_id).filter(Boolean))].join(", ");
-      await appendComment(
-        `Native crash could not be symbolicated: no 'native-symbols' build asset ` +
-          `for version_code ${versionCode}${ids ? ` (crash BuildId: ${ids})` : ""}. ` +
+      await appendSymbolication(
+        env,
+        ticketId,
+        "native",
+        "no_symbols",
+        `No 'native-symbols' build asset for version_code ${versionCode}` +
+          `${ids ? ` (crash BuildId: ${ids})` : ""}. ` +
           `Publish the build with its unstripped .so archive (${publishHint}).`,
       );
       return;
@@ -810,9 +845,12 @@ export async function symbolicateNativeCrashTicket(
       const outcome = r?.resolved ?? (r?.error ? `?? (${r.error})` : "??");
       return `#${String(f.index).padStart(2, "0")} ${f.offset} ${f.soname} — ${outcome}`;
     });
-    await appendComment(
-      "Symbolicated native stack (auto-resolved from native-symbols):\n\n" +
-        lines.join("\n").slice(0, 20_000),
+    await appendSymbolication(
+      env,
+      ticketId,
+      "native",
+      "symbolicated",
+      lines.join("\n").slice(0, 20_000),
     );
   } catch (err) {
     console.error(
@@ -1061,18 +1099,6 @@ export async function symbolicateDsymCrashTicket(
 ): Promise<void> {
   try {
     if (versionCode === null || frames.length === 0 || images.length === 0) return;
-    const appendComment = async (body: string) => {
-      await env.DB.batch([
-        env.DB.prepare(
-          `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
-           VALUES (?1, ?2, 'quiver-symbolicate', ?3, 1, ?4)`,
-        ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
-        env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
-          Date.now(),
-          ticketId,
-        ),
-      ]);
-    };
 
     // Map each frame to its containing image → { index, offset(hex), image }.
     const containerFrames: Array<{ index: number; offset: string; image: string }> = [];
@@ -1101,9 +1127,13 @@ export async function symbolicateDsymCrashTicket(
       .first<{ r2_key: string }>();
     if (!dsym) {
       const uuids = [...new Set(images.map((i) => i.uuid).filter(Boolean))].slice(0, 6).join(", ");
-      await appendComment(
-        `iOS crash could not be symbolicated: no 'dsym' build asset for ` +
-          `version_code ${versionCode}${uuids ? ` (image UUIDs: ${uuids})` : ""}. ` +
+      await appendSymbolication(
+        env,
+        ticketId,
+        "ios-dsym",
+        "no_symbols",
+        `No 'dsym' build asset for version_code ${versionCode}` +
+          `${uuids ? ` (image UUIDs: ${uuids})` : ""}. ` +
           `Publish the build with its dSYM archive (hands builds publish-ios --dsym).`,
       );
       return;
@@ -1138,9 +1168,12 @@ export async function symbolicateDsymCrashTicket(
       const outcome = r?.resolved ?? (r?.error ? `?? (${r.error})` : "??");
       return `#${String(cf.index).padStart(2, "0")} ${cf.image} ${cf.offset} — ${outcome}`;
     });
-    await appendComment(
-      "Symbolicated iOS stack (auto-resolved from dSYM):\n\n" +
-        lines.join("\n").slice(0, 20_000),
+    await appendSymbolication(
+      env,
+      ticketId,
+      "ios-dsym",
+      "symbolicated",
+      lines.join("\n").slice(0, 20_000),
     );
   } catch (err) {
     console.error(
@@ -1163,19 +1196,6 @@ export async function symbolicateMinidumpCrashTicket(
   minidumpR2Key: string,
 ): Promise<void> {
   try {
-    const appendComment = async (body: string) => {
-      await env.DB.batch([
-        env.DB.prepare(
-          `INSERT INTO feedback_comments (id, ticket_id, author_actor, body, internal, created_at)
-           VALUES (?1, ?2, 'quiver-symbolicate', ?3, 1, ?4)`,
-        ).bind(crypto.randomUUID(), ticketId, body, Date.now()),
-        env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(
-          Date.now(),
-          ticketId,
-        ),
-      ]);
-    };
-
     const dumpObj = await env.APK_BUCKET.get(minidumpR2Key);
     if (!dumpObj) return;
     const dumpBytes = await dumpObj.arrayBuffer();
@@ -1225,19 +1245,82 @@ export async function symbolicateMinidumpCrashTicket(
       `Symbolicated Electron crash (minidump-stackwalk` +
       `${symBytes ? "" : ", no breakpad-symbols asset — module+offset only"}):` +
       `${parsed.crash_reason ? `\nReason: ${parsed.crash_reason}${parsed.crash_address ? ` @ ${parsed.crash_address}` : ""}` : ""}`;
-    await appendComment(`${header}\n\n${stack}`.slice(0, 20_000));
-
-    if (!symBytes && versionCode !== null) {
-      await appendComment(
-        `Tip: upload the version's Breakpad symbols (dump_syms → quiver builds ` +
+    const tip =
+      !symBytes && versionCode !== null
+        ? `\n\nTip: upload the version's Breakpad symbols (dump_syms → quiver builds ` +
           `publish-electron --symbols) for version_code ${versionCode} to get ` +
-          `function/file:line resolution instead of raw module+offset.`,
-      );
-    }
+          `function/file:line resolution instead of raw module+offset.`
+        : "";
+    await appendSymbolication(
+      env,
+      ticketId,
+      "electron-minidump",
+      "symbolicated",
+      `${header}\n\n${stack}${tip}`.slice(0, 20_000),
+    );
   } catch (err) {
     console.error(
       `[symbolicate-minidump] failed for ticket ${ticketId}: ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+}
+
+/**
+ * Run every applicable symbolication lane for a crash ticket sequentially and
+ * persist the result on the ticket (symbolicated_stack / symbolication_status).
+ * Used both on crash ingest and by the on-demand re-run endpoint. Lanes run
+ * sequentially so their appends to the single field don't race; status settles
+ * to a terminal value so it never stays "pending".
+ */
+export async function dispatchSymbolication(
+  env: Env,
+  app: { id: string; platform?: string | null },
+  ticketId: string,
+  versionCode: number | null,
+  metadata: Record<string, unknown>,
+  logKey: string | null,
+): Promise<void> {
+  await resetSymbolication(env, ticketId);
+  let ran = false;
+
+  if (logKey) {
+    ran = true;
+    await retraceCrashTicket(env, app.id, ticketId, versionCode, logKey);
+  }
+  const nativeFrames = parseNativeFrames(metadata["crash_native_frames"]);
+  if (nativeFrames.length > 0) {
+    ran = true;
+    await symbolicateNativeCrashTicket(env, app.id, ticketId, versionCode, nativeFrames);
+  }
+  if (app.platform === "ohos" && logKey) {
+    ran = true;
+    await symbolicateOhosCrashTicket(env, app.id, ticketId, versionCode, logKey);
+  }
+  const dsymImages = parseBinaryImages(metadata["crash_binary_images"]);
+  const dsymFrames = parseCrashFrames(metadata["crash_frames"]);
+  if (dsymImages.length > 0 && dsymFrames.length > 0) {
+    ran = true;
+    await symbolicateDsymCrashTicket(env, app.id, ticketId, versionCode, dsymImages, dsymFrames);
+  }
+
+  const row = await env.DB.prepare(
+    "SELECT symbolication_status FROM feedback_tickets WHERE id = ?1",
+  )
+    .bind(ticketId)
+    .first<{ symbolication_status: string | null }>();
+  if (!row) return;
+  if (!ran) {
+    await env.DB.prepare(
+      "UPDATE feedback_tickets SET symbolication_status = 'not_applicable', symbolicated_at = ?1 WHERE id = ?2",
+    )
+      .bind(Date.now(), ticketId)
+      .run();
+  } else if (row.symbolication_status === "pending") {
+    await env.DB.prepare(
+      "UPDATE feedback_tickets SET symbolication_status = 'unsymbolicated', symbolicated_at = ?1 WHERE id = ?2",
+    )
+      .bind(Date.now(), ticketId)
+      .run();
   }
 }
 
@@ -1422,6 +1505,64 @@ export async function handleGetFeedback(c: AdminContext) {
     .bind(ticketId)
     .all();
   return c.json({ ticket, attachments, comments });
+}
+
+/**
+ * On-demand (re-)symbolication of a crash ticket — powers the detail panel's
+ * one-click "Symbolicate / Re-run" button (#136). Reconstructs the crash frames
+ * from the stored metadata + log attachment and runs dispatchSymbolication
+ * synchronously, then returns the fresh symbolication fields.
+ */
+export async function handleResymbolicateFeedback(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const resolved = await resolveTicketId(c.env.DB, appId, c.req.param("ticketId"));
+  if ("error" in resolved) return ticketResolveError(c, resolved);
+  const ticketId = resolved.id;
+  const ticket = await c.env.DB.prepare(
+    "SELECT id, kind, version_code, metadata_json FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
+  )
+    .bind(appId, ticketId)
+    .first<{ id: string; kind: string; version_code: number | null; metadata_json: string }>();
+  if (!ticket) return c.json({ error: "ticket not found" }, 404);
+  if (ticket.kind !== "crash") {
+    return c.json({ error: "only crash tickets can be symbolicated" }, 400);
+  }
+  const app = await c.env.DB.prepare("SELECT id, platform FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string; platform: string | null }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+
+  let metadata: Record<string, unknown> = {};
+  try {
+    metadata = JSON.parse(ticket.metadata_json || "{}") as Record<string, unknown>;
+  } catch {
+    metadata = {};
+  }
+  const logRow = await c.env.DB.prepare(
+    "SELECT r2_key FROM feedback_attachments WHERE ticket_id = ?1 ORDER BY created_at LIMIT 1",
+  )
+    .bind(ticketId)
+    .first<{ r2_key: string }>();
+
+  await dispatchSymbolication(
+    c.env,
+    { id: app.id, platform: app.platform },
+    ticketId,
+    ticket.version_code,
+    metadata,
+    logRow?.r2_key ?? null,
+  );
+
+  const updated = await c.env.DB.prepare(
+    "SELECT symbolication_status, symbolicated_stack, symbolicated_at FROM feedback_tickets WHERE id = ?1",
+  )
+    .bind(ticketId)
+    .first<{
+      symbolication_status: string | null;
+      symbolicated_stack: string | null;
+      symbolicated_at: number | null;
+    }>();
+  return c.json({ id: ticketId, ...(updated ?? {}) });
 }
 
 export async function handleUpdateFeedback(c: AdminContext) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -21,7 +21,12 @@ import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
 import { requireAppRole, requireCurrentOrgRole, requireFeedbackTriageRole } from "../src/lib/permissions";
-import { handleUpdateFeedback, handleAddFeedbackComment } from "../src/routes/feedback";
+import {
+  handleUpdateFeedback,
+  handleAddFeedbackComment,
+  resetSymbolication,
+  appendSymbolication,
+} from "../src/routes/feedback";
 import {
   httpsRedirectUrl,
   isSecureRequest,
@@ -302,6 +307,9 @@ function makeMockDb() {
       client_ip_hash TEXT,
       assignee TEXT,
       signature TEXT,
+      symbolication_status TEXT,
+      symbolicated_stack TEXT,
+      symbolicated_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -845,6 +853,46 @@ describe("quiver route handlers — SQL smoke", () => {
       .bind("member-app")
       .all();
     expect(seededChannels.results.map((row: any) => row.slug)).toEqual(["main", "nightly", "preview"]);
+  });
+
+  it("appendSymbolication writes the ticket field + raises status by rank; reset clears it", async () => {
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES ('sym-t', 'sym-app', 'crash', 'open', 'boom', '{}', ?, ?)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const readSym = () =>
+      env.DB.prepare(
+        "SELECT symbolication_status, symbolicated_stack FROM feedback_tickets WHERE id = ?1",
+      )
+        .bind("sym-t")
+        .first() as Promise<{ symbolication_status: string; symbolicated_stack: string | null }>;
+
+    await appendSymbolication(env as any, "sym-t", "native", "no_symbols", "no native-symbols asset");
+    let row = await readSym();
+    expect(row.symbolication_status).toBe("no_symbols");
+    expect(row.symbolicated_stack).toContain("[native]");
+    expect(row.symbolicated_stack).toContain("no native-symbols asset");
+
+    // A real symbolicated result outranks no_symbols and appends its block.
+    await appendSymbolication(env as any, "sym-t", "android-r8", "symbolicated", "at Foo.bar(Foo.kt:1)");
+    row = await readSym();
+    expect(row.symbolication_status).toBe("symbolicated");
+    expect(row.symbolicated_stack).toContain("[native]");
+    expect(row.symbolicated_stack).toContain("[android-r8]");
+
+    // A later no_symbols must NOT downgrade a symbolicated status.
+    await appendSymbolication(env as any, "sym-t", "ios-dsym", "no_symbols", "no dsym");
+    row = await readSym();
+    expect(row.symbolication_status).toBe("symbolicated");
+
+    await resetSymbolication(env as any, "sym-t");
+    const cleared = await readSym();
+    expect(cleared.symbolication_status).toBe("pending");
+    expect(cleared.symbolicated_stack).toBeNull();
   });
 
   it("lets org members triage feedback (update status + comment) while viewers cannot", async () => {
@@ -4325,7 +4373,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(parseNativeFrames(42)).toEqual([]);
   });
 
-  it("symbolicateNativeCrashTicket leaves an actionable comment when symbols are missing", async () => {
+  it("symbolicateNativeCrashTicket records no_symbols on the ticket when symbols are missing", async () => {
     const env = makeEnv();
     const { symbolicateNativeCrashTicket } = await import("../src/routes/feedback");
     await env.DB.prepare(
@@ -4335,13 +4383,13 @@ describe("quiver public API v2 — scope resolution", () => {
     await symbolicateNativeCrashTicket(env as any, "app-scope", "tick-nat", 1000200, [
       { index: 0, offset: "0x1a2b", soname: "libraft.so", build_id: "abcd1234" },
     ]);
-    const comment = (await env.DB.prepare(
-      "SELECT author_actor, body FROM feedback_comments WHERE ticket_id = ?1",
-    ).bind("tick-nat").all()).results[0] as { author_actor: string; body: string };
-    expect(comment.author_actor).toBe("quiver-symbolicate");
-    expect(comment.body).toContain("native-symbols");
-    expect(comment.body).toContain("1000200");
-    expect(comment.body).toContain("abcd1234");
+    const row = (await env.DB.prepare(
+      "SELECT symbolication_status, symbolicated_stack FROM feedback_tickets WHERE id = ?1",
+    ).bind("tick-nat").first()) as { symbolication_status: string; symbolicated_stack: string };
+    expect(row.symbolication_status).toBe("no_symbols");
+    expect(row.symbolicated_stack).toContain("native-symbols");
+    expect(row.symbolicated_stack).toContain("1000200");
+    expect(row.symbolicated_stack).toContain("abcd1234");
   });
 
   it("parseOhosNativeFrames extracts frames from a debuggerd-style HarmonyOS fault log", async () => {
@@ -4440,13 +4488,13 @@ describe("quiver public API v2 — scope resolution", () => {
       1040000,
       "feedback/app-scope/tick-ohos/0-crash.log",
     );
-    const comment = (await env.DB.prepare(
-      "SELECT author_actor, body FROM feedback_comments WHERE ticket_id = ?1",
-    ).bind("tick-ohos").all()).results[0] as { author_actor: string; body: string };
-    expect(comment.author_actor).toBe("quiver-symbolicate");
-    expect(comment.body).toContain("native-symbols");
-    expect(comment.body).toContain("publish-ohos");
-    expect(comment.body).toContain("aabbccddeeff0011");
+    const row = (await env.DB.prepare(
+      "SELECT symbolication_status, symbolicated_stack FROM feedback_tickets WHERE id = ?1",
+    ).bind("tick-ohos").first()) as { symbolication_status: string; symbolicated_stack: string };
+    expect(row.symbolication_status).toBe("no_symbols");
+    expect(row.symbolicated_stack).toContain("native-symbols");
+    expect(row.symbolicated_stack).toContain("publish-ohos");
+    expect(row.symbolicated_stack).toContain("aabbccddeeff0011");
   });
 
   it("symbolicateOhosCrashTicket ignores non-OHOS logs", async () => {
@@ -4509,13 +4557,13 @@ describe("quiver public API v2 — scope resolution", () => {
       [{ uuid: "DEADBEEF", load_address: 0x100000000n, end_address: 0x100100000n, name: "Raft" }],
       [{ index: 0, address: 0x100004000n }],
     );
-    const comment = (await env.DB.prepare(
-      "SELECT author_actor, body FROM feedback_comments WHERE ticket_id = ?1",
-    ).bind("tick-dsym").all()).results[0] as { author_actor: string; body: string };
-    expect(comment.author_actor).toBe("quiver-symbolicate");
-    expect(comment.body).toContain("dsym");
-    expect(comment.body).toContain("1000200");
-    expect(comment.body).toContain("DEADBEEF");
+    const row = (await env.DB.prepare(
+      "SELECT symbolication_status, symbolicated_stack FROM feedback_tickets WHERE id = ?1",
+    ).bind("tick-dsym").first()) as { symbolication_status: string; symbolicated_stack: string };
+    expect(row.symbolication_status).toBe("no_symbols");
+    expect(row.symbolicated_stack).toContain("dsym");
+    expect(row.symbolicated_stack).toContain("1000200");
+    expect(row.symbolicated_stack).toContain("DEADBEEF");
   });
 
   it("handlePublicMinidumpSubmit ingests a Crashpad minidump as an electron crash ticket", async () => {


### PR DESCRIPTION
## Problem

Crash symbolication only ran once, on ingest, and posted its result as an internal feedback comment. The result was not queryable, the detail panel had to scan comments to surface it, and there was no way to re-run symbolication after uploading previously-missing symbols.

## Changes

- Migration 0043 adds `symbolication_status`, `symbolicated_stack`, and `symbolicated_at` to `feedback_tickets`.
- `resetSymbolication` and `appendSymbolication` write the result onto the ticket. Status is raised by rank (`symbolicated` > `no_symbols` > `unsymbolicated` > `failed` > `not_applicable`) so a real stack is never downgraded, and each lane appends a labeled block. All five lanes (Android R8, native `.so`, OHOS, iOS dSYM, Electron minidump) now write the field instead of a comment.
- `dispatchSymbolication` runs every applicable lane sequentially, avoiding a write race on the single field, and settles a terminal status. Both crash ingest and the re-run endpoint use it.
- New endpoint `POST /api/apps/:appId/feedback/:ticketId/symbolicate` reconstructs the crash frames from the stored metadata and log attachment, recomputes on demand, and returns the fresh fields.
- Admin: the crash detail panel renders `symbolicated_stack` directly, shows a status badge, and adds a one-click Symbolicate / Re-run button. This also works for crashes with no text-log attachment.

## Follow-up

A bounded container-side symbol cache keyed by build UUID is a separate performance optimization and is not included here.

## Testing

- Worker `tsc` and the full test suite (144 tests) pass.
- Admin `tsc` passes.