### PR TITLE
feat: add Node external builds and harden Electron migration

### DIFF
--- a/admin/src/components/AppCreationWizard.tsx
+++ b/admin/src/components/AppCreationWizard.tsx
@@ -8,6 +8,12 @@ import {
   DialogBody,
   DialogFooter,
   DialogClose,
+  Select,
+  SelectContent,
+  SelectIcon,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "raft-ui";
 import { createApp } from "../lib/api";
 import { useToast } from "./Toast";
@@ -41,6 +47,18 @@ const DEFAULT_PRODUCT_TYPES: Array<{
     artifact_note: "APK assets are selected later when creating builds/releases.",
   },
   {
+    name: "ios-ipa",
+    display_name: "iOS IPA",
+    description: "Signed iOS application and dSYM archive",
+    artifact_note: "Signed IPA and dSYM assets are uploaded from macOS CI.",
+  },
+  {
+    name: "ohos-app",
+    display_name: "OHOS app",
+    description: "Signed App Pack and HAP artifacts",
+    artifact_note: "AppGallery and sideload artifacts are uploaded from OHOS CI.",
+  },
+  {
     name: "electron-installer",
     display_name: "Electron desktop app",
     description: "Cross-platform desktop (darwin / linux / win32)",
@@ -53,14 +71,24 @@ const DEFAULT_PRODUCT_TYPES: Array<{
     description: "JS bundle hot-update (replaces JS layer only)",
     artifact_note: "Bundle assets are selected later when creating builds/releases.",
   },
+  {
+    name: "cli-binary",
+    display_name: "Node / CLI binary",
+    description: "Externally hosted Node SEA or CLI binary",
+    artifact_note:
+      "Hands records immutable target URLs, hashes, sizes, and runtime metadata without copying external bytes into Hands storage.",
+  },
 ];
+
+const APP_PLATFORMS = ["android", "ios", "ohos", "electron", "node"] as const;
+type AppPlatform = (typeof APP_PLATFORMS)[number];
 
 const DEFAULT_CHANNELS = [
   {
     slug: "main",
     name: "Main",
     description: "Primary stable lane for normal users",
-    enabled_product_types: ["android-apk", "electron-installer", "rn-bundle"],
+    enabled_product_types: ["android-apk", "electron-installer", "rn-bundle", "ios-ipa", "ohos-app", "cli-binary"],
   },
   {
     slug: "preview",
@@ -97,6 +125,7 @@ export function AppCreationWizard({
   const [slug, setSlug] = useState("");
   const [slugAuto, setSlugAuto] = useState(true);
   const [description, setDescription] = useState("");
+  const [platform, setPlatform] = useState<AppPlatform>("android");
   const createToastId = useRef<string | null>(null);
 
   const toast = useToast();
@@ -106,7 +135,7 @@ export function AppCreationWizard({
       createApp({
         slug: slug || slugify(name),
         name,
-        platform: "android",
+        platform,
         description: description.trim() || undefined,
       }),
     onMutate: () => {
@@ -200,6 +229,25 @@ export function AppCreationWizard({
                   }}
                   placeholder="my-app"
                 />
+              </div>
+              <div>
+                <label className="label">Platform *</label>
+                <Select
+                  value={platform}
+                  onValueChange={(value) => setPlatform(value as AppPlatform)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                    <SelectIcon />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {APP_PLATFORMS.map((value) => (
+                      <SelectItem key={value} value={value}>
+                        {value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <label className="label">Description (optional)</label>

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -130,6 +130,9 @@ function productTypeMatchesPlatform(productType: ProductType, appPlatform?: stri
   if (platform === "electron") {
     return productType.name.includes("electron") || productType.parser_kind === "electron-asar";
   }
+  if (platform === "node") {
+    return productType.name === "cli-binary" || productType.parser_kind === "external";
+  }
   if (platform === "rn" || platform === "react-native") {
     return productType.name.includes("rn") || productType.parser_kind === "rn-bundle";
   }

--- a/clients/electron/README.md
+++ b/clients/electron/README.md
@@ -31,6 +31,7 @@ import * as Hands from "@botiverse/hands-electron/main";
 Hands.init({
   appSlug: "my-desktop-app",     // your Hands app slug
   clientKey: "qk_live_...",      // public client key (safe to ship)
+  endpoint: "https://hands.build", // explicit during Quiver -> Hands migration
   release: app.getVersion(),     // version_name (defaults to app.getVersion())
   versionCode: 1020300,          // Hands version_code → picks the symbol set
   environment: "stable",         // channel

--- a/clients/electron/package.json
+++ b/clients/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-electron",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Hands crash reporting for Electron apps — main + renderer, Crashpad minidumps auto-uploaded and symbolicated server-side.",
   "license": "MIT",
   "type": "module",
@@ -24,13 +24,15 @@
   ],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "electron": ">=22"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
   },
   "publishConfig": {
     "access": "public"

--- a/clients/electron/src/common.ts
+++ b/clients/electron/src/common.ts
@@ -4,6 +4,8 @@
 /** IPC channel renderers use to forward scope updates to the main process. */
 export const CONTEXT_CHANNEL = "hands:context";
 export const DEFAULT_HANDS_ENDPOINT = "https://hands.build";
+// Preserve existing install identity and throttling across the Quiver -> Hands rename.
+export const METRICS_STATE_FILENAME = "quiver-metrics.json";
 
 export interface HandsBreadcrumb {
   message: string;

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import {
   CONTEXT_CHANNEL,
   DEFAULT_HANDS_ENDPOINT,
+  METRICS_STATE_FILENAME,
   buildGlobalExtra,
   buildSubmitURL,
   toParam,
@@ -152,7 +153,7 @@ async function reportMetrics(options: HandsElectronOptions, force = false): Prom
 }
 
 function statePath(): string {
-  return join(app.getPath("userData"), "quiver-metrics.json");
+  return join(app.getPath("userData"), METRICS_STATE_FILENAME);
 }
 
 function loadMetricsState(): { deviceId: string; lastPingAt: number } {

--- a/clients/electron/test/common.test.ts
+++ b/clients/electron/test/common.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HANDS_ENDPOINT,
+  METRICS_STATE_FILENAME,
+  buildSubmitURL,
+} from "../src/common.js";
+
+describe("Hands Electron migration contracts", () => {
+  it("uses the Hands production origin by default", () => {
+    expect(DEFAULT_HANDS_ENDPOINT).toBe("https://hands.build");
+    expect(buildSubmitURL({ appSlug: "raft", clientKey: "public-key" })).toBe(
+      "https://hands.build/public/v2/apps/raft/minidump?client_key=public-key",
+    );
+  });
+
+  it("honors an explicit endpoint without a duplicate trailing slash", () => {
+    expect(
+      buildSubmitURL({
+        appSlug: "raft desktop",
+        clientKey: "public/key",
+        endpoint: "https://preview.hands.build/",
+      }),
+    ).toBe(
+      "https://preview.hands.build/public/v2/apps/raft%20desktop/minidump?client_key=public%2Fkey",
+    );
+  });
+
+  it("preserves the legacy metrics state filename", () => {
+    expect(METRICS_STATE_FILENAME).toBe("quiver-metrics.json");
+  });
+});

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -84,6 +84,28 @@ List builds for an app:
 hands builds list raft-android
 ```
 
+## Register External Node / CLI Bytes
+
+For an app created with platform `node`, `builds publish-version` records one
+externally hosted target without copying it into Hands storage:
+
+```bash
+hands builds publish-version raft-computer \
+  --version 0.72.13 \
+  --target linux-x64 \
+  --source-url https://cdn.raft.build/computer/0.72.13/linux-x64 \
+  --raw-sha256 "$RAW_SHA256" --raw-size "$RAW_SIZE" \
+  --gzip-sha256 "$GZIP_SHA256" --gzip-size "$GZIP_SIZE" \
+  --node-version 22.23.1 \
+  --source-commit "$GIT_COMMIT"
+```
+
+Run the command once per target. Hands stores the URL, raw/gzip hashes and
+sizes, Node version, and provenance under one app/version build. An identical
+declaration replays successfully; changing version-level or target-level
+immutable fields returns a conflict. This command does not upload bytes or
+activate a release/channel pointer.
+
 ## Publish Android
 
 Use `builds publish-android` to upload an APK and create a release. Per the

--- a/docs/sdk-parity/electron.md
+++ b/docs/sdk-parity/electron.md
@@ -1,4 +1,4 @@
-# Electron SDK inventory (`@botiverse/hands-electron` v0.2.0)
+# Electron SDK inventory (`@botiverse/hands-electron` v0.2.1)
 
 Source: `clients/electron/src/{main,renderer,preload,common}.ts`. Peer dep
 `electron >= 22`, zero runtime deps. Model: thin wrapper over Electron's
@@ -22,7 +22,10 @@ built-in Crashpad reporter with Hands as the minidump endpoint.
   `window.hands` (preload); ring buffer 100; attached to the next crash
   annotation only (8 KB cap).
 - **Device analytics** — 24h-throttled metrics ping, device id persisted in
-  `userData/quiver-metrics.json`.
+  `userData/quiver-metrics.json` (kept stable across the Quiver → Hands
+  endpoint migration).
+- **Endpoint migration** — the default origin is `https://hands.build`;
+  callers may still pass an explicit endpoint for preview or staged rollout.
 
 ## Absent (→ roadmap)
 
@@ -46,7 +49,7 @@ built-in Crashpad reporter with Hands as the minidump endpoint.
 versionCode, environment, uploadToServer, extra, onCrash. Scope APIs:
 setUser/setTag/setExtra/addBreadcrumb.
 
-## Related: `@botiverse/hands-cli` v0.4.0
+## Related: `@botiverse/hands-cli` v0.5.7
 
 Publish + triage only, no runtime telemetry: `builds publish-electron
 --symbols/--metadata/--installer/--blockmap`, `publish-android --mapping/

--- a/migrations/sql/0044_external_build_targets.sql
+++ b/migrations/sql/0044_external_build_targets.sql
@@ -1,0 +1,90 @@
+-- Migration 0044: externally-hosted build declarations for Node/CLI releases.
+-- Hands records immutable release evidence while the source URL remains the
+-- byte authority. These rows deliberately do not masquerade as R2 assets.
+
+CREATE TABLE IF NOT EXISTS external_build_targets (
+  id                 TEXT PRIMARY KEY,
+  app_id             TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  build_id           TEXT NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+  version_name       TEXT NOT NULL,
+  target             TEXT NOT NULL,
+  source_url         TEXT NOT NULL,
+  raw_sha256         TEXT NOT NULL,
+  raw_size_bytes     INTEGER NOT NULL,
+  gzip_sha256        TEXT,
+  gzip_size_bytes    INTEGER,
+  node_version       TEXT,
+  metadata_json      TEXT NOT NULL DEFAULT '{}',
+  created_at         INTEGER NOT NULL,
+  updated_at         INTEGER NOT NULL,
+  UNIQUE (app_id, version_name, target)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_build_targets_build
+  ON external_build_targets(build_id, target);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_builds_external_app_version
+  ON builds(app_id, version_name)
+  WHERE source = 'external';
+
+INSERT INTO product_types (id, app_id, name, display_name, description,
+                           supported_platforms_json, default_assets_json,
+                           parser_kind, schema_json, created_at, updated_at)
+SELECT
+  lower(hex(randomblob(16))),
+  a.id,
+  'ohos-app',
+  'OHOS app',
+  'Signed App Pack and HAP artifacts for AppGallery and sideloading',
+  '["ohos"]',
+  '[{"platform":"ohos","filetype":"app"},{"platform":"ohos","filetype":"hap"}]',
+  'ohos-package',
+  '{}',
+  unixepoch() * 1000,
+  unixepoch() * 1000
+FROM apps a
+WHERE NOT EXISTS (
+  SELECT 1 FROM product_types pt
+  WHERE pt.app_id = a.id AND pt.name = 'ohos-app'
+);
+
+INSERT INTO product_types (id, app_id, name, display_name, description,
+                           supported_platforms_json, default_assets_json,
+                           parser_kind, schema_json, created_at, updated_at)
+SELECT
+  lower(hex(randomblob(16))),
+  a.id,
+  'cli-binary',
+  'Node / CLI binary',
+  'Externally hosted Node SEA or CLI binaries',
+  '["darwin-arm64","darwin-x64","linux-arm64","linux-x64","win32-arm64","win32-x64"]',
+  '[]',
+  'external',
+  '{"external_source":true}',
+  unixepoch() * 1000,
+  unixepoch() * 1000
+FROM apps a
+WHERE NOT EXISTS (
+  SELECT 1 FROM product_types pt
+  WHERE pt.app_id = a.id AND pt.name = 'cli-binary'
+);
+
+UPDATE channels
+SET enabled_product_types_json = json_insert(enabled_product_types_json, '$[#]', 'cli-binary')
+WHERE slug = 'main'
+  AND json_valid(enabled_product_types_json)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each(enabled_product_types_json)
+    WHERE value = 'cli-binary'
+  );
+
+UPDATE channels
+SET enabled_product_types_json = json_insert(enabled_product_types_json, '$[#]', 'ohos-app')
+WHERE slug = 'main'
+  AND json_valid(enabled_product_types_json)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each(enabled_product_types_json)
+    WHERE value = 'ohos-app'
+  );

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,9 +4,9 @@ Hands CLI — manage apps, builds, releases from the terminal.
 
 Status: **alpha**. The npm package is public as `@botiverse/hands-cli`; v1 ships
 `login`, `logout`, `whoami`, `apps list/get`, `builds list/get`, and
-`builds publish-android`, `builds publish-ios`, `builds publish-ohos`, and
-`builds publish-electron`. Other commands listed in `docs/cli-reference.md` land
-incrementally as backend endpoints become available.
+`builds publish-version`, `builds publish-android`, `builds publish-ios`,
+`builds publish-ohos`, and `builds publish-electron`. Other commands listed in
+`docs/cli-reference.md` land incrementally as backend endpoints become available.
 
 ## Install
 
@@ -15,7 +15,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.0 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.7 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build
@@ -44,6 +44,23 @@ hands builds publish-android raft-android \
   --version-name 1.0.3 \
   --version-code 1000300
 ```
+
+For a Node app whose artifacts remain on an external CDN, register one
+immutable target declaration at a time:
+
+```bash
+hands builds publish-version raft-computer \
+  --version 0.72.13 \
+  --target darwin-arm64 \
+  --source-url https://cdn.raft.build/computer/0.72.13/darwin-arm64 \
+  --raw-sha256 "$RAW_SHA256" --raw-size "$RAW_SIZE" \
+  --gzip-sha256 "$GZIP_SHA256" --gzip-size "$GZIP_SIZE" \
+  --node-version 22.23.1
+```
+
+This records external byte evidence; it does not upload the artifact or
+activate a release. Repeating the same declaration is idempotent. Changing an
+immutable version or target field returns a conflict.
 
 ## CI mode
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -144,6 +144,22 @@ describe("electron build helpers", () => {
   });
 });
 
+describe("external build publish helpers", () => {
+  it("splits the public target into the existing platform/arch storage shape", async () => {
+    const { splitBuildTarget } = await import("../src/commands/builds.js");
+    expect(splitBuildTarget("darwin-arm64")).toEqual({ platform: "darwin", arch: "arm64" });
+    expect(splitBuildTarget("linux-x64")).toEqual({ platform: "linux", arch: "x64" });
+    expect(() => splitBuildTarget("node")).toThrow("--target must be");
+  });
+
+  it("derives an ordering code for numeric semantic versions", async () => {
+    const { versionCodeFromVersion } = await import("../src/commands/builds.js");
+    expect(versionCodeFromVersion("0.72.12")).toBe(72_012);
+    expect(versionCodeFromVersion("1.2.3-beta.1")).toBe(1_002_003);
+    expect(() => versionCodeFromVersion("nightly")).toThrow("--version-code is required");
+  });
+});
+
 describe("iOS build helper contract", () => {
   it("documents signed IPA as the installable artifact shape", async () => {
     const { inferIosFiletype } = await import("../src/commands/builds.js");

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -159,6 +159,116 @@ export function registerBuildCommands(program: Command): void {
     );
 
   builds
+    .command("publish-version <appIdOrSlug>")
+    .description("Register an immutable externally hosted Node/CLI build target.")
+    .requiredOption("--version <version>", "Release version name.")
+    .option(
+      "--version-code <code>",
+      "Hands ordering code. Defaults to a numeric dotted-version encoding.",
+    )
+    .requiredOption(
+      "--target <target>",
+      "Artifact target, for example darwin-arm64 or linux-x64.",
+    )
+    .requiredOption("--source-url <url>", "Authoritative external HTTPS artifact URL.")
+    .requiredOption("--raw-sha256 <sha256>", "SHA-256 of the uncompressed artifact bytes.")
+    .requiredOption("--raw-size <bytes>", "Uncompressed artifact size in bytes.")
+    .option("--gzip-sha256 <sha256>", "SHA-256 of the gzip transport bytes.")
+    .option("--gzip-size <bytes>", "Gzip transport size in bytes.")
+    .option("--node-version <version>", "Node runtime version embedded in the artifact.")
+    .option("--channel <slug>", "Hands channel slug.", "main")
+    .option("--product-type <type>", "Hands product type.", "cli-binary")
+    .option("--release-type <type>", "Hands release type.", "stable")
+    .option("--source-commit <sha>", "Source commit SHA.")
+    .option("--ci-provider <name>", "CI provider name.")
+    .option("--ci-run-id <id>", "CI run id.")
+    .option("--ci-url <url>", "CI run URL.")
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        opts: {
+          version: string;
+          versionCode?: string;
+          target: string;
+          sourceUrl: string;
+          rawSha256: string;
+          rawSize: string;
+          gzipSha256?: string;
+          gzipSize?: string;
+          nodeVersion?: string;
+          channel: string;
+          productType: string;
+          releaseType: string;
+          sourceCommit?: string;
+          ciProvider?: string;
+          ciRunId?: string;
+          ciUrl?: string;
+          json?: boolean;
+        },
+      ) => {
+        splitBuildTarget(opts.target);
+        const versionCode = opts.versionCode
+          ? parseNonNegativeInteger(opts.versionCode, "--version-code")
+          : versionCodeFromVersion(opts.version);
+        const rawSize = parseNonNegativeInteger(opts.rawSize, "--raw-size");
+        const hasGzipHash = opts.gzipSha256 !== undefined;
+        const hasGzipSize = opts.gzipSize !== undefined;
+        if (hasGzipHash !== hasGzipSize) {
+          throw new Error("--gzip-sha256 and --gzip-size must be provided together");
+        }
+
+        const appId = await resolveAppId(appIdOrSlug);
+        const channelId = await resolveChannelId(appId, opts.channel);
+        const result = await apiRequest<{
+          app_id: string;
+          build_id: string;
+          target_id: string;
+          version: string;
+          target: string;
+          platform: string;
+          arch: string;
+          replayed: boolean;
+        }>(`/api/apps/${appId}/builds/publish-version`, {
+          method: "POST",
+          body: {
+            channel_id: channelId,
+            version_name: opts.version,
+            version_code: versionCode,
+            target: opts.target,
+            source_url: opts.sourceUrl,
+            raw_sha256: opts.rawSha256,
+            raw_size_bytes: rawSize,
+            gzip_sha256: opts.gzipSha256 ?? null,
+            gzip_size_bytes: hasGzipSize
+              ? parseNonNegativeInteger(opts.gzipSize as string, "--gzip-size")
+              : null,
+            node_version: opts.nodeVersion ?? null,
+            product_type: opts.productType,
+            release_type: opts.releaseType,
+            provenance_json: {
+              source_commit: opts.sourceCommit ?? null,
+              ci_provider: opts.ciProvider ?? null,
+              ci_run_id: opts.ciRunId ?? null,
+              ci_url: opts.ciUrl ?? null,
+            },
+          },
+        });
+
+        if (shouldOutputJson(program, opts.json)) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(
+          `${result.replayed ? "Verified" : "Registered"} ${result.version} ${result.target}`,
+        );
+        console.log(`  build:  ${result.build_id}`);
+        console.log(`  target: ${result.target_id}`);
+        console.log(`  source: ${opts.sourceUrl}`);
+      },
+    );
+
+  builds
     .command("publish-android <appIdOrSlug>")
     .description("Create an Android build/release and upload APK plus support artifacts.")
     .requiredOption("--apk <path>", "Installable APK path.")
@@ -1203,6 +1313,36 @@ export function inferElectronPlatform(filePath: string | undefined): string {
     return "linux";
   }
   return "win32";
+}
+
+export function splitBuildTarget(target: string): { platform: string; arch: string } {
+  const match = /^(darwin|linux|win32)-(arm64|x64)$/.exec(target);
+  if (!match) {
+    throw new Error(
+      "--target must be darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, or win32-x64",
+    );
+  }
+  return { platform: match[1]!, arch: match[2]! };
+}
+
+function parseNonNegativeInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+export function versionCodeFromVersion(version: string): number {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) {
+    throw new Error("--version-code is required when --version is not numeric major.minor.patch");
+  }
+  const parts = match.slice(1).map(Number);
+  if (parts.some((part) => !Number.isSafeInteger(part) || part > 999)) {
+    throw new Error("numeric version components must each be between 0 and 999");
+  }
+  return parts[0]! * 1_000_000 + parts[1]! * 1_000 + parts[2]!;
 }
 
 export function inferElectronFiletype(filePath: string): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.6")
+  .version("0.5.7")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
 
   container:
     dependencies:

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -123,8 +123,10 @@ import {
   handleDeleteBuildAsset,
   handleDownloadBuildAsset,
   handleGetBuild,
+  handleListExternalBuildTargets,
   handleListBuildAssets,
   handleListBuilds,
+  handlePublishExternalBuildVersion,
   handleUpdateBuild,
 } from "./routes/builds";
 import {
@@ -610,10 +612,20 @@ admin.put("/api/apps/:appId/feature-flags/:key", requireAppRole("publisher"), ha
 
 admin.get("/api/apps/:appId/builds", requireAppRole("viewer"), handleListBuilds);
 admin.post("/api/apps/:appId/builds", requireAppRole("publisher"), handleCreateBuild);
+admin.post(
+  "/api/apps/:appId/builds/publish-version",
+  requireAppRole("publisher"),
+  handlePublishExternalBuildVersion,
+);
 admin.get("/api/apps/:appId/builds/:buildId", requireAppRole("viewer"), handleGetBuild);
 admin.patch("/api/apps/:appId/builds/:buildId", requireAppRole("publisher"), handleUpdateBuild);
 admin.delete("/api/apps/:appId/builds/:buildId", requireAppRole("admin"), handleDeleteBuild);
 admin.get("/api/apps/:appId/builds/:buildId/assets", requireAppRole("viewer"), handleListBuildAssets);
+admin.get(
+  "/api/apps/:appId/builds/:buildId/external-targets",
+  requireAppRole("viewer"),
+  handleListExternalBuildTargets,
+);
 admin.post("/api/apps/:appId/builds/:buildId/assets", requireAppRole("publisher"), handleCreateBuildAsset);
 admin.get(
   "/api/apps/:appId/builds/:buildId/assets/:assetId/download",

--- a/worker/src/lib/app_platform.ts
+++ b/worker/src/lib/app_platform.ts
@@ -1,0 +1,7 @@
+export const APP_PLATFORMS = ["android", "ios", "ohos", "electron", "node"] as const;
+
+export type AppPlatform = (typeof APP_PLATFORMS)[number];
+
+export function isAppPlatform(value: unknown): value is AppPlatform {
+  return typeof value === "string" && (APP_PLATFORMS as readonly string[]).includes(value);
+}

--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -51,6 +51,32 @@ const BuildAssetInput = z
   .catchall(z.unknown())
   .openapi("BuildAssetInput");
 
+const ExternalBuildVersionInput = z
+  .object({
+    channel_id: z.string(),
+    version_name: z.string(),
+    version_code: z.number().int().nonnegative(),
+    target: z.enum([
+      "darwin-arm64",
+      "darwin-x64",
+      "linux-arm64",
+      "linux-x64",
+      "win32-arm64",
+      "win32-x64",
+    ]),
+    source_url: z.string().url(),
+    raw_sha256: z.string().regex(/^[a-f0-9]{64}$/i),
+    raw_size_bytes: z.number().int().nonnegative(),
+    gzip_sha256: z.string().regex(/^[a-f0-9]{64}$/i).nullable().optional(),
+    gzip_size_bytes: z.number().int().nonnegative().nullable().optional(),
+    node_version: z.string().nullable().optional(),
+    product_type: z.string().default("cli-binary").optional(),
+    release_type: z.string().default("stable").optional(),
+    metadata_json: z.record(z.string(), z.unknown()).optional(),
+    provenance_json: z.record(z.string(), z.unknown()).optional(),
+  })
+  .openapi("ExternalBuildVersionInput");
+
 export function registerBuildRoutes(registry: OpenApiRegistry) {
   register(registry, {
     method: "get",
@@ -86,6 +112,28 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
       201: success("Created build.", GenericObject),
       400: error("Invalid build payload."),
       403: error("Current principal cannot create builds."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/builds/publish-version",
+    tags: ["Builds"],
+    summary: "Register an immutable externally hosted build target",
+    description:
+      "Creates or reuses a Node build ledger entry. The external HTTPS URL remains the byte authority; Hands records hashes, sizes, and runtime metadata without pretending the artifact is stored in Hands R2.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      body: { content: json(ExternalBuildVersionInput), required: true },
+    },
+    responses: {
+      200: success("Idempotent replay of an identical declaration.", GenericObject),
+      201: success("Registered external build target.", GenericObject),
+      400: error("Invalid external build declaration."),
+      403: error("Current principal cannot publish builds."),
+      404: error("App was not found."),
+      409: error("App platform or immutable declaration conflicts."),
     },
   });
 
@@ -163,6 +211,23 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
       201: success("Created build asset.", GenericObject),
       400: error("Invalid build asset payload."),
       403: error("Current principal cannot create build assets."),
+      404: error("Build was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/builds/{buildId}/external-targets",
+    tags: ["Builds"],
+    summary: "List externally hosted targets for a build",
+    security: auth,
+    request: { params: AppBuildParams },
+    responses: {
+      200: success(
+        "External build target declarations.",
+        z.object({ targets: z.array(GenericObject) }),
+      ),
+      403: error("Current principal cannot view build targets."),
       404: error("Build was not found."),
     },
   });

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Context } from "hono";
+import { APP_PLATFORMS, isAppPlatform } from "../lib/app_platform";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { currentAccount, currentDeployToken } from "../lib/permissions";
 
@@ -108,6 +109,16 @@ export async function handleCreateApp(c: AdminContext) {
   if (!body.slug || !body.name || !body.platform) {
     return c.json({ error: "slug, name, platform required" }, 400);
   }
+  if (!isAppPlatform(body.platform)) {
+    return c.json(
+      {
+        error: "unsupported app platform",
+        code: "UNSUPPORTED_APP_PLATFORM",
+        supported_platforms: APP_PLATFORMS,
+      },
+      400,
+    );
+  }
   const id = crypto.randomUUID();
   const now = Date.now();
   const orgId = await currentOrgId(c);
@@ -131,9 +142,15 @@ export async function handleCreateApp(c: AdminContext) {
     c.env.DB.prepare(
       `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'ios-ipa', 'iOS app', 'iOS IPA distributed through TestFlight, ad-hoc, or enterprise lanes', '["ios"]', '[{"platform":"ios","filetype":"ipa"},{"platform":"ios","filetype":"dsym.zip","artifact_kind":"dsym"}]', 'ipa-info', '{"distribution_profile_required":true}', ?, ?)`,
     ).bind(crypto.randomUUID(), id, now, now),
+    c.env.DB.prepare(
+      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'ohos-app', 'OHOS app', 'Signed App Pack and HAP artifacts for AppGallery and sideloading', '["ohos"]', '[{"platform":"ohos","filetype":"app"},{"platform":"ohos","filetype":"hap"}]', 'ohos-package', '{}', ?, ?)`,
+    ).bind(crypto.randomUUID(), id, now, now),
+    c.env.DB.prepare(
+      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'cli-binary', 'Node / CLI binary', 'Externally hosted Node SEA or CLI binaries', '["darwin-arm64","darwin-x64","linux-arm64","linux-x64","win32-arm64","win32-x64"]', '[]', 'external', '{"external_source":true}', ?, ?)`,
+    ).bind(crypto.randomUUID(), id, now, now),
     // channels (with default bundle_id overrides for parallel install)
     c.env.DB.prepare(
-      `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'main', 'Main', NULL, NULL, NULL, '["android-apk","electron-installer","rn-bundle","ios-ipa"]', '{}', ?)`,
+      `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'main', 'Main', NULL, NULL, NULL, '["android-apk","electron-installer","rn-bundle","ios-ipa","ohos-app","cli-binary"]', '{}', ?)`,
     ).bind(crypto.randomUUID(), id, now),
     c.env.DB.prepare(
       `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'preview', 'Preview', ?, NULL, NULL, '["android-apk","rn-bundle","ios-ipa"]', '{}', ?)`,

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -39,6 +39,38 @@ export interface BuildAssetInput {
   metadata_json?: unknown;
 }
 
+export interface ExternalBuildVersionInput {
+  channel_id: string;
+  version_name: string;
+  version_code: number;
+  target: string;
+  source_url: string;
+  raw_sha256: string;
+  raw_size_bytes: number;
+  gzip_sha256?: string | null;
+  gzip_size_bytes?: number | null;
+  node_version?: string | null;
+  product_type?: string;
+  release_type?: string;
+  metadata_json?: unknown;
+  provenance_json?: unknown;
+}
+
+interface ExternalBuildTargetRow {
+  id: string;
+  app_id: string;
+  build_id: string;
+  version_name: string;
+  target: string;
+  source_url: string;
+  raw_sha256: string;
+  raw_size_bytes: number;
+  gzip_sha256: string | null;
+  gzip_size_bytes: number | null;
+  node_version: string | null;
+  metadata_json: string;
+}
+
 interface BuildRow {
   id: string;
   app_id: string;
@@ -77,6 +109,154 @@ interface BuildAssetDownloadRow {
 function jsonString(value: unknown, fallback: JsonRecord = {}): string {
   if (typeof value === "string") return value;
   return JSON.stringify(value ?? fallback);
+}
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as JsonRecord)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalJson(entry)]),
+    );
+  }
+  return value;
+}
+
+function externalJsonString(value: unknown): string {
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(canonicalJson(JSON.parse(value)));
+    } catch {
+      return value;
+    }
+  }
+  return JSON.stringify(canonicalJson(value ?? {}));
+}
+
+const BUILD_TARGET_PATTERN = /^(darwin|linux|win32)-(arm64|x64)$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+
+export function splitBuildTarget(target: string): { platform: string; arch: string } {
+  const match = BUILD_TARGET_PATTERN.exec(target);
+  if (!match) {
+    throw new Error(
+      "target must be darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, or win32-x64",
+    );
+  }
+  return { platform: match[1]!, arch: match[2]! };
+}
+
+function normalizeSha256(value: string, field: string): string {
+  if (!SHA256_PATTERN.test(value)) throw new Error(`${field} must be a 64-character SHA-256 hex digest`);
+  return value.toLowerCase();
+}
+
+function normalizeExternalBuildInput(input: ExternalBuildVersionInput): ExternalBuildVersionInput {
+  if (!input.channel_id || !input.version_name || !input.target || !input.source_url) {
+    throw new Error("channel_id, version_name, target, source_url required");
+  }
+  splitBuildTarget(input.target);
+  const source = new URL(input.source_url);
+  if (source.protocol !== "https:") throw new Error("source_url must use https");
+  if (source.username || source.password) {
+    throw new Error("source_url must not contain embedded credentials");
+  }
+  if (!Number.isSafeInteger(Number(input.version_code)) || Number(input.version_code) < 0) {
+    throw new Error("version_code must be a non-negative integer");
+  }
+  if (!Number.isSafeInteger(Number(input.raw_size_bytes)) || Number(input.raw_size_bytes) < 0) {
+    throw new Error("raw_size_bytes must be a non-negative integer");
+  }
+  const hasGzipHash = input.gzip_sha256 !== undefined && input.gzip_sha256 !== null;
+  const hasGzipSize = input.gzip_size_bytes !== undefined && input.gzip_size_bytes !== null;
+  if (hasGzipHash !== hasGzipSize) {
+    throw new Error("gzip_sha256 and gzip_size_bytes must be provided together");
+  }
+  if (hasGzipSize && (!Number.isSafeInteger(Number(input.gzip_size_bytes)) || Number(input.gzip_size_bytes) < 0)) {
+    throw new Error("gzip_size_bytes must be a non-negative integer");
+  }
+  return {
+    ...input,
+    version_code: Number(input.version_code),
+    raw_sha256: normalizeSha256(input.raw_sha256, "raw_sha256"),
+    raw_size_bytes: Number(input.raw_size_bytes),
+    gzip_sha256: hasGzipHash ? normalizeSha256(input.gzip_sha256 as string, "gzip_sha256") : null,
+    gzip_size_bytes: hasGzipSize ? Number(input.gzip_size_bytes) : null,
+    node_version: input.node_version?.trim() || null,
+    product_type: input.product_type ?? "cli-binary",
+    release_type: input.release_type ?? "stable",
+  };
+}
+
+function externalDeclarationMatches(
+  existing: ExternalBuildTargetRow,
+  input: ExternalBuildVersionInput,
+): boolean {
+  return (
+    existing.source_url === input.source_url &&
+    existing.raw_sha256 === input.raw_sha256 &&
+    existing.raw_size_bytes === input.raw_size_bytes &&
+    existing.gzip_sha256 === (input.gzip_sha256 ?? null) &&
+    existing.gzip_size_bytes === (input.gzip_size_bytes ?? null) &&
+    existing.node_version === (input.node_version ?? null) &&
+    existing.metadata_json === externalJsonString(input.metadata_json)
+  );
+}
+
+interface ExternalBuildRow {
+  id: string;
+  channel_id: string;
+  product_type: string;
+  release_type: string;
+  version_code: number;
+  provenance_json: string;
+}
+
+function externalVersionMatches(
+  existing: ExternalBuildRow,
+  input: ExternalBuildVersionInput,
+): boolean {
+  return (
+    existing.channel_id === input.channel_id &&
+    existing.product_type === input.product_type &&
+    existing.release_type === input.release_type &&
+    existing.version_code === input.version_code &&
+    existing.provenance_json === externalJsonString(input.provenance_json)
+  );
+}
+
+async function getExternalBuild(
+  db: D1Database,
+  appId: string,
+  versionName: string,
+): Promise<ExternalBuildRow | null> {
+  return await db
+    .prepare(
+      `SELECT id, channel_id, product_type, release_type, version_code, provenance_json
+       FROM builds
+       WHERE app_id = ?1 AND version_name = ?2 AND source = 'external'`,
+    )
+    .bind(appId, versionName)
+    .first<ExternalBuildRow>();
+}
+
+async function getExternalTarget(
+  db: D1Database,
+  appId: string,
+  versionName: string,
+  target: string,
+): Promise<ExternalBuildTargetRow | null> {
+  return await db
+    .prepare(
+      `SELECT id, app_id, build_id, version_name, target, source_url,
+              raw_sha256, raw_size_bytes, gzip_sha256, gzip_size_bytes,
+              node_version, metadata_json
+       FROM external_build_targets
+       WHERE app_id = ?1 AND version_name = ?2 AND target = ?3`,
+    )
+    .bind(appId, versionName, target)
+    .first<ExternalBuildTargetRow>();
 }
 
 async function insertAuditLog(
@@ -285,6 +465,226 @@ export async function handleGetBuild(c: Context<{ Bindings: Env }>) {
     .first();
   if (!row) return c.json({ error: "not found" }, 404);
   return c.json(row);
+}
+
+export async function handlePublishExternalBuildVersion(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  let input: ExternalBuildVersionInput;
+  try {
+    input = normalizeExternalBuildInput((await c.req.json()) as ExternalBuildVersionInput);
+  } catch (error) {
+    return c.json({ error: (error as Error).message, code: "INVALID_EXTERNAL_BUILD" }, 400);
+  }
+
+  const app = await c.env.DB.prepare("SELECT id, platform FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string; platform: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+  if (app.platform !== "node") {
+    return c.json(
+      {
+        error: "external Node build publishing requires app platform 'node'",
+        code: "APP_PLATFORM_MISMATCH",
+        app_platform: app.platform,
+      },
+      409,
+    );
+  }
+
+  const channel = await c.env.DB
+    .prepare("SELECT id FROM channels WHERE app_id = ?1 AND id = ?2")
+    .bind(appId, input.channel_id)
+    .first<{ id: string }>();
+  if (!channel) return c.json({ error: "channel_id not found for app" }, 400);
+
+  let build = await getExternalBuild(c.env.DB, appId, input.version_name);
+
+  if (build) {
+    if (!externalVersionMatches(build, input)) {
+      return c.json(
+        {
+          error: "external version metadata conflicts with the existing immutable version",
+          code: "EXTERNAL_VERSION_CONFLICT",
+          build_id: build.id,
+        },
+        409,
+      );
+    }
+  }
+
+  const replay = await getExternalTarget(c.env.DB, appId, input.version_name, input.target);
+  if (replay) {
+    if (!externalDeclarationMatches(replay, input)) {
+      return c.json(
+        {
+          error: "external build declaration conflicts with the existing immutable target",
+          code: "EXTERNAL_BUILD_CONFLICT",
+          build_id: replay.build_id,
+          target_id: replay.id,
+          target: replay.target,
+        },
+        409,
+      );
+    }
+    const { platform, arch } = splitBuildTarget(input.target);
+    return c.json({
+      app_id: appId,
+      build_id: replay.build_id,
+      target_id: replay.id,
+      version: input.version_name,
+      target: input.target,
+      platform,
+      arch,
+      replayed: true,
+    });
+  }
+
+  if (!build) {
+    const buildId = crypto.randomUUID();
+    try {
+      await createBuild(
+        c.env.DB,
+        appId,
+        {
+          channel_id: input.channel_id,
+          product_type: input.product_type!,
+          release_type: input.release_type!,
+          version_name: input.version_name,
+          version_code: input.version_code,
+          source: "external",
+          status: "succeeded",
+          build_metadata_json: { external_source: true },
+          provenance_json: externalJsonString(input.provenance_json),
+        },
+        currentActor(c),
+        buildId,
+      );
+      build = {
+        id: buildId,
+        channel_id: input.channel_id,
+        product_type: input.product_type!,
+        release_type: input.release_type!,
+        version_code: input.version_code,
+        provenance_json: externalJsonString(input.provenance_json),
+      };
+    } catch (error) {
+      build = await getExternalBuild(c.env.DB, appId, input.version_name);
+      if (!build) throw error;
+      if (!externalVersionMatches(build, input)) {
+        return c.json(
+          {
+            error: "external version metadata conflicts with the existing immutable version",
+            code: "EXTERNAL_VERSION_CONFLICT",
+            build_id: build.id,
+          },
+          409,
+        );
+      }
+    }
+  }
+
+  const targetId = crypto.randomUUID();
+  const now = Date.now();
+  try {
+    await c.env.DB
+      .prepare(
+        `INSERT INTO external_build_targets
+         (id, app_id, build_id, version_name, target, source_url,
+          raw_sha256, raw_size_bytes, gzip_sha256, gzip_size_bytes,
+          node_version, metadata_json, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)`,
+      )
+      .bind(
+        targetId,
+        appId,
+        build.id,
+        input.version_name,
+        input.target,
+        input.source_url,
+        input.raw_sha256,
+        input.raw_size_bytes,
+        input.gzip_sha256 ?? null,
+        input.gzip_size_bytes ?? null,
+        input.node_version ?? null,
+        externalJsonString(input.metadata_json),
+        now,
+        now,
+      )
+      .run();
+  } catch (error) {
+    const concurrent = await getExternalTarget(c.env.DB, appId, input.version_name, input.target);
+    if (!concurrent) throw error;
+    if (!externalDeclarationMatches(concurrent, input)) {
+      return c.json(
+        {
+          error: "external build declaration conflicts with the existing immutable target",
+          code: "EXTERNAL_BUILD_CONFLICT",
+          build_id: concurrent.build_id,
+          target_id: concurrent.id,
+          target: concurrent.target,
+        },
+        409,
+      );
+    }
+    const { platform, arch } = splitBuildTarget(input.target);
+    return c.json({
+      app_id: appId,
+      build_id: concurrent.build_id,
+      target_id: concurrent.id,
+      version: input.version_name,
+      target: input.target,
+      platform,
+      arch,
+      replayed: true,
+    });
+  }
+
+  await insertAuditLog(c.env.DB, appId, "external_build.publish", currentActor(c), {
+    buildId: build.id,
+    targetId,
+    version: input.version_name,
+    target: input.target,
+    source_url: input.source_url,
+    raw_sha256: input.raw_sha256,
+    raw_size_bytes: input.raw_size_bytes,
+    gzip_sha256: input.gzip_sha256 ?? null,
+    gzip_size_bytes: input.gzip_size_bytes ?? null,
+    node_version: input.node_version ?? null,
+  });
+
+  const { platform, arch } = splitBuildTarget(input.target);
+  return c.json(
+    {
+      app_id: appId,
+      build_id: build.id,
+      target_id: targetId,
+      version: input.version_name,
+      target: input.target,
+      platform,
+      arch,
+      replayed: false,
+    },
+    201,
+  );
+}
+
+export async function handleListExternalBuildTargets(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const buildId = c.req.param("buildId") ?? "";
+  const build = await getBuildForApp(c.env.DB, appId, buildId);
+  if (!build) return c.json({ error: "build not found" }, 404);
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT id, build_id, version_name, target, source_url,
+              raw_sha256, raw_size_bytes, gzip_sha256, gzip_size_bytes,
+              node_version, metadata_json, created_at, updated_at
+       FROM external_build_targets
+       WHERE app_id = ?1 AND build_id = ?2
+       ORDER BY target ASC`,
+    )
+    .bind(appId, buildId)
+    .all();
+  return c.json({ targets: results });
 }
 
 export async function handleCreateBuild(c: AdminContext) {

--- a/worker/test/external_builds.test.ts
+++ b/worker/test/external_builds.test.ts
@@ -1,0 +1,308 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { APP_PLATFORMS } from "../src/lib/app_platform";
+import { handleCreateApp } from "../src/routes/apps";
+import {
+  handleListExternalBuildTargets,
+  handlePublishExternalBuildVersion,
+} from "../src/routes/builds";
+
+function makeDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  sqlite.exec(`
+    CREATE TABLE apps (
+      id TEXT PRIMARY KEY,
+      platform TEXT NOT NULL
+    );
+    CREATE TABLE channels (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE
+    );
+    CREATE TABLE builds (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      channel_id TEXT,
+      product_type TEXT NOT NULL,
+      release_type TEXT NOT NULL,
+      version_name TEXT NOT NULL,
+      version_code INTEGER NOT NULL,
+      changelog TEXT,
+      source TEXT NOT NULL,
+      status TEXT NOT NULL,
+      build_metadata_json TEXT NOT NULL,
+      parsed_metadata_json TEXT NOT NULL,
+      should_force_update INTEGER NOT NULL,
+      availability_at INTEGER,
+      provenance_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER
+    );
+    CREATE UNIQUE INDEX idx_builds_external_app_version
+      ON builds(app_id, version_name)
+      WHERE source = 'external';
+    CREATE TABLE external_build_targets (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      build_id TEXT NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+      version_name TEXT NOT NULL,
+      target TEXT NOT NULL,
+      source_url TEXT NOT NULL,
+      raw_sha256 TEXT NOT NULL,
+      raw_size_bytes INTEGER NOT NULL,
+      gzip_sha256 TEXT,
+      gzip_size_bytes INTEGER,
+      node_version TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (app_id, version_name, target)
+    );
+    CREATE TABLE audit_logs (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      action TEXT NOT NULL,
+      actor TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+  `);
+
+  const normalize = (sql: string) => sql.replace(/\?\d+/g, "?");
+  return {
+    prepare(sql: string) {
+      const statement = sqlite.prepare(normalize(sql));
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              statement.run(...params);
+              return { success: true };
+            },
+            async first<T>() {
+              return (statement.get(...params) as T | undefined) ?? null;
+            },
+            async all<T>() {
+              return { results: statement.all(...params) as T[], success: true };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function jsonContext(
+  db: ReturnType<typeof makeDb>,
+  params: Record<string, string>,
+  body: unknown = {},
+) {
+  return {
+    env: { DB: db },
+    req: {
+      param: (name: string) => params[name] ?? "",
+      json: async () => body,
+    },
+    get: (name: string) => (name === "admin_actor" ? "external-build-test" : undefined),
+    json: (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  } as any;
+}
+
+const RAW_SHA = "a".repeat(64);
+const OTHER_SHA = "b".repeat(64);
+const GZIP_SHA = "c".repeat(64);
+
+function declaration(target = "darwin-arm64") {
+  return {
+    channel_id: "main",
+    version_name: "0.72.13",
+    version_code: 7213,
+    target,
+    source_url: `https://cdn.raft.build/computer/0.72.13/${target}`,
+    raw_sha256: RAW_SHA,
+    raw_size_bytes: 12_345,
+    gzip_sha256: GZIP_SHA,
+    gzip_size_bytes: 5_432,
+    node_version: "22.23.1",
+    metadata_json: { source: "computer-release" },
+    provenance_json: { commit: "0123456789abcdef" },
+  };
+}
+
+describe("external Node build declarations", () => {
+  it("rejects app platform values outside the shared closed set", async () => {
+    const response = await handleCreateApp(
+      jsonContext(makeDb(), {}, { slug: "bad", name: "Bad", platform: "web" }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported app platform",
+      code: "UNSUPPORTED_APP_PLATFORM",
+      supported_platforms: APP_PLATFORMS,
+    });
+  });
+
+  it("publishes immutable per-target evidence and replays the same declaration", async () => {
+    const db = makeDb();
+    await db.prepare("INSERT INTO apps (id, platform) VALUES (?1, 'node')").bind("computer").run();
+    await db.prepare("INSERT INTO channels (id, app_id) VALUES ('main', ?1)").bind("computer").run();
+
+    const first = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, declaration()),
+    );
+    expect(first.status).toBe(201);
+    const firstBody = await first.json() as any;
+    expect(firstBody).toMatchObject({
+      app_id: "computer",
+      version: "0.72.13",
+      target: "darwin-arm64",
+      platform: "darwin",
+      arch: "arm64",
+      replayed: false,
+    });
+
+    const replay = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, declaration()),
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      build_id: firstBody.build_id,
+      target_id: firstBody.target_id,
+      replayed: true,
+    });
+
+    const secondTarget = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, declaration("linux-x64")),
+    );
+    expect(secondTarget.status).toBe(201);
+    await expect(secondTarget.json()).resolves.toMatchObject({
+      build_id: firstBody.build_id,
+      target: "linux-x64",
+      platform: "linux",
+      arch: "x64",
+      replayed: false,
+    });
+
+    const list = await handleListExternalBuildTargets(
+      jsonContext(db, { appId: "computer", buildId: firstBody.build_id }),
+    );
+    expect(list.status).toBe(200);
+    const listBody = await list.json() as any;
+    expect(listBody.targets.map((target: any) => target.target)).toEqual([
+      "darwin-arm64",
+      "linux-x64",
+    ]);
+  });
+
+  it("canonicalizes nested declaration JSON for idempotent replay", async () => {
+    const db = makeDb();
+    await db.prepare("INSERT INTO apps (id, platform) VALUES (?1, 'node')").bind("computer").run();
+    await db.prepare("INSERT INTO channels (id, app_id) VALUES ('main', ?1)").bind("computer").run();
+
+    const first = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, {
+        ...declaration(),
+        metadata_json: { source: "computer-release", nested: { left: 1, right: 2 } },
+        provenance_json: {
+          commit: "0123456789abcdef",
+          run: { provider: "github", id: "42" },
+        },
+      }),
+    );
+    expect(first.status).toBe(201);
+    const firstBody = await first.json() as any;
+
+    const replay = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, {
+        ...declaration(),
+        metadata_json: { nested: { right: 2, left: 1 }, source: "computer-release" },
+        provenance_json: {
+          run: { id: "42", provider: "github" },
+          commit: "0123456789abcdef",
+        },
+      }),
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      build_id: firstBody.build_id,
+      target_id: firstBody.target_id,
+      replayed: true,
+    });
+  });
+
+  it("rejects changed bytes for an existing app/version/target declaration", async () => {
+    const db = makeDb();
+    await db.prepare("INSERT INTO apps (id, platform) VALUES (?1, 'node')").bind("computer").run();
+    await db.prepare("INSERT INTO channels (id, app_id) VALUES ('main', ?1)").bind("computer").run();
+
+    const first = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, declaration()),
+    );
+    expect(first.status).toBe(201);
+
+    const conflict = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, { ...declaration(), raw_sha256: OTHER_SHA }),
+    );
+    expect(conflict.status).toBe(409);
+    await expect(conflict.json()).resolves.toMatchObject({
+      code: "EXTERNAL_BUILD_CONFLICT",
+      target: "darwin-arm64",
+    });
+  });
+
+  it("rejects changed version-level metadata before treating a target as a replay", async () => {
+    const db = makeDb();
+    await db.prepare("INSERT INTO apps (id, platform) VALUES (?1, 'node')").bind("computer").run();
+    await db.prepare("INSERT INTO channels (id, app_id) VALUES ('main', ?1)").bind("computer").run();
+
+    const first = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, declaration()),
+    );
+    expect(first.status).toBe(201);
+
+    const conflict = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "computer" }, { ...declaration(), version_code: 72_014 }),
+    );
+    expect(conflict.status).toBe(409);
+    await expect(conflict.json()).resolves.toMatchObject({
+      code: "EXTERNAL_VERSION_CONFLICT",
+    });
+  });
+
+  it("requires a node app", async () => {
+    const db = makeDb();
+    await db.prepare("INSERT INTO apps (id, platform) VALUES (?1, 'electron')").bind("desktop").run();
+    await db.prepare("INSERT INTO channels (id, app_id) VALUES ('main', ?1)").bind("desktop").run();
+
+    const response = await handlePublishExternalBuildVersion(
+      jsonContext(db, { appId: "desktop" }, declaration()),
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "APP_PLATFORM_MISMATCH",
+      app_platform: "electron",
+    });
+  });
+
+  it("rejects source URLs that embed credentials", async () => {
+    const response = await handlePublishExternalBuildVersion(
+      jsonContext(makeDb(), { appId: "computer" }, {
+        ...declaration(),
+        source_url: "https://token@example.test/computer",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "INVALID_EXTERNAL_BUILD",
+      error: "source_url must not contain embedded credentials",
+    });
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -75,6 +75,8 @@ describe("quiver OpenAPI document", () => {
       "/apps/{slug}/history",
       "/api/apps",
       "/api/apps/{appId}/builds",
+      "/api/apps/{appId}/builds/publish-version",
+      "/api/apps/{appId}/builds/{buildId}/external-targets",
       "/api/apps/{appId}/releases/{releaseId}/publish",
       "/api/apps/{appId}/feedback/{ticketId}/comments",
       "/api/apps/{appId}/client-key",


### PR DESCRIPTION
## Summary

- add Node and OpenHarmony as closed app platforms
- add immutable external-CDN build declarations keyed by app, version, platform, and target
- add `hands builds publish-version` as registration-only CLI flow with typed replay/conflict behavior
- update the Electron SDK to default to `https://hands.build` while preserving `quiver-metrics.json`
- expose platform selection in the admin release flow

## Contract

External build registration accepts only HTTPS source URLs without embedded credentials. Exact replays are idempotent; a changed declaration for an existing version/target returns a typed conflict. Registration does not upload bytes or activate release pointers.

## Verification

- Worker: 151/151 tests + build
- CLI: 16/16 tests + build
- Electron: 3/3 tests + build
- Admin: typecheck + production build
- migrations: 0001 through 0044
- package pack checks
- diff-check

## Follow-up

Before matrix CI relies on per-target provenance, split stable version-source provenance from target publication-run provenance. Exact `source_url` immutability in this PR is intentional.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786623147&installation_id=145465820&pr_number=288&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F288&signature=1367c7e526a8eca7d61aae27893fa0e60f1849b41fb0565d1f30d5686c638a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->