### PR TITLE
Remove download stats from the public share page

### DIFF
--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -20,8 +20,6 @@ type ShareStrings = {
   statsLabel: string;
   visitors: string;
   views: string;
-  downloaders: string;
-  downloads: string;
   downloadApk: string;
   scanHint: string;
   passwordRequired: string; // password page title + heading
@@ -47,8 +45,6 @@ const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
     statsLabel: "Stats",
     visitors: "visitors",
     views: "views",
-    downloaders: "downloaders",
-    downloads: "downloads",
     downloadApk: "Download APK",
     scanHint: "Scan to open on your phone",
     passwordRequired: "Password required",
@@ -72,8 +68,6 @@ const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
     statsLabel: "统计",
     visitors: "访客数",
     views: "浏览次数",
-    downloaders: "下载人数",
-    downloads: "下载次数",
     downloadApk: "下载 APK",
     scanHint: "扫码在手机上打开",
     passwordRequired: "需要密码",
@@ -801,8 +795,6 @@ function renderSharePage(
       <dd class="stats">
         <span class="stat"><strong>${stats.unique_view_count}</strong><span>${t.visitors}</span></span>
         <span class="stat"><strong>${stats.view_count}</strong><span>${t.views}</span></span>
-        <span class="stat"><strong>${stats.unique_download_count}</strong><span>${t.downloaders}</span></span>
-        <span class="stat"><strong>${stats.download_count}</strong><span>${t.downloads}</span></span>
       </dd>
     </dl>
     <div class="get-it">


### PR DESCRIPTION
The public share page no longer shows downloader/download counts; visitors and views remain. Download stats are still available in the console share list. Worker vitest 112/112, tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786731502&installation_id=145465820&pr_number=292&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F292&signature=8cf7696cf28145af3cea24719871e87b45c549a655139a23d4d91c223b1b8915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->