### PR TITLE
fix(cli): avoid publish-version option collision

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -91,7 +91,7 @@ externally hosted target without copying it into Hands storage:
 
 ```bash
 hands builds publish-version raft-computer \
-  --version 0.72.13 \
+  --version-name 0.72.13 \
   --target linux-x64 \
   --source-url https://cdn.raft.build/computer/0.72.13/linux-x64 \
   --raw-sha256 "$RAW_SHA256" --raw-size "$RAW_SIZE" \

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.9 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.10 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build
@@ -50,7 +50,7 @@ immutable target declaration at a time:
 
 ```bash
 hands builds publish-version raft-computer \
-  --version 0.72.13 \
+  --version-name 0.72.13 \
   --target darwin-arm64 \
   --source-url https://cdn.raft.build/computer/0.72.13/darwin-arm64 \
   --raw-sha256 "$RAW_SHA256" --raw-size "$RAW_SIZE" \

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -251,6 +251,65 @@ describe("external build publish helpers", () => {
     expect(versionCodeFromVersion("1.2.3-beta.1")).toBe(1_002_003);
     expect(() => versionCodeFromVersion("nightly")).toThrow("--version-code is required");
   });
+
+  it("publishes through the true root command without colliding with --version", async () => {
+    const requests: Array<{ url: string; body?: any }> = [];
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "computer" }] }));
+      if (req.url === "/api/apps/app-1/channels") return res.end(JSON.stringify({ channels: [{ id: "channel-1", slug: "shadow", name: "Shadow" }] }));
+      if (req.url === "/api/apps/app-1/builds/publish-version") return res.end(JSON.stringify({
+        app_id: "app-1", build_id: "build-1", target_id: "target-1", version: "1.0.5",
+        target: "darwin-arm64", platform: "darwin", arch: "arm64", replayed: false,
+      }));
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { registerBuildCommands } = await import("../src/commands/builds.js");
+      const program = new Command().version("0.5.10").option("--json", "JSON output", false);
+      registerBuildCommands(program);
+      await program.parseAsync([
+        "node", "hands", "builds", "publish-version", "computer",
+        "--version-name", "1.0.5",
+        "--target", "darwin-arm64",
+        "--source-url", "https://cdn.example.test/computer/1.0.5/darwin-arm64",
+        "--raw-sha256", "a".repeat(64),
+        "--raw-size", "123",
+        "--channel", "shadow",
+      ]);
+
+      expect(requests.find((request) => request.url.endsWith("/publish-version"))?.body).toMatchObject({
+        channel_id: "channel-1",
+        version_name: "1.0.5",
+        version_code: 1_000_005,
+        target: "darwin-arm64",
+        raw_size_bytes: 123,
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });
 
 describe("iOS build helper contract", () => {

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -161,7 +161,7 @@ export function registerBuildCommands(program: Command): void {
   builds
     .command("publish-version <appIdOrSlug>")
     .description("Register an immutable externally hosted Node/CLI build target.")
-    .requiredOption("--version <version>", "Release version name.")
+    .requiredOption("--version-name <version>", "Release version name.")
     .option(
       "--version-code <code>",
       "Hands ordering code. Defaults to a numeric dotted-version encoding.",
@@ -188,7 +188,7 @@ export function registerBuildCommands(program: Command): void {
       async (
         appIdOrSlug: string,
         opts: {
-          version: string;
+          versionName: string;
           versionCode?: string;
           target: string;
           sourceUrl: string;
@@ -210,7 +210,7 @@ export function registerBuildCommands(program: Command): void {
         splitBuildTarget(opts.target);
         const versionCode = opts.versionCode
           ? parseNonNegativeInteger(opts.versionCode, "--version-code")
-          : versionCodeFromVersion(opts.version);
+          : versionCodeFromVersion(opts.versionName);
         const rawSize = parseNonNegativeInteger(opts.rawSize, "--raw-size");
         const hasGzipHash = opts.gzipSha256 !== undefined;
         const hasGzipSize = opts.gzipSize !== undefined;
@@ -233,7 +233,7 @@ export function registerBuildCommands(program: Command): void {
           method: "POST",
           body: {
             channel_id: channelId,
-            version_name: opts.version,
+            version_name: opts.versionName,
             version_code: versionCode,
             target: opts.target,
             source_url: opts.sourceUrl,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.9")
+  .version("0.5.10")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",


### PR DESCRIPTION
## Problem

`hands builds publish-version --version 1.0.5` collided with the root `hands --version` option. Space-separated usage printed the CLI version and exited; `--version=...` only worked accidentally through Commander parsing.

## Changes

- rename the external build input to `--version-name`, matching the other publish commands
- register the real root version option in a full publish-version API regression
- update public/CLI docs
- bump the CLI package to 0.5.10

## Testing

- Hands Node SDK build passed
- CLI build passed
- CLI tests: 20 passed, including root-command apps/channel/publish-version HTTP flow
- repository scan found no remaining Hands-owned `publish-version --version` examples
- `git diff --check` passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786962330&installation_id=145465820&pr_number=312&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F312&signature=57440f29cb74c2526040fd84fe4078cb4b1857e4ddc81e4ee8cacfa2dc305d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->