### PR TITLE
Expose list-channels and create-channel as agent manifest actions

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -800,6 +800,18 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         endpoint: { method: "GET", path: "/api/apps" },
       },
       {
+        name: "list-channels",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/channels" },
+        description: "List an app's release channels (id, slug, name). Requires app viewer.",
+      },
+      {
+        name: "create-channel",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/channels" },
+        params: { slug: "string (lowercase channel slug)", name: "string (display name)" },
+        description:
+          "Create a release channel on an app (channels are never auto-created by publish). Requires app admin. Creating a channel activates nothing.",
+      },
+      {
         name: "list-releases",
         description: "List an app's releases (id, status, channel, version, rollout). Requires app viewer.",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/releases" },


### PR DESCRIPTION
Channels are never auto-created by publish, and channel creation had no agent surface (console/admin-API only). The gap has blocked two real flows today alone: per-platform Electron channel setup and shadow-channel provisioning for a new app — each needing manual intervention.

Both actions map to existing routes with their existing role gates unchanged (`viewer` for list, `admin` for create). Creating a channel activates nothing.

Worker 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786961633&installation_id=145465820&pr_number=310&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F310&signature=b5a263f0a457af91a4cfa9c37954c7f4d38997124a9c26a603015905e42338f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->