### PR TITLE
Deploy-token create: strict body validation + expires_in_days

### DIFF
--- a/worker/src/routes/deploy_tokens.ts
+++ b/worker/src/routes/deploy_tokens.ts
@@ -72,7 +72,20 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
     name?: unknown;
     app_role?: unknown;
     expires_at?: unknown;
-  };
+    expires_in_days?: unknown;
+  } & Record<string, unknown>;
+
+  // Token minting is strict-validated: an unrecognized field must 400, never
+  // silently mint a broader token than the caller asked for (a misspelled
+  // expiry field used to yield a NON-EXPIRING token).
+  const allowedKeys = new Set(["name", "app_role", "expires_at", "expires_in_days"]);
+  const unknownKeys = Object.keys(body).filter((k) => !allowedKeys.has(k));
+  if (unknownKeys.length > 0) {
+    return c.json(
+      { error: `unknown field(s): ${unknownKeys.join(", ")} — accepted: name, app_role, expires_at (unix ms), expires_in_days` },
+      400,
+    );
+  }
 
   const name = typeof body.name === "string" ? body.name.trim() : "";
   if (!name) return c.json({ error: "name is required" }, 400);
@@ -81,9 +94,20 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
     return c.json({ error: "app_role must be publisher or viewer" }, 400);
   }
 
+  if (body.expires_at != null && body.expires_in_days != null) {
+    return c.json({ error: "provide expires_at or expires_in_days, not both" }, 400);
+  }
   let expiresAt: number | null;
   try {
-    expiresAt = parseExpiresAt(body.expires_at);
+    if (body.expires_in_days != null) {
+      const days = Number(body.expires_in_days);
+      if (!Number.isFinite(days) || days <= 0 || days > 3650) {
+        throw new Error("expires_in_days must be a positive number of days (max 3650)");
+      }
+      expiresAt = Date.now() + Math.round(days * 24 * 60 * 60 * 1000);
+    } else {
+      expiresAt = parseExpiresAt(body.expires_at);
+    }
   } catch (err) {
     return c.json({ error: (err as Error).message }, 400);
   }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2097,6 +2097,51 @@ describe("quiver Hono app — auth + dispatch", () => {
     });
   });
 
+  it("deploy-token create: expires_in_days persists, unknown fields 400, both expiry fields 400", async () => {
+    const env = makeMockEnv();
+    const now = Date.now();
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).bind("dt-app", "default", "dt-app", "DT App", "android", now).run();
+    const { handleCreateAppDeployToken } = await import("../src/routes/deploy_tokens");
+    const ctx = (body: unknown) =>
+      ({
+        env,
+        req: {
+          url: "https://quiver-worker.test/api/apps/dt-app/deploy-tokens",
+          param: (name: string) => (name === "appId" ? "dt-app" : ""),
+          query: () => undefined,
+          json: async () => body,
+          header: () => undefined,
+        },
+        get: (name: string) => (name === "admin_actor" ? "tester" : undefined),
+        json: (data: unknown, status = 200) =>
+          new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } }),
+      }) as any;
+
+    // A misspelled/unknown field must 400 — never silently mint a
+    // non-expiring token (the original bug: expires_in_days was ignored).
+    const unknown = await handleCreateAppDeployToken(ctx({ name: "t1", app_role: "publisher", expire_days: 7 }));
+    expect(unknown.status).toBe(400);
+
+    // expires_in_days is accepted and persisted as a real expiry.
+    const ok = await handleCreateAppDeployToken(ctx({ name: "t2", app_role: "publisher", expires_in_days: 7 }));
+    expect(ok.status).toBe(201);
+    const created = (await ok.json()) as any;
+    expect(created.deploy_token.expires_at).toBeGreaterThan(now + 6.9 * 86_400_000);
+    expect(created.deploy_token.expires_at).toBeLessThan(now + 7.1 * 86_400_000);
+
+    // Both expiry fields together → 400.
+    const both = await handleCreateAppDeployToken(
+      ctx({ name: "t3", app_role: "publisher", expires_at: now + 86_400_000, expires_in_days: 1 }),
+    );
+    expect(both.status).toBe(400);
+
+    // Invalid days → 400.
+    const bad = await handleCreateAppDeployToken(ctx({ name: "t4", app_role: "publisher", expires_in_days: -1 }));
+    expect(bad.status).toBe(400);
+  });
+
   it("loads app-scoped deploy tokens and updates last_used_at", async () => {
     const env = makeMockEnv();
     const now = Date.now();


### PR DESCRIPTION
Found in live use: a caller passing `expires_in_days` (a field the API didn't accept) got it silently ignored and received a **non-expiring** token — the opposite of the request. Same fail-open family as silently defaulting credentials.

- Unknown fields in the token-create body now 400 with the accepted field list — minting never silently broadens a token.
- `expires_in_days` is accepted server-side (positive, ≤3650), converted to `expires_at`.
- Supplying both expiry fields 400s.
- Auth-time expiry enforcement already existed; unchanged.

Tests: worker 164/164 (new: unknown-field 400, persisted expiry window, both-fields 400, invalid days 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786962181&installation_id=145465820&pr_number=311&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F311&signature=a0a104b7aad288ad15b7f55d1b03918fe58cd699c103f037ac9b5573eee91e01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->