### PR TITLE
fix(admin): align landing title with agent-native positioning

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -896,7 +896,7 @@ function CliCallback({ token }: { token: string }) {
 
 function PublicLanding({ account }: { account?: AuthAccount }) {
   useEffect(() => {
-    document.title = "Hands - Client release operations";
+    document.title = "Hands - Agent-native platform for client apps";
   }, []);
 
   return (


### PR DESCRIPTION
## Problem

The public landing page browser title described Hands as "Client release operations", which no longer matches the product's agent-native positioning.

## Changes

- Rename the public landing page title to `Hands - Agent-native platform for client apps`.
- Keep authenticated route titles and documentation page titles unchanged.

## Follow-up

None.

## Testing

- `git diff --check`
- Admin build and type checks run in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786529360&installation_id=145465820&pr_number=287&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F287&signature=d4719122bb471e7af1dcf3f487d76a98938ed4a84f23b37686df00a7af8cffaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->