### PR TITLE
fix(android): isolate Hands file provider

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.11.1"
+        default: "0.11.2"
   push:
     tags:
       - "android-sdk-v*"

--- a/clients/android/src/main/AndroidManifest.xml
+++ b/clients/android/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
           host app that already declares its own FileProvider.
         -->
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name="build.hands.update.HandsFileProvider"
             android:authorities="${applicationId}.hands.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.11.1"
+        const val SDK_VERSION = "0.11.2"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFileProvider.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFileProvider.kt
@@ -1,0 +1,6 @@
+package build.hands.update
+
+import androidx.core.content.FileProvider
+
+/** Keeps the SDK provider distinct from a host app's own FileProvider. */
+class HandsFileProvider : FileProvider()


### PR DESCRIPTION
## Problem

Android manifest merger identifies providers by `android:name`. SDK 0.11.1 declares `androidx.core.content.FileProvider`, which collides with any host app that already declares the standard FileProvider class even when authorities differ. Raft therefore cannot consume 0.11.1.

## Changes

- Add a no-behavior-change `HandsFileProvider : FileProvider` subclass.
- Reference the unique subclass from the SDK manifest while retaining `${applicationId}.hands.fileprovider` and `hands_file_paths`.
- Advance the SDK-reported/default publication version to 0.11.2 because 0.11.1 is immutable.

## Follow-up

Publish tag `android-sdk-v0.11.2` after merge. Mobile PR #1267 already targets 0.11.2 and retains its own standard FileProvider without manifest overrides.

## Testing

- `publishReleasePublicationToMavenLocal -PVERSION_NAME=0.11.2` passed with AAR and native-symbol classifier.
- Raft `:androidApp:processDebugMainManifest` passed against local SDK 0.11.2; both provider classes/authorities coexist without `tools:replace`.
- Raft `:androidApp:copyHandsNativeSymbols` passed for 0.11.2.
- `git diff --check` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786980282&installation_id=145465820&pr_number=315&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F315&signature=928ce6623c44a4757018033710f9cca93f1a7a01903367dce33538b715f6c776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->