### PR TITLE
Document the iOS TestFlight release flow

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -30,6 +30,13 @@ const pages = [
     source: "agent-cli-feedback.md",
   },
   {
+    slug: "ios-testflight",
+    source: "ios-testflight.md",
+    title: "iOS Releases & TestFlight",
+    category: "For agents",
+    description: "How iOS builds reach TestFlight: Hands uploads server-side with the stored ASC credential.",
+  },
+  {
     slug: "admin-user-guide",
     title: "Admin User Guide",
     category: "Console",

--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -1,0 +1,65 @@
+# iOS releases & TestFlight
+
+How a Raft iOS build travels from CI to TestFlight. The key fact: **Hands
+uploads to Apple server-side** — the App Store Connect credential lives
+encrypted in Hands, and the `.p8` key never leaves it. CI does not need Apple
+upload credentials, and nobody runs `altool`.
+
+## The flow
+
+```
+iOS Release workflow          Hands                          Apple
+────────────────────          ─────                          ─────
+build + sign IPA  ──────────▶ build + assets in R2
+                              (publish_hands=true)
+                              testflight-upload  ───────────▶ Build Upload API
+                              (streams IPA from R2)           PROCESSING → COMPLETE
+```
+
+1. **Build + sign + publish** — dispatch the `iOS Release` workflow
+   (botiverse/mobile) with `publish_hands=true`. It builds, signs with the
+   distribution certificate, and uploads the IPA + dSYM to Hands as a build
+   (usually with a draft release).
+2. **Upload to TestFlight** — trigger the server-side upload for that build:
+
+   ```
+   POST /api/apps/{app_id}/builds/{build_id}/testflight-upload
+   ```
+
+   Hands streams the IPA from R2 straight to Apple's Build Upload API
+   (create → register file → part PUTs → commit) and returns the initial
+   state. Console: the build row's TestFlight action.
+3. **Poll processing** —
+
+   ```
+   GET /api/apps/{app_id}/testflight-uploads/{build_upload_id}
+   ```
+
+   States: `AWAITING_UPLOAD → PROCESSING → COMPLETE | FAILED`. On COMPLETE
+   the build appears in App Store Connect → TestFlight.
+
+## One-time setup (app admin)
+
+Store the App Store Connect API credential in Hands: console → App →
+Settings → TestFlight (`PUT /api/apps/{app_id}/asc-credentials`). Generate the
+key in App Store Connect → Users and Access → Integrations (App Manager role);
+you need the Key ID, Issuer ID, and the `.p8` file. The credential is
+encrypted at rest and can be verified without exposing it
+(`POST .../asc-credentials/verify`). The same credential powers the
+App Store review-state surface (`GET /api/apps/{app_id}/appstore-review`).
+
+## Versioning rules
+
+- The **marketing version** (e.g. `1.0.0`) may repeat across uploads.
+- The **build number** (`versionCode`, e.g. `1000004`) must be unique and
+  ascending for that marketing version — Apple rejects reused build numbers.
+  Hands build history is the quick way to see the last used code.
+
+## What CI must NOT do
+
+- No `ASC_API_KEY_*` secrets in GitHub, no `xcrun altool` in workflows: the
+  upload path is Hands. Duplicating the credential into CI widens the key
+  surface and splits rotation.
+- Cross-job artifact downloads on Blacksmith macOS runners fail
+  (`ECONNREFUSED`); the design above avoids moving the IPA between jobs at
+  all — Hands already has it.


### PR DESCRIPTION
Docs-only. Adds an "iOS Releases & TestFlight" page (registered in the docs site build) covering the real pipeline: CI builds/signs/publishes to Hands → Hands uploads to Apple server-side with the stored encrypted ASC credential. Endpoints, one-time setup, versioning rules, and anti-patterns (no ASC secrets in CI, no altool, no cross-job IPA transfer — the exact mistakes made during task #112). Docs build clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786887915&installation_id=145465820&pr_number=297&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F297&signature=07590fce8bc682a194dc8fe9fd839e22d19ae2cea7b39d7cc50086cb0a76f8e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->