### PR TITLE
docs(android-sdk): native-symbols classifier consumption + FileProvider comment fix

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -64,10 +64,34 @@ GET /public/v2/apps/{slug}/updates/check
 
 The server resolves release scope, rollout, version comparison, and APK asset selection.
 
+## Native symbols (for crash symbolication)
+
+The AAR ships a stripped `libhandscrash.so`. Release pipelines that report
+native crashes to Hands need the matching unstripped library, published as the
+`native-symbols` Maven classifier on the same version (GitHub Packages):
+
+```text
+https://maven.pkg.github.com/botiverse/hands/build/hands/hands-android-sdk/<version>/hands-android-sdk-<version>-native-symbols.zip
+```
+
+The zip contains `<abi>/libhandscrash.so` (unstripped, with `.debug_info`) for
+`arm64-v8a`, `armeabi-v7a`, `x86_64`, plus a `manifest.json` with the per-ABI
+Build ID and SHA-256. Verify each Build ID against the `.so` inside your APK
+before uploading the zip to Hands (`hands builds publish-android --symbols`);
+treat a missing or mismatched classifier as a release blocker. Published since
+`0.11.1`.
+
+The classifier is also served by JitPack, but **AAR and classifier must come
+from the same channel**: JitPack rebuilds from source, so its Build IDs differ
+from the GitHub Packages build of the same tag. Never mix a JitPack AAR with a
+GitHub Packages classifier (or vice versa) — the Build ID check exists exactly
+to catch that.
+
 ## Release
 
 Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.11.0`). That publishes to
-GitHub Packages (`build.hands:hands-android-sdk:<version>`) and, on the first
+GitHub Packages (`build.hands:hands-android-sdk:<version>`, including the
+`native-symbols` classifier) and, on the first
 request, builds the same version on JitPack
 (`com.github.botiverse:hands:android-sdk-v<version>`) — so both channels stay in
 sync from one tag. Or run the `Publish Android SDK` workflow manually.

--- a/clients/android/src/main/AndroidManifest.xml
+++ b/clients/android/src/main/AndroidManifest.xml
@@ -6,8 +6,9 @@
         <!--
           Grants the system package installer read access to a locally
           reconstructed (delta-applied) APK sitting in the host app's cacheDir.
-          Authority is namespaced with `.hands.` so it never collides with a
-          host app that already declares its own FileProvider.
+          The provider is our own HandsFileProvider subclass: manifest merger
+          keys providers on android:name, so reusing the androidx class would
+          collide with a host app's own FileProvider regardless of authority.
         -->
         <provider
             android:name="build.hands.update.HandsFileProvider"

--- a/docs/symbolication-matrix.md
+++ b/docs/symbolication-matrix.md
@@ -18,6 +18,21 @@ lane exists.
 
 ## Decisions
 
+0. **Android `native-symbols` provenance (2026-07-18, shipped in SDK 0.11.1+).**
+   App pipelines must not repackage the `.so` bytes from their own build
+   tree — the SDK's AAR (and therefore the APK) contains a *stripped*
+   `libhandscrash.so`, so "intermediates from the app build" are fake symbols.
+   The real symbols ship as the `native-symbols` Maven classifier of
+   `build.hands:hands-android-sdk` (packaged from the CMake unstripped obj by
+   `scripts/package_android_native_symbols.sh` via the
+   `packageReleaseNativeSymbols` gradle task in the publish workflow;
+   fail-closed on stripped/missing/duplicate/Build-ID-less input, with a
+   `manifest.json` of per-ABI Build IDs). The app release flow resolves the
+   classifier for its exact SDK version, verifies per-ABI Build IDs against
+   the APK's stripped `.so`, and only then uploads the zip as the build's
+   `native-symbols` asset — missing or mismatched ⇒ release fails closed.
+   **AAR and classifier must come from the same channel** (GitHub Packages vs
+   JitPack build separately; their Build IDs differ).
 1. **Server tooling is Linux-only, standardized on the Rust symbolication
    stack** (owner call, 2026-07-05): Sentry's `symbolic` for dSYM/ELF
    frame resolution and Mozilla's `rust-minidump`/`minidump-stackwalk` for


### PR DESCRIPTION
Follow-up to #314/#315 (Android native-symbols chain, task #163 context):

- **clients/android/README.md**: new "Native symbols (for crash symbolication)" section — classifier coordinates, zip layout (`<abi>/libhandscrash.so` + manifest.json), Build ID verification + fail-closed consumption rule, and the **same-channel requirement** (JitPack rebuilds from source → different Build IDs than the GitHub Packages build of the same tag; verified empirically: JitPack serves the classifier but its Build IDs differ, so AAR and classifier must never be mixed across channels).
- **docs/symbolication-matrix.md**: decision 0 records the Android native-symbols provenance — the AAR's `libhandscrash.so` is stripped, so app-build intermediates are fake symbols; real symbols ship as the per-version Maven classifier (`scripts/package_android_native_symbols.sh` + `packageReleaseNativeSymbols`, fail-closed).
- **clients/android/src/main/AndroidManifest.xml**: replaces the now-stale comment claiming authority namespacing prevents provider collisions — manifest merger keys on android:name; the `HandsFileProvider` subclass (#315) is what avoids the collision.

Docs/comments only, no behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786981199&installation_id=145465820&pr_number=316&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F316&signature=6d99cb5b152e8ac08ccb225b0b111e08aa24aa13a5a944102f4c594dd06a2f50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->