### PR TITLE
Expose release management to agents via manifest actions

### DIFF
--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -84,7 +84,35 @@ All CLI commands accept `--json` for scripting.
 ### Release flow (draft-first policy)
 
 CI creates drafts; an agent reviews and publishes. **Never publish without
-reviewing the changelog.**
+reviewing the changelog, and never activate without explicit, current human
+authorization.**
+
+**Raft agents — manifest actions (no CLI, no tokens).** After a one-time
+`raft integration login --service <hands-service>`, release management is
+plain `raft integration invoke`; the server enforces app RBAC (viewer for
+reads, publisher for writes):
+
+```bash
+# create a DRAFT from an existing verified build (draft is the default)
+raft integration invoke --service <hands-service> --action create-release \
+  --param app_id=<app-uuid> --param build_id=<build-uuid>
+
+# attach reviewed bilingual notes (change-logs/<version>/*.md is the source of truth)
+raft integration invoke --service <hands-service> --action update-release \
+  --param app_id=<app-uuid> --param release_id=<release-uuid> \
+  --param release_notes='{"en":"...","zh-CN":"..."}'
+
+# ONLY after explicit human approval of the draft:
+raft integration invoke --service <hands-service> --action publish-release \
+  --param app_id=<app-uuid> --param release_id=<release-uuid>
+```
+
+Also available: `list-releases`, `get-release` (viewer). When reporting a
+release, always cite the build's APK SHA-256 — the binary hash is the
+authority, not a branch head or run id. A 403 means your identity lacks the
+app role: ask an app admin to grant it; never borrow credentials.
+
+**Humans / CI — hands CLI** (browser login or deploy token):
 
 ```bash
 hands releases show <app> <releaseId>                 # inspect draft + raw changelog

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -93,7 +93,8 @@ plain `raft integration invoke`; the server enforces app RBAC (viewer for
 reads, publisher for writes):
 
 ```bash
-# create a DRAFT from an existing verified build (draft is the default)
+# create a DRAFT from an existing verified build (the server enforces draft;
+# activation is impossible on this endpoint — publish-release is the only path)
 raft integration invoke --service <hands-service> --action create-release \
   --param app_id=<app-uuid> --param build_id=<build-uuid>
 
