### PR TITLE
feat(public): add latest release landing page

### DIFF
--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -954,6 +954,15 @@ function PublicHistoryToggle({ appId, app }: { appId: string; app: App }) {
               >
                 /apps/{app.slug}/history
               </a>
+              {" · latest landing: "}
+              <a
+                className="underline"
+                href={`/apps/${app.slug}/latest`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                /apps/{app.slug}/latest
+              </a>
               .
             </>
           ) : (

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -88,6 +88,8 @@ import { handleSessionEvent, handleReleaseHealth } from "./routes/sessions";
 import {
   handlePublicAppHistory,
   handlePublicAppHistoryDownload,
+  handlePublicLatestReleaseDownload,
+  handlePublicLatestReleaseLanding,
   handlePublicReleaseNotes,
   handlePublicReleaseNotesJson,
 } from "./routes/history";
@@ -533,6 +535,8 @@ app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachme
 app.get("/public/apps/:slug/icon", handlePublicAppIcon);
 app.get("/apps/:slug/history", handlePublicAppHistory);
 app.get("/apps/:slug/history/:releaseId/download", handlePublicAppHistoryDownload);
+app.get("/apps/:slug/latest", handlePublicLatestReleaseLanding);
+app.get("/apps/:slug/latest/download", handlePublicLatestReleaseDownload);
 app.get("/notes/:slug", handlePublicReleaseNotes);
 app.get("/api/invites/:token", handleGetInvite);
 

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -521,6 +521,36 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
 
   register(registry, {
     method: "get",
+    path: "/apps/{slug}/latest",
+    tags: ["Public pages"],
+    summary: "Render the latest active release landing page",
+    request: {
+      params: SlugParam,
+      query: z.object({ channel: z.string().optional(), lang: z.string().optional() }),
+    },
+    responses: {
+      200: { description: "Latest release landing page HTML.", content: html() },
+      404: error("App history is private or no active release exists."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/apps/{slug}/latest/download",
+    tags: ["Public downloads"],
+    summary: "Download the latest active release artifact",
+    request: {
+      params: SlugParam,
+      query: z.object({ channel: z.string().optional() }),
+    },
+    responses: {
+      302: { description: "Redirects to a signed latest-release artifact URL." },
+      404: error("App history is private or no active release exists."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
     path: "/apps/{slug}/history",
     tags: ["Public pages"],
     summary: "Render public version history",

--- a/worker/src/proxy-shim.ts
+++ b/worker/src/proxy-shim.ts
@@ -60,10 +60,12 @@ function isMachinePath(pathname: string): boolean {
   ) {
     return true;
   }
-  // `/apps/:slug/history` and `/apps/:slug/history/:releaseId/download` are
-  // JSON / machine downloads. The bare `/apps/:slug` client-side admin route is
-  // a human page (falls through to redirect).
-  if (pathname.startsWith("/apps/") && pathname.includes("/history")) {
+  // Public app pages and their downloads are origin routes. The bare
+  // `/apps/:slug` client-side admin route remains a human dashboard route.
+  if (
+    pathname.startsWith("/apps/") &&
+    (pathname.includes("/history") || pathname.includes("/latest"))
+  ) {
     return true;
   }
   // `/share/:token` is a human page (redirect). Its sub-resources

--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -27,6 +27,10 @@ type HistoryStrings = {
   latestBadge: string; // badge
   noNotesForVersion: string; // per-version empty notes
   noNotesYet: string; // page empty state
+  packageLabel: string;
+  artifactLabel: string;
+  platformLabel: string;
+  checksumLabel: string;
 };
 
 const HISTORY_I18N: { en: HistoryStrings; zh: HistoryStrings } = {
@@ -46,6 +50,10 @@ const HISTORY_I18N: { en: HistoryStrings; zh: HistoryStrings } = {
     latestBadge: "Latest",
     noNotesForVersion: "No release notes for this version.",
     noNotesYet: "No release notes yet.",
+    packageLabel: "Package",
+    artifactLabel: "Artifact",
+    platformLabel: "Platform",
+    checksumLabel: "Checksum",
   },
   zh: {
     htmlLang: "zh",
@@ -63,6 +71,10 @@ const HISTORY_I18N: { en: HistoryStrings; zh: HistoryStrings } = {
     latestBadge: "最新",
     noNotesForVersion: "此版本暂无更新说明。",
     noNotesYet: "暂无更新说明。",
+    packageLabel: "包名",
+    artifactLabel: "安装包",
+    platformLabel: "平台",
+    checksumLabel: "校验和",
   },
 };
 
@@ -80,6 +92,16 @@ type HistoryRow = {
   version_code: number;
   changelog: string | null;
   size_bytes: number | null;
+};
+
+type LatestLandingRow = HistoryRow & {
+  package_id: string | null;
+  platform: string;
+  arch: string | null;
+  variant: string | null;
+  filetype: string;
+  r2_key: string;
+  file_hash: string;
 };
 
 async function loadHistoryApp(db: D1Database, slug: string) {
@@ -113,6 +135,79 @@ const HISTORY_SQL = `
   WHERE r.app_id = ?1 AND r.hidden = 0 AND r.status IN ('active', 'superseded')
   ORDER BY b.version_code DESC, released_at DESC
   LIMIT 50`;
+
+const LATEST_LANDING_SQL = `
+  SELECT r.id AS release_id, r.status AS release_status,
+         COALESCE(b.completed_at, r.created_at) AS released_at,
+         ch.slug AS channel_slug,
+         b.version_name, b.version_code,
+         COALESCE(r.changelog, b.changelog) AS changelog,
+         COALESCE(
+           json_extract(b.parsed_metadata_json, '$.package_id'),
+           json_extract(b.parsed_metadata_json, '$.package_name'),
+           json_extract(b.build_metadata_json, '$.package_id'),
+           json_extract(b.build_metadata_json, '$.package_name'),
+           json_extract(b.build_metadata_json, '$.android.package_id')
+         ) AS package_id,
+         ba.platform, ba.arch, ba.variant, ba.filetype,
+         ba.size_bytes, ba.r2_key, ba.file_hash
+  FROM releases r
+  JOIN builds b ON b.id = r.build_id
+  JOIN channels ch ON ch.id = r.channel_id
+  JOIN build_assets ba ON ba.build_id = b.id AND ba.artifact_kind = 'installable'
+  WHERE r.app_id = ?1 AND r.hidden = 0 AND r.status = 'active'
+    AND (?2 IS NULL OR ch.slug = ?2)
+  ORDER BY CASE WHEN ?2 IS NULL AND ch.slug = 'main' THEN 0 ELSE 1 END,
+           b.version_code DESC, released_at DESC,
+           ba.filetype = 'apk' DESC, ba.created_at ASC
+  LIMIT 1`;
+
+async function loadLatestLanding(
+  db: D1Database,
+  appId: string,
+  channel: string | null,
+): Promise<LatestLandingRow | null> {
+  return db.prepare(LATEST_LANDING_SQL).bind(appId, channel).first<LatestLandingRow>();
+}
+
+/** Stable public landing page for the current active release. Unlike a share
+ * token, this URL is app-level and intentionally rolls forward on publish. */
+export async function handlePublicLatestReleaseLanding(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await loadHistoryApp(c.env.DB, slug);
+  if (!app || !app.public_history) return new Response("Not found", { status: 404 });
+  const channel = c.req.query("channel")?.trim() || null;
+  const row = await loadLatestLanding(c.env.DB, app.id, channel);
+  if (!row) return new Response("No active release", { status: 404 });
+  const lang =
+    c.req.query("lang")?.trim() ||
+    (c.req.header("accept-language") ?? "").split(",")[0]?.trim().split(";")[0] ||
+    null;
+  return new Response(renderLatestLandingPage(app, row, lang, historyStrings(c)), {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "public, max-age=60",
+    },
+  });
+}
+
+export async function handlePublicLatestReleaseDownload(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ error: "slug required" }, 400);
+  const app = await loadHistoryApp(c.env.DB, slug);
+  if (!app || !app.public_history) return new Response("Not found", { status: 404 });
+  const channel = c.req.query("channel")?.trim() || null;
+  const row = await loadLatestLanding(c.env.DB, app.id, channel);
+  if (!row) return c.json({ error: "no active release" }, 404);
+  const url = await generateSignedR2Url(
+    c.env,
+    row.r2_key,
+    Number(c.env.SIGNED_URL_TTL_SECONDS ?? "3600"),
+    requestOrigin(c),
+  );
+  return c.redirect(url, 302);
+}
 
 // Like HISTORY_SQL but also includes the single draft whose version_code
 // equals ?2 — so the release-notes page can preview a not-yet-published
@@ -289,6 +384,62 @@ function formatSize(bytes: number | null): string {
   if (!bytes) return "";
   const mb = bytes / (1024 * 1024);
   return `${mb.toFixed(1)} MB`;
+}
+
+function renderLatestLandingPage(
+  app: { slug: string; name: string; platform: string; icon_r2_key: string | null },
+  row: LatestLandingRow,
+  lang: string | null,
+  t: HistoryStrings,
+): string {
+  const notes = resolveChangelog(row.changelog, lang);
+  const channelQuery = `?channel=${encodeURIComponent(row.channel_slug)}`;
+  return `<!doctype html>
+<html lang="${t.htmlLang}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${esc(app.name)} — ${esc(row.version_name)}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f5f5f2; color: #1e1f22; }
+    main { width: min(560px, calc(100vw - 32px)); padding: 32px 0; }
+    header { display: flex; align-items: center; gap: 16px; }
+    header img { border-radius: 12px; }
+    h1 { margin: 0 0 6px; font-size: 28px; }
+    p { margin: 0; color: #5b616e; line-height: 1.5; }
+    .badge { display: inline-block; margin-left: 8px; padding: 2px 7px; border-radius: 999px; background: #d8f3e8; color: #176f5d; font-size: 12px; vertical-align: middle; }
+    dl { display: grid; grid-template-columns: 130px 1fr; gap: 10px 16px; margin: 28px 0; }
+    dt { color: #707782; }
+    dd { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
+    .download { display: inline-flex; min-height: 44px; padding: 0 18px; align-items: center; border-radius: 6px; background: #176f5d; color: white; text-decoration: none; font-weight: 700; }
+    .notes { margin-top: 24px; color: #3b3f45; }
+    .notes ul { padding-left: 20px; }
+    .history { display: inline-block; margin-left: 14px; color: #176f5d; }
+    @media (prefers-color-scheme: dark) { body { background: #17191c; color: #f5f5f2; } p, dt { color: #aeb5bf; } .notes { color: #d2d6dc; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      ${app.icon_r2_key ? `<img src="/public/apps/${esc(app.slug)}/icon" alt="" width="56" height="56">` : ""}
+      <div>
+        <h1>${esc(app.name)} <span class="badge">${t.latestBadge}</span></h1>
+        <p>${esc(row.version_name)} · ${t.build} ${row.version_code} · ${esc(row.channel_slug)}</p>
+      </div>
+    </header>
+    <dl>
+      <dt>${t.packageLabel}</dt><dd>${esc(row.package_id || app.slug)}</dd>
+      <dt>${t.artifactLabel}</dt><dd>${esc(row.filetype.toUpperCase())} · ${formatSize(row.size_bytes)}</dd>
+      <dt>${t.platformLabel}</dt><dd>${esc([row.platform, row.arch, row.variant].filter(Boolean).join(" / "))}</dd>
+      <dt>${t.checksumLabel}</dt><dd>${esc(row.file_hash)}</dd>
+    </dl>
+    <a class="download" href="/apps/${esc(app.slug)}/latest/download${channelQuery}">${t.download}</a>
+    <a class="history" href="/apps/${esc(app.slug)}/history">${t.versionHistory}</a>
+    ${notes ? `<div class="notes">${changelogToHtml(notes)}</div>` : ""}
+  </main>
+</body>
+</html>`;
 }
 
 function renderHistoryPage(

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -27,6 +27,7 @@ type ShareStrings = {
   shareUnavailable: string; // error page title + heading
   errMissingToken: string;
   errUnavailable: string;
+  goToLatest: string;
 };
 
 const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
@@ -49,6 +50,7 @@ const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
     shareUnavailable: "Share unavailable",
     errMissingToken: "Missing share token",
     errUnavailable: "This share link is expired, revoked, or unavailable.",
+    goToLatest: "Open the latest release",
   },
   zh: {
     htmlLang: "zh",
@@ -69,6 +71,7 @@ const SHARE_I18N: { en: ShareStrings; zh: ShareStrings } = {
     shareUnavailable: "分享不可用",
     errMissingToken: "缺少分享令牌",
     errUnavailable: "此分享链接已过期、被撤销或不可用。",
+    goToLatest: "打开最新版本",
   },
 };
 
@@ -401,7 +404,8 @@ export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
   const row = await findActiveShare(c.env.DB, token);
 
   if (!row) {
-    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
+    const latestSlug = await findLatestLandingSlugForInactiveShare(c.env.DB, token);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable, latestSlug), 404);
   }
 
   if (row.password_hash && !(await hasValidUnlockCookie(c, row))) {
@@ -425,7 +429,8 @@ export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: En
 
   const row = await findActiveShare(c.env.DB, token);
   if (!row) {
-    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
+    const latestSlug = await findLatestLandingSlugForInactiveShare(c.env.DB, token);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable, latestSlug), 404);
   }
 
   if (row.password_hash && !(await hasValidUnlockCookie(c, row))) {
@@ -461,7 +466,8 @@ export async function handlePublicReleaseShareUnlock(c: Context<{ Bindings: Env 
   if (!token) return htmlResponse(renderErrorPage(t, t.errMissingToken), 400);
   const row = await findActiveShare(c.env.DB, token);
   if (!row) {
-    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
+    const latestSlug = await findLatestLandingSlugForInactiveShare(c.env.DB, token);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable, latestSlug), 404);
   }
   if (!row.password_hash) return c.redirect(`/share/${token}`, 302);
 
@@ -593,6 +599,37 @@ async function findActiveShare(db: D1Database, token: string): Promise<SharePage
   )
     .bind(tokenHash, Date.now())
     .first<SharePageRow>();
+}
+
+/** Resolve only known inactive tokens to a public app that currently has an
+ * active installable. Random tokens must not disclose app identity. */
+async function findLatestLandingSlugForInactiveShare(
+  db: D1Database,
+  token: string,
+): Promise<string | null> {
+  const tokenHash = await sha256Hex(token);
+  const row = await db.prepare(
+    `SELECT a.slug
+     FROM release_shares rs
+     JOIN releases seed ON seed.id = rs.release_id
+     JOIN apps a ON a.id = seed.app_id
+     WHERE rs.token_hash = ?1
+       AND (rs.revoked_at IS NOT NULL OR (rs.expires_at IS NOT NULL AND rs.expires_at <= ?2))
+       AND a.archived = 0
+       AND a.public_history = 1
+       AND EXISTS (
+         SELECT 1 FROM releases latest
+         JOIN build_assets ba ON ba.build_id = latest.build_id
+         WHERE latest.app_id = a.id
+           AND latest.status = 'active'
+           AND latest.hidden = 0
+           AND ba.artifact_kind = 'installable'
+       )
+     LIMIT 1`,
+  )
+    .bind(tokenHash, Date.now())
+    .first<{ slug: string }>();
+  return row?.slug ?? null;
 }
 
 async function recordShareEvent(
@@ -803,7 +840,7 @@ function renderPasswordPage(t: ShareStrings, token: string, failed: boolean): st
 </html>`;
 }
 
-function renderErrorPage(t: ShareStrings, message: string): string {
+function renderErrorPage(t: ShareStrings, message: string, latestSlug: string | null = null): string {
   return `<!doctype html>
 <html lang="${t.htmlLang}">
 <head>
@@ -817,6 +854,7 @@ function renderErrorPage(t: ShareStrings, message: string): string {
     .badge { width: 44px; height: 44px; margin: 0 auto 16px; border-radius: 12px; display: grid; place-items: center; background: rgba(125,125,125,0.12); font-size: 22px; }
     h1 { margin: 0 0 8px; font-size: 22px; line-height: 1.2; }
     p { margin: 0; color: #5b616e; line-height: 1.5; }
+    a { display: inline-block; margin-top: 16px; color: #176f5d; font-weight: 700; }
     @media (prefers-color-scheme: dark) {
       body { background: #17191c; color: #f5f5f2; }
       p { color: #aeb5bf; }
@@ -828,6 +866,7 @@ function renderErrorPage(t: ShareStrings, message: string): string {
     <div class="badge" aria-hidden="true">🔗</div>
     <h1>${t.shareUnavailable}</h1>
     <p>${escapeHtml(message)}</p>
+    ${latestSlug ? `<a href="/apps/${escapeAttribute(encodeURIComponent(latestSlug))}/latest">${t.goToLatest}</a>` : ""}
   </main>
 </body>
 </html>`;

--- a/worker/test/proxy-shim.test.ts
+++ b/worker/test/proxy-shim.test.ts
@@ -54,6 +54,8 @@ describe("proxy-shim isMachinePath", () => {
   it("proxies /apps history JSON + download, redirects bare SPA route", () => {
     expect(isMachinePath("/apps/raft-android/history")).toBe(true);
     expect(isMachinePath("/apps/raft-android/history/rel-id/download")).toBe(true);
+    expect(isMachinePath("/apps/raft-android/latest")).toBe(true);
+    expect(isMachinePath("/apps/raft-android/latest/download")).toBe(true);
     // bare admin SPA route -> human -> redirect
     expect(isMachinePath("/apps/raft-android")).toBe(false);
   });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -74,6 +74,8 @@ describe("quiver OpenAPI document", () => {
       "/public/v2/apps/{slug}/feedback",
       "/public/v2/apps/{slug}/metrics",
       "/apps/{slug}/history",
+      "/apps/{slug}/latest",
+      "/apps/{slug}/latest/download",
       "/api/apps",
       "/api/apps/{appId}/builds",
       "/api/apps/{appId}/builds/publish-version",
@@ -3670,6 +3672,55 @@ describe("quiver public API v2 — scope resolution", () => {
       .run();
     const expiredPage = await handlePublicReleaseShare(makeSharePublicContext(env, expiredToken));
     expect(expiredPage.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("latest landing: stable app URL renders the highest active published release", async () => {
+    const env = makeEnv();
+    await env.DB.prepare("UPDATE apps SET public_history = 1 WHERE id = ?")
+      .bind("app-scope")
+      .run();
+    await seedRelease(env, "rel-landing-1", "build-landing-1", [["full", "all"]], {
+      createdAt: 100,
+      versionCode: 1,
+      versionName: "1.0.0",
+    });
+    await seedAsset(env, "build-landing-1", "asset-landing-1");
+    await seedRelease(env, "rel-landing-2", "build-landing-2", [["full", "all"]], {
+      createdAt: 200,
+      versionCode: 2,
+      versionName: "2.0.0",
+    });
+    await seedAsset(env, "build-landing-2", "asset-landing-2");
+    const { handlePublicLatestReleaseLanding } = await import("../src/routes/history");
+    const makeContext = (channel?: string) => ({
+      env,
+      req: {
+        param: (name: string) => (name === "slug" ? "scope-app" : ""),
+        query: (name: string) => (name === "channel" ? channel : undefined),
+        header: (name: string) => (name.toLowerCase() === "accept-language" ? "en-US" : undefined),
+      },
+      json: (data: unknown, status = 200) =>
+        new Response(JSON.stringify(data), {
+          status,
+          headers: { "content-type": "application/json" },
+        }),
+    } as any);
+
+    const page = await handlePublicLatestReleaseLanding(makeContext());
+    expect(page.status).toBe(200);
+    const html = await page.text();
+    expect(html).toContain("2.0.0");
+    expect(html).toContain("/apps/scope-app/latest/download?channel=production");
+    expect(html).toContain("Latest");
+
+    const missingChannel = await handlePublicLatestReleaseLanding(makeContext("beta"));
+    expect(missingChannel.status).toBe(404);
+
+    await env.DB.prepare("UPDATE apps SET public_history = 0 WHERE id = ?")
+      .bind("app-scope")
+      .run();
+    const privatePage = await handlePublicLatestReleaseLanding(makeContext());
+    expect(privatePage.status).toBe(404);
   });
 
   // ------------------------------------------------------------------

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3670,8 +3670,17 @@ describe("quiver public API v2 — scope resolution", () => {
     await env.DB.prepare("UPDATE release_shares SET expires_at = 1 WHERE id = ?1")
       .bind(expiredCreate.id)
       .run();
+    await env.DB.prepare("UPDATE apps SET public_history = 1 WHERE id = ?1")
+      .bind("app-scope")
+      .run();
     const expiredPage = await handlePublicReleaseShare(makeSharePublicContext(env, expiredToken));
     expect(expiredPage.status).toBeGreaterThanOrEqual(400);
+    expect(await expiredPage.text()).toContain("/apps/scope-app/latest");
+
+    const unknownPage = await handlePublicReleaseShare(
+      makeSharePublicContext(env, "not-a-real-share-token"),
+    );
+    expect(await unknownPage.text()).not.toContain("/apps/scope-app/latest");
   });
 
   it("latest landing: stable app URL renders the highest active published release", async () => {


### PR DESCRIPTION
## What
- add a stable public landing page at `/apps/:slug/latest`
- always render the newest active, non-hidden release; prefer the `main` channel when present, with `?channel=` for an explicit channel
- add `/apps/:slug/latest/download` for the matching installable
- show app/version/channel/package/artifact/platform/checksum/changelog and link to version history
- expose the stable URL beside Public version history in the admin console
- when a known share token is expired/revoked, offer a link to the app latest landing page if one exists

## Access and compatibility
- gated by the existing `public_history` app setting
- existing active `/share/:token` links remain fixed and unchanged
- random/forged tokens do not disclose app identity or receive a latest link
- no schema migration and no token semantics change

## Verification
- worker full suite: 8 files / 166 tests passed
- latest landing regression selects 2.0.0 over 1.0.0, honors channel filtering, and 404s when public history is disabled
- expired known-token regression links to `/apps/:slug/latest`; unknown-token regression does not
- worker TypeScript build and admin production build passed

Raft task #164