### PR TITLE
Add a getting-started page: install Hands from the Raft Marketplace

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -16,6 +16,13 @@ const EXTERNAL_ICON = ` <svg class="ext-icon" viewBox="0 0 24 24" fill="none" st
 
 const pages = [
   {
+    slug: "getting-started",
+    source: "getting-started.md",
+    title: "Getting Started",
+    category: "Start here",
+    description: "Connect Hands to your Raft server from the Marketplace — one install enables human and agent sign-in.",
+  },
+  {
     slug: "agent-guide",
     title: "Agent Guide",
     category: "For agents",

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -1,0 +1,50 @@
+# Getting started: connect Hands to your Raft server
+
+Hands signs everyone in through Raft — there are no separate Hands accounts.
+Before anyone on your Raft server can use Hands, a **server admin installs the
+Hands app from the Raft Marketplace once**. That single install enables both
+human sign-in (Login with Raft) and agent sign-in (Raft Agent Login) for the
+whole server.
+
+## Install (server admin, once)
+
+1. In Raft, open **Connected Apps** (server settings) and choose
+   **Marketplace**.
+2. Find **Hands** (Dev Tools, by Botiverse) and open its listing.
+3. Review the listing — publisher, homepage/callback domain (`hands.build`),
+   and the declared access scopes it may request.
+4. Click **Install to this server**.
+
+That's it. Raft reviews marketplace listings before they appear; installing
+also signs your server's agents in without per-agent approval.
+
+## After installing
+
+**Humans** — open [hands.build](https://hands.build) and sign in with
+**Login with Raft**. First user from your server: create an organization and
+your first app. Everyone else: ask an org admin for an invite, or accept the
+pending one.
+
+**Agents** — one-time login from any Raft-connected machine:
+
+```bash
+raft integration login --service <hands-service>
+raft integration invoke --service <hands-service> --action help
+```
+
+The `help` action lists everything an agent can do (feedback triage, builds,
+releases); see the [Agent Guide](agent-guide.md) for the full workflows.
+
+## Access model in one paragraph
+
+Your Raft identity is your Hands identity. What you can do is governed by two
+RBAC layers inside Hands: an **org role** (owner / admin / member / viewer)
+and per-app **app roles** (admin / publisher / member / viewer) — granted in
+the console under App → Access. Installing the marketplace app connects the
+server; it grants no org or app roles by itself.
+
+## Uninstalling
+
+Removing the app from Connected Apps disconnects the server: sign-ins from
+that server stop working, but your Hands orgs, apps, and data remain and are
+restored by reinstalling.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -450,6 +450,7 @@ app.get("/api-docs", (c) => c.html(`<!doctype html>
 </html>`));
 const publicDocs = new Set([
   "/docs/",
+  "/docs/getting-started/",
   "/docs/agent-guide/",
   "/docs/admin-user-guide/",
   "/docs/android-sdk/",


### PR DESCRIPTION
Nothing in the docs explained the prerequisite artin flagged: a server admin must install the Hands app from Raft's Marketplace (Connected Apps → Marketplace → Hands → Install to this server) before anyone on that server can sign in. New "Start here" page covers the one-time install, what it enables (human Login with Raft + agent Raft Agent Login), first-run steps for both, the org/app RBAC model in brief, and uninstall semantics. Registered in the docs build **and** the worker `publicDocs` allowlist (the miss from #297). Docs build + tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786889195&installation_id=145465820&pr_number=300&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F300&signature=8d81a014ed308078e225c27423960bfc847dc1fb4f83d05ce35adddb8633118f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->