### PR TITLE
Add ios-testflight to the public docs allowlist

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -458,6 +458,7 @@ const publicDocs = new Set([
   "/docs/electron-sdk/",
   "/docs/cli-reference/",
   "/docs/agent-cli-feedback/",
+  "/docs/ios-testflight/",
   "/docs/public-api-reference/",
 ]);
 


### PR DESCRIPTION
Follow-up to #297: the page shipped in the assets build, but the worker's `publicDocs` allowlist gates HTML doc routes and didn't include `/docs/ios-testflight/` — HTML 404'd while the `.md` twin worked. One-line allowlist addition.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786888152&installation_id=145465820&pr_number=298&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F298&signature=e21b3e7cd30e73458df24a7ee28f5ebd22fe89e386e0da35f8a0ee32decbd17f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->