### PR TITLE
Hands↔Stamp integration: draft-created webhook + advisory release checks

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1151,8 +1151,29 @@ export const getBuildAssetDownloadUrl = (
 export const listReleases = (appId: string) =>
   request<{ releases: Release[] }>(`/api/apps/${appId}/releases`, { admin: true });
 
+export interface ReleaseCheck {
+  id: string;
+  source: string;
+  run_id: string | null;
+  run_url: string | null;
+  verdict: "passed" | "failed" | "warning" | "skipped";
+  cases_total: number | null;
+  cases_passed: number | null;
+  summary: string | null;
+  reviewer: string | null;
+  reviewed_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
 export const getRelease = (appId: string, releaseId: string) =>
-  request<{ release: Release; build: Build; assets: BuildAsset[]; scopes: ReleaseScope[] }>(
+  request<{
+    release: Release;
+    build: Build;
+    assets: BuildAsset[];
+    scopes: ReleaseScope[];
+    checks: ReleaseCheck[];
+  }>(
     `/api/apps/${appId}/releases/${releaseId}`,
     { admin: true },
   );
@@ -1255,6 +1276,7 @@ export type WebhookEventType =
   | "crash:new_group"
   | "crash:spike"
   | "release:new"
+  | "release:draft_created"
   | "release:superseded"
   | "release:rolled_back"
   | "release:cancelled"
@@ -1266,6 +1288,7 @@ export const WEBHOOK_EVENT_TYPES: WebhookEventType[] = [
   "crash:new_group",
   "crash:spike",
   "release:new",
+  "release:draft_created",
   "release:superseded",
   "release:rolled_back",
   "release:cancelled",

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -586,6 +586,47 @@ function ReleaseRow({
               </tbody>
             </table>
           )}
+          {(detail.data.checks ?? []).length > 0 && (
+            <div className="mt-2">
+              <div className="text-slate-500 mb-1">Checks (advisory)</div>
+              {detail.data.checks.map((chk) => (
+                <div key={chk.id} className="flex items-center gap-2 mb-0.5">
+                  <span
+                    className={
+                      chk.verdict === "passed"
+                        ? "text-emerald-600 font-medium"
+                        : chk.verdict === "failed"
+                          ? "text-red-600 font-medium"
+                          : "text-amber-600 font-medium"
+                    }
+                  >
+                    {chk.verdict}
+                  </span>
+                  <span className="font-mono">{chk.source}</span>
+                  {chk.cases_total !== null && (
+                    <span className="text-slate-500">
+                      {chk.cases_passed ?? 0}/{chk.cases_total} cases
+                    </span>
+                  )}
+                  {chk.run_url && (
+                    <a
+                      href={chk.run_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      run
+                    </a>
+                  )}
+                  {chk.summary && (
+                    <span className="text-slate-500 truncate" title={chk.summary}>
+                      {chk.summary}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/migrations/sql/0045_release_checks.sql
+++ b/migrations/sql/0045_release_checks.sql
@@ -1,0 +1,24 @@
+-- Advisory QA/verification results written back by external systems (e.g.
+-- Stamp) after a release:draft_created webhook. One row per (release, source):
+-- a source re-posting replaces its previous verdict for that release. Checks
+-- are informational only — they never gate publish.
+CREATE TABLE release_checks (
+  id TEXT PRIMARY KEY,
+  release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  app_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  run_id TEXT,
+  run_url TEXT,
+  verdict TEXT NOT NULL CHECK (verdict IN ('passed', 'failed', 'warning', 'skipped')),
+  cases_total INTEGER,
+  cases_passed INTEGER,
+  summary TEXT,
+  reviewer TEXT,
+  reviewed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (release_id, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_release_checks_release
+  ON release_checks(release_id, updated_at);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -140,6 +140,8 @@ import {
   handlePublishRelease,
   handleRollbackRelease,
   handleUpdateRelease,
+  handleUpsertReleaseCheck,
+  handleListReleaseChecks,
 } from "./routes/releases";
 import { handleListChannels, handleCreateChannel, handleUpdateChannel, handleDeleteChannel } from "./routes/channels";
 import { handleListProductTypes, handleCreateProductType, handleUpdateProductType, handleDeleteProductType } from "./routes/product_types";
@@ -651,6 +653,8 @@ admin.delete("/api/apps/:appId/releases/:releaseId", requireAppRole("publisher")
 admin.post("/api/apps/:appId/releases/:releaseId/rollback", requireAppRole("publisher"), handleRollbackRelease);
 admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("publisher"), handleBumpRollout);
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
+admin.get("/api/apps/:appId/releases/:releaseId/checks", requireAppRole("viewer"), handleListReleaseChecks);
+admin.post("/api/apps/:appId/releases/:releaseId/checks", requireAppRole("publisher"), handleUpsertReleaseCheck);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
 admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);
 admin.get("/api/apps/:appId/client-key", requireAppRole("admin"), handleGetClientKey);

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -4,6 +4,8 @@ import { emitWebhookEvent } from "./webhooks";
 import { generateDeltaPatchesForBuild } from "./delta";
 import { requestOrigin } from "../lib/origin";
 import { parseReleaseNotes, stringifyReleaseNotes, type ReleaseNotes } from "../lib/release_notes";
+import { presignR2DownloadUrl } from "../lib/r2_presign";
+import { generateSignedR2Url } from "./public_v2";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 import { getBuildForApp } from "./builds";
@@ -421,13 +423,244 @@ export async function handleGetRelease(c: Context<{ Bindings: Env }>) {
   )
     .bind(releaseId)
     .all();
+  const { results: checks } = await c.env.DB.prepare(
+    `SELECT id, source, run_id, run_url, verdict, cases_total, cases_passed,
+            summary, reviewer, reviewed_at, created_at, updated_at
+     FROM release_checks WHERE release_id = ?1 ORDER BY updated_at DESC`,
+  )
+    .bind(releaseId)
+    .all();
 
   return c.json({
     release: withReleaseNotes(release as { changelog?: string | null }),
     build,
     assets,
     scopes,
+    checks,
   });
+}
+
+// ============================================================================
+// Release checks — advisory QA write-back (task #153, Hands↔Stamp)
+// ============================================================================
+
+const CHECK_VERDICTS = ["passed", "failed", "warning", "skipped"] as const;
+
+/**
+ * Upsert an advisory verification result from an external system (one row per
+ * release+source; re-posting replaces that source's verdict). Advisory only —
+ * publish never consults this table.
+ */
+export async function handleUpsertReleaseCheck(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  const release = await getReleaseForApp(c.env.DB, appId, releaseId);
+  if (!release) return c.json({ error: "not found" }, 404);
+
+  const body = (await c.req.json().catch(() => ({}))) as {
+    source?: string;
+    run_id?: string;
+    run_url?: string;
+    verdict?: string;
+    cases_total?: number;
+    cases_passed?: number;
+    summary?: string;
+    reviewer?: string;
+    reviewed_at?: number;
+  };
+  const source = (body.source ?? "").trim().slice(0, 100);
+  if (!source) return c.json({ error: "source required" }, 400);
+  if (!body.verdict || !(CHECK_VERDICTS as readonly string[]).includes(body.verdict)) {
+    return c.json({ error: `verdict must be one of: ${CHECK_VERDICTS.join(", ")}` }, 400);
+  }
+  if (body.run_url !== undefined) {
+    try {
+      new URL(body.run_url);
+    } catch {
+      return c.json({ error: "run_url must be a valid URL" }, 400);
+    }
+  }
+  const intOrNull = (v: unknown) =>
+    typeof v === "number" && Number.isFinite(v) ? Math.floor(v) : null;
+
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  await c.env.DB.batch([
+    c.env.DB
+      .prepare(
+        `INSERT INTO release_checks
+         (id, release_id, app_id, source, run_id, run_url, verdict,
+          cases_total, cases_passed, summary, reviewer, reviewed_at,
+          created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+         ON CONFLICT (release_id, source) DO UPDATE SET
+           run_id = excluded.run_id,
+           run_url = excluded.run_url,
+           verdict = excluded.verdict,
+           cases_total = excluded.cases_total,
+           cases_passed = excluded.cases_passed,
+           summary = excluded.summary,
+           reviewer = excluded.reviewer,
+           reviewed_at = excluded.reviewed_at,
+           updated_at = excluded.updated_at`,
+      )
+      .bind(
+        id,
+        releaseId,
+        appId,
+        source,
+        body.run_id?.slice(0, 200) ?? null,
+        body.run_url ?? null,
+        body.verdict,
+        intOrNull(body.cases_total),
+        intOrNull(body.cases_passed),
+        body.summary?.slice(0, 4000) ?? null,
+        body.reviewer?.slice(0, 200) ?? null,
+        intOrNull(body.reviewed_at),
+        now,
+        now,
+      ),
+    c.env.DB
+      .prepare(
+        "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+      )
+      .bind(
+        crypto.randomUUID(),
+        appId,
+        "release.check",
+        currentActor(c),
+        JSON.stringify({ release_id: releaseId, source, verdict: body.verdict, run_id: body.run_id ?? null }),
+        now,
+      ),
+  ]);
+
+  const saved = await c.env.DB.prepare(
+    `SELECT id, release_id, source, run_id, run_url, verdict, cases_total,
+            cases_passed, summary, reviewer, reviewed_at, created_at, updated_at
+     FROM release_checks WHERE release_id = ?1 AND source = ?2`,
+  )
+    .bind(releaseId, source)
+    .first();
+  return c.json({ check: saved }, 201);
+}
+
+export async function handleListReleaseChecks(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  const release = await getReleaseForApp(c.env.DB, appId, releaseId);
+  if (!release) return c.json({ error: "not found" }, 404);
+  const { results: checks } = await c.env.DB.prepare(
+    `SELECT id, release_id, source, run_id, run_url, verdict, cases_total,
+            cases_passed, summary, reviewer, reviewed_at, created_at, updated_at
+     FROM release_checks WHERE release_id = ?1 ORDER BY updated_at DESC`,
+  )
+    .bind(releaseId)
+    .all();
+  return c.json({ checks });
+}
+
+/**
+ * Emit `release:draft_created` for a freshly created draft — the QA/integration
+ * trigger (e.g. Stamp picks it up, downloads the artifact, runs its suite, and
+ * writes a release check back). The payload carries the human-stable
+ * identifiers (app slug, channel slug, version) plus a presigned artifact URL
+ * so a consumer can fetch the installable without a Hands credential; the
+ * `download_api` path is the durable token-authenticated fallback once the
+ * presigned URL expires. Best-effort: a payload-assembly failure never fails
+ * the release creation.
+ */
+async function emitReleaseDraftCreated(
+  c: AdminContext,
+  appId: string,
+  releaseId: string,
+): Promise<void> {
+  try {
+    const orgId = c.get("org_id");
+    if (!orgId) return;
+    const row = await c.env.DB.prepare(
+      `SELECT r.build_id, r.channel_id, r.product_type, r.release_type,
+              a.slug AS app_slug,
+              b.version_name, b.version_code,
+              c.slug AS channel
+       FROM releases r
+       JOIN apps a ON a.id = r.app_id
+       JOIN builds b ON b.id = r.build_id
+       LEFT JOIN channels c ON c.id = r.channel_id
+       WHERE r.app_id = ?1 AND r.id = ?2`,
+    )
+      .bind(appId, releaseId)
+      .first<{
+        build_id: string;
+        channel_id: string | null;
+        product_type: string;
+        release_type: string;
+        app_slug: string;
+        version_name: string;
+        version_code: number;
+        channel: string | null;
+      }>();
+    if (!row) return;
+
+    const asset = await c.env.DB.prepare(
+      `SELECT id, filetype, r2_key, size_bytes FROM build_assets
+       WHERE build_id = ?1 AND artifact_kind = 'installable'
+       ORDER BY created_at DESC LIMIT 1`,
+    )
+      .bind(row.build_id)
+      .first<{ id: string; filetype: string; r2_key: string; size_bytes: number | null }>();
+
+    // Presign long enough to cover the delivery retry window (5m/30m/2h) with
+    // slack for the consumer's own queueing.
+    const ttl = 24 * 60 * 60;
+    let downloadUrl: string | null = null;
+    if (asset) {
+      const filename = `${row.app_slug}-${row.version_name}-${row.version_code}.${asset.filetype}`;
+      downloadUrl = await presignR2DownloadUrl(
+        c.env,
+        {
+          key: asset.r2_key,
+          filetype: asset.filetype,
+          contentDisposition: `attachment; filename="${filename.replace(/"/g, "")}"`,
+        },
+        ttl,
+      );
+      if (!downloadUrl) {
+        downloadUrl = await generateSignedR2Url(c.env, asset.r2_key, ttl, requestOrigin(c));
+      }
+    }
+
+    await emitWebhookEvent(c.env.DB, {
+      orgId,
+      appId,
+      event: "release:draft_created",
+      body: {
+        release_id: releaseId,
+        app_id: appId,
+        app_slug: row.app_slug,
+        build_id: row.build_id,
+        channel_id: row.channel_id,
+        channel: row.channel,
+        product_type: row.product_type,
+        release_type: row.release_type,
+        version_name: row.version_name,
+        version_code: row.version_code,
+        artifact: asset
+          ? {
+              asset_id: asset.id,
+              filetype: asset.filetype,
+              size_bytes: asset.size_bytes,
+              download_url: downloadUrl,
+              download_url_expires_at: downloadUrl ? Date.now() + ttl * 1000 : null,
+              download_api: `/api/apps/${appId}/builds/${row.build_id}/assets/${asset.id}/download?presign=1`,
+            }
+          : null,
+      },
+    });
+  } catch (err) {
+    console.error(
+      `[release:draft_created] emit failed for release ${releaseId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 /**
@@ -447,6 +680,7 @@ export async function handleCreateReleaseDraft(c: AdminContext) {
   try {
     const draftBody: ReleaseInput = { ...body, status: "draft" };
     const id = await createRelease(c.env.DB, appId, draftBody, currentActor(c));
+    c.executionCtx?.waitUntil(emitReleaseDraftCreated(c, appId, id));
     const changelog = inputChangelog(draftBody) ?? null;
     return c.json(
       {
@@ -470,7 +704,8 @@ export async function handleCreateRelease(c: AdminContext) {
   try {
     const id = await createRelease(c.env.DB, appId, body, currentActor(c));
     const status = releaseStatus(body.status);
-    // Emit webhook event only when the release is actually live.
+    // release:new fires only when the release is actually live; drafts get
+    // their own QA-trigger event.
     const orgId = c.get("org_id");
     if (status === "active" && orgId) {
       c.executionCtx?.waitUntil(
@@ -481,6 +716,8 @@ export async function handleCreateRelease(c: AdminContext) {
           body: { release_id: id, app_id: appId, build_id: body.build_id, channel_id: body.channel_id },
         }),
       );
+    } else if (status === "draft") {
+      c.executionCtx?.waitUntil(emitReleaseDraftCreated(c, appId, id));
     }
     const changelog = inputChangelog(body) ?? null;
     return c.json({

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -8,7 +8,8 @@
  * (events only from that app). v1 keeps it simple — only org-wide webhooks.
  *
  * Events emitted (from worker/src/routes/webhook_events.ts):
- *   release:new        - release created
+ *   release:new           - release activated (created active or published)
+ *   release:draft_created - draft release created (QA/integration trigger)
  *   release:superseded - release marked superseded by a new one
  *   release:rolled_back - explicit rollback
  *   release:cancelled   - release cancelled
@@ -28,6 +29,7 @@ type WebhookEventType =
   | "crash:new_group"
   | "crash:spike"
   | "release:new"
+  | "release:draft_created"
   | "release:superseded"
   | "release:rolled_back"
   | "release:cancelled"

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -256,6 +256,23 @@ function makeMockDb() {
       current_count INTEGER NOT NULL DEFAULT 0,
       last_checked_at INTEGER
     );
+    CREATE TABLE release_checks (
+      id TEXT PRIMARY KEY,
+      release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+      app_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      run_id TEXT,
+      run_url TEXT,
+      verdict TEXT NOT NULL CHECK (verdict IN ('passed', 'failed', 'warning', 'skipped')),
+      cases_total INTEGER,
+      cases_passed INTEGER,
+      summary TEXT,
+      reviewer TEXT,
+      reviewed_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (release_id, source)
+    );
     CREATE TABLE release_shares (
       id TEXT PRIMARY KEY,
       release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
@@ -2995,7 +3012,7 @@ describe("quiver public API v2 — scope resolution", () => {
         "default",
         "https://example.test/quiver",
         "secret",
-        JSON.stringify(["build:succeeded", "release:new", "feedback:new", "crash:new_group"]),
+        JSON.stringify(["build:succeeded", "release:new", "release:draft_created", "feedback:new", "crash:new_group"]),
         Date.now(),
         Date.now(),
       )
@@ -3228,8 +3245,110 @@ describe("quiver public API v2 — scope resolution", () => {
     const eventTypes = deliveryRows.map((row) => row.event_type);
     expect(eventTypes).toContain("build:succeeded");
     expect(eventTypes).toContain("release:new");
+    expect(eventTypes).toContain("release:draft_created");
     expect(eventTypes).toContain("feedback:new");
     expect(eventTypes).toContain("crash:new_group");
+
+    // The draft-created payload carries the QA-consumer contract: stable
+    // slugs, version identity, and an artifact block with a durable API path.
+    const draftDelivery = (await env.DB.prepare(
+      "SELECT payload_json FROM webhook_deliveries WHERE webhook_id = ?1 AND event_type = 'release:draft_created'",
+    )
+      .bind("wh-e2e")
+      .first()) as { payload_json: string };
+    const draftPayload = JSON.parse(draftDelivery.payload_json).payload;
+    expect(draftPayload).toMatchObject({
+      release_id: draft.id,
+      app_slug: "scope-app",
+      build_id: build.id,
+      channel: "production",
+      version_name: "9.9.9",
+      version_code: 9090900,
+    });
+    expect(draftPayload.artifact.download_api).toBe(
+      `/api/apps/app-scope/builds/${build.id}/assets/${draftPayload.artifact.asset_id}/download?presign=1`,
+    );
+  });
+
+  it("release checks: upsert per source, advisory read-back on get-release", async () => {
+    const env = makeEnv();
+    await seedRelease(env, "rel-check", "build-check", [["full", "all"]]);
+    const {
+      handleUpsertReleaseCheck,
+      handleListReleaseChecks,
+      handleGetRelease,
+    } = await import("../src/routes/releases");
+    const ctx = (params: Record<string, string>, body: unknown = {}) =>
+      ({
+        env,
+        req: {
+          url: "https://quiver-worker.test/api/apps/app-scope/releases/rel-check/checks",
+          param: (name: string) => params[name] ?? "",
+          query: () => undefined,
+          json: async () => body,
+        },
+        get: (name: string) => (name === "admin_actor" ? "stamp-bot" : undefined),
+        json: (data: unknown, status = 200) =>
+          new Response(JSON.stringify(data), {
+            status,
+            headers: { "content-type": "application/json" },
+          }),
+      }) as any;
+
+    // Verdict is validated; unknown release 404s.
+    const badVerdict = await handleUpsertReleaseCheck(
+      ctx({ appId: "app-scope", releaseId: "rel-check" }, { source: "stamp", verdict: "meh" }),
+    );
+    expect(badVerdict.status).toBe(400);
+    const missing = await handleUpsertReleaseCheck(
+      ctx({ appId: "app-scope", releaseId: "rel-nope" }, { source: "stamp", verdict: "passed" }),
+    );
+    expect(missing.status).toBe(404);
+
+    const first = await handleUpsertReleaseCheck(
+      ctx(
+        { appId: "app-scope", releaseId: "rel-check" },
+        {
+          source: "stamp",
+          run_id: "run-1",
+          run_url: "https://stamp.test/runs/1",
+          verdict: "failed",
+          cases_total: 5,
+          cases_passed: 3,
+          summary: "2 cases failed",
+          reviewer: "vera",
+          reviewed_at: 1234,
+        },
+      ),
+    );
+    expect(first.status).toBe(201);
+
+    // Same source posts again → replaces its verdict, no second row.
+    const second = await handleUpsertReleaseCheck(
+      ctx(
+        { appId: "app-scope", releaseId: "rel-check" },
+        { source: "stamp", run_id: "run-2", verdict: "passed", cases_total: 5, cases_passed: 5 },
+      ),
+    );
+    expect(second.status).toBe(201);
+
+    const listed = await responseJson<any>(
+      await handleListReleaseChecks(ctx({ appId: "app-scope", releaseId: "rel-check" })),
+    );
+    expect(listed.checks).toHaveLength(1);
+    expect(listed.checks[0]).toMatchObject({
+      source: "stamp",
+      run_id: "run-2",
+      verdict: "passed",
+      cases_total: 5,
+      cases_passed: 5,
+    });
+
+    const detail = await responseJson<any>(
+      await handleGetRelease(ctx({ appId: "app-scope", releaseId: "rel-check" })),
+    );
+    expect(detail.checks).toHaveLength(1);
+    expect(detail.checks[0].verdict).toBe("passed");
   });
 
   it("shares: no ttl never expires, url is re-copyable, expiry semantics on update", async () => {


### PR DESCRIPTION
Implements both halves of the QA integration loop proposed for Stamp.

## Hands → Stamp: `release:draft_created` webhook

New webhook event type, emitted when a draft release is created — via `POST /releases/draft` or the legacy `POST /releases` with `status: draft`. Uses the existing webhook system (org/app subscriptions, HMAC `X-Hands-Signature`/`X-Quiver-Signature`, retry with backoff).

Payload (under the standard envelope's `payload` key):

```json
{
  "release_id": "…", "app_id": "…", "app_slug": "raft-android",
  "build_id": "…", "channel_id": "…", "channel": "main",
  "product_type": "android-apk", "release_type": "stable",
  "version_name": "1.5.0", "version_code": 1050000,
  "artifact": {
    "asset_id": "…", "filetype": "apk", "size_bytes": 123,
    "download_url": "<presigned, 24h>",
    "download_url_expires_at": 1784400000000,
    "download_api": "/api/apps/{app}/builds/{build}/assets/{asset}/download?presign=1"
  }
}
```

`download_url` covers the delivery retry window without credentials; `download_api` is the durable fallback for consumers holding a deploy token. Emission is best-effort (wrapped, logged) — it can never fail or slow release creation.

## Stamp → Hands: advisory release checks

- Migration `0045_release_checks`: one row per `(release_id, source)`, verdict constrained to `passed | failed | warning | skipped`, cascade-deletes with the release.
- `POST /api/apps/:appId/releases/:releaseId/checks` (publisher role, deploy-token friendly): upsert — a source re-posting replaces its previous verdict. Audit-logged as `release.check`.
- `GET …/checks` (viewer) and `checks` included in get-release.
- Console release detail shows checks read-only (verdict, source, case counts, run link, summary).
- Checks are advisory only: publish logic does not consult them.

## Tests

- e2e smoke extended: draft creation now asserts a `release:draft_created` delivery with the payload contract above.
- New test covering verdict validation, 404 on unknown release, per-source upsert semantics, and read-back via list + get-release.
- 155 worker tests + `pnpm build` + admin `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786908791&installation_id=145465820&pr_number=304&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F304&signature=8d6256142716cde103d27ad40e252b596345e368b37284abc93f762a188d6b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->