### PR TITLE
feat: add Tauri updater publishing

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -297,13 +297,17 @@ hands builds publish-tauri my-app \
   --channel main \
   --bundle target/release/bundle/macos/MyApp.app.tar.gz \
   --signature target/release/bundle/macos/MyApp.app.tar.gz.sig \
-  --target darwin-arm64 \
-  --draft
+  --target darwin-aarch64
 ```
 
 Repeat `--bundle`, `--signature`, and `--target` in matching order for a
-multi-platform release. Supported updater bundles are macOS/Linux `.tar.gz`
-and Windows `.nsis.zip` / `.msi.zip`. The Tauri signing private key remains in
+multi-platform release. Supported updater bundles are macOS `.app.tar.gz`,
+Linux `.AppImage` or compatibility `.tar.gz`, and Windows `.nsis.zip` /
+`.msi.zip`. Targets use Tauri's own names, such as `darwin-aarch64`,
+`linux-x86_64`, and `windows-x86_64`.
+
+The command creates a draft by default. Review it and publish explicitly; use
+`--publish` only in an already-authorized automation lane. The Tauri signing private key remains in
 CI; Hands stores only the signed bundle and the detached signature required by
 the updater response. Use separate `main`, `preview`, and `nightly` endpoints
 when applications follow different release channels.

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -312,6 +312,11 @@ CI; Hands stores only the signed bundle and the detached signature required by
 the updater response. Use separate `main`, `preview`, and `nightly` endpoints
 when applications follow different release channels.
 
+The Tauri lane currently serves full-channel releases only. Percentage rollout
+and scoped cohort releases require a stable client identifier that Tauri does
+not send by default, so non-full releases return no update instead of being
+expanded to every client.
+
 ## Review and Publish (draft flow)
 
 CI creates drafts; publishing is an explicit step after changelog review:

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -271,6 +271,43 @@ release, then a human or agent reviews release notes and explicitly publishes.
 macOS update artifacts must be signed before upload; Hands hosts the signed
 files but does not sign Electron applications.
 
+## Publish Tauri updater artifacts
+
+Tauri v2 applications can use a Hands channel as a dynamic updater endpoint:
+
+```json
+{
+  "bundle": { "createUpdaterArtifacts": true },
+  "plugins": {
+    "updater": {
+      "pubkey": "CONTENT FROM PUBLICKEY.PEM",
+      "endpoints": [
+        "https://hands.build/tauri/my-app/main/{{target}}/{{arch}}/{{current_version}}"
+      ]
+    }
+  }
+}
+```
+
+Publish the updater bundles and their Tauri-generated signatures together:
+
+```bash
+hands builds publish-tauri my-app \
+  --version 1.2.3 \
+  --channel main \
+  --bundle target/release/bundle/macos/MyApp.app.tar.gz \
+  --signature target/release/bundle/macos/MyApp.app.tar.gz.sig \
+  --target darwin-arm64 \
+  --draft
+```
+
+Repeat `--bundle`, `--signature`, and `--target` in matching order for a
+multi-platform release. Supported updater bundles are macOS/Linux `.tar.gz`
+and Windows `.nsis.zip` / `.msi.zip`. The Tauri signing private key remains in
+CI; Hands stores only the signed bundle and the detached signature required by
+the updater response. Use separate `main`, `preview`, and `nightly` endpoints
+when applications follow different release channels.
+
 ## Review and Publish (draft flow)
 
 CI creates drafts; publishing is an explicit step after changelog review:

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -302,8 +302,8 @@ hands builds publish-tauri my-app \
 
 Repeat `--bundle`, `--signature`, and `--target` in matching order for a
 multi-platform release. Supported updater bundles are macOS `.app.tar.gz`,
-Linux `.AppImage` or compatibility `.tar.gz`, and Windows `.nsis.zip` /
-`.msi.zip`. Targets use Tauri's own names, such as `darwin-aarch64`,
+Linux `.AppImage` or compatibility `.tar.gz`, and Windows `.exe` / `.msi`
+(or v1-compatible `.nsis.zip` / `.msi.zip`). Targets use Tauri's own names, such as `darwin-aarch64`,
 `linux-x86_64`, and `windows-x86_64`.
 
 The command creates a draft by default. Review it and publish explicitly; use

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -207,6 +207,13 @@ target and architecture, so an activation change cannot switch the bytes after
 an update check. Signature verification is performed by Tauri using the public key
 embedded in the application; Hands never receives the signing private key.
 
+Only full-scope active releases are eligible. Scoped or percentage rollout is
+not applied to Tauri requests because the default updater request has no stable
+installation identifier. Once an active release is superseded, its release-ID
+artifact URL remains downloadable so clients that already received the update
+response can finish. This immutable-cache contract assumes published build
+assets are never overwritten; publish a new build/release for changed bytes.
+
 macOS updates still require signed app artifacts. Hands only hosts the
 already-built and signed files; it does not sign Electron applications.
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -190,6 +190,22 @@ Example asset conventions:
 | `Raft Setup 1.2.3.exe` | `win32` | `x64` | `exe` | `installable` |
 | `Raft Setup 1.2.3.exe.blockmap` | `win32` | `x64` | `blockmap` | `electron-blockmap` |
 
+### Tauri updater
+
+Tauri v2 applications can configure this dynamic updater endpoint:
+
+```text
+GET /tauri/:appSlug/:channel/:target/:arch/:currentVersion
+```
+
+`target` is `darwin`, `windows`, or `linux`; `arch` follows Tauri's updater
+values such as `aarch64` and `x86_64`. The endpoint returns `204 No Content`
+when the active `tauri-updater` release is not newer. Otherwise it returns the
+Tauri updater JSON fields `version`, `url`, `signature`, and optional release
+notes/date. The artifact URL is immutable and belongs to the same active Hands
+release. Signature verification is performed by Tauri using the public key
+embedded in the application; Hands never receives the signing private key.
+
 macOS updates still require signed app artifacts. Hands only hosts the
 already-built and signed files; it does not sign Electron applications.
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -202,8 +202,9 @@ GET /tauri/:appSlug/:channel/:target/:arch/:currentVersion
 values such as `aarch64` and `x86_64`. The endpoint returns `204 No Content`
 when the active `tauri-updater` release is not newer. Otherwise it returns the
 Tauri updater JSON fields `version`, `url`, `signature`, and optional release
-notes/date. The artifact URL is immutable and belongs to the same active Hands
-release. Signature verification is performed by Tauri using the public key
+notes/date. The immutable artifact URL includes the concrete release ID plus
+target and architecture, so an activation change cannot switch the bytes after
+an update check. Signature verification is performed by Tauri using the public key
 embedded in the application; Hands never receives the signing private key.
 
 macOS updates still require signed app artifacts. Hands only hosts the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,7 @@ Hands CLI — manage apps, builds, releases from the terminal.
 Status: **alpha**. The npm package is public as `@botiverse/hands-cli`; v1 ships
 `login`, `logout`, `whoami`, `apps list/get`, `builds list/get`, and
 `builds publish-version`, `builds publish-android`, `builds publish-ios`,
-`builds publish-ohos`, and `builds publish-electron`. Other commands listed in
+`builds publish-ohos`, `builds publish-electron`, and `builds publish-tauri`. Other commands listed in
 `docs/cli-reference.md` land incrementally as backend endpoints become available.
 
 ## Install
@@ -15,7 +15,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.7 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.8 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -162,6 +162,79 @@ describe("Tauri build helpers", () => {
     expect(splitTauriTarget("darwin-aarch64")).toEqual({ platform: "darwin", arch: "aarch64" });
     expect(() => splitTauriTarget("win32-arm64")).toThrow("Tauri target must be");
   });
+
+  it("publishes a signed target through the full draft-first API flow", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hands-tauri-publish-"));
+    const bundle = join(dir, "App.AppImage");
+    const signature = `${bundle}.sig`;
+    writeFileSync(bundle, "bundle-bytes");
+    writeFileSync(signature, "detached-signature\n");
+
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "desktop" }] }));
+      if (req.url === "/api/apps/app-1/channels") return res.end(JSON.stringify({ channels: [{ id: "channel-1", slug: "main", name: "Main" }] }));
+      if (req.url === "/api/apps/app-1/builds") return res.end(JSON.stringify({ id: "build-1" }));
+      if (req.url === "/api/apps/app-1/upload") return res.end(JSON.stringify({
+        file_hash: "hash-1", r2_key: "apps/app-1/App.AppImage", size_bytes: 12, original_filename: "App.AppImage",
+      }));
+      if (req.url === "/api/apps/app-1/builds/build-1/assets") return res.end(JSON.stringify({ id: "asset-1" }));
+      if (req.url === "/api/apps/app-1/releases") return res.end(JSON.stringify({ id: "release-1" }));
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { registerBuildCommands } = await import("../src/commands/builds.js");
+      const program = new Command().option("--json", "JSON output", false);
+      registerBuildCommands(program);
+      await program.parseAsync([
+        "node", "hands", "builds", "publish-tauri", "desktop",
+        "--version", "1.2.3",
+        "--bundle", bundle,
+        "--signature", signature,
+        "--target", "linux-x86_64",
+      ]);
+
+      const assetRequest = requests.find((request) => request.url.endsWith("/assets"));
+      expect(assetRequest?.body).toMatchObject({
+        artifact_kind: "tauri-updater",
+        platform: "linux",
+        arch: "x86_64",
+        filetype: "AppImage",
+        signature: "detached-signature",
+      });
+      const releaseRequest = requests.find((request) => request.url.endsWith("/releases"));
+      expect(releaseRequest?.body).toMatchObject({
+        status: "draft",
+        product_type: "tauri-updater",
+        scopes: [{ scope_type: "full", scope_value: "all" }],
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("external build publish helpers", () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -144,6 +144,16 @@ describe("electron build helpers", () => {
   });
 });
 
+describe("Tauri build helpers", () => {
+  it("accepts only updater bundle formats produced by Tauri v2", async () => {
+    const { inferTauriFiletype } = await import("../src/commands/builds.js");
+    expect(inferTauriFiletype("App.app.tar.gz")).toBe("tar.gz");
+    expect(inferTauriFiletype("App_1.2.3_x64-setup.nsis.zip")).toBe("nsis.zip");
+    expect(inferTauriFiletype("App_1.2.3_x64_en-US.msi.zip")).toBe("msi.zip");
+    expect(() => inferTauriFiletype("App.dmg")).toThrow("unsupported Tauri updater bundle");
+  });
+});
+
 describe("external build publish helpers", () => {
   it("splits the public target into the existing platform/arch storage shape", async () => {
     const { splitBuildTarget } = await import("../src/commands/builds.js");

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -150,7 +150,15 @@ describe("Tauri build helpers", () => {
     expect(inferTauriFiletype("App.app.tar.gz")).toBe("tar.gz");
     expect(inferTauriFiletype("App_1.2.3_x64-setup.nsis.zip")).toBe("nsis.zip");
     expect(inferTauriFiletype("App_1.2.3_x64_en-US.msi.zip")).toBe("msi.zip");
+    expect(inferTauriFiletype("App_1.2.3_amd64.AppImage")).toBe("AppImage");
     expect(() => inferTauriFiletype("App.dmg")).toThrow("unsupported Tauri updater bundle");
+  });
+
+  it("maps official Tauri targets to Hands platform storage", async () => {
+    const { splitTauriTarget } = await import("../src/commands/builds.js");
+    expect(splitTauriTarget("windows-x86_64")).toEqual({ platform: "win32", arch: "x86_64" });
+    expect(splitTauriTarget("darwin-aarch64")).toEqual({ platform: "darwin", arch: "aarch64" });
+    expect(() => splitTauriTarget("win32-arm64")).toThrow("Tauri target must be");
   });
 });
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -151,6 +151,8 @@ describe("Tauri build helpers", () => {
     expect(inferTauriFiletype("App_1.2.3_x64-setup.nsis.zip")).toBe("nsis.zip");
     expect(inferTauriFiletype("App_1.2.3_x64_en-US.msi.zip")).toBe("msi.zip");
     expect(inferTauriFiletype("App_1.2.3_amd64.AppImage")).toBe("AppImage");
+    expect(inferTauriFiletype("App_1.2.3_x64-setup.exe")).toBe("exe");
+    expect(inferTauriFiletype("App_1.2.3_x64_en-US.msi")).toBe("msi");
     expect(() => inferTauriFiletype("App.dmg")).toThrow("unsupported Tauri updater bundle");
   });
 

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -921,17 +921,17 @@ export function registerBuildCommands(program: Command): void {
     .option("--version-code <code>", "Hands version code. Defaults from numeric semver.")
     .requiredOption("--bundle <path>", "Tauri updater bundle. Repeat once per target.", collect, [])
     .requiredOption("--signature <path>", "Tauri .sig file matching --bundle. Repeat in the same order.", collect, [])
-    .requiredOption("--target <target>", "Target: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, or win32-x64. Repeat in the same order.", collect, [])
+    .requiredOption("--target <target>", "Target: darwin|linux|windows plus aarch64|x86_64|i686|armv7. Repeat in the same order.", collect, [])
     .option("--channel <slug>", "Hands release channel slug.", "main")
     .option("--release-type <type>", "Release type metadata.", "stable")
     .option("--changelog <text>", "Inline changelog. Repeatable with lang=text.", collect, [])
     .option("--changelog-file <path>", "Read changelog from file. Repeatable with lang=path.", collect, [])
-    .option("--draft", "Create draft release instead of active.", false)
+    .option("--publish", "Create an active release instead of the default draft.", false)
     .option("--json", "Output JSON.", false)
     .action(async (appIdOrSlug: string, opts: {
       version: string; versionCode?: string; bundle: string[]; signature: string[];
       target: string[]; channel: string; releaseType: string;
-      changelog?: string[]; changelogFile?: string[]; draft?: boolean; json?: boolean;
+      changelog?: string[]; changelogFile?: string[]; publish?: boolean; json?: boolean;
     }) => {
       if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(opts.version)) {
         throw new Error("--version must be a valid semantic version");
@@ -960,15 +960,14 @@ export function registerBuildCommands(program: Command): void {
       });
       const assets = [];
       for (let index = 0; index < opts.bundle.length; index++) {
-        const target = splitBuildTarget(opts.target[index]!);
-        const updaterArch = target.arch === "arm64" ? "aarch64" : "x86_64";
+        const target = splitTauriTarget(opts.target[index]!);
         const signature = readFileSync(opts.signature[index]!, "utf8").trim();
         if (!signature) throw new Error(`empty signature file: ${opts.signature[index]}`);
         const bundle = opts.bundle[index]!;
         assets.push(await uploadAndRegisterAsset(appId, build.id, bundle, {
           artifact_kind: "tauri-updater",
           platform: target.platform,
-          arch: updaterArch,
+          arch: target.arch,
           filetype: inferTauriFiletype(bundle),
           variant: basename(bundle),
           signature,
@@ -979,13 +978,13 @@ export function registerBuildCommands(program: Command): void {
         method: "POST",
         body: {
           build_id: build.id, channel_id: channelId, product_type: "tauri-updater",
-          release_type: opts.releaseType, status: opts.draft ? "draft" : "active",
+          release_type: opts.releaseType, status: opts.publish ? "active" : "draft",
           changelog, scopes: [{ scope_type: "full", scope_value: "all" }],
         },
       });
       const result = { build_id: build.id, release_id: release.id, channel: opts.channel, version: opts.version, assets };
       if (shouldOutputJson(program, opts.json)) console.log(JSON.stringify(result, null, 2));
-      else console.log(`Published Tauri updater ${opts.version} to ${opts.channel} (${assets.length} target${assets.length === 1 ? "" : "s"})`);
+      else console.log(`Published Tauri ${opts.publish ? "release" : "draft"} ${opts.version} to ${opts.channel} (${assets.length} target${assets.length === 1 ? "" : "s"})`);
     });
 
   builds
@@ -1431,10 +1430,22 @@ export function inferElectronFiletype(filePath: string): string {
 
 export function inferTauriFiletype(filePath: string): string {
   const name = basename(filePath).toLowerCase();
+  if (name.endsWith(".appimage")) return "AppImage";
   if (name.endsWith(".tar.gz")) return "tar.gz";
   if (name.endsWith(".nsis.zip")) return "nsis.zip";
   if (name.endsWith(".msi.zip")) return "msi.zip";
   throw new Error(`unsupported Tauri updater bundle: ${basename(filePath)}`);
+}
+
+export function splitTauriTarget(target: string): { platform: string; arch: string } {
+  const match = /^(darwin|linux|windows)-(aarch64|x86_64|i686|armv7)$/.exec(target);
+  if (!match) {
+    throw new Error("Tauri target must be darwin|linux|windows plus aarch64|x86_64|i686|armv7");
+  }
+  return {
+    platform: match[1] === "windows" ? "win32" : match[1]!,
+    arch: match[2]!,
+  };
 }
 
 export function inferIosFiletype(filePath: string): string {

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -915,6 +915,80 @@ export function registerBuildCommands(program: Command): void {
     );
 
   builds
+    .command("publish-tauri <appIdOrSlug>")
+    .description("Create a Tauri updater build/release and upload signed updater bundles.")
+    .requiredOption("--version <version>", "Tauri application semver.")
+    .option("--version-code <code>", "Hands version code. Defaults from numeric semver.")
+    .requiredOption("--bundle <path>", "Tauri updater bundle. Repeat once per target.", collect, [])
+    .requiredOption("--signature <path>", "Tauri .sig file matching --bundle. Repeat in the same order.", collect, [])
+    .requiredOption("--target <target>", "Target: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, or win32-x64. Repeat in the same order.", collect, [])
+    .option("--channel <slug>", "Hands release channel slug.", "main")
+    .option("--release-type <type>", "Release type metadata.", "stable")
+    .option("--changelog <text>", "Inline changelog. Repeatable with lang=text.", collect, [])
+    .option("--changelog-file <path>", "Read changelog from file. Repeatable with lang=path.", collect, [])
+    .option("--draft", "Create draft release instead of active.", false)
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: {
+      version: string; versionCode?: string; bundle: string[]; signature: string[];
+      target: string[]; channel: string; releaseType: string;
+      changelog?: string[]; changelogFile?: string[]; draft?: boolean; json?: boolean;
+    }) => {
+      if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(opts.version)) {
+        throw new Error("--version must be a valid semantic version");
+      }
+      if (opts.bundle.length === 0) throw new Error("provide at least one --bundle, --signature, and --target set");
+      if (opts.bundle.length !== opts.signature.length || opts.bundle.length !== opts.target.length) {
+        throw new Error("repeat --bundle, --signature, and --target the same number of times and in matching order");
+      }
+      for (const file of [...opts.bundle, ...opts.signature]) {
+        if (!existsSync(file)) throw new Error(`missing file: ${file}`);
+      }
+      const appId = await resolveAppId(appIdOrSlug);
+      const channelId = await resolveChannelId(appId, opts.channel);
+      const versionCode = opts.versionCode
+        ? parseNonNegativeInteger(opts.versionCode, "--version-code")
+        : versionCodeFromVersion(opts.version);
+      const changelog = parseChangelogOptions(opts);
+      const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
+        method: "POST",
+        body: {
+          channel_id: channelId, product_type: "tauri-updater", release_type: opts.releaseType,
+          version_name: opts.version, version_code: versionCode, changelog,
+          source: "cli", status: "succeeded",
+          build_metadata_json: { tauri: { targets: opts.target } },
+        },
+      });
+      const assets = [];
+      for (let index = 0; index < opts.bundle.length; index++) {
+        const target = splitBuildTarget(opts.target[index]!);
+        const updaterArch = target.arch === "arm64" ? "aarch64" : "x86_64";
+        const signature = readFileSync(opts.signature[index]!, "utf8").trim();
+        if (!signature) throw new Error(`empty signature file: ${opts.signature[index]}`);
+        const bundle = opts.bundle[index]!;
+        assets.push(await uploadAndRegisterAsset(appId, build.id, bundle, {
+          artifact_kind: "tauri-updater",
+          platform: target.platform,
+          arch: updaterArch,
+          filetype: inferTauriFiletype(bundle),
+          variant: basename(bundle),
+          signature,
+          metadata_json: { filename: basename(bundle), tauri_target: opts.target[index] },
+        }));
+      }
+      const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
+        method: "POST",
+        body: {
+          build_id: build.id, channel_id: channelId, product_type: "tauri-updater",
+          release_type: opts.releaseType, status: opts.draft ? "draft" : "active",
+          changelog, scopes: [{ scope_type: "full", scope_value: "all" }],
+        },
+      });
+      const result = { build_id: build.id, release_id: release.id, channel: opts.channel, version: opts.version, assets };
+      if (shouldOutputJson(program, opts.json)) console.log(JSON.stringify(result, null, 2));
+      else console.log(`Published Tauri updater ${opts.version} to ${opts.channel} (${assets.length} target${assets.length === 1 ? "" : "s"})`);
+    });
+
+  builds
     .command("publish-electron <appIdOrSlug>")
     .description("Create an Electron generic-provider build/release and upload electron-builder output.")
     .requiredOption("--version-name <name>", "Electron app version.")
@@ -1163,6 +1237,7 @@ async function uploadAndRegisterAsset(
     platform: string;
     arch: string | null;
     filetype: string;
+    signature?: string | null;
     variant?: string | null;
     metadata_json?: Record<string, unknown>;
   },
@@ -1181,6 +1256,7 @@ async function uploadAndRegisterAsset(
       r2_key: uploaded.r2_key,
       file_hash: uploaded.file_hash,
       size_bytes: uploaded.size_bytes,
+      signature: metadata.signature ?? null,
       variant: metadata.variant ?? null,
       metadata_json: {
         original_filename: uploaded.original_filename,
@@ -1351,6 +1427,14 @@ export function inferElectronFiletype(filePath: string): string {
   if (name.endsWith(".AppImage")) return "AppImage";
   const ext = extname(name).replace(/^\./, "");
   return ext || "bin";
+}
+
+export function inferTauriFiletype(filePath: string): string {
+  const name = basename(filePath).toLowerCase();
+  if (name.endsWith(".tar.gz")) return "tar.gz";
+  if (name.endsWith(".nsis.zip")) return "nsis.zip";
+  if (name.endsWith(".msi.zip")) return "msi.zip";
+  throw new Error(`unsupported Tauri updater bundle: ${basename(filePath)}`);
 }
 
 export function inferIosFiletype(filePath: string): string {

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -1431,6 +1431,8 @@ export function inferElectronFiletype(filePath: string): string {
 export function inferTauriFiletype(filePath: string): string {
   const name = basename(filePath).toLowerCase();
   if (name.endsWith(".appimage")) return "AppImage";
+  if (name.endsWith(".exe")) return "exe";
+  if (name.endsWith(".msi")) return "msi";
   if (name.endsWith(".tar.gz")) return "tar.gz";
   if (name.endsWith(".nsis.zip")) return "nsis.zip";
   if (name.endsWith(".msi.zip")) return "msi.zip";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.7")
+  .version("0.5.8")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -515,7 +515,7 @@ app.get("/public/r2/:key", handlePublicR2Download);
 // Internal signed R2 fetch (delta-patch container pulls source APKs by key).
 app.get("/internal/r2/:key", handleInternalR2Download);
 app.get("/electron/:slug/:channel/:file", handleElectronGenericAsset);
-app.get("/tauri/:slug/:channel/artifacts/:target/:arch/:file", handleTauriArtifact);
+app.get("/tauri/:slug/:channel/artifacts/:releaseId/:target/:arch/:file", handleTauriArtifact);
 app.get("/tauri/:slug/:channel/:target/:arch/:currentVersion", handleTauriUpdate);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -57,6 +57,7 @@ import {
   handlePublicV2UpdateCheck,
 } from "./routes/public_v2";
 import { handleElectronGenericAsset } from "./routes/electron";
+import { handleTauriArtifact, handleTauriUpdate } from "./routes/tauri";
 import {
   handleCreateReleaseShare,
   handleListReleaseShares,
@@ -514,6 +515,8 @@ app.get("/public/r2/:key", handlePublicR2Download);
 // Internal signed R2 fetch (delta-patch container pulls source APKs by key).
 app.get("/internal/r2/:key", handleInternalR2Download);
 app.get("/electron/:slug/:channel/:file", handleElectronGenericAsset);
+app.get("/tauri/:slug/:channel/artifacts/:target/:arch/:file", handleTauriArtifact);
+app.get("/tauri/:slug/:channel/:target/:arch/:currentVersion", handleTauriUpdate);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);
 app.post("/share/:token/unlock", handlePublicReleaseShareUnlock);

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -392,6 +392,53 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
 
   register(registry, {
     method: "get",
+    path: "/tauri/{slug}/{channel}/{target}/{arch}/{currentVersion}",
+    tags: ["Public update"],
+    summary: "Check for a signed Tauri update",
+    description:
+      "Returns the Tauri v2 dynamic updater response for the active tauri-updater release, or 204 when the channel has no newer compatible version.",
+    request: {
+      params: z.object({
+        slug: z.string().openapi({ param: { name: "slug", in: "path" } }),
+        channel: z.string().openapi({ param: { name: "channel", in: "path" } }),
+        target: z.enum(["darwin", "windows", "linux"]).openapi({ param: { name: "target", in: "path" } }),
+        arch: z.enum(["x86_64", "aarch64", "i686", "armv7"]).openapi({ param: { name: "arch", in: "path" } }),
+        currentVersion: z.string().openapi({ param: { name: "currentVersion", in: "path" }, example: "1.2.3" }),
+      }),
+    },
+    responses: {
+      200: success("Signed Tauri update manifest.", z.object({
+        version: z.string(), url: z.string().url(), signature: z.string(),
+        notes: z.string().optional(), pub_date: z.string().optional(),
+      })),
+      204: { description: "No newer update is available." },
+      400: error("Updater parameters are invalid."),
+      404: error("The active release lacks a matching signed artifact."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/tauri/{slug}/{channel}/artifacts/{target}/{arch}/{file}",
+    tags: ["Public update"],
+    summary: "Download an active Tauri updater artifact",
+    request: {
+      params: z.object({
+        slug: z.string().openapi({ param: { name: "slug", in: "path" } }),
+        channel: z.string().openapi({ param: { name: "channel", in: "path" } }),
+        target: z.enum(["darwin", "windows", "linux"]).openapi({ param: { name: "target", in: "path" } }),
+        arch: z.enum(["x86_64", "aarch64", "i686", "armv7"]).openapi({ param: { name: "arch", in: "path" } }),
+        file: z.string().openapi({ param: { name: "file", in: "path" } }),
+      }),
+    },
+    responses: {
+      200: { description: "Immutable signed Tauri updater bundle.", content: binary() },
+      404: error("The active release or matching artifact was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
     path: "/public/r2/{key}",
     tags: ["Public downloads"],
     summary: "Download a signed public release artifact",

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -419,13 +419,14 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
 
   register(registry, {
     method: "get",
-    path: "/tauri/{slug}/{channel}/artifacts/{target}/{arch}/{file}",
+    path: "/tauri/{slug}/{channel}/artifacts/{releaseId}/{target}/{arch}/{file}",
     tags: ["Public update"],
     summary: "Download an active Tauri updater artifact",
     request: {
       params: z.object({
         slug: z.string().openapi({ param: { name: "slug", in: "path" } }),
         channel: z.string().openapi({ param: { name: "channel", in: "path" } }),
+        releaseId: z.string().openapi({ param: { name: "releaseId", in: "path" } }),
         target: z.enum(["darwin", "windows", "linux"]).openapi({ param: { name: "target", in: "path" } }),
         arch: z.enum(["x86_64", "aarch64", "i686", "armv7"]).openapi({ param: { name: "arch", in: "path" } }),
         file: z.string().openapi({ param: { name: "file", in: "path" } }),

--- a/worker/src/proxy-shim.ts
+++ b/worker/src/proxy-shim.ts
@@ -48,6 +48,7 @@ function isMachinePath(pathname: string): boolean {
     pathname.startsWith("/public/") || // update-check, feedback/minidump/metrics POST, r2, icon
     pathname.startsWith("/api/") || // auth + admin API
     pathname.startsWith("/electron/") || // electron-updater asset fetches
+    pathname.startsWith("/tauri/") || // Tauri updater manifests + artifacts
     pathname.startsWith("/.well-known/") // agent manifests
   ) {
     return true;

--- a/worker/src/routes/tauri.ts
+++ b/worker/src/routes/tauri.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 
 type TauriRelease = {
+  release_id: string;
   build_id: string;
   version_name: string;
   changelog: string | null;
@@ -40,14 +41,13 @@ export async function handleTauriUpdate(c: Context<{ Bindings: Env }>) {
   }
 
   const asset = await findAsset(c.env.DB, release.build_id, target, arch);
-  if (!asset || !asset.signature) {
-    return c.json({ error: "active Tauri release is missing a matching signed updater artifact" }, 404);
-  }
+  if (!asset) return new Response(null, { status: 204, headers: noStoreHeaders() });
+  if (!asset.signature) return c.json({ error: "active Tauri release has an unsigned updater artifact" }, 500);
   const fileName = assetName(asset);
   if (!fileName) return c.json({ error: "Tauri updater artifact has no public filename" }, 500);
   const origin = new URL(c.req.url).origin;
   const publicTarget = target === "win32" ? "windows" : target;
-  const url = `${origin}/tauri/${encodeURIComponent(slug)}/${encodeURIComponent(channel)}/artifacts/${publicTarget}/${arch}/${encodeURIComponent(fileName)}`;
+  const url = `${origin}/tauri/${encodeURIComponent(slug)}/${encodeURIComponent(channel)}/artifacts/${encodeURIComponent(release.release_id)}/${publicTarget}/${arch}/${encodeURIComponent(fileName)}`;
 
   return c.json({
     version: release.version_name,
@@ -61,13 +61,14 @@ export async function handleTauriUpdate(c: Context<{ Bindings: Env }>) {
 export async function handleTauriArtifact(c: Context<{ Bindings: Env }>) {
   const slug = c.req.param("slug") ?? "";
   const channel = c.req.param("channel") || "main";
+  const releaseId = c.req.param("releaseId") ?? "";
   const target = normalizeTarget(c.req.param("target") ?? "");
   const arch = normalizeArch(c.req.param("arch") ?? "");
   const file = decodeFileName(c.req.param("file") ?? "");
-  if (!slug || !target || !arch || !file) return c.json({ error: "invalid Tauri artifact parameters" }, 400);
+  if (!slug || !releaseId || !target || !arch || !file) return c.json({ error: "invalid Tauri artifact parameters" }, 400);
 
-  const release = await findActiveRelease(c.env.DB, slug, channel);
-  if (!release) return c.json({ error: "no active Tauri release found" }, 404);
+  const release = await findPublishedRelease(c.env.DB, slug, channel, releaseId);
+  if (!release) return c.json({ error: "published Tauri release not found" }, 404);
   const { results } = await c.env.DB.prepare(
     `SELECT platform, arch, variant, filetype, r2_key, size_bytes, signature, metadata_json
      FROM build_assets WHERE build_id = ?1 AND artifact_kind = 'tauri-updater'
