### PR TITLE
Fix untyped generic calls in draft-only release test

### DIFF
--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -5421,15 +5421,15 @@ describe("quiver public API v2 — scope resolution", () => {
     // hostile: explicit active must be rejected outright (nothing created)
     const hostile = await handleCreateReleaseDraft(ctx({ build_id: "build-draftonly", status: "active" }));
     expect(hostile.status).toBe(400);
-    const hostileBody = await responseJson<any>(hostile);
+    const hostileBody = (await hostile.json()) as any;
     expect(hostileBody.error).toContain("draft");
 
     // normal: no status -> created as draft (NOT the legacy active default)
     const ok = await handleCreateReleaseDraft(ctx({ build_id: "build-draftonly" }));
     expect(ok.status).toBe(201);
-    const created = await responseJson<any>(ok);
+    const created = (await ok.json()) as any;
     expect(created.status).toBe("draft");
-    const row = await env.DB.prepare("SELECT status FROM releases WHERE id = ?1").bind(created.id).first<any>();
+    const row = (await env.DB.prepare("SELECT status FROM releases WHERE id = ?1").bind(created.id).first()) as any;
     expect(row.status).toBe("draft");
   });
 


### PR DESCRIPTION
The deploy build (`tsc --noEmit` with test files included) rejected `responseJson<any>`/`first<any>` in the describe block where those helpers are untyped — broke the Deploy Hands Server run after #295. Casts the awaited results instead. `pnpm build` + vitest 113/113 verified locally with the CI command.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786863183&installation_id=145465820&pr_number=296&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F296&signature=0d6ca9a88b7ca93244ec96b8f8002be0dfd835a5b7192617f042265a0424ae51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->