@@ -107,7 +108,10 @@ raft integration invoke --service <hands-service> --action publish-release \
   --param app_id=<app-uuid> --param release_id=<release-uuid>
 ```
 
-Also available: `list-releases`, `get-release` (viewer). When reporting a
+Also available: `list-releases`, `get-release`, `list-release-shares`
+(viewer), `create-release-share` / `revoke-release-share` (publisher —
+share pages are how a draft gets to a human for device review; links have no
+expiry unless you set one and die only on revoke). When reporting a
 release, always cite the build's APK SHA-256 — the binary hash is the
 authority, not a branch head or run id. A 403 means your identity lacks the
 app role: ask an app admin to grant it; never borrow credentials.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -132,6 +132,7 @@ import {
 import {
   handleBumpRollout,
   handleCreateRelease,
+  handleCreateReleaseDraft,
   handleDeleteRelease,
   handleForceUpdate,
   handleGetRelease,
@@ -640,6 +641,7 @@ admin.delete(
 
 admin.get("/api/apps/:appId/releases", requireAppRole("viewer"), handleListReleases);
 admin.post("/api/apps/:appId/releases", requireAppRole("publisher"), handleCreateRelease);
+admin.post("/api/apps/:appId/releases/draft", requireAppRole("publisher"), handleCreateReleaseDraft);
 admin.get("/api/apps/:appId/releases/:releaseId", requireAppRole("viewer"), handleGetRelease);
 admin.patch("/api/apps/:appId/releases/:releaseId", requireAppRole("publisher"), handleUpdateRelease);
 admin.post("/api/apps/:appId/releases/:releaseId/publish", requireAppRole("publisher"), handlePublishRelease);

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -733,7 +733,9 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       comment_ticket:
         "POST /api/apps/{app_id}/feedback/{ticket_id}/comments — body: {text: string}",
       create_release:
-        "POST /api/apps/{app_id}/releases — body: {build_id, status?: draft|active (default draft), changelog?, release_notes?: {en, zh-CN}} — publisher",
+        "POST /api/apps/{app_id}/releases/draft — body: {build_id, changelog?, release_notes?: {en, zh-CN}} — publisher; server-enforced draft, activate only via publish",
+      create_share:
+        "POST /api/apps/{app_id}/releases/{release_id}/shares — body: {ttl_seconds?, password?} — publisher; no expiry unless set",
       update_release:
         "PATCH /api/apps/{app_id}/releases/{release_id} — body: {changelog?, release_notes?, hidden?} — publisher",
       publish_release:
@@ -808,13 +810,12 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "create-release",
         description:
-          "Create a release from an existing build. Defaults to a DRAFT (pass status=active only when explicitly authorized to go live). Requires app publisher.",
-        endpoint: { method: "POST", path: "/api/apps/{app_id}/releases" },
+          "Create a DRAFT release from an existing build. The server enforces draft — activation has exactly one path: the publish-release action. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/draft" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           build_id: { type: "string", in: "body", required: true, description: "Hands build UUID to release." },
           channel_id: { type: "string", in: "body", required: false, description: "Channel UUID (defaults to the build's channel)." },
-          status: { type: "string", in: "body", required: false, description: "'draft' (default) or 'active'." },
           changelog: { type: "string", in: "body", required: false, description: "Changelog text (single-language fallback)." },
           release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes, e.g. {\"en\": \"...\", \"zh-CN\": \"...\"}." },
         },
@@ -840,6 +841,37 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+        },
+      },
+      {
+        name: "list-release-shares",
+        description: "List a release's share links (metadata + stats; URLs for shares created after tokens were stored). Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/releases/{release_id}/shares" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+        },
+      },
+      {
+        name: "create-release-share",
+        description:
+          "Create a public share/download page for a release (works for drafts — that's the review flow). No expiry unless ttl_seconds is passed; lives until revoked. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/{release_id}/shares" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          ttl_seconds: { type: "number", in: "body", required: false, description: "Optional expiry; omit for a link that lives until revoked." },
+          password: { type: "string", in: "body", required: false, description: "Optional password protection." },
+        },
+      },
+      {
+        name: "revoke-release-share",
+        description: "Revoke a share link (the only way a no-expiry link dies). Requires app publisher.",
+        endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}/shares/{share_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          share_id: { type: "string", in: "path", required: true, description: "Share UUID." },
         },
       },
       {

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -715,6 +715,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       "1. Authenticate (see `auth` below), then GET /api/apps to find your app_id.",
       "2. Crash triage: list-feedback (kind=crash) → get-feedback (device context + attachments) → presign-feedback-attachment, then curl the returned download_url yourself (raw-bytes endpoints get corrupted through agent transports).",
       "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
+      "4. Release management (app publisher): create-release from an existing build (DRAFT by default) → update-release with bilingual release_notes → after explicit human authorization, publish-release. See docs.release_guide.",
     ],
     auth: {
       raft_agents:
@@ -731,9 +732,16 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
         "PATCH /api/apps/{app_id}/feedback/{ticket_id} — body: {status?: open|in_progress|resolved|closed, assignee?: string|null}",
       comment_ticket:
         "POST /api/apps/{app_id}/feedback/{ticket_id}/comments — body: {text: string}",
+      create_release:
+        "POST /api/apps/{app_id}/releases — body: {build_id, status?: draft|active (default draft), changelog?, release_notes?: {en, zh-CN}} — publisher",
+      update_release:
+        "PATCH /api/apps/{app_id}/releases/{release_id} — body: {changelog?, release_notes?, hidden?} — publisher",
+      publish_release:
+        "POST /api/apps/{app_id}/releases/{release_id}/publish — publisher; live-facing, needs explicit human authorization",
     },
     docs: {
       agent_guide: `${origin}/docs/agent-cli-feedback`,
+      release_guide: `${origin}/docs/agent-guide/`,
       cli_reference: `${origin}/docs/cli-reference`,
       api_reference: `${origin}/docs/public-api-reference`,
       openapi: `${origin}/openapi.json`,
@@ -779,6 +787,60 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         name: "list-apps",
         description: "List apps the caller can access.",
         endpoint: { method: "GET", path: "/api/apps" },
+      },
+      {
+        name: "list-releases",
+        description: "List an app's releases (id, status, channel, version, rollout). Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/releases" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+        },
+      },
+      {
+        name: "get-release",
+        description: "Get one release with its changelog/release notes and rollout state. Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/releases/{release_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+        },
+      },
+      {
+        name: "create-release",
+        description:
+          "Create a release from an existing build. Defaults to a DRAFT (pass status=active only when explicitly authorized to go live). Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/releases" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          build_id: { type: "string", in: "body", required: true, description: "Hands build UUID to release." },
+          channel_id: { type: "string", in: "body", required: false, description: "Channel UUID (defaults to the build's channel)." },
+          status: { type: "string", in: "body", required: false, description: "'draft' (default) or 'active'." },
+          changelog: { type: "string", in: "body", required: false, description: "Changelog text (single-language fallback)." },
+          release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes, e.g. {\"en\": \"...\", \"zh-CN\": \"...\"}." },
+        },
+      },
+      {
+        name: "update-release",
+        description:
+          "Update a release's changelog/bilingual release notes, rollout fields, or hidden flag. Requires app publisher.",
+        endpoint: { method: "PATCH", path: "/api/apps/{app_id}/releases/{release_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          changelog: { type: "string", in: "body", required: false, description: "Changelog text." },
+          release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes object." },
+          hidden: { type: "boolean", in: "body", required: false, description: "Hide/show on public history without deleting." },
+        },
+      },
+      {
+        name: "publish-release",
+        description:
+          "Publish (activate) a draft release. Live-facing: only run with explicit human authorization. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/{release_id}/publish" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+        },
       },
       {
         name: "create-deploy-token",

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -430,6 +430,40 @@ export async function handleGetRelease(c: Context<{ Bindings: Env }>) {
   });
 }
 
+/**
+ * Draft-only creation for the agent manifest path. The server enforces draft:
+ * an explicit status other than 'draft' is rejected outright (activation has
+ * exactly one path — the publish endpoint, behind explicit authorization).
+ */
+export async function handleCreateReleaseDraft(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const body = (await c.req.json()) as ReleaseInput;
+  if (body.status !== undefined && body.status !== "draft") {
+    return c.json(
+      { error: "this endpoint creates drafts only; use the publish action (with explicit authorization) to activate" },
+      400,
+    );
+  }
+  try {
+    const draftBody: ReleaseInput = { ...body, status: "draft" };
+    const id = await createRelease(c.env.DB, appId, draftBody, currentActor(c));
+    const changelog = inputChangelog(draftBody) ?? null;
+    return c.json(
+      {
+        id,
+        app_id: appId,
+        status: "draft",
+        ...draftBody,
+        changelog,
+        release_notes: parseReleaseNotes(changelog),
+      },
+      201,
+    );
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 400);
+  }
+}
+
 export async function handleCreateRelease(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const body = (await c.req.json()) as ReleaseInput;

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -5399,6 +5399,40 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(updated.status).toBe(409);
   });
 
+  it("draft-only release endpoint enforces draft even against a hostile status=active", async () => {
+    const env = makeEnv();
+    const { handleCreateReleaseDraft } = await import("../src/routes/releases");
+    // seed a build to release
+    await seedRelease(env, "rel-seed", "build-draftonly", [["full", "all"]], { versionCode: 21 });
+    const ctx = (body: unknown) =>
+      ({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        req: {
+          url: "https://quiver-worker.test/api/apps/app-scope/releases/draft",
+          param: (name: string) => (name === "appId" ? "app-scope" : ""),
+          json: async () => body,
+        },
+        get: (name: string) => (name === "admin_actor" ? "tester" : name === "org_id" ? "default" : undefined),
+        json: (data: unknown, status = 200) =>
+          new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } }),
+      }) as any;
+
+    // hostile: explicit active must be rejected outright (nothing created)
+    const hostile = await handleCreateReleaseDraft(ctx({ build_id: "build-draftonly", status: "active" }));
+    expect(hostile.status).toBe(400);
+    const hostileBody = await responseJson<any>(hostile);
+    expect(hostileBody.error).toContain("draft");
+
+    // normal: no status -> created as draft (NOT the legacy active default)
+    const ok = await handleCreateReleaseDraft(ctx({ build_id: "build-draftonly" }));
+    expect(ok.status).toBe(201);
+    const created = await responseJson<any>(ok);
+    expect(created.status).toBe("draft");
+    const row = await env.DB.prepare("SELECT status FROM releases WHERE id = ?1").bind(created.id).first<any>();
+    expect(row.status).toBe("draft");
+  });
+
   it("create release share rejects invalid TTL and cancelled releases", async () => {
     const env = makeEnv();
     const { handleCreateReleaseShare } = await import("../src/routes/shares");


### PR DESCRIPTION
The agent manifest covered reads and feedback triage only; release writes required the publisher deploy token that lives in CI secrets, forcing a GitHub workflow hop for what is otherwise one API call.

## Changes
- Manifest actions backed by the existing RBAC-gated release routes: `list-releases`/`get-release` (viewer), `create-release` (publisher, **drafts by default**), `update-release` (publisher: changelog / bilingual `release_notes` / `hidden`), `publish-release` (publisher, live-facing, documented as requiring explicit human authorization).
- Agent help action: release flow step + write-endpoint shapes + release-guide doc link.
- Agent guide: raft-integration release path documented ahead of the CLI examples (agents cannot complete the CLI browser login), with draft-first and binary-SHA-citation rules.

No new endpoints and no auth changes — actions map onto existing `requireAppRole`-gated routes. Worker vitest 112/112, tsc clean, docs build clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786862230&installation_id=145465820&pr_number=295&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F295&signature=0add32af400c2e06a84a2c67e5bf6181d9143784d84c265ad35bc80da9696085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->