@@ -90,7 +91,7 @@ export async function handleTauriArtifact(c: Context<{ Bindings: Env }>) {
 
 async function findActiveRelease(db: D1Database, slug: string, channel: string): Promise<TauriRelease | null> {
   return await db.prepare(
-    `SELECT b.id AS build_id, b.version_name, r.changelog, r.created_at
+    `SELECT r.id AS release_id, b.id AS build_id, b.version_name, r.changelog, r.created_at
      FROM apps a
      JOIN channels ch ON ch.app_id = a.id
      JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
@@ -99,6 +100,24 @@ async function findActiveRelease(db: D1Database, slug: string, channel: string):
        AND r.status = 'active' AND (r.availability_at IS NULL OR r.availability_at <= ?4)
      ORDER BY r.created_at DESC, r.id ASC LIMIT 1`,
   ).bind(slug, channel, PRODUCT_TYPE, Date.now()).first<TauriRelease>();
+}
+
+async function findPublishedRelease(
+  db: D1Database,
+  slug: string,
+  channel: string,
+  releaseId: string,
+): Promise<TauriRelease | null> {
+  return await db.prepare(
+    `SELECT r.id AS release_id, b.id AS build_id, b.version_name, r.changelog, r.created_at
+     FROM apps a
+     JOIN channels ch ON ch.app_id = a.id
+     JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
+     JOIN builds b ON b.id = r.build_id
+     WHERE a.slug = ?1 AND ch.slug = ?2 AND r.id = ?3 AND r.product_type = ?4
+       AND r.status IN ('active', 'superseded')
+     LIMIT 1`,
+  ).bind(slug, channel, releaseId, PRODUCT_TYPE).first<TauriRelease>();
 }
 
 async function findAsset(db: D1Database, buildId: string, platform: string, arch: string): Promise<TauriAsset | null> {
@@ -136,6 +155,7 @@ function decodeFileName(value: string): string {
 }
 
 function contentType(filetype: string): string {
+  if (filetype === "AppImage") return "application/octet-stream";
   if (filetype === "tar.gz") return "application/gzip";
   return "application/zip";
 }

--- a/worker/src/routes/tauri.ts
+++ b/worker/src/routes/tauri.ts
@@ -97,7 +97,8 @@ async function findActiveRelease(db: D1Database, slug: string, channel: string):
      JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
      JOIN builds b ON b.id = r.build_id
      WHERE a.slug = ?1 AND ch.slug = ?2 AND r.product_type = ?3
-       AND r.status = 'active' AND (r.availability_at IS NULL OR r.availability_at <= ?4)
+       AND r.status = 'active' AND r.is_full = 1
+       AND (r.availability_at IS NULL OR r.availability_at <= ?4)
      ORDER BY r.created_at DESC, r.id ASC LIMIT 1`,
   ).bind(slug, channel, PRODUCT_TYPE, Date.now()).first<TauriRelease>();
 }

--- a/worker/src/routes/tauri.ts
+++ b/worker/src/routes/tauri.ts
@@ -1,0 +1,176 @@
+import type { Context } from "hono";
+
+type TauriRelease = {
+  build_id: string;
+  version_name: string;
+  changelog: string | null;
+  created_at: number;
+};
+
+type TauriAsset = {
+  platform: string;
+  arch: string | null;
+  variant: string | null;
+  filetype: string;
+  r2_key: string;
+  size_bytes: number;
+  signature: string | null;
+  metadata_json: string;
+};
+
+const PRODUCT_TYPE = "tauri-updater";
+
+export async function handleTauriUpdate(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug") ?? "";
+  const channel = c.req.param("channel") || "main";
+  const target = normalizeTarget(c.req.param("target") ?? "");
+  const arch = normalizeArch(c.req.param("arch") ?? "");
+  const currentVersion = c.req.param("currentVersion") ?? "";
+  if (!slug || !target || !arch || !parseSemver(currentVersion)) {
+    return c.json({ error: "invalid Tauri updater parameters" }, 400);
+  }
+
+  const release = await findActiveRelease(c.env.DB, slug, channel);
+  if (!release) return new Response(null, { status: 204, headers: noStoreHeaders() });
+  if (!parseSemver(release.version_name)) {
+    return c.json({ error: "active Tauri release has invalid semver" }, 500);
+  }
+  if (compareSemver(release.version_name, currentVersion) <= 0) {
+    return new Response(null, { status: 204, headers: noStoreHeaders() });
+  }
+
+  const asset = await findAsset(c.env.DB, release.build_id, target, arch);
+  if (!asset || !asset.signature) {
+    return c.json({ error: "active Tauri release is missing a matching signed updater artifact" }, 404);
+  }
+  const fileName = assetName(asset);
+  if (!fileName) return c.json({ error: "Tauri updater artifact has no public filename" }, 500);
+  const origin = new URL(c.req.url).origin;
+  const publicTarget = target === "win32" ? "windows" : target;
+  const url = `${origin}/tauri/${encodeURIComponent(slug)}/${encodeURIComponent(channel)}/artifacts/${publicTarget}/${arch}/${encodeURIComponent(fileName)}`;
+
+  return c.json({
+    version: release.version_name,
+    url,
+    signature: asset.signature,
+    notes: release.changelog ?? undefined,
+    pub_date: new Date(release.created_at).toISOString(),
+  }, 200, { "cache-control": "public, max-age=60, must-revalidate" });
+}
+
+export async function handleTauriArtifact(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug") ?? "";
+  const channel = c.req.param("channel") || "main";
+  const target = normalizeTarget(c.req.param("target") ?? "");
+  const arch = normalizeArch(c.req.param("arch") ?? "");
+  const file = decodeFileName(c.req.param("file") ?? "");
+  if (!slug || !target || !arch || !file) return c.json({ error: "invalid Tauri artifact parameters" }, 400);
+
+  const release = await findActiveRelease(c.env.DB, slug, channel);
+  if (!release) return c.json({ error: "no active Tauri release found" }, 404);
+  const { results } = await c.env.DB.prepare(
+    `SELECT platform, arch, variant, filetype, r2_key, size_bytes, signature, metadata_json
+     FROM build_assets WHERE build_id = ?1 AND artifact_kind = 'tauri-updater'
+       AND platform = ?2 AND arch = ?3`,
+  ).bind(release.build_id, target, arch).all<TauriAsset>();
+  const asset = results.find((candidate) => assetName(candidate) === file);
+  if (!asset) return c.json({ error: "Tauri updater artifact not found" }, 404);
+
+  const object = await c.env.APK_BUCKET.get(asset.r2_key);
+  if (!object) return c.json({ error: "object not found" }, 404);
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+  headers.set("etag", object.httpEtag);
+  headers.set("content-type", contentType(asset.filetype));
+  headers.set("content-length", String(asset.size_bytes));
+  headers.set("cache-control", "public, max-age=31536000, immutable");
+  headers.set("content-disposition", `attachment; filename*=UTF-8''${encodeURIComponent(file)}`);
+  return new Response(object.body, { headers });
+}
+
+async function findActiveRelease(db: D1Database, slug: string, channel: string): Promise<TauriRelease | null> {
+  return await db.prepare(
+    `SELECT b.id AS build_id, b.version_name, r.changelog, r.created_at
+     FROM apps a
+     JOIN channels ch ON ch.app_id = a.id
+     JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
+     JOIN builds b ON b.id = r.build_id
+     WHERE a.slug = ?1 AND ch.slug = ?2 AND r.product_type = ?3
+       AND r.status = 'active' AND (r.availability_at IS NULL OR r.availability_at <= ?4)
+     ORDER BY r.created_at DESC, r.id ASC LIMIT 1`,
+  ).bind(slug, channel, PRODUCT_TYPE, Date.now()).first<TauriRelease>();
+}
+
+async function findAsset(db: D1Database, buildId: string, platform: string, arch: string): Promise<TauriAsset | null> {
+  return await db.prepare(
+    `SELECT platform, arch, variant, filetype, r2_key, size_bytes, signature, metadata_json
+     FROM build_assets
+     WHERE build_id = ?1 AND artifact_kind = 'tauri-updater'
+       AND platform = ?2 AND arch = ?3
+     ORDER BY created_at ASC LIMIT 1`,
+  ).bind(buildId, platform, arch).first<TauriAsset>();
+}
+
+function normalizeTarget(target: string): string | null {
+  if (target === "darwin" || target === "linux") return target;
+  if (target === "windows" || target === "win32") return "win32";
+  return null;
+}
+
+function normalizeArch(arch: string): string | null {
+  if (arch === "x86_64" || arch === "aarch64" || arch === "i686" || arch === "armv7") return arch;
+  return null;
+}
+
+function assetName(asset: TauriAsset): string | null {
+  if (asset.variant) return asset.variant;
+  try {
+    const metadata = JSON.parse(asset.metadata_json || "{}") as Record<string, unknown>;
+    if (typeof metadata.filename === "string" && metadata.filename) return metadata.filename;
+  } catch { /* use R2 basename */ }
+  return asset.r2_key.split("/").pop() ?? null;
+}
+
+function decodeFileName(value: string): string {
+  try { return decodeURIComponent(value); } catch { return value; }
+}
+
+function contentType(filetype: string): string {
+  if (filetype === "tar.gz") return "application/gzip";
+  return "application/zip";
+}
+
+function noStoreHeaders(): HeadersInit {
+  return { "cache-control": "no-store" };
+}
+
+type Semver = [number, number, number, string[]];
+
+function parseSemver(value: string): Semver | null {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(value);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3]), match[4]?.split(".") ?? []];
+}
+
+export function compareSemver(left: string, right: string): number {
+  const a = parseSemver(left);
+  const b = parseSemver(right);
+  if (!a || !b) throw new Error("invalid semver");
+  for (let index = 0; index < 3; index++) {
+    if (a[index] !== b[index]) return (a[index] as number) > (b[index] as number) ? 1 : -1;
+  }
+  if (a[3].length === 0 || b[3].length === 0) return a[3].length === b[3].length ? 0 : a[3].length === 0 ? 1 : -1;
+  const length = Math.max(a[3].length, b[3].length);
+  for (let index = 0; index < length; index++) {
+    const x = a[3][index];
+    const y = b[3][index];
+    if (x === undefined || y === undefined) return x === y ? 0 : x === undefined ? -1 : 1;
+    if (x === y) continue;
+    const xNumeric = /^\d+$/.test(x);
+    const yNumeric = /^\d+$/.test(y);
+    if (xNumeric && yNumeric) return Number(x) > Number(y) ? 1 : -1;
+    if (xNumeric !== yNumeric) return xNumeric ? -1 : 1;
+    return x > y ? 1 : -1;
+  }
+  return 0;
+}

