### PR TITLE
Serve share links regardless of release status

### DIFF
--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -607,9 +607,9 @@ async function findActiveShare(db: D1Database, token: string): Promise<SharePage
      WHERE rs.token_hash = ?1
        AND rs.revoked_at IS NULL
        AND (rs.expires_at IS NULL OR rs.expires_at > ?2)
-       -- Serve active AND draft releases: draft-first testing needs a
-       -- shareable download before publish. Cancelled/superseded stay blocked.
-       AND r.status IN ('active', 'draft')
+       -- Release status does not gate a share: a link the user actively
+       -- created serves until the user revokes it (or its optional expiry
+       -- passes), even after the release is superseded or cancelled.
        AND ba.artifact_kind = 'installable'
      ORDER BY ba.filetype = 'apk' DESC, ba.created_at ASC
      LIMIT 1`,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3194,6 +3194,20 @@ describe("quiver public API v2 — scope resolution", () => {
     );
     expect(cleared.expires_at).toBeNull();
 
+    // Release status does not gate an existing share: the link keeps serving
+    // after the release is superseded or cancelled — only revoke/expiry kill it.
+    await env.DB.prepare("UPDATE releases SET status = 'superseded' WHERE id = ?")
+      .bind("rel-share")
+      .run();
+    expect((await handlePublicReleaseShare(makeSharePublicContext(env, token))).status).toBe(200);
+    await env.DB.prepare("UPDATE releases SET status = 'cancelled' WHERE id = ?")
+      .bind("rel-share")
+      .run();
+    expect((await handlePublicReleaseShare(makeSharePublicContext(env, token))).status).toBe(200);
+    await env.DB.prepare("UPDATE releases SET status = 'active' WHERE id = ?")
+      .bind("rel-share")
+      .run();
+
     // An expired legacy-style share still 4xxes publicly.
     const expiredCreate = await responseJson<any>(
       await handleCreateReleaseShare(


### PR DESCRIPTION
Follow-up to #290. A share page only served releases in `active` or `draft` status, so a link died the moment its release was superseded by the next version — even though the user never revoked it.

Share availability is the user's decision: a link they actively created serves until they revoke it (or its optional expiry passes), regardless of what later happens to the release. Creating a new share on a cancelled release remains blocked; only already-created links are status-agnostic.

Test: an existing share keeps serving after the release moves to `superseded` and `cancelled`. Worker vitest 112/112, tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786730839&installation_id=145465820&pr_number=291&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F291&signature=0bbdb64708516365619149c24c13b805be6e2a54ba67d21717cd4ef2717f2c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->