### PR TITLE
Rename Electron metrics state file to hands-metrics.json

### DIFF
--- a/clients/electron/src/common.ts
+++ b/clients/electron/src/common.ts
@@ -4,8 +4,12 @@
 /** IPC channel renderers use to forward scope updates to the main process. */
 export const CONTEXT_CHANNEL = "hands:context";
 export const DEFAULT_HANDS_ENDPOINT = "https://hands.build";
-// Preserve existing install identity and throttling across the Quiver -> Hands rename.
-export const METRICS_STATE_FILENAME = "quiver-metrics.json";
+// Metrics state file (install identity + ping throttling).
+export const METRICS_STATE_FILENAME = "hands-metrics.json";
+// Legacy filename from before the Quiver -> Hands rename. Existing installs have
+// this on disk; it is read as a one-way fallback when the current file is absent
+// so device identity + throttling carry over. The next save writes the new file.
+export const LEGACY_METRICS_STATE_FILENAME = "quiver-metrics.json";
 
 export interface HandsBreadcrumb {
   message: string;

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -17,6 +17,7 @@ import {
   CONTEXT_CHANNEL,
   DEFAULT_HANDS_ENDPOINT,
   METRICS_STATE_FILENAME,
+  LEGACY_METRICS_STATE_FILENAME,
   buildGlobalExtra,
   buildSubmitURL,
   toParam,
@@ -157,9 +158,17 @@ function statePath(): string {
 }
 
 function loadMetricsState(): { deviceId: string; lastPingAt: number } {
-  const path = statePath();
+  let path = statePath();
+  // One-way migration: if the current file is absent but the legacy
+  // quiver-metrics.json exists, read the legacy file so an existing install's
+  // device identity + throttling carry over. The next saveMetricsState writes
+  // the current (hands-metrics.json) file.
+  if (!existsSync(path)) {
+    const legacy = join(app.getPath("userData"), LEGACY_METRICS_STATE_FILENAME);
+    if (!existsSync(legacy)) return { deviceId: "", lastPingAt: 0 };
+    path = legacy;
+  }
   try {
-    if (!existsSync(path)) return { deviceId: "", lastPingAt: 0 };
     const parsed = JSON.parse(readFileSync(path, "utf8")) as { deviceId?: unknown; lastPingAt?: unknown };
     return {
       deviceId: typeof parsed.deviceId === "string" ? parsed.deviceId : "",

--- a/clients/electron/test/common.test.ts
+++ b/clients/electron/test/common.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HANDS_ENDPOINT,
   METRICS_STATE_FILENAME,
+  LEGACY_METRICS_STATE_FILENAME,
   buildSubmitURL,
 } from "../src/common.js";
 
@@ -25,7 +26,8 @@ describe("Hands Electron migration contracts", () => {
     );
   });
 
-  it("preserves the legacy metrics state filename", () => {
-    expect(METRICS_STATE_FILENAME).toBe("quiver-metrics.json");
+  it("uses the Hands metrics state filename and keeps the legacy fallback", () => {
+    expect(METRICS_STATE_FILENAME).toBe("hands-metrics.json");
+    expect(LEGACY_METRICS_STATE_FILENAME).toBe("quiver-metrics.json");
   });
 });

--- a/docs/sdk-parity/electron.md
+++ b/docs/sdk-parity/electron.md
@@ -22,8 +22,8 @@ built-in Crashpad reporter with Hands as the minidump endpoint.
   `window.hands` (preload); ring buffer 100; attached to the next crash
   annotation only (8 KB cap).
 - **Device analytics** — 24h-throttled metrics ping, device id persisted in
-  `userData/quiver-metrics.json` (kept stable across the Quiver → Hands
-  endpoint migration).
+  `userData/hands-metrics.json` (a legacy `quiver-metrics.json` is still read
+  once as a fallback so existing installs keep their device id + throttling).
 - **Endpoint migration** — the default origin is `https://hands.build`;
   callers may still pass an explicit endpoint for preview or staged rollout.
 


### PR DESCRIPTION
## Summary

Rename the Electron SDK's metrics state file from `quiver-metrics.json` to `hands-metrics.json`, with a one-way legacy fallback so existing installs keep their device identity and ping throttling.

## Details

- `METRICS_STATE_FILENAME` is now `hands-metrics.json`; `LEGACY_METRICS_STATE_FILENAME` (`quiver-metrics.json`) is added.
- `loadMetricsState` reads the current file, and falls back to the legacy file once when the current file is absent. The next `saveMetricsState` writes the new file.
- No data loss on upgrade: an existing install's device id and `lastPingAt` carry over.

## Compatibility

Legacy request headers (`X-Quiver-*`), environment variables (`QUIVER_*`), and other on-disk paths remain accepted as compatibility aliases and are unchanged in this PR — removing them would break existing clients and CI.

## Verification

- `clients/electron`: `tsc --noEmit` clean; `vitest run` 3/3 (the state-filename contract test now asserts the new name plus the legacy fallback constant).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786642766&installation_id=145465820&pr_number=289&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F289&signature=449314adeb64ab9c0a0a8a2d70af826442858be362dd7e180c426fd665713381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->