--- a/worker/src/routes/tauri.ts
+++ b/worker/src/routes/tauri.ts
@@ -156,6 +156,8 @@ function decodeFileName(value: string): string {
 
 function contentType(filetype: string): string {
   if (filetype === "AppImage") return "application/octet-stream";
+  if (filetype === "exe") return "application/vnd.microsoft.portable-executable";
+  if (filetype === "msi") return "application/x-msi";
   if (filetype === "tar.gz") return "application/gzip";
   return "application/zip";
 }

--- a/worker/test/tauri.test.ts
+++ b/worker/test/tauri.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { compareSemver, handleTauriArtifact, handleTauriUpdate } from "../src/routes/tauri";
 
-const release = { build_id: "build", version_name: "1.2.3", changelog: "Changes", created_at: 1_700_000_000_000 };
+const release = { release_id: "release", build_id: "build", version_name: "1.2.3", changelog: "Changes", created_at: 1_700_000_000_000 };
 type TestAsset = {
   platform: string; arch: string; variant: string; filetype: string;
   r2_key: string; size_bytes: number; signature: string | null; metadata_json: string;
@@ -23,7 +23,7 @@ function env(options: { release?: typeof release | null; asset?: TestAsset | nul
         return {
           bind(...values: unknown[]) { bindings = values; return this; },
           async first() {
-            if (sql.includes("SELECT b.id AS build_id")) return selectedRelease;
+            if (sql.includes("JOIN releases r")) return selectedRelease;
             if (sql.includes("artifact_kind = 'tauri-updater'")) {
               return bindings[1] === selectedAsset?.platform && bindings[2] === selectedAsset?.arch ? selectedAsset : null;
             }
@@ -61,7 +61,7 @@ describe("Tauri updater", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       version: "1.2.3", signature: "signed-value",
-      url: "https://hands.build/tauri/app/main/artifacts/darwin/aarch64/App.app.tar.gz",
+      url: "https://hands.build/tauri/app/main/artifacts/release/darwin/aarch64/App.app.tar.gz",
     });
   });
 
@@ -80,11 +80,19 @@ describe("Tauri updater", () => {
       { slug: "app", channel: "main", target: "darwin", arch: "aarch64", currentVersion: "1.0.0" },
       env({ asset: { ...asset, signature: null } }),
     ));
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(500);
+  });
+
+  it("returns 204 when a newer release has no bundle for this target", async () => {
+    const response = await handleTauriUpdate(context(
+      { slug: "app", channel: "main", target: "linux", arch: "x86_64", currentVersion: "1.0.0" },
+      env({ asset: null }),
+    ));
+    expect(response.status).toBe(204);
   });
 
   it("serves only an artifact attached to the active Tauri release", async () => {
-    const response = await handleTauriArtifact(context({ slug: "app", channel: "main", target: "darwin", arch: "aarch64", file: "App.app.tar.gz" }));
+    const response = await handleTauriArtifact(context({ slug: "app", channel: "main", releaseId: "release", target: "darwin", arch: "aarch64", file: "App.app.tar.gz" }));
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toContain("immutable");
     expect(await response.text()).toBe("payload");

--- a/worker/test/tauri.test.ts
+++ b/worker/test/tauri.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { compareSemver, handleTauriArtifact, handleTauriUpdate } from "../src/routes/tauri";
+
+const release = { build_id: "build", version_name: "1.2.3", changelog: "Changes", created_at: 1_700_000_000_000 };
+type TestAsset = {
+  platform: string; arch: string; variant: string; filetype: string;
+  r2_key: string; size_bytes: number; signature: string | null; metadata_json: string;
+};
+
+const asset: TestAsset = {
+  platform: "darwin", arch: "aarch64", variant: "App.app.tar.gz", filetype: "tar.gz",
+  r2_key: "apps/app/App.app.tar.gz", size_bytes: 7, signature: "signed-value",
+  metadata_json: JSON.stringify({ filename: "App.app.tar.gz" }),
+};
+
+function env(options: { release?: typeof release | null; asset?: TestAsset | null } = {}) {
+  const selectedRelease = options.release === undefined ? release : options.release;
+  const selectedAsset = options.asset === undefined ? asset : options.asset;
+  return {
+    DB: {
+      prepare(sql: string) {
+        let bindings: unknown[] = [];
+        return {
+          bind(...values: unknown[]) { bindings = values; return this; },
+          async first() {
+            if (sql.includes("SELECT b.id AS build_id")) return selectedRelease;
+            if (sql.includes("artifact_kind = 'tauri-updater'")) {
+              return bindings[1] === selectedAsset?.platform && bindings[2] === selectedAsset?.arch ? selectedAsset : null;
+            }
+            return null;
+          },
+          async all() { return { results: selectedAsset ? [selectedAsset] : [] }; },
+        };
+      },
+    },
+    APK_BUCKET: {
+      async get(key: string) {
+        if (key !== selectedAsset?.r2_key) return null;
+        return {
+          body: new Blob(["payload"]).stream(), httpEtag: '"etag"',
+          writeHttpMetadata(headers: Headers) { headers.set("x-test", "1"); },
+        };
+      },
+    },
+  };
+}
+
+function context(params: Record<string, string>, bindings = env()) {
+  return {
+    env: bindings,
+    req: { param: (name: string) => params[name], url: "https://hands.build/request" },
+    json(body: unknown, status = 200, headers?: HeadersInit) {
+      return Response.json(body, headers ? { status, headers } : { status });
+    },
+  } as any;
+}
+
+describe("Tauri updater", () => {
+  it("returns a signed dynamic update response for a newer compatible release", async () => {
+    const response = await handleTauriUpdate(context({ slug: "app", channel: "main", target: "darwin", arch: "aarch64", currentVersion: "1.2.2" }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      version: "1.2.3", signature: "signed-value",
+      url: "https://hands.build/tauri/app/main/artifacts/darwin/aarch64/App.app.tar.gz",
+    });
+  });
+
+  it.each(["1.2.3", "1.3.0"])("returns 204 when current version %s is not older", async (currentVersion) => {
+    const response = await handleTauriUpdate(context({ slug: "app", channel: "main", target: "darwin", arch: "aarch64", currentVersion }));
+    expect(response.status).toBe(204);
+  });
+
+  it("rejects an invalid current semantic version", async () => {
+    const response = await handleTauriUpdate(context({ slug: "app", channel: "main", target: "darwin", arch: "aarch64", currentVersion: "latest" }));
+    expect(response.status).toBe(400);
+  });
+
+  it("fails closed when the target artifact has no signature", async () => {
+    const response = await handleTauriUpdate(context(
+      { slug: "app", channel: "main", target: "darwin", arch: "aarch64", currentVersion: "1.0.0" },
+      env({ asset: { ...asset, signature: null } }),
+    ));
+    expect(response.status).toBe(404);
+  });
+
+  it("serves only an artifact attached to the active Tauri release", async () => {
+    const response = await handleTauriArtifact(context({ slug: "app", channel: "main", target: "darwin", arch: "aarch64", file: "App.app.tar.gz" }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("immutable");
+    expect(await response.text()).toBe("payload");
+  });
+
+  it("implements SemVer prerelease precedence", () => {
+    expect(compareSemver("1.2.3", "1.2.3-rc.1")).toBeGreaterThan(0);
+    expect(compareSemver("1.2.3-rc.2", "1.2.3-rc.10")).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

Tauri v2 desktop applications need a signed, channel-aware update path that supports multiple target/architecture bundles without exposing the updater signing private key to Hands.

## Changes

- add a dynamic Tauri updater endpoint with SemVer validation and `200`/`204` behavior
- bind immutable artifact URLs to release ID, target, and architecture so activation changes cannot switch bytes after an update check
- keep published superseded artifacts downloadable while excluding drafts and cancelled releases
- fail closed on scoped releases because default Tauri requests have no stable installation identifier for rollout bucketing
- add draft-first `hands builds publish-tauri` with official Tauri target names and `.sig` content storage
- support macOS archives, native Linux AppImage, native Windows EXE/MSI, and compatibility archives
- register proxy/OpenAPI routes and document Tauri v2 configuration and release flow

## Security

The Tauri signing private key remains in CI. Hands stores only signed updater bundles and detached signature text. Installed applications verify updates with the public key embedded in the app.

## Testing

- Worker tests: 163 passed
- CLI tests: 19 passed, including full apps/channel/build/upload/asset/release draft publish flow against an HTTP stub
- CLI build passed
- Worker proxy shim typecheck passed
- `git diff --check` passed
