### PR TITLE
fix(cli): avoid Tauri version option collision

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -293,7 +293,7 @@ Publish the updater bundles and their Tauri-generated signatures together:
 
 ```bash
 hands builds publish-tauri my-app \
-  --version 1.2.3 \
+  --version-name 1.2.3 \
   --channel main \
   --bundle target/release/bundle/macos/MyApp.app.tar.gz \
   --signature target/release/bundle/macos/MyApp.app.tar.gz.sig \

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.8 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.9 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -202,11 +202,11 @@ describe("Tauri build helpers", () => {
 
     try {
       const { registerBuildCommands } = await import("../src/commands/builds.js");
-      const program = new Command().option("--json", "JSON output", false);
+      const program = new Command().version("0.5.9").option("--json", "JSON output", false);
       registerBuildCommands(program);
       await program.parseAsync([
         "node", "hands", "builds", "publish-tauri", "desktop",
-        "--version", "1.2.3",
+        "--version-name", "1.2.3",
         "--bundle", bundle,
         "--signature", signature,
         "--target", "linux-x86_64",

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -917,7 +917,7 @@ export function registerBuildCommands(program: Command): void {
   builds
     .command("publish-tauri <appIdOrSlug>")
     .description("Create a Tauri updater build/release and upload signed updater bundles.")
-    .requiredOption("--version <version>", "Tauri application semver.")
+    .requiredOption("--version-name <version>", "Tauri application semver.")
     .option("--version-code <code>", "Hands version code. Defaults from numeric semver.")
     .requiredOption("--bundle <path>", "Tauri updater bundle. Repeat once per target.", collect, [])
     .requiredOption("--signature <path>", "Tauri .sig file matching --bundle. Repeat in the same order.", collect, [])
@@ -929,12 +929,12 @@ export function registerBuildCommands(program: Command): void {
     .option("--publish", "Create an active release instead of the default draft.", false)
     .option("--json", "Output JSON.", false)
     .action(async (appIdOrSlug: string, opts: {
-      version: string; versionCode?: string; bundle: string[]; signature: string[];
+      versionName: string; versionCode?: string; bundle: string[]; signature: string[];
       target: string[]; channel: string; releaseType: string;
       changelog?: string[]; changelogFile?: string[]; publish?: boolean; json?: boolean;
     }) => {
-      if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(opts.version)) {
-        throw new Error("--version must be a valid semantic version");
+      if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(opts.versionName)) {
+        throw new Error("--version-name must be a valid semantic version");
       }
       if (opts.bundle.length === 0) throw new Error("provide at least one --bundle, --signature, and --target set");
       if (opts.bundle.length !== opts.signature.length || opts.bundle.length !== opts.target.length) {
@@ -947,13 +947,13 @@ export function registerBuildCommands(program: Command): void {
       const channelId = await resolveChannelId(appId, opts.channel);
       const versionCode = opts.versionCode
         ? parseNonNegativeInteger(opts.versionCode, "--version-code")
-        : versionCodeFromVersion(opts.version);
+        : versionCodeFromVersion(opts.versionName);
       const changelog = parseChangelogOptions(opts);
       const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
         method: "POST",
         body: {
           channel_id: channelId, product_type: "tauri-updater", release_type: opts.releaseType,
-          version_name: opts.version, version_code: versionCode, changelog,
+          version_name: opts.versionName, version_code: versionCode, changelog,
           source: "cli", status: "succeeded",
           build_metadata_json: { tauri: { targets: opts.target } },
         },
@@ -982,9 +982,9 @@ export function registerBuildCommands(program: Command): void {
           changelog, scopes: [{ scope_type: "full", scope_value: "all" }],
         },
       });
-      const result = { build_id: build.id, release_id: release.id, channel: opts.channel, version: opts.version, assets };
+      const result = { build_id: build.id, release_id: release.id, channel: opts.channel, version: opts.versionName, assets };
       if (shouldOutputJson(program, opts.json)) console.log(JSON.stringify(result, null, 2));
-      else console.log(`Published Tauri ${opts.publish ? "release" : "draft"} ${opts.version} to ${opts.channel} (${assets.length} target${assets.length === 1 ? "" : "s"})`);
+      else console.log(`Published Tauri ${opts.publish ? "release" : "draft"} ${opts.versionName} to ${opts.channel} (${assets.length} target${assets.length === 1 ? "" : "s"})`);
     });
 
   builds

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.8")
+  .version("0.5.9")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",


### PR DESCRIPTION
## Problem

`hands builds publish-tauri --version ...` collided with the root `hands --version` option. The published 0.5.8 CLI printed its version and exited without creating a build or draft.

## Changes

- rename the Tauri release input to `--version-name`, matching the other platform publish commands
- register the root CLI version in the full draft-publish regression test so this collision is covered
- bump the CLI package to 0.5.9
- update the public CLI documentation

## Testing

- CLI build passed
- CLI tests: 19 passed
- local 0.5.9 command completed the production apps/channel/build/upload/asset/draft flow on an archived acceptance app
- `git diff --check` passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786957944&installation_id=145465820&pr_number=307&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F307&signature=609331bffb0cc215bd19570de18bd777049b323f26ca807dbbf30ceccbe29dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->