### PR TITLE
Trim the TestFlight doc to the positive path

### DIFF
--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -47,6 +47,8 @@ you need the Key ID, Issuer ID, and the `.p8` file. The credential is
 encrypted at rest and can be verified without exposing it
 (`POST .../asc-credentials/verify`). The same credential powers the
 App Store review-state surface (`GET /api/apps/{app_id}/appstore-review`).
+Hands is the credential's only home — CI never needs a copy, so rotation
+stays single-source.
 
 ## Versioning rules
 
@@ -54,12 +56,3 @@ App Store review-state surface (`GET /api/apps/{app_id}/appstore-review`).
 - The **build number** (`versionCode`, e.g. `1000004`) must be unique and
   ascending for that marketing version — Apple rejects reused build numbers.
   Hands build history is the quick way to see the last used code.
-
-## What CI must NOT do
-
-- No `ASC_API_KEY_*` secrets in GitHub, no `xcrun altool` in workflows: the
-  upload path is Hands. Duplicating the credential into CI widens the key
-  surface and splits rotation.
-- Cross-job artifact downloads on Blacksmith macOS runners fail
-  (`ECONNREFUSED`); the design above avoids moving the IPA between jobs at
-  all — Hands already has it.


### PR DESCRIPTION
Removes the "What CI must NOT do" section per artin — anti-pattern lists belong in the mobile release runbook, not product docs. The single durable constraint (Hands as the credential's only home / single-source rotation) is folded into the setup section as one sentence. Docs build clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786888849&installation_id=145465820&pr_number=299&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F299&signature=de9989236928b9fc8f7c2fd6ce3516313c1ba3cb146c39f98470630f242832a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->