### PR TITLE
feat(worker): external-target readback + atomic freeze/publish gate (task #160)

### DIFF
--- a/migrations/sql/0047_external_target_gate.sql
+++ b/migrations/sql/0047_external_target_gate.sql
@@ -1,0 +1,11 @@
+-- External-target publish gate (Computer CLI migration, task #160):
+-- 1. builds gains the target-set freeze: once a release of this build is
+--    published with a required-target contract, the set is frozen — new
+--    target declarations are permanently rejected and the required set is
+--    re-asserted on every publish attempt (including replays).
+-- 2. external_build_targets gains an explicit gzip transport URL so consumers
+--    never have to guess bytes addresses from digests.
+ALTER TABLE builds ADD COLUMN targets_frozen_at INTEGER;
+ALTER TABLE builds ADD COLUMN freeze_token TEXT;
+ALTER TABLE builds ADD COLUMN required_targets_json TEXT;
+ALTER TABLE external_build_targets ADD COLUMN gzip_source_url TEXT;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -58,6 +58,7 @@ import {
 } from "./routes/public_v2";
 import { handleElectronGenericAsset } from "./routes/electron";
 import { handleTauriArtifact, handleTauriUpdate } from "./routes/tauri";
+import { handleExternalLatestDl, handleExternalReleaseDl } from "./routes/external_dl";
 import {
   handleCreateReleaseShare,
   handleListReleaseShares,
@@ -516,6 +517,8 @@ app.get("/public/r2/:key", handlePublicR2Download);
 app.get("/internal/r2/:key", handleInternalR2Download);
 app.get("/electron/:slug/:channel/:file", handleElectronGenericAsset);
 app.get("/tauri/:slug/:channel/artifacts/:releaseId/:target/:arch/:file", handleTauriArtifact);
+app.get("/dl/:slug/releases/:releaseId/:file", handleExternalReleaseDl);
+app.get("/dl/:slug/:channel/:file", handleExternalLatestDl);
 app.get("/tauri/:slug/:channel/:target/:arch/:currentVersion", handleTauriUpdate);
 app.get("/share/:token/download", handlePublicReleaseShareDownload);
 app.get("/share/:token", handlePublicReleaseShare);

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -49,6 +49,7 @@ export interface ExternalBuildVersionInput {
   raw_size_bytes: number;
   gzip_sha256?: string | null;
   gzip_size_bytes?: number | null;
+  gzip_source_url?: string | null;
   node_version?: string | null;
   product_type?: string;
   release_type?: string;
@@ -585,14 +586,24 @@ export async function handlePublishExternalBuildVersion(c: AdminContext) {
 
   const targetId = crypto.randomUUID();
   const now = Date.now();
+  // gzip transport must be explicitly addressable (never consumer-guessed):
+  // caller may pass gzip_source_url; when a gzip digest exists without one,
+  // the server normalizes to source_url + ".gz" and stores the explicit URL.
+  const gzipSourceUrl =
+    typeof input.gzip_source_url === "string" && input.gzip_source_url
+      ? input.gzip_source_url
+      : input.gzip_sha256
+        ? `${input.source_url}.gz`
+        : null;
   try {
-    await c.env.DB
+    const inserted = await c.env.DB
       .prepare(
         `INSERT INTO external_build_targets
          (id, app_id, build_id, version_name, target, source_url,
           raw_sha256, raw_size_bytes, gzip_sha256, gzip_size_bytes,
-          node_version, metadata_json, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)`,
+          node_version, metadata_json, created_at, updated_at, gzip_source_url)
+         SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15
+         WHERE (SELECT targets_frozen_at FROM builds WHERE id = ?16) IS NULL`,
       )
       .bind(
         targetId,
@@ -609,8 +620,50 @@ export async function handlePublishExternalBuildVersion(c: AdminContext) {
         externalJsonString(input.metadata_json),
         now,
         now,
+        gzipSourceUrl,
+        build.id,
       )
       .run();
+    if ((inserted.meta?.changes ?? 0) === 0) {
+      // Conditional insert refused: the build's target set is frozen by a
+      // published release. Exact replays of an existing declaration stay
+      // idempotent (CI re-runs must not fail post-publish); a mismatched
+      // redeclaration is a conflict; a genuinely new target is frozen out.
+      const frozenExisting = await getExternalTarget(c.env.DB, appId, input.version_name, input.target);
+      if (frozenExisting) {
+        if (!externalDeclarationMatches(frozenExisting, input)) {
+          return c.json(
+            {
+              error: "external build declaration conflicts with the existing immutable target",
+              code: "EXTERNAL_BUILD_CONFLICT",
+              build_id: frozenExisting.build_id,
+              target_id: frozenExisting.id,
+              target: frozenExisting.target,
+            },
+            409,
+          );
+        }
+        const { platform, arch } = splitBuildTarget(input.target);
+        return c.json({
+          app_id: appId,
+          build_id: frozenExisting.build_id,
+          target_id: frozenExisting.id,
+          version: input.version_name,
+          target: input.target,
+          platform,
+          arch,
+          replayed: true,
+        });
+      }
+      return c.json(
+        {
+          error: "this build's target set is frozen by a published release; no new targets may be declared",
+          code: "EXTERNAL_TARGETS_FROZEN",
+          build_id: build.id,
+        },
+        409,
+      );
+    }
   } catch (error) {
     const concurrent = await getExternalTarget(c.env.DB, appId, input.version_name, input.target);
     if (!concurrent) throw error;

--- a/worker/src/routes/external_dl.ts
+++ b/worker/src/routes/external_dl.ts
@@ -1,0 +1,89 @@
+/**
+ * Public download surfaces for external build targets (task #160):
+ *
+ *   /dl/{slug}/releases/{releaseId}/{target}[.gz]   — immutable, release-bound.
+ *       active|superseded → 302 to the declared source URL; draft/cancelled
+ *       404. A manifest that pinned a release keeps resolving the same bytes
+ *       through supersession (rollback/audit continuity).
+ *
+ *   /dl/{slug}/{channel}/{target}[.gz]              — stable "latest".
+ *       302 to the immutable release-bound route for the channel's current
+ *       ACTIVE release (only active — that is what "latest" means), so
+ *       install scripts can hardcode one URL.
+ *
+ * .gz addresses the gzip transport and requires a declared gzip digest.
+ */
+import type { Context } from "hono";
+
+type DlTargetRow = {
+  target: string;
+  source_url: string;
+  gzip_source_url: string | null;
+  gzip_sha256: string | null;
+};
+
+function parseFile(file: string): { target: string; gzip: boolean } | null {
+  const gzip = file.endsWith(".gz");
+  const target = gzip ? file.slice(0, -3) : file;
+  if (!/^[a-z0-9]+-[a-z0-9_]+$/.test(target)) return null;
+  return { target, gzip };
+}
+
+const noStore = { "cache-control": "no-store" };
+
+export async function handleExternalReleaseDl(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  const parsed = parseFile(c.req.param("file") ?? "");
+  if (!slug || !releaseId || !parsed) return c.json({ error: "invalid download parameters" }, 400);
+
+  const release = await c.env.DB.prepare(
+    `SELECT r.id, r.build_id FROM releases r
+     JOIN apps a ON a.id = r.app_id
+     WHERE a.slug = ?1 AND r.id = ?2 AND r.status IN ('active', 'superseded')`,
+  )
+    .bind(slug, releaseId)
+    .first<{ id: string; build_id: string }>();
+  if (!release) return c.json({ error: "release not found" }, 404);
+
+  const row = await c.env.DB.prepare(
+    `SELECT target, source_url, gzip_source_url, gzip_sha256
+     FROM external_build_targets WHERE build_id = ?1 AND target = ?2`,
+  )
+    .bind(release.build_id, parsed.target)
+    .first<DlTargetRow>();
+  if (!row) return c.json({ error: "target not found" }, 404);
+
+  if (parsed.gzip) {
+    if (!row.gzip_sha256) return c.json({ error: "no gzip transport declared for this target" }, 404);
+    const url = row.gzip_source_url ?? `${row.source_url}.gz`;
+    return new Response(null, { status: 302, headers: { location: url, ...noStore } });
+  }
+  return new Response(null, { status: 302, headers: { location: row.source_url, ...noStore } });
+}
+
+export async function handleExternalLatestDl(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug") ?? "";
+  const channel = c.req.param("channel") ?? "";
+  const parsed = parseFile(c.req.param("file") ?? "");
+  if (!slug || !channel || channel === "releases" || !parsed) {
+    return c.json({ error: "invalid download parameters" }, 400);
+  }
+
+  const release = await c.env.DB.prepare(
+    `SELECT r.id FROM releases r
+     JOIN apps a ON a.id = r.app_id
+     JOIN channels ch ON ch.id = r.channel_id
+     JOIN builds b ON b.id = r.build_id
+     WHERE a.slug = ?1 AND ch.slug = ?2 AND r.status = 'active'
+       AND b.source = 'external'
+       AND (r.availability_at IS NULL OR r.availability_at <= ?3)
+     ORDER BY r.created_at DESC LIMIT 1`,
+  )
+    .bind(slug, channel, Date.now())
+    .first<{ id: string }>();
+  if (!release) return c.json({ error: "no active release" }, 404);
+
+  const location = `/dl/${encodeURIComponent(slug)}/releases/${encodeURIComponent(release.id)}/${encodeURIComponent(c.req.param("file") ?? "")}`;
+  return new Response(null, { status: 302, headers: { location, ...noStore } });
+}

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -431,12 +431,68 @@ export async function handleGetRelease(c: Context<{ Bindings: Env }>) {
     .bind(releaseId)
     .all();
 
+  // External target declarations (Computer-CLI-style builds): full readback so
+  // a consumer can enumerate and assert required targets from the release
+  // itself. gzip transport is always explicitly addressable — legacy rows
+  // without a stored gzip_source_url are normalized here, never guessed by
+  // the consumer.
+  const { results: externalTargetRows } = await c.env.DB.prepare(
+    `SELECT target, source_url, gzip_source_url, raw_sha256, raw_size_bytes,
+            gzip_sha256, gzip_size_bytes, node_version, metadata_json, created_at
+     FROM external_build_targets
+     WHERE build_id = (SELECT build_id FROM releases WHERE id = ?1 AND app_id = ?2)
+     ORDER BY target`,
+  )
+    .bind(releaseId, appId)
+    .all<{
+      target: string;
+      source_url: string;
+      gzip_source_url: string | null;
+      raw_sha256: string;
+      raw_size_bytes: number;
+      gzip_sha256: string | null;
+      gzip_size_bytes: number | null;
+      node_version: string | null;
+      metadata_json: string;
+      created_at: number;
+    }>();
+  const externalTargets = (externalTargetRows || []).map((row) => {
+    let metadata: unknown = {};
+    try {
+      metadata = JSON.parse(row.metadata_json || "{}");
+    } catch {
+      metadata = {};
+    }
+    return {
+      target: row.target,
+      raw_source_url: row.source_url,
+      gzip_source_url: row.gzip_source_url ?? (row.gzip_sha256 ? `${row.source_url}.gz` : null),
+      raw_sha256: row.raw_sha256,
+      raw_size_bytes: row.raw_size_bytes,
+      gzip_sha256: row.gzip_sha256,
+      gzip_size_bytes: row.gzip_size_bytes,
+      node_version: row.node_version,
+      metadata,
+      created_at: row.created_at,
+    };
+  });
+  let provenance: unknown = null;
+  try {
+    provenance = build && (build as any).provenance_json ? JSON.parse((build as any).provenance_json) : null;
+  } catch {
+    provenance = null;
+  }
+
   return c.json({
     release: withReleaseNotes(release as { changelog?: string | null }),
     build,
     assets,
     scopes,
     checks,
+    external_targets: externalTargets,
+    external_targets_count: externalTargets.length,
+    external_targets_frozen: Boolean(build && (build as any).freeze_token),
+    provenance,
   });
 }
 
@@ -747,11 +803,159 @@ export async function handleUpdateRelease(c: AdminContext) {
   }
 }
 
+// ---- External-target publish gate (task #160, Computer CLI migration) ------
+
+function canonicalizeRequiredTargets(raw: unknown): { set: string[] } | { error: string } {
+  if (!Array.isArray(raw) || raw.some((t) => typeof t !== "string")) {
+    return { error: "required_external_targets must be an array of target strings" };
+  }
+  const seen = new Set<string>();
+  for (const t of raw as string[]) {
+    const norm = t.trim();
+    if (!/^[a-z0-9]+-[a-z0-9_]+$/.test(norm)) {
+      return { error: `unknown target format: ${t} (expected e.g. darwin-arm64)` };
+    }
+    if (seen.has(norm)) return { error: `duplicate target: ${norm}` };
+    seen.add(norm);
+  }
+  return { set: [...seen].sort() };
+}
+
+function targetSetDiff(required: string[], declared: string[]): { missing: string[]; unexpected: string[] } {
+  const dec = new Set(declared);
+  const req = new Set(required);
+  return {
+    missing: required.filter((t) => !dec.has(t)),
+    unexpected: declared.filter((t) => !req.has(t)),
+  };
+}
+
+/**
+ * Freeze + assert the external-target contract inside the publish path.
+ * Every external build's target set is frozen on its first publish attempt
+ * (freeze_token = random ownership; declarations are conditionally rejected
+ * once frozen). cli-binary requires a caller-supplied exact expected set; a
+ * failed assertion clears ONLY a freeze this attempt created. Runs on every
+ * publish attempt including already-active replays — no early no-op path.
+ * Returns a Response on failure, null to proceed.
+ */
+async function assertExternalTargetGate(
+  c: AdminContext,
+  release: { build_id: string },
+  requiredRaw: unknown,
+): Promise<Response | null> {
+  const build = await c.env.DB.prepare(
+    `SELECT id, source, product_type, freeze_token, required_targets_json FROM builds WHERE id = ?1`,
+  )
+    .bind(release.build_id)
+    .first<{ id: string; source: string; product_type: string; freeze_token: string | null; required_targets_json: string | null }>();
+  if (!build) return c.json({ error: "release build not found" }, 409);
+
+  if (build.source !== "external") {
+    if (requiredRaw !== undefined) {
+      return c.json({ error: "required_external_targets only applies to external builds" }, 400);
+    }
+    return null;
+  }
+
+  let callerSet: string[] | undefined;
+  if (requiredRaw !== undefined) {
+    const canon = canonicalizeRequiredTargets(requiredRaw);
+    if ("error" in canon) return c.json({ error: canon.error }, 400);
+    callerSet = canon.set;
+  }
+  if (build.product_type === "cli-binary" && !callerSet && !build.freeze_token) {
+    return c.json(
+      { error: "required_external_targets is required when publishing a cli-binary external build" },
+      400,
+    );
+  }
+
+  const readDeclared = async (): Promise<string[]> => {
+    const { results } = await c.env.DB.prepare(
+      `SELECT target FROM external_build_targets WHERE build_id = ?1 ORDER BY target`,
+    )
+      .bind(build.id)
+      .all<{ target: string }>();
+    return (results || []).map((r) => r.target);
+  };
+
+  if (!build.freeze_token) {
+    const token = crypto.randomUUID();
+    const cas = await c.env.DB.prepare(
+      `UPDATE builds SET freeze_token = ?1, targets_frozen_at = ?2, required_targets_json = ?3
+       WHERE id = ?4 AND freeze_token IS NULL`,
+    )
+      .bind(token, Date.now(), JSON.stringify(callerSet ?? []), build.id)
+      .run();
+    if ((cas.meta?.changes ?? 0) === 1) {
+      // We own the freeze; declarations are now blocked, so this read is final.
+      const declared = await readDeclared();
+      const required = callerSet ?? declared;
+      await c.env.DB.prepare(
+        `UPDATE builds SET required_targets_json = ?1 WHERE id = ?2 AND freeze_token = ?3`,
+      )
+        .bind(JSON.stringify(required), build.id, token)
+        .run();
+      const diff = targetSetDiff(required, declared);
+      if (diff.missing.length > 0 || diff.unexpected.length > 0) {
+        // Roll back OUR freeze only, so the build isn't locked by a failed attempt.
+        await c.env.DB.prepare(
+          `UPDATE builds SET freeze_token = NULL, targets_frozen_at = NULL, required_targets_json = NULL
+           WHERE id = ?1 AND freeze_token = ?2`,
+        )
+          .bind(build.id, token)
+          .run();
+        return c.json(
+          { error: "external target set does not match the required set", code: "EXTERNAL_TARGETS_MISMATCH", missing: diff.missing, unexpected: diff.unexpected },
+          400,
+        );
+      }
+      return null;
+    }
+    // Lost the freeze race — fall through to the stored-contract path.
+  }
+
+  const frozen = await c.env.DB.prepare(
+    `SELECT required_targets_json FROM builds WHERE id = ?1`,
+  )
+    .bind(build.id)
+    .first<{ required_targets_json: string | null }>();
+  let stored: string[] = [];
+  try {
+    stored = JSON.parse(frozen?.required_targets_json ?? "[]") as string[];
+  } catch {
+    stored = [];
+  }
+  if (callerSet && (callerSet.length !== stored.length || callerSet.some((t, i) => t !== stored[i]))) {
+    return c.json(
+      { error: "required_external_targets differs from the frozen contract", code: "EXTERNAL_TARGETS_CONTRACT_MISMATCH", frozen: stored },
+      400,
+    );
+  }
+  const declared = await readDeclared();
+  const diff = targetSetDiff(stored, declared);
+  if (diff.missing.length > 0 || diff.unexpected.length > 0) {
+    // Frozen contract violated after freeze — declarations are blocked, so
+    // this indicates out-of-band mutation; fail closed.
+    return c.json(
+      { error: "declared targets no longer match the frozen contract", code: "EXTERNAL_TARGETS_MISMATCH", missing: diff.missing, unexpected: diff.unexpected },
+      409,
+    );
+  }
+  return null;
+}
+
 export async function handlePublishRelease(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const releaseId = c.req.param("releaseId") ?? "";
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  // The external-target gate runs on EVERY publish attempt — including
+  // already-active replays — before any no-op shortcut.
+  const publishBody = (await c.req.json().catch(() => ({}))) as { required_external_targets?: unknown };
+  const gateFail = await assertExternalTargetGate(c, existing, publishBody.required_external_targets);
+  if (gateFail) return gateFail;
   if (existing.status === "active") return c.json(existing);
   if (existing.status !== "draft") {
     return c.json({ error: `cannot publish ${existing.status} release` }, 409);

--- a/worker/test/external_builds.test.ts
+++ b/worker/test/external_builds.test.ts
@@ -38,7 +38,10 @@ function makeDb() {
       provenance_json TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
-      completed_at INTEGER
+      completed_at INTEGER,
+      targets_frozen_at INTEGER,
+      freeze_token TEXT,
+      required_targets_json TEXT
     );
     CREATE UNIQUE INDEX idx_builds_external_app_version
       ON builds(app_id, version_name)
@@ -58,6 +61,7 @@ function makeDb() {
       metadata_json TEXT NOT NULL DEFAULT '{}',
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
+      gzip_source_url TEXT,
       UNIQUE (app_id, version_name, target)
     );
     CREATE TABLE audit_logs (
@@ -78,8 +82,8 @@ function makeDb() {
         bind(...params: unknown[]) {
           return {
             async run() {
-              statement.run(...params);
-              return { success: true };
+              const info = statement.run(...params);
+              return { success: true, meta: { changes: Number(info.changes ?? 0) } };
             },
             async first<T>() {
               return (statement.get(...params) as T | undefined) ?? null;

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -183,8 +183,29 @@ function makeMockDb() {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       completed_at INTEGER,
+      targets_frozen_at INTEGER,
+      freeze_token TEXT,
+      required_targets_json TEXT,
       FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE,
       FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE SET NULL
+    );
+    CREATE TABLE external_build_targets (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      build_id TEXT NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+      version_name TEXT NOT NULL,
+      target TEXT NOT NULL,
+      source_url TEXT NOT NULL,
+      raw_sha256 TEXT NOT NULL,
+      raw_size_bytes INTEGER NOT NULL,
+      gzip_sha256 TEXT,
+      gzip_size_bytes INTEGER,
+      node_version TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      gzip_source_url TEXT,
+      UNIQUE (app_id, version_name, target)
     );
     CREATE TABLE signing_credentials (
       id TEXT PRIMARY KEY,
@@ -533,8 +554,8 @@ function makeMockDb() {
 
   // Replace `?N` numbered placeholders with anonymous `?` (better-sqlite3 compat).
   // The real D1 migration keeps `?N` — same SQL semantics, just different binding.
-  const normalize = (sql: string) => sql.replace(/\?\d+/g, "?");
-
+  // Numbered placeholders may repeat (`?1, ?1` binds one value on D1), so track
+  // the index sequence and expand the bound params to match the anonymous slots.
   return {
     batch: async (statements: Array<{ run: () => Promise<unknown> }>) => {
       const results = [];
@@ -544,23 +565,32 @@ function makeMockDb() {
       return results;
     },
     prepare(sql: string) {
-      const normSql = normalize(sql);
-      const stmt = sqlite.prepare(normSql);
-      const bind = (...params: any[]) => ({
-        run: async () => {
-          stmt.run(...params);
-          return { success: true, meta: { changes: 0 } };
-        },
-        all: async () => {
-          const rows = stmt.all(...params);
-          return { results: rows, success: true };
-        },
-        first: async () => {
-          const rows = stmt.all(...params);
-          return rows[0] ?? null;
-        },
+      const indexSequence: number[] = [];
+      const normSql = sql.replace(/\?(\d+)/g, (_match, n) => {
+        indexSequence.push(Number(n));
+        return "?";
       });
-      return { bind };
+      const stmt = sqlite.prepare(normSql);
+      const bind = (...params: any[]) => {
+        const expanded =
+          indexSequence.length > 0 ? indexSequence.map((n) => params[n - 1]) : params;
+        return {
+          run: async () => {
+            const info = stmt.run(...expanded);
+            return { success: true, meta: { changes: info.changes } };
+          },
+          all: async () => {
+            const rows = stmt.all(...expanded);
+            return { results: rows, success: true };
+          },
+          first: async () => {
+            const rows = stmt.all(...expanded);
+            return rows[0] ?? null;
+          },
+        };
+      };
+      // D1 also allows run/all/first directly on the unbound statement.
+      return { bind, run: () => bind().run(), all: () => bind().all(), first: () => bind().first() };
     },
   };
 }
@@ -3313,6 +3343,138 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(draftPayload.artifact.download_api).toBe(
       `/api/apps/app-scope/builds/${build.id}/assets/${draftPayload.artifact.asset_id}/download?presign=1`,
     );
+  });
+
+  it("external-target gate: freeze on publish, set assertion, replay re-assert, dl routes", async () => {
+    const env = makeEnv();
+    const now = Date.now();
+    // External build with 2 declared targets + a draft release on it.
+    await env.DB.prepare(
+      `INSERT INTO builds (id, app_id, channel_id, product_type, release_type, version_name, version_code,
+                           source, status, build_metadata_json, parsed_metadata_json, should_force_update,
+                           provenance_json, created_at, updated_at)
+       VALUES ('b-ext', 'app-scope', 'ch-scope-prod', 'cli-binary', 'stable', '2.0.0', 2000000,
+               'external', 'succeeded', '{}', '{}', 0, '{"ci_provider":"gha","source_commit":"abc123"}', ?1, ?1)`,
+    ).bind(now).run();
+    for (const [t, gz] of [["darwin-arm64", "https://cdn.test/2.0.0/darwin-arm64.gz"], ["linux-x64", null]] as const) {
+      await env.DB.prepare(
+        `INSERT INTO external_build_targets
+         (id, app_id, build_id, version_name, target, source_url, raw_sha256, raw_size_bytes,
+          gzip_sha256, gzip_size_bytes, node_version, metadata_json, created_at, updated_at, gzip_source_url)
+         VALUES (?1, 'app-scope', 'b-ext', '2.0.0', ?2, ?3, ?4, 100, ?5, ?6, '24.15.0', '{}', ?7, ?7, ?8)`,
+      ).bind(
+        `t-${t}`, t, `https://cdn.test/2.0.0/${t}`, "a".repeat(64),
+        t === "darwin-arm64" ? "b".repeat(64) : null, t === "darwin-arm64" ? 90 : null, now, gz,
+      ).run();
+    }
+    await env.DB.prepare(
+      `INSERT INTO releases (id, app_id, build_id, channel_id, product_type, release_type, status,
+                             is_full, changelog, created_by, created_at, updated_at)
+       VALUES ('rel-ext', 'app-scope', 'b-ext', 'ch-scope-prod', 'cli-binary', 'stable', 'draft', 1, NULL, 'tester', ?1, ?1)`,
+    ).bind(now).run();
+
+    const { handlePublishRelease, handleGetRelease } = await import("../src/routes/releases");
+    const ctx = (params: Record<string, string>, body: unknown = {}) =>
+      ({
+        env,
+        executionCtx: { waitUntil: () => undefined },
+        req: {
+          url: "https://quiver-worker.test/api/apps/app-scope/releases/rel-ext/publish",
+          param: (name: string) => params[name] ?? "",
+          query: () => undefined,
+          json: async () => body,
+        },
+        get: (name: string) => (name === "admin_actor" ? "tester" : name === "org_id" ? "default" : undefined),
+        json: (data: unknown, status = 200) =>
+          new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } }),
+      }) as any;
+
+    // cli-binary publish without a required set → 400 (not yet frozen).
+    const noSet = await handlePublishRelease(ctx({ appId: "app-scope", releaseId: "rel-ext" }));
+    expect(noSet.status).toBe(400);
+
+    // Wrong set → 400 with named missing/unexpected; freeze rolled back.
+    const wrong = await handlePublishRelease(
+      ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["darwin-arm64", "win32-x64"] }),
+    );
+    expect(wrong.status).toBe(400);
+    const wrongBody = (await wrong.json()) as any;
+    expect(wrongBody.missing).toEqual(["win32-x64"]);
+    expect(wrongBody.unexpected).toEqual(["linux-x64"]);
+    const afterFail = (await env.DB.prepare("SELECT freeze_token FROM builds WHERE id = 'b-ext'").first()) as any;
+    expect(afterFail.freeze_token).toBeNull();
+
+    // Duplicate target in the set → 400.
+    const dup = await handlePublishRelease(
+      ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["linux-x64", "linux-x64"] }),
+    );
+    expect(dup.status).toBe(400);
+
+    // Exact set → publish succeeds and freezes.
+    const ok = await handlePublishRelease(
+      ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["linux-x64", "darwin-arm64"] }),
+    );
+    expect(ok.status).toBe(200);
+    const frozen = (await env.DB.prepare("SELECT freeze_token, required_targets_json FROM builds WHERE id = 'b-ext'").first()) as any;
+    expect(frozen.freeze_token).not.toBeNull();
+    expect(JSON.parse(frozen.required_targets_json)).toEqual(["darwin-arm64", "linux-x64"]);
+
+    // Post-freeze: replay publish (already active) re-asserts and no-ops OK;
+    // a different set on replay → contract mismatch.
+    const replayOk = await handlePublishRelease(
+      ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["darwin-arm64", "linux-x64"] }),
+    );
+    expect(replayOk.status).toBe(200);
+    const replayBad = await handlePublishRelease(
+      ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["darwin-arm64"] }),
+    );
+    expect(replayBad.status).toBe(400);
+
+    // Readback: external_targets with explicit raw/gzip URLs (legacy null gzip
+    // normalized), count, frozen flag, structured provenance.
+    const detail = await responseJson<any>(
+      await handleGetRelease(ctx({ appId: "app-scope", releaseId: "rel-ext" })),
+    );
+    expect(detail.external_targets_count).toBe(2);
+    expect(detail.external_targets_frozen).toBe(true);
+    expect(detail.provenance).toMatchObject({ ci_provider: "gha", source_commit: "abc123" });
+    const dArm = detail.external_targets.find((t: any) => t.target === "darwin-arm64");
+    expect(dArm.raw_source_url).toBe("https://cdn.test/2.0.0/darwin-arm64");
+    expect(dArm.gzip_source_url).toBe("https://cdn.test/2.0.0/darwin-arm64.gz");
+    const lX64 = detail.external_targets.find((t: any) => t.target === "linux-x64");
+    expect(lX64.gzip_source_url).toBeNull(); // no gzip digest declared
+
+    // /dl routes: latest → immutable → source; lifecycle semantics.
+    const { handleExternalLatestDl, handleExternalReleaseDl } = await import("../src/routes/external_dl");
+    const dlCtx = (params: Record<string, string>) =>
+      ({
+        env,
+        req: { param: (name: string) => params[name] ?? "", query: () => undefined },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      }) as any;
+    const latest = await handleExternalLatestDl(dlCtx({ slug: "scope-app", channel: "production", file: "darwin-arm64" }));
+    expect(latest.status).toBe(302);
+    expect(latest.headers.get("location")).toBe("/dl/scope-app/releases/rel-ext/darwin-arm64");
+    const imm = await handleExternalReleaseDl(dlCtx({ slug: "scope-app", releaseId: "rel-ext", file: "darwin-arm64" }));
+    expect(imm.status).toBe(302);
+    expect(imm.headers.get("location")).toBe("https://cdn.test/2.0.0/darwin-arm64");
+    const immGz = await handleExternalReleaseDl(dlCtx({ slug: "scope-app", releaseId: "rel-ext", file: "darwin-arm64.gz" }));
+    expect(immGz.status).toBe(302);
+    expect(immGz.headers.get("location")).toBe("https://cdn.test/2.0.0/darwin-arm64.gz");
+    // .gz without a declared gzip digest → 404.
+    const noGz = await handleExternalReleaseDl(dlCtx({ slug: "scope-app", releaseId: "rel-ext", file: "linux-x64.gz" }));
+    expect(noGz.status).toBe(404);
+
+    // Supersede the release: immutable URL keeps serving; latest moves off it.
+    await env.DB.prepare("UPDATE releases SET status = 'superseded' WHERE id = 'rel-ext'").run();
+    const immSuper = await handleExternalReleaseDl(dlCtx({ slug: "scope-app", releaseId: "rel-ext", file: "darwin-arm64" }));
+    expect(immSuper.status).toBe(302);
+    const latestGone = await handleExternalLatestDl(dlCtx({ slug: "scope-app", channel: "production", file: "darwin-arm64" }));
+    expect(latestGone.status).toBe(404);
+    // Cancelled → immutable URL 404s (kill switch).
+    await env.DB.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'rel-ext'").run();
+    const immCancelled = await handleExternalReleaseDl(dlCtx({ slug: "scope-app", releaseId: "rel-ext", file: "darwin-arm64" }));
+    expect(immCancelled.status).toBe(404);
   });
 
   it("release checks: upsert per source, advisory read-back on get-release", async () => {


### PR DESCRIPTION
## 背景

Computer CLI 切 Hands 指针的 shadow 实跑（XX）发现：external Node target 的 release 用 get-release / list-build-assets 读回时 **assets 恒为 []**，发布方无法从 release 自枚举/自断言 target；发布路径也没有冻结 target 契约的机制。

## 改动

**Readback**
- `handleGetRelease` 返回 `external_targets`（build 已声明 target 的完整枚举 + 归一化 gzip URL）、`provenance`、`external_targets_count`、`external_targets_frozen`。
- gzip 传输地址全链显式化：声明时可传 `gzip_source_url`；有 gzip digest 但未传时服务端归一化为 `source_url + '.gz'` 并落库（migration 0047 加列）。消费者不再从 digest 猜地址。

**Publish gate（原子）**
- builds 增加 `targets_frozen_at` / `freeze_token` / `required_targets_json`。build 首个 publish 尝试用 CAS 冻结 target 集合；断言失败时仅冻结所有者可回滚。
- cli-binary 外构首次 publish **必须** 带 `required_external_targets`；不匹配 → 400（具名 missing/unexpected）并回滚冻结。每次 publish（含已 active 的重放）都重断言，无提前 no-op 路径。
- 冻结后的新 target 声明被条件插入拒绝；精确重放保持幂等（CI 重跑不炸），冲突重声明 409。

**下载路由**
- `/dl/:slug/releases/:releaseId/:file[.gz]` — 不可变、绑定 release；active|superseded 302 到声明源，draft/cancelled 404（superseded 仍可解析，保证 manifest 钉住的 release 在回滚/审计时字节可达）。
- `/dl/:slug/:channel/:file[.gz]` — 稳定 latest，302 到该 channel 当前 active 外构 release 的不可变路由。

## 测试

- routes.test.ts 新增 external-target gate 端到端（冻结/错误集合/重复集合/精确集合/重放重断言/两条 dl 路由）。
- D1 mock 按真实语义修正：`?N` 重复占位符的参数展开、better-sqlite3 真实 changes 计数（CAS 依赖）、未 bind 的 run/all/first。
- **165/165 tests + tsc clean。**

## 部署注意

worker 部署前/同时需要对 Hands D1 执行 `migrations/sql/0047_external_target_gate.sql`。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786995041&installation_id=145465820&pr_number=317&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F317&signature=062ba63de4a8a8198457ec56bbfe10c95d74fbeb8aa1f877491132e7974d11cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->