### PR TITLE
Make share links durable: no default expiry, recoverable URLs

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1343,9 +1343,11 @@ export const listWebhookDeliveries = (orgId: string, webhookId: string) =>
 export interface AppShare {
   id: string;
   release_id: string;
+  // Copyable URL; null for legacy shares created before tokens were stored.
+  share_url: string | null;
   created_by: string;
   created_at: number;
-  expires_at: number;
+  expires_at: number | null;
   revoked_at: number | null;
   has_password: number; // 0 | 1 from SQLite
   release_status: string;
@@ -1366,7 +1368,7 @@ export const createReleaseShare = (
   releaseId: string,
   body: { ttl_seconds?: number; expires_at?: number; password?: string },
 ) =>
-  request<{ id: string; share_url: string; expires_at: number; has_password: boolean }>(
+  request<{ id: string; share_url: string; expires_at: number | null; has_password: boolean }>(
     `/api/apps/${appId}/releases/${releaseId}/shares`,
     { method: "POST", body: JSON.stringify(body), admin: true },
   );
@@ -1375,9 +1377,9 @@ export const renewReleaseShare = (
   appId: string,
   releaseId: string,
   shareId: string,
-  body: { ttl_seconds?: number; expires_at?: number; password?: string | null },
+  body: { ttl_seconds?: number; expires_at?: number | null; password?: string | null },
 ) =>
-  request<{ id: string; expires_at: number }>(
+  request<{ id: string; expires_at: number | null }>(
     `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,
     { method: "PATCH", body: JSON.stringify(body), admin: true },
   );

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -2,8 +2,9 @@
  * App-level share management (task #65 P1).
  *
  * Lists every share link for the app across releases with stats, lets
- * admins create (with optional password), renew, and revoke them. The
- * share URL is only visible at creation time — tokens are stored hashed.
+ * admins create (with optional password), copy the URL, and revoke them.
+ * Shares have no expiry — they live until revoked. Legacy shares created
+ * before tokens were stored have no recoverable URL.
  */
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -17,8 +18,6 @@ import {
   revokeReleaseShare,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
-
-const WEEK_SECONDS = 7 * 24 * 60 * 60;
 
 export function AppShares({ appId }: { appId: string }) {
   const toast = useToast();
@@ -34,28 +33,10 @@ export function AppShares({ appId }: { appId: string }) {
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["app-shares", appId] });
 
-  const renew = useMutation({
-    mutationFn: (share: AppShare) =>
-      renewReleaseShare(appId, share.release_id, share.id, {
-        ttl_seconds: WEEK_SECONDS,
-      }),
-    onSuccess: () => {
-      toast.show({ kind: "success", title: "Share extended by 7 days" });
-      invalidate();
-    },
-    onError: (e) =>
-      toast.show({
-        kind: "error",
-        title: "Renew failed",
-        description: (e as Error).message,
-      }),
-  });
-
   const setPassword = useMutation({
     mutationFn: ({ share, password }: { share: AppShare; password: string | null }) =>
       renewReleaseShare(appId, share.release_id, share.id, {
-        // PATCH requires an expiry; keep the current one.
-        expires_at: share.expires_at,
+        // Omitting expiry keeps the share's current expiry unchanged.
         password,
       }),
     onSuccess: (_data, vars) => {
@@ -96,8 +77,8 @@ export function AppShares({ appId }: { appId: string }) {
         <div>
           <h2 className="text-lg font-bold">Shares</h2>
           <p className="text-sm text-slate-500">
-            Public download pages for this app's releases. URLs are shown only
-            once at creation — tokens are stored hashed.
+            Public download pages for this app's releases. Links live until
+            revoked and their URLs can be re-copied here anytime.
           </p>
         </div>
         <Button variant="primary" className="text-sm" onClick={() => setShowCreate(true)}>
@@ -153,7 +134,7 @@ export function AppShares({ appId }: { appId: string }) {
                 <th className="py-2 pr-3">Release</th>
                 <th className="py-2 pr-3">Status</th>
                 <th className="py-2 pr-3">Created</th>
-                <th className="py-2 pr-3">Expires</th>
+                <th className="py-2 pr-3">URL</th>
                 <th className="py-2 pr-3">Views</th>
                 <th className="py-2 pr-3">Downloads</th>
                 <th className="py-2" />
@@ -164,7 +145,11 @@ export function AppShares({ appId }: { appId: string }) {
                 <ShareRow
                   key={share.id}
                   share={share}
-                  onRenew={() => renew.mutate(share)}
+                  onCopyUrl={() => {
+                    if (!share.share_url) return;
+                    navigator.clipboard?.writeText(share.share_url);
+                    toast.show({ kind: "success", title: "Copied share URL" });
+                  }}
                   onRevoke={() => revoke.mutate(share)}
                   onSetPassword={() => {
                     const next = window.prompt(
@@ -178,7 +163,7 @@ export function AppShares({ appId }: { appId: string }) {
                       password: next.trim() ? next.trim() : null,
                     });
                   }}
-                  busy={renew.isPending || revoke.isPending || setPassword.isPending}
+                  busy={revoke.isPending || setPassword.isPending}
                 />
               ))}
             </tbody>
@@ -203,19 +188,22 @@ export function AppShares({ appId }: { appId: string }) {
 
 function shareState(share: AppShare): { label: string; className: string } {
   if (share.revoked_at) return { label: "revoked", className: "bg-slate-200 text-slate-600" };
-  if (share.expires_at <= Date.now()) return { label: "expired", className: "bg-amber-100 text-amber-800" };
+  // Legacy shares may still carry an expiry; new ones live until revoked.
+  if (share.expires_at != null && share.expires_at <= Date.now()) {
+    return { label: "expired", className: "bg-amber-100 text-amber-800" };
+  }
   return { label: "active", className: "bg-emerald-100 text-emerald-800" };
 }
 
 function ShareRow({
   share,
-  onRenew,
+  onCopyUrl,
   onRevoke,
   onSetPassword,
   busy,
 }: {
   share: AppShare;
-  onRenew: () => void;
+  onCopyUrl: () => void;
   onRevoke: () => void;
   onSetPassword: () => void;
   busy: boolean;
@@ -244,8 +232,16 @@ function ShareRow({
       <td className="py-2 pr-3 text-xs text-slate-600">
         {new Date(share.created_at).toLocaleString()}
       </td>
-      <td className="py-2 pr-3 text-xs text-slate-600">
-        {new Date(share.expires_at).toLocaleString()}
+      <td className="py-2 pr-3 text-xs">
+        {share.share_url ? (
+          <Button variant="link" size="sm" onClick={onCopyUrl}>
+            Copy URL
+          </Button>
+        ) : (
+          <span className="text-slate-400" title="Created before URLs were stored; the link itself still works.">
+            unavailable (legacy)
+          </span>
+        )}
       </td>
       <td className="py-2 pr-3">
         {share.view_count}
@@ -258,9 +254,6 @@ function ShareRow({
       <td className="py-2 text-right text-xs whitespace-nowrap">
         {actionable && (
           <>
-            <Button variant="link" size="sm" className="mr-2" onClick={onRenew} disabled={busy}>
-              +7 days
-            </Button>
             <Button variant="link" size="sm" className="mr-2" onClick={onSetPassword} disabled={busy}>
               {share.has_password ? "Password…" : "Set password"}
             </Button>
@@ -286,7 +279,6 @@ function CreateShareModal({
   const toast = useToast();
   const [releaseId, setReleaseId] = useState("");
   const [password, setPassword] = useState("");
-  const [ttlDays, setTtlDays] = useState(7);
 
   const releases = useQuery({
     queryKey: ["releases", appId],
@@ -302,8 +294,8 @@ function CreateShareModal({
 
   const create = useMutation({
     mutationFn: () =>
+      // No ttl: the share lives until revoked.
       createReleaseShare(appId, releaseId, {
-        ttl_seconds: ttlDays * 24 * 60 * 60,
         ...(password.trim() ? { password: password.trim() } : {}),
       }),
     onSuccess: (data) => {
@@ -353,17 +345,6 @@ function CreateShareModal({
                 ))}
               </SelectContent>
             </Select>
-          </label>
-          <label className="block text-xs text-slate-600">
-            Lifetime (days)
-            <Input
-              type="number"
-              min={1}
-              max={30}
-              value={ttlDays}
-              onChange={(e) => setTtlDays(Math.min(30, Math.max(1, Number(e.target.value) || 7)))}
-              className="mt-1 py-1.5!"
-            />
           </label>
           <label className="block text-xs text-slate-600">
             Password (optional)

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -2,9 +2,10 @@
  * App-level share management (task #65 P1).
  *
  * Lists every share link for the app across releases with stats, lets
- * admins create (with optional password), copy the URL, and revoke them.
- * Shares have no expiry — they live until revoked. Legacy shares created
- * before tokens were stored have no recoverable URL.
+ * admins create (with optional password/expiry), copy the URL, and revoke
+ * them. Shares have no default expiry — they live until revoked; an expiry
+ * is opt-in and only shown when set. Legacy shares created before tokens
+ * were stored have no recoverable URL.
  */
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -32,6 +33,27 @@ export function AppShares({ appId }: { appId: string }) {
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["app-shares", appId] });
+
+  const setExpiry = useMutation({
+    mutationFn: ({ share, ttlDays }: { share: AppShare; ttlDays: number | null }) =>
+      renewReleaseShare(appId, share.release_id, share.id, {
+        // Explicit null clears the expiry (never expires).
+        ...(ttlDays === null ? { expires_at: null } : { ttl_seconds: ttlDays * 24 * 60 * 60 }),
+      }),
+    onSuccess: (_data, vars) => {
+      toast.show({
+        kind: "success",
+        title: vars.ttlDays === null ? "Expiry removed — link lives until revoked" : `Expires in ${vars.ttlDays} days`,
+      });
+      invalidate();
+    },
+    onError: (e) =>
+      toast.show({
+        kind: "error",
+        title: "Expiry update failed",
+        description: (e as Error).message,
+      }),
+  });
 
   const setPassword = useMutation({
     mutationFn: ({ share, password }: { share: AppShare; password: string | null }) =>
@@ -150,6 +172,26 @@ export function AppShares({ appId }: { appId: string }) {
                     navigator.clipboard?.writeText(share.share_url);
                     toast.show({ kind: "success", title: "Copied share URL" });
                   }}
+                  onSetExpiry={() => {
+                    const next = window.prompt(
+                      "Days until this link expires (leave empty for never):",
+                      share.expires_at
+                        ? String(Math.max(1, Math.ceil((share.expires_at - Date.now()) / 86_400_000)))
+                        : "",
+                    );
+                    if (next === null) return;
+                    const trimmed = next.trim();
+                    if (!trimmed) {
+                      setExpiry.mutate({ share, ttlDays: null });
+                      return;
+                    }
+                    const days = Number(trimmed);
+                    if (!Number.isFinite(days) || days <= 0) {
+                      toast.show({ kind: "error", title: "Enter a positive number of days" });
+                      return;
+                    }
+                    setExpiry.mutate({ share, ttlDays: days });
+                  }}
                   onRevoke={() => revoke.mutate(share)}
                   onSetPassword={() => {
                     const next = window.prompt(
@@ -163,7 +205,7 @@ export function AppShares({ appId }: { appId: string }) {
                       password: next.trim() ? next.trim() : null,
                     });
                   }}
-                  busy={revoke.isPending || setPassword.isPending}
+                  busy={revoke.isPending || setPassword.isPending || setExpiry.isPending}
                 />
               ))}
             </tbody>
@@ -198,12 +240,14 @@ function shareState(share: AppShare): { label: string; className: string } {
 function ShareRow({
   share,
   onCopyUrl,
+  onSetExpiry,
   onRevoke,
   onSetPassword,
   busy,
 }: {
   share: AppShare;
   onCopyUrl: () => void;
+  onSetExpiry: () => void;
   onRevoke: () => void;
   onSetPassword: () => void;
   busy: boolean;
@@ -227,6 +271,11 @@ function ShareRow({
           <span className="ml-1 rounded-sm bg-sky-100 px-1.5 py-0.5 text-xs font-medium text-sky-800">
             password
           </span>
+        )}
+        {share.expires_at != null && !share.revoked_at && share.expires_at > Date.now() && (
+          <div className="mt-0.5 text-xs text-slate-400">
+            expires {new Date(share.expires_at).toLocaleString()}
+          </div>
         )}
       </td>
       <td className="py-2 pr-3 text-xs text-slate-600">
@@ -254,6 +303,9 @@ function ShareRow({
       <td className="py-2 text-right text-xs whitespace-nowrap">
         {actionable && (
           <>
+            <Button variant="link" size="sm" className="mr-2" onClick={onSetExpiry} disabled={busy}>
+              Expiry…
+            </Button>
             <Button variant="link" size="sm" className="mr-2" onClick={onSetPassword} disabled={busy}>
               {share.has_password ? "Password…" : "Set password"}
             </Button>
@@ -279,6 +331,7 @@ function CreateShareModal({
   const toast = useToast();
   const [releaseId, setReleaseId] = useState("");
   const [password, setPassword] = useState("");
+  const [ttlDays, setTtlDays] = useState("");
 
   const releases = useQuery({
     queryKey: ["releases", appId],
@@ -294,8 +347,9 @@ function CreateShareModal({
 
   const create = useMutation({
     mutationFn: () =>
-      // No ttl: the share lives until revoked.
+      // No ttl (the default): the share lives until revoked.
       createReleaseShare(appId, releaseId, {
+        ...(ttlDays.trim() ? { ttl_seconds: Number(ttlDays) * 24 * 60 * 60 } : {}),
         ...(password.trim() ? { password: password.trim() } : {}),
       }),
     onSuccess: (data) => {
@@ -345,6 +399,17 @@ function CreateShareModal({
                 ))}
               </SelectContent>
             </Select>
+          </label>
+          <label className="block text-xs text-slate-600">
+            Expires in days (optional)
+            <Input
+              type="number"
+              min={1}
+              value={ttlDays}
+              onChange={(e) => setTtlDays(e.target.value)}
+              placeholder="Leave empty — link lives until revoked"
+              className="mt-1 py-1.5!"
+            />
           </label>
           <label className="block text-xs text-slate-600">
             Password (optional)

--- a/migrations/sql/0044_release_shares_nullable_expiry.sql
+++ b/migrations/sql/0044_release_shares_nullable_expiry.sql
@@ -1,0 +1,34 @@
+-- Share links become durable and recoverable:
+-- 1. expires_at is now nullable — NULL means the link lives until explicitly
+--    revoked, and creating a share without a ttl no longer defaults to 7 days.
+--    Old-version links handed out in chats must not silently die.
+-- 2. The share token is stored so the URL can be re-copied from the console
+--    later (owner-accepted trade-off: tokens readable by DB admins; shares are
+--    unlisted-public download links, optionally password-protected). Legacy
+--    rows only have the hash, so their URLs stay unrecoverable.
+-- SQLite cannot drop NOT NULL in place, so rebuild the table.
+PRAGMA defer_foreign_keys = true;
+
+CREATE TABLE release_shares_new (
+  id TEXT PRIMARY KEY,
+  release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  token TEXT,
+  token_hash TEXT NOT NULL UNIQUE,
+  created_by TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER,
+  revoked_at INTEGER,
+  password_hash TEXT
+);
+
+INSERT INTO release_shares_new (id, release_id, token, token_hash, created_by, created_at, expires_at, revoked_at, password_hash)
+SELECT id, release_id, NULL, token_hash, created_by, created_at, expires_at, revoked_at, password_hash FROM release_shares;
+
+DROP TABLE release_shares;
+ALTER TABLE release_shares_new RENAME TO release_shares;
+
+CREATE INDEX IF NOT EXISTS idx_release_shares_release
+  ON release_shares(release_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_release_shares_token_active
+  ON release_shares(token_hash, expires_at, revoked_at);

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -17,7 +17,6 @@ type ShareStrings = {
   artifactLabel: string;
   platformLabel: string;
   checksumLabel: string;
-  expiresLabel: string;
   statsLabel: string;
   visitors: string;
   views: string;
@@ -45,7 +44,6 @@ const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
     artifactLabel: "Artifact",
     platformLabel: "Platform",
     checksumLabel: "Checksum",
-    expiresLabel: "Expires",
     statsLabel: "Stats",
     visitors: "visitors",
     views: "views",
@@ -71,7 +69,6 @@ const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
     artifactLabel: "安装包",
     platformLabel: "平台",
     checksumLabel: "校验和",
-    expiresLabel: "过期时间",
     statsLabel: "统计",
     visitors: "访客数",
     views: "浏览次数",
@@ -101,7 +98,7 @@ type ShareRow = {
   id: string;
   token_hash: string;
   created_at: number;
-  expires_at: number;
+  expires_at: number | null;
   revoked_at: number | null;
   view_count: number;
   unique_view_count: number;
@@ -114,7 +111,7 @@ type SharePageRow = {
   icon_r2_key: string | null;
   package_id: string | null;
   share_id: string;
-  expires_at: number;
+  expires_at: number | null;
   app_slug: string;
   app_name: string;
   channel_slug: string;
@@ -140,8 +137,9 @@ type ShareStats = {
   unique_download_count: number;
 };
 
-const DEFAULT_SHARE_TTL_SECONDS = 7 * 24 * 60 * 60;
-const MAX_SHARE_TTL_SECONDS = 30 * 24 * 60 * 60;
+// Shares have no default expiry: a share without an explicit ttl_seconds /
+// expires_at lives until revoked (expires_at NULL). Old-version links handed
+// out in chats must not silently die.
 
 export async function handleCreateReleaseShare(c: AdminContext) {
   const appId = c.req.param("appId");
@@ -167,10 +165,9 @@ export async function handleCreateReleaseShare(c: AdminContext) {
   }
 
   const now = Date.now();
-  let expiresAt: number;
+  let expiresAt: number | null;
   try {
-    const ttlSeconds = normalizeShareTtl(body.ttl_seconds);
-    expiresAt = normalizeExpiresAt(body.expires_at, now, ttlSeconds);
+    expiresAt = resolveExpiry(body.ttl_seconds, body.expires_at, now);
   } catch (err) {
     return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
   }
@@ -182,9 +179,9 @@ export async function handleCreateReleaseShare(c: AdminContext) {
   await c.env.DB.batch([
     c.env.DB.prepare(
       `INSERT INTO release_shares
-       (id, release_id, token_hash, created_by, created_at, expires_at, revoked_at, password_hash)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7)`,
-    ).bind(id, releaseId, tokenHash, currentActor(c), now, expiresAt, passwordHash),
+       (id, release_id, token, token_hash, created_by, created_at, expires_at, revoked_at, password_hash)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8)`,
+    ).bind(id, releaseId, token, tokenHash, currentActor(c), now, expiresAt, passwordHash),
     c.env.DB.prepare(
       `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
        VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
@@ -222,7 +219,7 @@ export async function handleListReleaseShares(c: AdminContext) {
   const { results } = await c.env.DB.prepare(
     `SELECT
        rs.id,
-       rs.token_hash,
+       rs.token,
        rs.created_at,
        rs.expires_at,
        rs.revoked_at,
@@ -238,8 +235,21 @@ export async function handleListReleaseShares(c: AdminContext) {
      ORDER BY rs.created_at DESC`,
   )
     .bind(releaseId)
-    .all<ShareRow>();
-  return c.json({ shares: results });
+    .all<ShareRow & { token: string | null }>();
+  return c.json({ shares: (results ?? []).map((row) => withShareUrl(c, row)) });
+}
+
+/** Replace the stored token with a copyable share_url. Legacy rows (created
+ *  before tokens were stored) have no token, so their URL is unrecoverable. */
+function withShareUrl<T extends { token?: string | null }>(
+  c: AdminContext,
+  row: T,
+): Omit<T, "token"> & { share_url: string | null } {
+  const { token, ...rest } = row;
+  return {
+    ...rest,
+    share_url: token ? new URL(`/share/${token}`, publicRequestOrigin(c)).toString() : null,
+  };
 }
 
 export async function handleListAppShares(c: AdminContext) {
@@ -248,6 +258,7 @@ export async function handleListAppShares(c: AdminContext) {
     `SELECT
        rs.id,
        rs.release_id,
+       rs.token,
        rs.created_by,
        rs.created_at,
        rs.expires_at,
@@ -272,8 +283,8 @@ export async function handleListAppShares(c: AdminContext) {
      LIMIT 500`,
   )
     .bind(appId)
-    .all();
-  return c.json({ shares: results });
+    .all<{ token: string | null }>();
+  return c.json({ shares: (results ?? []).map((row) => withShareUrl(c, row)) });
 }
 
 export async function handleRevokeReleaseShare(c: AdminContext) {
@@ -319,8 +330,8 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
   const releaseId = c.req.param("releaseId");
   const shareId = c.req.param("shareId");
   const body = await c.req.json().catch(() => ({})) as {
-    ttl_seconds?: number;
-    expires_at?: number;
+    ttl_seconds?: number | null;
+    expires_at?: number | null;
     password?: string | null;
   };
   const now = Date.now();
@@ -332,16 +343,21 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
      WHERE r.app_id = ?1 AND r.id = ?2 AND rs.id = ?3`,
   )
     .bind(appId, releaseId, shareId)
-    .first<{ id: string; expires_at: number; revoked_at: number | null }>();
+    .first<{ id: string; expires_at: number | null; revoked_at: number | null }>();
   if (!existing) return c.json({ error: "share not found" }, 404);
   if (existing.revoked_at) {
     return c.json({ error: "cannot update revoked share" }, 409);
   }
 
-  let expiresAt: number;
+  // Expiry semantics mirror the password field: both keys absent = leave
+  // unchanged; explicit null (either key) = clear, the share never expires;
+  // a value = set.
+  let expiresAt: number | null;
   try {
-    const ttlSeconds = normalizeShareTtl(body.ttl_seconds);
-    expiresAt = normalizeExpiresAt(body.expires_at, now, ttlSeconds);
+    expiresAt =
+      body.ttl_seconds === undefined && body.expires_at === undefined
+        ? existing.expires_at
+        : resolveExpiry(body.ttl_seconds, body.expires_at, now);
   } catch (err) {
     return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
   }
@@ -590,7 +606,7 @@ async function findActiveShare(db: D1Database, token: string): Promise<SharePage
      JOIN build_assets ba ON ba.build_id = b.id
      WHERE rs.token_hash = ?1
        AND rs.revoked_at IS NULL
-       AND rs.expires_at > ?2
+       AND (rs.expires_at IS NULL OR rs.expires_at > ?2)
        -- Serve active AND draft releases: draft-first testing needs a
        -- shareable download before publish. Cancelled/superseded stay blocked.
        AND r.status IN ('active', 'draft')
@@ -636,26 +652,26 @@ async function loadShareStats(db: D1Database, shareId: string): Promise<ShareSta
   };
 }
 
-function normalizeShareTtl(ttl: number | undefined): number {
-  if (ttl === undefined || ttl === null) return DEFAULT_SHARE_TTL_SECONDS;
-  if (!Number.isFinite(ttl) || ttl <= 0) {
-    throw new Error("ttl_seconds must be positive");
-  }
-  return Math.min(Math.floor(ttl), MAX_SHARE_TTL_SECONDS);
-}
-
-function normalizeExpiresAt(
-  expiresAt: number | undefined,
+/** Resolve an optional expiry: no ttl_seconds/expires_at (or explicit null)
+ *  means the share never expires. expires_at wins over ttl_seconds. */
+function resolveExpiry(
+  ttlSeconds: number | null | undefined,
+  expiresAt: number | null | undefined,
   now: number,
-  ttlSeconds: number,
-): number {
-  if (expiresAt === undefined || expiresAt === null) {
-    return now + ttlSeconds * 1000;
+): number | null {
+  if (expiresAt !== undefined && expiresAt !== null) {
+    if (!Number.isFinite(expiresAt) || expiresAt <= now) {
+      throw new Error("expires_at must be a future unix millisecond timestamp");
+    }
+    return Math.floor(expiresAt);
   }
-  if (!Number.isFinite(expiresAt) || expiresAt <= now) {
-    throw new Error("expires_at must be a future unix millisecond timestamp");
+  if (ttlSeconds !== undefined && ttlSeconds !== null) {
+    if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+      throw new Error("ttl_seconds must be positive");
+    }
+    return now + Math.floor(ttlSeconds) * 1000;
   }
-  return Math.min(Math.floor(expiresAt), now + MAX_SHARE_TTL_SECONDS * 1000);
+  return null;
 }
 
 function randomToken(): string {
@@ -720,7 +736,6 @@ function renderSharePage(
   shareToken: string,
 ): string {
   const title = `${row.app_slug} ${row.version_name} (${row.version_code})`;
-  const expiresIso = new Date(row.expires_at).toISOString();
   const qrSvg = renderShareQrSvg(shareUrl);
   return `<!doctype html>
 <html lang="${t.htmlLang}">
@@ -782,7 +797,6 @@ function renderSharePage(
       <dt>${t.artifactLabel}</dt><dd>${escapeHtml(row.filetype.toUpperCase())} · ${formatBytes(row.size_bytes)}</dd>
       <dt>${t.platformLabel}</dt><dd>${escapeHtml([row.platform, row.arch, row.variant].filter(Boolean).join(" / "))}</dd>
       <dt>${t.checksumLabel}</dt><dd>${escapeHtml(row.file_hash)}</dd>
-      <dt>${t.expiresLabel}</dt><dd><time id="expires-at" datetime="${escapeAttribute(expiresIso)}" data-expires-at="${row.expires_at}">${escapeHtml(expiresIso)}</time></dd>
       <dt>${t.statsLabel}</dt>
       <dd class="stats">
         <span class="stat"><strong>${stats.unique_view_count}</strong><span>${t.visitors}</span></span>
@@ -797,22 +811,6 @@ function renderSharePage(
     </div>
     ${row.changelog ? `<div class="notes">${changelogToHtml(row.changelog)}</div>` : ""}
   </main>
-  <script>
-    (() => {
-      const el = document.getElementById("expires-at");
-      const ms = Number(el?.dataset.expiresAt);
-      if (!el || !Number.isFinite(ms)) return;
-      try {
-        el.textContent = new Intl.DateTimeFormat(undefined, {
-          dateStyle: "medium",
-          timeStyle: "short",
-          timeZoneName: "short",
-        }).format(new Date(ms));
-      } catch {
-        el.textContent = new Date(ms).toLocaleString();
-      }
-    })();
-  </script>
 </body>
 </html>`;
 }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -256,10 +256,11 @@ function makeMockDb() {
     CREATE TABLE release_shares (
       id TEXT PRIMARY KEY,
       release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+      token TEXT,
       token_hash TEXT NOT NULL UNIQUE,
       created_by TEXT NOT NULL,
       created_at INTEGER NOT NULL,
-      expires_at INTEGER NOT NULL,
+      expires_at INTEGER,
       revoked_at INTEGER,
       password_hash TEXT
     );
@@ -3109,6 +3110,106 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(eventTypes).toContain("crash:new_group");
   });
 
+  it("shares: no ttl never expires, url is re-copyable, expiry semantics on update", async () => {
+    const env = makeEnv();
+    await seedRelease(env, "rel-share", "build-share", [["full", "all"]]);
+    await seedAsset(env, "build-share", "asset-share");
+    const {
+      handleCreateReleaseShare,
+      handleListAppShares,
+      handleUpdateReleaseShare,
+      handlePublicReleaseShare,
+    } = await import("../src/routes/shares");
+
+    // Create without ttl → never expires.
+    const created = await responseJson<any>(
+      await handleCreateReleaseShare(
+        makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-share" }),
+      ),
+    );
+    expect(created.expires_at).toBeNull();
+    const token = new URL(created.share_url).pathname.replace("/share/", "");
+
+    // The never-expiring share serves publicly.
+    const page = await handlePublicReleaseShare(makeSharePublicContext(env, token));
+    expect(page.status).toBe(200);
+    const pageHtml = await page.text();
+    expect(pageHtml).toContain("Download APK");
+    // Expiry is no longer shown on the public page.
+    expect(pageHtml).not.toContain("expires-at");
+
+    // The URL is recoverable from the list.
+    const listed = await responseJson<any>(
+      await handleListAppShares(makeShareAdminContext(env, { appId: "app-scope" })),
+    );
+    const row = listed.shares.find((s: any) => s.id === created.id);
+    expect(row.share_url).toBe(created.share_url);
+    expect(row.token).toBeUndefined();
+
+    // Legacy rows without a stored token have no recoverable URL.
+    await env.DB.prepare(
+      `INSERT INTO release_shares (id, release_id, token, token_hash, created_by, created_at, expires_at)
+       VALUES (?, ?, NULL, ?, ?, ?, NULL)`,
+    )
+      .bind("share-legacy", "rel-share", "legacy-hash", "tester", 1)
+      .run();
+    const listed2 = await responseJson<any>(
+      await handleListAppShares(makeShareAdminContext(env, { appId: "app-scope" })),
+    );
+    expect(listed2.shares.find((s: any) => s.id === "share-legacy").share_url).toBeNull();
+
+    // Update: absent expiry keys leave the expiry unchanged (password-only PATCH).
+    const patchedPw = await responseJson<any>(
+      await handleUpdateReleaseShare(
+        makeShareAdminContext(
+          env,
+          { appId: "app-scope", releaseId: "rel-share", shareId: created.id },
+          { password: "s3cret" },
+        ),
+      ),
+    );
+    expect(patchedPw.expires_at).toBeNull();
+
+    // Update: an explicit ttl sets an expiry; explicit null clears it again.
+    const withTtl = await responseJson<any>(
+      await handleUpdateReleaseShare(
+        makeShareAdminContext(
+          env,
+          { appId: "app-scope", releaseId: "rel-share", shareId: created.id },
+          { ttl_seconds: 3600 },
+        ),
+      ),
+    );
+    expect(withTtl.expires_at).toBeGreaterThan(Date.now());
+    const cleared = await responseJson<any>(
+      await handleUpdateReleaseShare(
+        makeShareAdminContext(
+          env,
+          { appId: "app-scope", releaseId: "rel-share", shareId: created.id },
+          { expires_at: null },
+        ),
+      ),
+    );
+    expect(cleared.expires_at).toBeNull();
+
+    // An expired legacy-style share still 4xxes publicly.
+    const expiredCreate = await responseJson<any>(
+      await handleCreateReleaseShare(
+        makeShareAdminContext(
+          env,
+          { appId: "app-scope", releaseId: "rel-share" },
+          { ttl_seconds: 1 },
+        ),
+      ),
+    );
+    const expiredToken = new URL(expiredCreate.share_url).pathname.replace("/share/", "");
+    await env.DB.prepare("UPDATE release_shares SET expires_at = 1 WHERE id = ?1")
+      .bind(expiredCreate.id)
+      .run();
+    const expiredPage = await handlePublicReleaseShare(makeSharePublicContext(env, expiredToken));
+    expect(expiredPage.status).toBeGreaterThanOrEqual(400);
+  });
+
   // ------------------------------------------------------------------
   // helpers — re-implement matchesScope here so we can unit-test it
   // without spinning up the Hono context. Mirrors public_v2.ts.
@@ -4079,7 +4180,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(rows.results[0].revoked_at).toBeNull();
   });
 
-  it("defaults release shares to seven days and updates share expiry", async () => {
+  it("creates release shares without a default expiry and updates share expiry", async () => {
     const env = makeEnv();
     const { handleCreateReleaseShare, handleUpdateReleaseShare } = await import("../src/routes/shares");
     await seedRelease(env, "rel-share", "build-share", [["full", "all"]], {
@@ -4087,17 +4188,13 @@ describe("quiver public API v2 — scope resolution", () => {
       versionName: "1.0.11",
     });
 
-    const createStart = Date.now();
     const created = await handleCreateReleaseShare(
       makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-share" }, {}),
     );
-    const createEnd = Date.now();
 
     expect(created.status).toBe(201);
     const createdBody = await responseJson<any>(created);
-    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
-    expect(createdBody.expires_at).toBeGreaterThanOrEqual(createStart + sevenDaysMs);
-    expect(createdBody.expires_at).toBeLessThanOrEqual(createEnd + sevenDaysMs);
+    expect(createdBody.expires_at).toBeNull();
 
     const expiresAt = Date.now() + 14 * 24 * 60 * 60 * 1000;
     const updated = await handleUpdateReleaseShare(
@@ -4150,9 +4247,8 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(html).toContain("build 11");
     expect(html).toContain("arm64-v8a");
     expect(html).toContain(`/share/${token}/download`);
-    expect(html).toContain('id="expires-at"');
-    expect(html).toContain("data-expires-at=");
-    expect(html).toContain("Intl.DateTimeFormat");
+    // Expiry is intentionally not shown on the public page.
+    expect(html).not.toContain('id="expires-at"');
     expect(html).toContain("<dt>Stats</dt>");
     expect(html).toContain("<span>visitors</span>");
 


### PR DESCRIPTION
Share links previously defaulted to a 7-day TTL (capped at 30 days) and their URLs were only visible once at creation, so links handed out for older versions silently died and could not be re-copied.

## Changes
- A share created without `ttl_seconds`/`expires_at` never expires (`expires_at` NULL) and lives until revoked. Explicit expiries are still honored, without the previous 30-day cap.
- PATCH semantics mirror the password field: omitting both expiry keys leaves the expiry unchanged, an explicit `null` clears it, a value sets it. A password-only update no longer resets the expiry.
- The share token is now stored so the URL can be re-copied from the console at any time (`share_url` in list responses). Legacy rows only have the hash; their URLs are listed as unavailable while the links themselves keep working.
- Console: drops the Expires column, the "+7 days" action, and the create dialog's lifetime field; adds a per-row Copy URL action.
- The public share page no longer displays an expiry.
- Migration 0044 rebuilds `release_shares` with nullable `expires_at` and the `token` column (legacy rows get NULL token).

## Tests
- New test covering: create-without-ttl → never expires and serves publicly, URL recoverable from the list (raw token not exposed), legacy NULL-token rows return `share_url: null`, password-only PATCH preserves expiry, explicit ttl sets / explicit null clears, expired shares still blocked publicly.
- Updated the previous default-7-days and share-page tests to the new semantics.
- Worker vitest 112/112, worker + admin tsc clean, admin build clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786728088&installation_id=145465820&pr_number=290&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F290&signature=50d46d22eecf2cc16a13ad0acc9ff4dd984dc84286eb19136a9d6f5a47ff6d58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->