### PR TITLE
auth/me accepts the session cookie

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -533,9 +533,12 @@ export async function handleAuthMe(c: Context<{ Bindings: Env }>) {
   const bearerToken = authHeader?.startsWith("Bearer ")
     ? authHeader.slice("Bearer ".length).trim()
     : undefined;
+  // Accept the session cookie like every other authenticated route — agent
+  // integration sessions are cookie-based, and this route (the manifest's
+  // whoami/context_check) otherwise 401s for them.
   const sessionAccount = await loadAccountFromAuthToken(
     c.env,
-    bearerToken,
+    bearerToken ?? getCookie(c, SESSION_COOKIE),
   );
   if (!sessionAccount) {
     return c.json(

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -780,6 +780,12 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         endpoint: { method: "GET", path: "/api/agent/help" },
       },
       {
+        name: "whoami",
+        description:
+          "Return the caller's Hands account: account id, server identity, org and roles. Use the account id when asking an app admin for a membership grant.",
+        endpoint: { method: "GET", path: "/api/auth/me" },
+      },
+      {
         name: "list-orgs",
         description:
           "List every organization the current Raft identity can access across linked servers, including role and server identity.",


### PR DESCRIPTION
`/api/auth/me` read only the `Authorization: Bearer` header, so cookie-based agent integration sessions received 401 from the new `whoami` manifest action (and from the manifest's `context_check`) even though the same session authenticates every other route. It now falls back to the `hands_session` cookie via the shared loader, mirroring the middleware's own `bearer ?? cookie` order.

Found live-smoking the whoami action after PR #308. Worker 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786961182&installation_id=145465820&pr_number=309&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F309&signature=e616d54e937c2e9803a4b9d6ec15f842a2fd1911107311624ed60dce6d5e54b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->