### PR TITLE
docs: link CI examples from getting-started and CLI reference

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -334,6 +334,17 @@ so existing CI keeps working unchanged.
 Legacy equivalents `QUIVER_API`, `QUIVER_BEARER_TOKEN`, `QUIVER_AUTH_TOKEN` are
 still accepted.
 
+## CI Examples
+
+Copy-ready pipelines built on these commands live in
+[botiverse/hands-examples](https://github.com/botiverse/hands-examples):
+
+- A reusable GitHub Action: `uses: botiverse/hands-examples/publish-android@v1`.
+- Complete GitHub Actions and GitLab CI workflows for Android, iOS
+  (publish + server-side [TestFlight upload](ios-testflight.md)), and
+  Electron (per-platform channels for the generic provider).
+- Plain-bash scripts for Jenkins, Buildkite, or any runner with bash and npm.
+
 ## Versioning Guidance
 
 For Android releases, keep APK `versionCode` and Hands `version_code` identical. Clients only update when the server release has a higher version code than the installed app.

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -43,6 +43,17 @@ and per-app **app roles** (admin / publisher / member / viewer) — granted in
 the console under App → Access. Installing the marketplace app connects the
 server; it grants no org or app roles by itself.
 
+## Publishing from CI
+
+Ready-to-copy CI examples live in
+[botiverse/hands-examples](https://github.com/botiverse/hands-examples):
+a reusable GitHub Action for Android
+(`uses: botiverse/hands-examples/publish-android@v1`), complete GitHub
+Actions and GitLab CI workflows for Android, iOS (with server-side
+TestFlight), and Electron, plus plain-bash scripts for any other CI. All
+examples publish draft releases with an app-scoped `publisher` deploy token;
+see the [CLI Reference](cli-reference.md) for the underlying commands.
+
 ## Uninstalling
 
 Removing the app from Connected Apps disconnects the server: sign-ins from


### PR DESCRIPTION
Adds entry points to the new [hands-examples](https://github.com/botiverse/hands-examples) repository:

- **Getting Started** gains a "Publishing from CI" section covering the reusable Android publish action, the complete workflow examples, and the generic bash scripts.
- **CLI Reference** gains a "CI Examples" section between the CI environment variables and versioning guidance, mapping each example category to the commands it uses.

Existing pages only — no registry or worker allowlist changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891870&installation_id=145465820&pr_number=302&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F302&signature=0d666d45954b9eff8cf61f0c74dc249aab8c6d48214b651403fa84d15d5baf22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->