### PR TITLE
Select symbolication lanes by app platform, not content presence

### DIFF
--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -700,7 +700,7 @@ export async function retraceCrashTicket(
         "android-r8",
         "no_symbols",
         `No proguard-mapping asset for version_code ${versionCode}. ` +
-          "Publish the build with its R8 mapping (quiver builds publish-android --mapping).",
+          "Publish the build with its R8 mapping (hands builds publish-android --mapping).",
       );
       return;
     }
@@ -796,7 +796,7 @@ export async function symbolicateNativeCrashTicket(
   ticketId: string,
   versionCode: number | null,
   frames: NativeFrame[],
-  publishHint: string = "quiver builds publish-android --symbols",
+  publishHint: string = "hands builds publish-android --symbols",
 ): Promise<void> {
   try {
     if (versionCode === null || frames.length === 0) return;
@@ -997,7 +997,7 @@ export async function symbolicateOhosCrashTicket(
       ticketId,
       versionCode,
       frames,
-      "quiver builds publish-ohos --symbols",
+      "hands builds publish-ohos --symbols",
     );
   } catch (err) {
     console.error(
@@ -1255,7 +1255,7 @@ export async function symbolicateMinidumpCrashTicket(
       `${parsed.crash_reason ? `\nReason: ${parsed.crash_reason}${parsed.crash_address ? ` @ ${parsed.crash_address}` : ""}` : ""}`;
     const tip =
       !symBytes && versionCode !== null
-        ? `\n\nTip: upload the version's Breakpad symbols (dump_syms → quiver builds ` +
+        ? `\n\nTip: upload the version's Breakpad symbols (dump_syms → hands builds ` +
           `publish-electron --symbols) for version_code ${versionCode} to get ` +
           `function/file:line resolution instead of raw module+offset.`
         : "";
@@ -1289,26 +1289,53 @@ export async function dispatchSymbolication(
   logKey: string | null,
 ): Promise<void> {
   await resetSymbolication(env, ticketId);
+  // Lane applicability is platform-first: content presence alone (a crash log
+  // attachment, structured frames) must never select another platform's lane —
+  // an iOS crash txt used to satisfy the log-attachment gate and fall into
+  // android-r8, reporting a missing ProGuard mapping on an iOS ticket. A null
+  // platform (legacy app rows) keeps the content-based behavior.
+  const platform = app.platform ?? null;
   let ran = false;
 
-  if (logKey) {
+  if (logKey && (platform === null || platform === "android")) {
     ran = true;
     await retraceCrashTicket(env, app.id, ticketId, versionCode, logKey);
   }
   const nativeFrames = parseNativeFrames(metadata["crash_native_frames"]);
-  if (nativeFrames.length > 0) {
+  if (
+    nativeFrames.length > 0 &&
+    (platform === null || platform === "android" || platform === "ohos")
+  ) {
     ran = true;
     await symbolicateNativeCrashTicket(env, app.id, ticketId, versionCode, nativeFrames);
   }
-  if (app.platform === "ohos" && logKey) {
+  if (platform === "ohos" && logKey) {
     ran = true;
     await symbolicateOhosCrashTicket(env, app.id, ticketId, versionCode, logKey);
   }
   const dsymImages = parseBinaryImages(metadata["crash_binary_images"]);
   const dsymFrames = parseCrashFrames(metadata["crash_frames"]);
-  if (dsymImages.length > 0 && dsymFrames.length > 0) {
+  if (
+    dsymImages.length > 0 &&
+    dsymFrames.length > 0 &&
+    (platform === null || platform === "ios")
+  ) {
     ran = true;
     await symbolicateDsymCrashTicket(env, app.id, ticketId, versionCode, dsymImages, dsymFrames);
+  } else if (platform === "ios" && logKey) {
+    // iOS crash without the SDK's structured frame metadata: report the iOS
+    // gap instead of settling on a silent not_applicable.
+    ran = true;
+    await appendSymbolication(
+      env,
+      ticketId,
+      "ios-dsym",
+      "no_symbols",
+      "Crash report has no structured frame metadata (crash_binary_images / " +
+        "crash_frames), so server-side dSYM symbolication cannot run. Update " +
+        "the Hands iOS SDK to include them, and publish builds with their " +
+        "dSYM archive (hands builds publish-ios --dsym).",
+    );
   }
 
   const row = await env.DB.prepare(

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -26,6 +26,7 @@ import {
   handleAddFeedbackComment,
   resetSymbolication,
   appendSymbolication,
+  dispatchSymbolication,
 } from "../src/routes/feedback";
 import {
   httpsRedirectUrl,
@@ -896,6 +897,125 @@ describe("quiver route handlers — SQL smoke", () => {
     const cleared = await readSym();
     expect(cleared.symbolication_status).toBe("pending");
     expect(cleared.symbolicated_stack).toBeNull();
+  });
+
+  it("dispatchSymbolication selects lanes by app platform, never by content alone", async () => {
+    env.APK_BUCKET = { put: async () => undefined, get: async () => null };
+    const now = Date.now();
+    const mkTicket = async (id: string) => {
+      await env.DB.prepare(
+        `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+         VALUES (?1, 'lane-app', 'crash', 'open', 'boom', '{}', ?2, ?3)`,
+      )
+        .bind(id, now, now)
+        .run();
+    };
+    const readSym = (id: string) =>
+      env.DB.prepare(
+        "SELECT symbolication_status, symbolicated_stack FROM feedback_tickets WHERE id = ?1",
+      )
+        .bind(id)
+        .first() as Promise<{ symbolication_status: string; symbolicated_stack: string | null }>;
+    const dsymMeta = {
+      crash_binary_images: [
+        { uuid: "ABCD-1234", load_address: "0x100000000", end_address: "0x100010000", name: "App" },
+      ],
+      crash_frames: [{ index: 0, address: "0x100000f00" }],
+    };
+
+    // iOS + crash log but no structured frames: the android-r8 lane must NOT
+    // fire off the log attachment (task #158 regression, ticket 24f26409);
+    // instead the iOS metadata gap is reported.
+    await mkTicket("lane-ios-log");
+    await dispatchSymbolication(
+      env as any,
+      { id: "lane-app", platform: "ios" },
+      "lane-ios-log",
+      42,
+      {},
+      "r2/ios-crash.txt",
+    );
+    let row = await readSym("lane-ios-log");
+    expect(row.symbolicated_stack).not.toContain("[android-r8]");
+    expect(row.symbolicated_stack).not.toContain("proguard");
+    expect(row.symbolicated_stack).toContain("[ios-dsym]");
+    expect(row.symbolicated_stack).toContain("crash_binary_images");
+    expect(row.symbolication_status).toBe("no_symbols");
+
+    // iOS with structured frames but no dsym asset: only the iOS dSYM gap.
+    await mkTicket("lane-ios-meta");
+    await dispatchSymbolication(
+      env as any,
+      { id: "lane-app", platform: "ios" },
+      "lane-ios-meta",
+      42,
+      dsymMeta,
+      "r2/ios-crash.txt",
+    );
+    row = await readSym("lane-ios-meta");
+    expect(row.symbolicated_stack).not.toContain("[android-r8]");
+    expect(row.symbolicated_stack).toContain("[ios-dsym]");
+    expect(row.symbolicated_stack).toContain("No 'dsym' build asset");
+    expect(row.symbolication_status).toBe("no_symbols");
+
+    // Android + crash log, no mapping asset: android-r8 lane with the R8 hint,
+    // and iOS-shaped metadata must not drag in the dSYM lane.
+    await mkTicket("lane-android");
+    await dispatchSymbolication(
+      env as any,
+      { id: "lane-app", platform: "android" },
+      "lane-android",
+      42,
+      dsymMeta,
+      "r2/android-crash.txt",
+    );
+    row = await readSym("lane-android");
+    expect(row.symbolicated_stack).toContain("[android-r8]");
+    expect(row.symbolicated_stack).toContain("hands builds publish-android --mapping");
+    expect(row.symbolicated_stack).not.toContain("[ios-dsym]");
+
+    // Android native frames, no symbols asset: native lane only.
+    await mkTicket("lane-android-native");
+    await dispatchSymbolication(
+      env as any,
+      { id: "lane-app", platform: "android" },
+      "lane-android-native",
+      42,
+      { crash_native_frames: [{ index: 0, offset: "0x1234", soname: "libapp.so" }] },
+      null,
+    );
+    row = await readSym("lane-android-native");
+    expect(row.symbolicated_stack).toContain("[native]");
+    expect(row.symbolicated_stack).toContain("hands builds publish-android --symbols");
+
+    // OHOS + crash log: android-r8 must not fire; the ohos lane owns the log.
+    await mkTicket("lane-ohos");
+    await dispatchSymbolication(
+      env as any,
+      { id: "lane-app", platform: "ohos" },
+      "lane-ohos",
+      42,
+      {},
+      "r2/ohos-fault.log",
+    );
+    row = await readSym("lane-ohos");
+    expect(row.symbolicated_stack ?? "").not.toContain("[android-r8]");
+    expect(row.symbolication_status).toBe("unsymbolicated");
+
+    // Electron + crash log: no dispatch lane applies (minidumps have their own
+    // ingest path) — settles on not_applicable instead of an Android block.
+    await mkTicket("lane-electron");
+    await dispatchSymbolication(
+      env as any,
+      { id: "lane-app", platform: "electron" },
+      "lane-electron",
+      42,
+      {},
+      "r2/renderer-crash.txt",
+    );
+    row = await readSym("lane-electron");
+    expect(row.symbolicated_stack).toBeNull();
+    expect(row.symbolication_status).toBe("not_applicable");
   });
 
   it("lets org members triage feedback (update status + comment) while viewers cannot", async () => {


### PR DESCRIPTION
iOS crash tickets were falling into the android-r8 retrace lane: `dispatchSymbolication` gated that lane only on the presence of a crash-log attachment, so an iOS crash txt triggered it and the ticket surfaced `[android-r8]` output asking for an Android ProGuard mapping (observed on ticket `24f26409`).

Changes:

- **Platform-first lane applicability** in `dispatchSymbolication`: android-r8 runs only for `android` apps, the native-symbols lane for `android`/`ohos`, the dSYM lane for `ios`. A `null` platform (legacy rows) keeps the previous content-based behavior. The OHOS lane gate is unchanged; Electron minidumps already have their own ingest path.
- **iOS no-symbols fallback**: an iOS crash with a log but without `crash_binary_images`/`crash_frames` metadata now reports that iOS-specific gap (with the `hands builds publish-ios --dsym` hint) instead of settling on a silent `not_applicable`.
- **Copy fixes**: stale `quiver builds` CLI hints in no-symbols messages updated to `hands builds` (android mapping, android/ohos symbols, electron breakpad tip).
- **Regression test**: cross-platform lane-selection coverage (iOS log-only, iOS with frames, Android R8, Android native, OHOS, Electron) asserting no cross-platform lane blocks appear.

Re-running symbolication on an affected ticket clears the old polluted blocks (`resetSymbolication` already nulls `symbolicated_stack` before a fresh run).

Tests: 154 passed; `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893975&installation_id=145465820&pr_number=303&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F303&signature=b026b366a7eaddd4e82b142ce65e3f810a717b027f2883fce7f938fd3692bf3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->