### PR TITLE
fix(android): publish unstripped crash symbols

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.10.1"
+        default: "0.11.1"
   push:
     tags:
       - "android-sdk-v*"
@@ -26,6 +26,11 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - uses: android-actions/setup-android@v3
+
+      - name: Install pinned Android NDK
+        run: sdkmanager "ndk;26.3.11579264"
+
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "8.10.2"
@@ -40,8 +45,15 @@ jobs:
             echo "value=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build SDK
-        run: gradle -p clients/android assembleRelease
+      - name: Build SDK and unstripped native symbols
+        run: gradle -p clients/android assembleRelease packageReleaseNativeSymbols -PVERSION_NAME=${{ steps.version.outputs.value }}
+
+      - name: Upload native symbols as workflow evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: hands-android-sdk-${{ steps.version.outputs.value }}-native-symbols
+          path: clients/android/build/outputs/native-symbols/*-native-symbols.zip
+          if-no-files-found: error
 
       - name: Publish SDK to GitHub Packages
         env:

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -8,6 +8,26 @@ plugins {
 group = "build.hands"
 version = providers.gradleProperty("VERSION_NAME").orElse("0.1.0-SNAPSHOT").get()
 
+val nativeSymbolsZip = layout.buildDirectory.file(
+    "outputs/native-symbols/hands-android-sdk-${project.version}-native-symbols.zip"
+)
+
+val packageReleaseNativeSymbols by tasks.registering(Exec::class) {
+    dependsOn("externalNativeBuildRelease")
+    inputs.file(rootProject.file("../../scripts/package_android_native_symbols.sh"))
+    outputs.file(nativeSymbolsZip)
+    commandLine(
+        "bash",
+        rootProject.file("../../scripts/package_android_native_symbols.sh"),
+        "--build-dir",
+        layout.buildDirectory.get().asFile,
+        "--output",
+        nativeSymbolsZip.get().asFile,
+        "--sdk-version",
+        project.version.toString()
+    )
+}
+
 android {
     namespace = "build.hands.update"
     compileSdk = 34
@@ -57,6 +77,11 @@ afterEvaluate {
                 groupId = "build.hands"
                 artifactId = "hands-android-sdk"
                 version = project.version.toString()
+                artifact(nativeSymbolsZip) {
+                    classifier = "native-symbols"
+                    extension = "zip"
+                    builtBy(packageReleaseNativeSymbols)
+                }
 
                 pom {
                     name.set("Hands Android SDK")

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.10.1"
+        const val SDK_VERSION = "0.11.1"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/scripts/package_android_native_symbols.sh
+++ b/scripts/package_android_native_symbols.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR=""
+OUTPUT=""
+SDK_VERSION=""
+
+die() {
+  echo "error: $*" >&2
+  exit 64
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --build-dir)
+      [ "$#" -ge 2 ] || die "--build-dir requires a value"
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --output)
+      [ "$#" -ge 2 ] || die "--output requires a value"
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --sdk-version)
+      [ "$#" -ge 2 ] || die "--sdk-version requires a value"
+      SDK_VERSION="$2"
+      shift 2
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[ -n "$BUILD_DIR" ] || die "--build-dir is required"
+[ -n "$OUTPUT" ] || die "--output is required"
+[ -n "$SDK_VERSION" ] || die "--sdk-version is required"
+[ -d "$BUILD_DIR/intermediates/cxx" ] || die "missing release CMake intermediates under $BUILD_DIR"
+
+find_readelf() {
+  local candidate
+  for candidate in \
+    "${HANDS_LLVM_READELF:-}" \
+    "${ANDROID_NDK_ROOT:-}/toolchains/llvm/prebuilt"/*/bin/llvm-readelf \
+    "${ANDROID_HOME:-}/ndk"/*/toolchains/llvm/prebuilt/*/bin/llvm-readelf \
+    llvm-readelf \
+    readelf; do
+    [ -n "$candidate" ] || continue
+    if [[ "$candidate" == */* ]]; then
+      [ -x "$candidate" ] && printf '%s\n' "$candidate" && return 0
+    elif command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+READELF="$(find_readelf)" || die "llvm-readelf/readelf not found"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+MANIFEST_ROWS="$STAGE/manifest-rows.tsv"
+printf 'arch\tbuild_id\tsha256\n' > "$MANIFEST_ROWS"
+
+count=0
+seen_arches=""
+while IFS= read -r so; do
+  arch="$(basename "$(dirname "$so")")"
+  module="$(basename "$so")"
+  case "|$seen_arches|" in
+    *"|$arch|"*) die "multiple native symbol candidates found for ABI $arch; clean the SDK build first" ;;
+  esac
+  seen_arches="${seen_arches}|${arch}"
+  build_id="$($READELF -n "$so" | awk '/Build ID:/ {print $3; exit}')"
+  [ -n "$build_id" ] || die "missing build ID: $so"
+  if ! "$READELF" -S "$so" | awk '/\.debug_info/ { found=1 } END { exit(found ? 0 : 1) }'; then
+    die "refusing stripped native symbol file without .debug_info: $so"
+  fi
+  mkdir -p "$STAGE/$arch"
+  cp -p "$so" "$STAGE/$arch/$module"
+  sha="$(sha256sum "$so" | awk '{print $1}')"
+  printf '%s\t%s\t%s\n' "$arch" "$build_id" "$sha" >> "$MANIFEST_ROWS"
+  count=$((count + 1))
+done < <(find "$BUILD_DIR/intermediates/cxx" -type f -path '*/obj/*/libhandscrash.so' | sort)
+
+[ "$count" -eq 3 ] || die "expected 3 SDK ABIs, found $count"
+for required_arch in arm64-v8a armeabi-v7a x86_64; do
+  case "|$seen_arches|" in
+    *"|$required_arch|"*) ;;
+    *) die "missing native symbols for ABI $required_arch" ;;
+  esac
+done
+SOURCE_COMMIT="$(git -C "$(dirname "$0")/.." rev-parse HEAD)"
+python3 - "$SDK_VERSION" "$SOURCE_COMMIT" "$MANIFEST_ROWS" "$STAGE/manifest.json" <<'PY'
+import csv
+import json
+import sys
+
+sdk_version, source_commit, rows_path, output_path = sys.argv[1:]
+abis = {}
+with open(rows_path, newline="", encoding="utf-8") as handle:
+    for row in csv.DictReader(handle, delimiter="\t"):
+        abis[row["arch"]] = {
+            "build_id": row["build_id"],
+            "sha256": row["sha256"],
+        }
+payload = {
+    "sdk_version": sdk_version,
+    "soname": "libhandscrash.so",
+    "abis": abis,
+    "source": {
+        "repo": "https://github.com/botiverse/hands",
+        "commit": source_commit,
+    },
+}
+with open(output_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+mkdir -p "$(dirname "$OUTPUT")"
+OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
+rm -f "$OUTPUT"
+(
+  cd "$STAGE"
+  zip -X -qr "$OUTPUT" manifest.json arm64-v8a armeabi-v7a x86_64
+)
+echo "Packaged $count unstripped Hands Android native symbol files: $OUTPUT"


### PR DESCRIPTION
## Problem

The Android SDK AAR correctly ships stripped native libraries, but the release pipeline did not preserve the matching unstripped `libhandscrash.so` files. Native crash frames such as `libhandscrash.so+0x2e00` therefore cannot be symbolicated.

## Changes

- Package the three release ABIs from CMake unstripped objects.
- Require build IDs and `.debug_info`; reject duplicate, missing, or stripped candidates.
- Publish the archive as the version-matched Maven `native-symbols` classifier.
- Use the fixed contract `<abi>/libhandscrash.so` plus `manifest.json` with SDK version, source commit, build IDs, and SHA-256 values.
- Upload the same archive as workflow evidence and set the SDK-reported/default publication version to 0.11.1.

## Follow-up

Publish Android SDK 0.11.1 after merge so the mobile release pipeline can consume the classifier. Existing 0.10.2 and 0.11.0 packages are immutable and cannot receive a new classifier.

## Testing

- `packageReleaseNativeSymbols` built all three ABIs and produced the archive.
- `publishReleasePublicationToMavenLocal -PVERSION_NAME=0.11.1` succeeded and published AAR, sources, POM/module metadata, and `hands-android-sdk-0.11.1-native-symbols.zip`.
- Verified classifier build IDs match the stripped AAR libraries for all three ABIs, every classifier library retains `.debug_info`, and manifest build IDs/hashes match archive bytes.
- `bash -n scripts/package_android_native_symbols.sh`
- workflow YAML parse and `git diff --check` passed.