### PR TITLE
Expose whoami as an agent manifest action

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -780,6 +780,12 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         endpoint: { method: "GET", path: "/api/agent/help" },
       },
       {
+        name: "whoami",
+        description:
+          "Return the caller's Hands account: account id, server identity, org and roles. Use the account id when asking an app admin for a membership grant.",
+        endpoint: { method: "GET", path: "/api/auth/me" },
+      },
+      {
         name: "list-orgs",
         description:
           "List every organization the current Raft identity can access across linked servers, including role and server identity.",


### PR DESCRIPTION
Cross-server app-membership grants need the grantee's Hands account id, but the agent manifest had no surface returning it — `/api/auth/me` exists but wasn't exposed as an action, and agent isolation rules forbid reading a host CLI session.

`whoami` maps to the existing `/api/auth/me` route (already returns `account.id`, server identity, org and roles). No new handler code.

Tests: worker 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786960897&installation_id=145465820&pr_number=308&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F308&signature=a7714776049a0195b53ee0674578df0c4cf2b5b25e99762ece206b805172b12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->