### PR TITLE
Deploy-token create accepts app_id in the body

### DIFF
--- a/worker/src/routes/deploy_tokens.ts
+++ b/worker/src/routes/deploy_tokens.ts
@@ -78,7 +78,9 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
   // Token minting is strict-validated: an unrecognized field must 400, never
   // silently mint a broader token than the caller asked for (a misspelled
   // expiry field used to yield a NON-EXPIRING token).
-  const allowedKeys = new Set(["name", "app_role", "expires_at", "expires_in_days"]);
+  // app_id appears in the body when invoked through the agent-manifest layer
+  // (path params are mirrored into the body); accept and ignore it.
+  const allowedKeys = new Set(["name", "app_role", "expires_at", "expires_in_days", "app_id"]);
   const unknownKeys = Object.keys(body).filter((k) => !allowedKeys.has(k));
   if (unknownKeys.length > 0) {
     return c.json(


### PR DESCRIPTION
The agent-manifest invoke layer mirrors path parameters into the request body, so the strict-validation change (PR #311) rejected every `create-token` action invocation with `unknown field: app_id`. The field is now accepted and ignored (it duplicates the path parameter).

Caught by Codex-Android-DevOPS during task #162 verification. Worker 164/164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786962818&installation_id=145465820&pr_number=313&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F313&signature=8d50b3e0dc839cc854e1fcd297ab7774b8edd5c16c26dca2773be6aa2e0a246c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->