### PR TITLE
feat(feedback): list attachment filenames in the submit reference

### DIFF
--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -403,7 +403,15 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       ? String(versionCode)
       : null;
   const ticketUrl = `${dashboardOrigin(c.env)}/apps/${app.id}/feedback/${ticketId}`;
-  const reference = [app.slug, versionLabel, `ticket ${ticketId}`]
+  // List attachment filenames in the copyable reference so an agent reading a
+  // pasted ticket knows it carries images/files and will go fetch them.
+  const attachmentNames = attachmentRows.map((a) => a.filename).filter(Boolean);
+  const reference = [
+    app.slug,
+    versionLabel,
+    `ticket ${ticketId}`,
+    attachmentNames.length ? `attachments: ${attachmentNames.join(" ")}` : null,
+  ]
     .filter(Boolean)
     .join(" · ");
 
@@ -412,6 +420,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       id: ticketId,
       status: "open",
       attachments: attachmentRows.length,
+      attachment_names: attachmentNames,
       reference,
       ticket_url: ticketUrl,
     },

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -403,17 +403,16 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       ? String(versionCode)
       : null;
   const ticketUrl = `${dashboardOrigin(c.env)}/apps/${app.id}/feedback/${ticketId}`;
-  // List attachment filenames in the copyable reference so an agent reading a
-  // pasted ticket knows it carries images/files and will go fetch them.
+  // List attachment filenames in the copyable reference — one per line — so an
+  // agent reading a pasted ticket knows it carries images/files and will fetch
+  // them.
   const attachmentNames = attachmentRows.map((a) => a.filename).filter(Boolean);
-  const reference = [
-    app.slug,
-    versionLabel,
-    `ticket ${ticketId}`,
-    attachmentNames.length ? `attachments: ${attachmentNames.join(" ")}` : null,
-  ]
+  const referenceLine = [app.slug, versionLabel, `ticket ${ticketId}`]
     .filter(Boolean)
     .join(" · ");
+  const reference = attachmentNames.length
+    ? `${referenceLine}\nattachments:\n${attachmentNames.join("\n")}`
+    : referenceLine;
 
   return c.json(
     {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -5134,9 +5134,9 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(submittedBody.attachments).toBe(1);
     expect(submittedBody.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(submittedBody.reference).toContain(`ticket ${submittedBody.id}`);
-    // The copyable reference lists attachment filenames so a reading agent knows
-    // the ticket carries files and will fetch them.
-    expect(submittedBody.reference).toContain("attachments: logcat.txt");
+    // The copyable reference lists attachment filenames, one per line, so a
+    // reading agent knows the ticket carries files and will fetch them.
+    expect(submittedBody.reference).toContain("attachments:\nlogcat.txt");
     expect(submittedBody.attachment_names).toEqual(["logcat.txt"]);
     expect(submittedBody.ticket_url).toBe(
       `https://dashboard.example/apps/app-scope/feedback/${submittedBody.id}`,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -5134,6 +5134,10 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(submittedBody.attachments).toBe(1);
     expect(submittedBody.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(submittedBody.reference).toContain(`ticket ${submittedBody.id}`);
+    // The copyable reference lists attachment filenames so a reading agent knows
+    // the ticket carries files and will fetch them.
+    expect(submittedBody.reference).toContain("attachments: logcat.txt");
+    expect(submittedBody.attachment_names).toEqual(["logcat.txt"]);
     expect(submittedBody.ticket_url).toBe(
       `https://dashboard.example/apps/app-scope/feedback/${submittedBody.id}`,
     );


### PR DESCRIPTION
## Problem

The public feedback-submit response's copyable `reference` (the string a user pastes to an agent) only carried an attachment *count*. An agent reading a pasted ticket had no way to tell it includes an image/file, so it wouldn't fetch the attachments.

## Changes

- When the ticket has attachments, `reference` now appends an `attachments:` block listing each filename on its own line.
- Adds an `attachment_names` array to the submit response for programmatic consumers. The existing `attachments` count field is unchanged.

## Testing

Worker `tsc` and the full test suite pass; the public-submit test asserts the reference contains the `attachments:` block with `logcat.txt` on its own line and that `attachment_names` equals `["logcat.txt"]`.