### PR TITLE
Put Start here first in the docs nav

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -9,7 +9,7 @@ const outRoot = path.join(repoRoot, "admin/public/docs");
 
 // Docs are grouped by audience; CATEGORY_ORDER controls section order in the
 // sidebar and on the index. Hands is agent-native, so "For agents" leads.
-const CATEGORY_ORDER = ["For agents", "Console", "SDKs & API"];
+const CATEGORY_ORDER = ["Start here", "For agents", "Console", "SDKs & API"];
 
 // Lucide "external-link" (24x24), used for the OpenAPI explorer nav entry.
 const EXTERNAL_ICON = ` <svg class="ext-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>`;


### PR DESCRIPTION
CATEGORY_ORDER didn't include the new "Start here" category, so it fell into the appended-unknowns slot at the end of the nav. One-line fix; verified the built nav order is Start here | For agents | Console | SDKs & API.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786889613&installation_id=145465820&pr_number=301&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F301&signature=64ab4134d10ab9816a03caa93ab590818765274e7b3aa8b60b99718c9cecb995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->