### PR TITLE
fix(admin): restore human login CTA

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "node scripts/build-docs.mjs && vite build",
+    "test": "vitest run",
     "preview": "vite preview",
     "deploy": "wrangler pages deploy ./dist",
     "typecheck": "tsc --noEmit"
@@ -27,6 +28,7 @@
     "tailwindcss": "^4.3.2",
     "typescript": "^5.7.2",
     "vite": "^5.4.11",
+    "vitest": "^2.1.9",
     "wrangler": "^4.88.0"
   }
 }

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -62,6 +62,7 @@ import { isOrgSettingsTab, OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
 import { OrgSwitcher, useClearOrgCache } from "./components/OrgSwitcher";
+import { dashboardHref } from "./lib/authNavigation";
 import {
   clearActiveOrgId,
   getAuthToken,
@@ -893,10 +894,6 @@ function CliCallback({ token }: { token: string }) {
   );
 }
 
-function dashboardHref(): string {
-  return "/api/auth/dashboard?return=%2Fapps";
-}
-
 function PublicLanding({ account }: { account?: AuthAccount }) {
   useEffect(() => {
     document.title = "Hands - Client release operations";
@@ -923,7 +920,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
             >
               API explorer
             </a>
-            <Button variant="primary" render={<a href={dashboardHref()} />}>
+            <Button variant="primary" render={<a href={dashboardHref(account)} />}>
               <RaftIcon className="h-5 w-5" />
               {account ? "Open dashboard" : "Login"}
             </Button>
@@ -962,7 +959,7 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
                 ))}
               </div>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                <Button variant="primary" size="lg" render={<a href={dashboardHref()} />}>
+                <Button variant="primary" size="lg" render={<a href={dashboardHref(account)} />}>
                   <RaftIcon className="h-5 w-5" />
                   {account ? "Open dashboard" : "Login with Raft"}
                 </Button>

--- a/admin/src/lib/authNavigation.test.ts
+++ b/admin/src/lib/authNavigation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { dashboardHref } from "./authNavigation";
+import type { AuthAccount } from "./api";
+
+describe("dashboardHref", () => {
+  it("starts Login with Raft for unauthenticated visitors", () => {
+    expect(dashboardHref()).toBe("/api/auth/login?return=%2Fapps");
+  });
+
+  it("opens the dashboard directly for authenticated accounts", () => {
+    expect(dashboardHref({} as AuthAccount)).toBe("/apps");
+  });
+});

--- a/admin/src/lib/authNavigation.ts
+++ b/admin/src/lib/authNavigation.ts
@@ -1,0 +1,5 @@
+import { loginUrl, type AuthAccount } from "./api";
+
+export function dashboardHref(account?: AuthAccount): string {
+  return account ? "/apps" : loginUrl("/apps");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       vite:
         specifier: ^5.4.11
         version: 5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
       wrangler:
         specifier: ^4.88.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
@@ -3428,6 +3431,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)
 
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -4364,6 +4375,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@24.13.2)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
@@ -4408,6 +4437,41 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@24.13.2)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary

- restore account-aware landing CTA routing
- send unauthenticated visitors through `/api/auth/login?return=%2Fapps`
- keep authenticated visitors on the direct `/apps` dashboard path
- add focused admin regression coverage for both states

## Root cause

PR #261 changed both landing CTAs to unconditionally call `/api/auth/dashboard?return=%2Fapps`. That endpoint only redirects to the canonical dashboard origin; it does not start Login with Raft. An unauthenticated visitor therefore landed on the unauthenticated dashboard and saw the same CTA again, creating a redirect loop.

This change is consumer-only. It does not alter the Raft setup URL, client id, callback, or Worker login contract.

## Validation

- `pnpm --filter @botiverse/hands-admin test` — 2/2 passed
- `pnpm --filter @botiverse/hands-admin typecheck` — passed
- `pnpm --filter @botiverse/hands-admin build` — passed
- `pnpm -w build` — passed (after generating ignored Worker bindings with `wrangler types --config wrangler.hands.jsonc`)
- `pnpm -w test` — 173/173 passed
- `pnpm -w lint` — blocked by the existing Worker ESLint 9 configuration gap (`eslint.config.*` is absent)

## Post-deploy check

From a fresh unauthenticated tab, click both header **Login** and hero **Login with Raft**. Each must reach Raft `login-with-raft/setup`; after authentication, the callback must return to `/apps`. An authenticated visitor should still open `/apps` directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786518224&installation_id=145465820&pr_number=286&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F286&signature=9300f32df24e68b291fb3135d24b2253e7d26c440516ca8aa2446cd236ee3b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->