### PR TITLE
feat(android-sdk): add release health sessions

### DIFF
--- a/admin/src/components/ReleaseHealth.tsx
+++ b/admin/src/components/ReleaseHealth.tsx
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query";
+import { getReleaseHealth } from "../lib/api";
+
+function Rate({ value }: { value: number | null }) {
+  if (value == null) return <span className="text-slate-400">—</span>;
+  const color = value >= 99 ? "text-emerald-700" : value >= 95 ? "text-amber-700" : "text-red-700";
+  return <span className={`font-semibold tabular-nums ${color}`}>{value.toFixed(2)}%</span>;
+}
+
+/** Crash-free sessions/devices for releases that have SDK session telemetry. */
+export function ReleaseHealth({ appId }: { appId: string }) {
+  const query = useQuery({
+    queryKey: ["release-health", appId],
+    queryFn: () => getReleaseHealth(appId, 30),
+  });
+  const data = query.data;
+  if (query.isLoading || !data || data.totals.sessions === 0) return null;
+
+  return (
+    <div className="card p-4! mb-4">
+      <div className="flex items-baseline justify-between mb-4">
+        <h3 className="text-sm font-semibold">Release health</h3>
+        <span className="text-xs text-slate-500">last {data.window_days} days</span>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 mb-5">
+        <div className="rounded-md border border-slate-100 p-3">
+          <div className="text-xs text-slate-500 mb-1">Crash-free sessions</div>
+          <div className="text-2xl"><Rate value={data.totals.crash_free_sessions_pct} /></div>
+          <div className="text-xs text-slate-500 mt-1 tabular-nums">
+            {data.totals.sessions - data.totals.crashed_sessions} of {data.totals.sessions} sessions
+          </div>
+        </div>
+        <div className="rounded-md border border-slate-100 p-3">
+          <div className="text-xs text-slate-500 mb-1">Crash-free devices</div>
+          <div className="text-2xl"><Rate value={data.totals.crash_free_devices_pct} /></div>
+          <div className="text-xs text-slate-500 mt-1 tabular-nums">
+            {data.totals.devices - data.totals.crashed_devices} of {data.totals.devices} devices
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead className="text-slate-500">
+            <tr className="border-b border-slate-100">
+              <th className="py-1.5 pr-3 text-left font-medium">Version</th>
+              <th className="py-1.5 pr-3 text-left font-medium">Channel</th>
+              <th className="py-1.5 pr-3 text-right font-medium">Sessions</th>
+              <th className="py-1.5 pr-3 text-right font-medium">Crash-free sessions</th>
+              <th className="py-1.5 pr-3 text-right font-medium">Devices</th>
+              <th className="py-1.5 text-right font-medium">Crash-free devices</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.versions.slice(0, 8).map((version) => (
+              <tr
+                key={`${version.version_code ?? version.version_name}-${version.channel ?? ""}`}
+                className="border-b border-slate-50 last:border-0"
+              >
+                <td className="py-1.5 pr-3 whitespace-nowrap">
+                  <span className="font-medium text-slate-700">{version.version_name ?? "Unknown"}</span>
+                  {version.version_code != null && (
+                    <span className="ml-1 text-slate-400 tabular-nums">{version.version_code}</span>
+                  )}
+                </td>
+                <td className="py-1.5 pr-3 text-slate-600">{version.channel ?? "—"}</td>
+                <td className="py-1.5 pr-3 text-right tabular-nums">{version.sessions}</td>
+                <td className="py-1.5 pr-3 text-right"><Rate value={version.crash_free_sessions_pct} /></td>
+                <td className="py-1.5 pr-3 text-right tabular-nums">{version.devices}</td>
+                <td className="py-1.5 text-right"><Rate value={version.crash_free_devices_pct} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1621,6 +1621,32 @@ export interface DeviceAnalytics {
   by_channel: Array<{ channel: string; devices: number }>;
 }
 
+export interface ReleaseHealthVersion {
+  version_name: string | null;
+  version_code: number | null;
+  channel: string | null;
+  sessions: number;
+  crashed_sessions: number;
+  crash_free_sessions_pct: number | null;
+  devices: number;
+  crashed_devices: number;
+  crash_free_devices_pct: number | null;
+}
+
+export interface ReleaseHealth {
+  window_days: number;
+  since: number;
+  totals: {
+    sessions: number;
+    crashed_sessions: number;
+    crash_free_sessions_pct: number | null;
+    devices: number;
+    crashed_devices: number;
+    crash_free_devices_pct: number | null;
+  };
+  versions: ReleaseHealthVersion[];
+}
+
 export interface VersionMetric {
   release_id: string | null;
   build_id: string | null;
@@ -1675,6 +1701,12 @@ export const getDeviceDetail = (appId: string, deviceId: string) =>
 export const getDeviceAnalytics = (appId: string, windowDays = 30) =>
   request<DeviceAnalytics>(
     `/api/apps/${appId}/analytics/devices?window_days=${windowDays}`,
+    { admin: true },
+  );
+
+export const getReleaseHealth = (appId: string, windowDays = 30) =>
+  request<ReleaseHealth>(
+    `/api/apps/${appId}/release-health?window_days=${windowDays}`,
     { admin: true },
   );
 

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -25,6 +25,7 @@ import {
   type BadgeProps,
 } from "raft-ui";
 import { DeviceAnalytics } from "../components/DeviceAnalytics";
+import { ReleaseHealth } from "../components/ReleaseHealth";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { ConfirmActionDialog, TypedConfirmField } from "../components/ConfirmActionDialog";
@@ -122,6 +123,7 @@ export function AppDetail({ appId }: { appId: string }) {
       </section>
 
       <section className="mt-6">
+        <ReleaseHealth appId={appId} />
         <DeviceAnalytics appId={appId} />
       </section>
 

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -2,6 +2,11 @@
 
 Android SDK for Hands server-side update checks and APK installation.
 
+`Hands.install(...)` also enables crash capture, daily device analytics, and
+release-health session tracking by default. Session start/end/crash events are
+queued on-device and retried after network or process failures; set
+`trackSessions = false` only when the host app intentionally opts out.
+
 ## Coordinates
 
 Two ways to consume the SDK. **JitPack needs no token** — prefer it unless you

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     api("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     // Delta (incremental) APK apply. Maintained fork of Google's Play-Store
     // file-by-file engine; the CLI/CI side generates patches with the SAME jar.
     implementation("com.eidu:archive-patcher:3.0.0")

--- a/clients/android/src/main/kotlin/build/hands/update/Hands.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/Hands.kt
@@ -5,8 +5,8 @@ import android.content.Context
 /**
  * Single entry point for the Hands SDK. `Hands.install(...)` wires
  * everything the app needs at launch — JVM + native crash capture,
- * store-then-send upload of pending crashes, and the throttled
- * device-analytics ping — so the app calls one method.
+ * store-then-send upload of pending crashes, release-health session tracking,
+ * and the throttled device-analytics ping — so the app calls one method.
  *
  * Feedback submission is a user action, kept as a separate call
  * ([HandsFeedback]).
@@ -29,8 +29,20 @@ object Hands {
         uploadOnLaunch: Boolean = true,
         captureNativeCrashes: Boolean = true,
         reportDeviceAnalytics: Boolean = true,
+        trackSessions: Boolean = true,
         extraContext: (() -> String)? = null,
     ) {
+        if (trackSessions) {
+            HandsSessions.install(
+                context = context,
+                baseUrl = baseUrl,
+                appSlug = appSlug,
+                versionName = versionName,
+                versionCode = versionCode,
+                channel = channel,
+                clientKey = clientKey,
+            )
+        }
         HandsCrash.install(
             context = context,
             baseUrl = baseUrl,

--- a/clients/android/src/main/kotlin/build/hands/update/HandsCrash.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsCrash.kt
@@ -62,6 +62,9 @@ object HandsCrash {
         val appContext = context.applicationContext
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            // Persist the release-health crash marker before doing any heavier
+            // crash-log work. It is flushed on the next launch.
+            runCatching { HandsSessions.markCurrentCrashed() }
             val crashLog =
                 runCatching { buildCrashLog(appContext, thread, throwable, extraContext) }
                     .getOrElse { buildFallbackCrashLog(thread, throwable, it) }

--- a/clients/android/src/main/kotlin/build/hands/update/HandsSessions.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsSessions.kt
@@ -1,0 +1,247 @@
+package build.hands.update
+
+import android.content.Context
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import java.util.UUID
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Process-level release-health sessions.
+ *
+ * Events are committed to SharedPreferences before network delivery and sent
+ * in order on a single background executor. A foreground/background bounce
+ * shorter than [BACKGROUND_TIMEOUT_MS] remains one session. Fatal crashes add
+ * a sticky `crash` event synchronously; the next process launch flushes it.
+ */
+internal object HandsSessions {
+    private const val TAG = "HandsSessions"
+    private const val PREFS_NAME = "quiver_update"
+    private const val KEY_CURRENT = "hands_current_session"
+    private const val KEY_QUEUE = "hands_session_queue"
+    private const val MAX_QUEUED_EVENTS = 100
+    private const val BACKGROUND_TIMEOUT_MS = 30_000L
+
+    private data class Config(
+        val baseUrl: String,
+        val appSlug: String,
+        val versionName: String?,
+        val versionCode: Long?,
+        val channel: String?,
+        val clientKey: String?,
+    )
+
+    private val installed = AtomicBoolean(false)
+    private val lock = Any()
+    private val executor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "hands-session-upload").apply { isDaemon = true }
+    }
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .build()
+    }
+
+    private lateinit var appContext: Context
+    private lateinit var config: Config
+    private val endRunnable = Runnable { endCurrentSession() }
+
+    fun install(
+        context: Context,
+        baseUrl: String,
+        appSlug: String,
+        versionName: String?,
+        versionCode: Long?,
+        channel: String?,
+        clientKey: String?,
+    ) {
+        if (!installed.compareAndSet(false, true)) return
+        appContext = context.applicationContext
+        config = Config(baseUrl, appSlug, versionName, versionCode, channel, clientKey)
+
+        recoverStaleSession()
+        val lifecycle = ProcessLifecycleOwner.get().lifecycle
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) = foreground()
+
+            override fun onStop(owner: LifecycleOwner) {
+                mainHandler.removeCallbacks(endRunnable)
+                mainHandler.postDelayed(endRunnable, BACKGROUND_TIMEOUT_MS)
+            }
+        })
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) foreground()
+        scheduleFlush()
+    }
+
+    /** Called by the uncaught-exception handler; must remain synchronous. */
+    fun markCurrentCrashed() {
+        if (!installed.get()) return
+        synchronized(lock) {
+            val prefs = prefs()
+            val current = prefs.getString(KEY_CURRENT, null)?.let(::parseObject) ?: return
+            val event = copyEvent(current)
+                .put("event", "crash")
+                .put("duration_ms", elapsed(current))
+            enqueueLocked(prefs, event)
+            prefs.edit().remove(KEY_CURRENT).commit()
+        }
+    }
+
+    private fun foreground() {
+        mainHandler.removeCallbacks(endRunnable)
+        synchronized(lock) {
+            val prefs = prefs()
+            if (prefs.getString(KEY_CURRENT, null) != null) return
+            val now = System.currentTimeMillis()
+            val event = baseEvent("start", now)
+            prefs.edit().putString(KEY_CURRENT, event.toString()).commit()
+            enqueueLocked(prefs, event)
+        }
+        scheduleFlush()
+    }
+
+    private fun endCurrentSession() {
+        if (!installed.get()) return
+        synchronized(lock) {
+            val prefs = prefs()
+            val current = prefs.getString(KEY_CURRENT, null)?.let(::parseObject) ?: return
+            val event = copyEvent(current)
+                .put("event", "end")
+                .put("duration_ms", elapsed(current))
+            enqueueLocked(prefs, event)
+            prefs.edit().remove(KEY_CURRENT).commit()
+        }
+        scheduleFlush()
+    }
+
+    /** Close a session left behind by a process kill, then begin a fresh one. */
+    private fun recoverStaleSession() {
+        synchronized(lock) {
+            val prefs = prefs()
+            val stale = prefs.getString(KEY_CURRENT, null)?.let(::parseObject) ?: return
+            val event = if (hasNativeCrashSince(stale.optLong("started_at", Long.MAX_VALUE))) {
+                "crash"
+            } else {
+                "end"
+            }
+            enqueueLocked(prefs, copyEvent(stale).put("event", event))
+            prefs.edit().remove(KEY_CURRENT).commit()
+        }
+    }
+
+    private fun hasNativeCrashSince(startedAt: Long): Boolean =
+        (HandsNativeCrash.crashDir(appContext).listFiles { file -> file.name.endsWith(".qnc") }
+            ?: emptyArray()).any { record ->
+            record.lastModified() >= startedAt ||
+                runCatching { HandsNativeCrash.parseRecord(record.readText())?.crashAt ?: 0L }
+                    .getOrDefault(0L) >= startedAt
+        }
+
+    private fun baseEvent(event: String, startedAt: Long): JSONObject = JSONObject().apply {
+        put("_queue_id", UUID.randomUUID().toString())
+        put("session_id", UUID.randomUUID().toString())
+        put("device_id", HandsDeviceId.get(appContext))
+        put("event", event)
+        put("started_at", startedAt)
+        config.versionName?.let { put("version_name", it) }
+        config.versionCode?.let { put("version_code", it) }
+        config.channel?.let { put("channel", it) }
+        put("platform", "android")
+        put("os_version", Build.VERSION.RELEASE ?: Build.VERSION.SDK_INT.toString())
+        put("device_model", "${Build.MANUFACTURER} ${Build.MODEL}".trim())
+    }
+
+    private fun copyEvent(source: JSONObject): JSONObject =
+        JSONObject(source.toString()).put("_queue_id", UUID.randomUUID().toString())
+
+    private fun elapsed(event: JSONObject): Long =
+        (System.currentTimeMillis() - event.optLong("started_at", System.currentTimeMillis()))
+            .coerceAtLeast(0L)
+
+    private fun enqueueLocked(prefs: android.content.SharedPreferences, event: JSONObject) {
+        val queue = loadQueue(prefs)
+        queue.add(event)
+        while (queue.size > MAX_QUEUED_EVENTS) queue.removeAt(0)
+        persistQueue(prefs, queue)
+    }
+
+    private fun scheduleFlush() {
+        if (!installed.get()) return
+        executor.execute { flush() }
+    }
+
+    private fun flush() {
+        while (true) {
+            val event = synchronized(lock) { loadQueue(prefs()).firstOrNull() } ?: return
+            val queueId = event.optString("_queue_id")
+            val payload = JSONObject(event.toString()).apply { remove("_queue_id") }
+            val responseCode = runCatching { post(payload) }.getOrElse {
+                Log.d(TAG, "Session upload deferred", it)
+                return
+            }
+            val permanentFailure = responseCode in 400..499 && responseCode != 408 && responseCode != 429
+            if (responseCode !in 200..299 && !permanentFailure) return
+            if (permanentFailure) Log.w(TAG, "Dropping session event rejected with HTTP $responseCode")
+            synchronized(lock) {
+                val prefs = prefs()
+                val queue = loadQueue(prefs)
+                queue.removeAll { it.optString("_queue_id") == queueId }
+                persistQueue(prefs, queue)
+            }
+        }
+    }
+
+    private fun post(payload: JSONObject): Int {
+        val url = config.baseUrl.trimEnd('/').toHttpUrl().newBuilder()
+            .addPathSegments("public/v2/apps")
+            .addPathSegment(config.appSlug)
+            .addPathSegment("sessions")
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("accept", "application/json")
+            .apply {
+                if (!config.clientKey.isNullOrBlank()) {
+                    header("X-Hands-Client-Key", config.clientKey!!)
+                }
+            }
+            .post(payload.toString().toRequestBody("application/json".toMediaTypeOrNull()))
+            .build()
+        return client.newCall(request).execute().use { it.code }
+    }
+
+    private fun prefs() = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun parseObject(raw: String): JSONObject? = runCatching { JSONObject(raw) }.getOrNull()
+
+    private fun loadQueue(prefs: android.content.SharedPreferences): MutableList<JSONObject> {
+        val array = runCatching { JSONArray(prefs.getString(KEY_QUEUE, "[]")) }.getOrElse { JSONArray() }
+        return MutableList(array.length()) { index -> array.optJSONObject(index) ?: JSONObject() }
+    }
+
+    private fun persistQueue(
+        prefs: android.content.SharedPreferences,
+        queue: List<JSONObject>,
+    ) {
+        val array = JSONArray()
+        queue.forEach(array::put)
+        prefs.edit().putString(KEY_QUEUE, array.toString()).commit()
+    }
+}

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -132,6 +132,19 @@ with its R8/ProGuard `mapping.txt` (and, for NDK crashes, the unstripped
 `.so` archive) — Hands symbolicates crash reports for that `versionCode`
 automatically.
 
+## Release health
+
+`Hands.install(...)` tracks foreground sessions automatically. A session ends
+after the app has remained in the background for 30 seconds; a quick activity
+or configuration transition stays within the same session. Start/end/crash
+events are committed on-device before delivery and retried after a network or
+process failure.
+
+The app overview uses these events to show crash-free sessions and crash-free
+devices by version and channel. Pass `trackSessions = false` to
+`Hands.install` only when the host app intentionally opts out of release-health
+telemetry.
+
 ## Device analytics
 
 `Hands.install(...)` already sends a lightweight launch/install metrics ping (throttled

--- a/docs/sdk-parity/roadmap.md
+++ b/docs/sdk-parity/roadmap.md
@@ -7,20 +7,25 @@ value-per-effort. Each P0/P1 item lists the concrete change per layer
 ## P0 — small effort, large value
 
 ### P0.1 Session events → crash-free rate (release health)
-The single most persuasive Sentry metric. Today all four SDKs send only a
-24-hour-throttled device ping, so there is no session denominator and
-crash-free rate cannot be computed.
+The single most persuasive Sentry metric.
 
-- **Server**: `POST /public/v2/apps/:slug/sessions` accepting
+**Status (2026-07-19):** server ingest/rollup and the admin Release Health
+panel are complete. Android now tracks process sessions with the same 30-second
+background threshold as Sentry, persists events before delivery, and marks a
+fatal session crashed for next-launch upload. iOS, OHOS, and Electron lifecycle
+hooks remain.
+
+- **Server**: ✅ `POST /public/v2/apps/:slug/sessions` accepting
   `{device_id, session_id, event: "start"|"end", version_code, version_name,
-  channel, os, model, duration_ms?, crashed?}`; D1 table `app_sessions`
-  (rollup-friendly: daily aggregates per version). Crash reports carry
-  `session_id` so a session is marked crashed even when `end` never arrives.
-- **SDKs**: emit `start` on install/foreground, `end` on background (Android
+  channel, platform, os_version, device_model, duration_ms?, crashed?}`; D1
+  table `app_sessions`. Crash markers are sticky, and `end`/`crash` can create
+  a stub when an earlier `start` was lost.
+- **SDKs**: Android ✅; iOS/OHOS/Electron pending. Emit `start` on
+  install/foreground and `end` after backgrounding (Android
   `ProcessLifecycleOwner` / iOS `UIApplication` notifications / OHOS ability
-  lifecycle / Electron `app` events). Store-and-forward like crashes; batch
-  on next launch if offline.
-- **Admin**: Release Health panel — crash-free sessions %, crash-free
+  lifecycle / Electron `app` events). Persist before delivery and retry queued
+  events on the next launch when offline.
+- **Admin**: ✅ Release Health panel — crash-free sessions %, crash-free
   devices %, per release/channel; adoption curve already exists via device
   pings.
 

--- a/worker/src/routes/sessions.ts
+++ b/worker/src/routes/sessions.ts
@@ -132,20 +132,21 @@ export async function handleReleaseHealth(c: AdminContext) {
   const since = Date.now() - windowDays * 24 * 60 * 60 * 1000;
 
   const { results } = await c.env.DB.prepare(
-    `SELECT version_code, version_name,
+    `SELECT version_code, version_name, channel,
             COUNT(*) AS sessions,
             SUM(crashed) AS crashed_sessions,
             COUNT(DISTINCT device_id) AS devices,
             COUNT(DISTINCT CASE WHEN crashed = 1 THEN device_id END) AS crashed_devices
      FROM app_sessions
      WHERE app_id = ?1 AND started_at >= ?2
-     GROUP BY version_code, version_name
+     GROUP BY version_code, version_name, channel
      ORDER BY version_code DESC`,
   )
     .bind(appId, since)
     .all<{
       version_code: number | null;
       version_name: string | null;
+      channel: string | null;
       sessions: number;
       crashed_sessions: number | null;
       devices: number;
@@ -158,6 +159,7 @@ export async function handleReleaseHealth(c: AdminContext) {
     return {
       version_code: r.version_code,
       version_name: r.version_name,
+      channel: r.channel,
       sessions: r.sessions,
       crashed_sessions: crashedSessions,
       crash_free_sessions_pct:
@@ -169,24 +171,41 @@ export async function handleReleaseHealth(c: AdminContext) {
     };
   });
 
-  const totals = versions.reduce(
-    (acc, v) => {
-      acc.sessions += v.sessions;
-      acc.crashed_sessions += v.crashed_sessions;
-      return acc;
-    },
-    { sessions: 0, crashed_sessions: 0 },
-  );
+  const totals = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS sessions,
+            SUM(crashed) AS crashed_sessions,
+            COUNT(DISTINCT device_id) AS devices,
+            COUNT(DISTINCT CASE WHEN crashed = 1 THEN device_id END) AS crashed_devices
+     FROM app_sessions
+     WHERE app_id = ?1 AND started_at >= ?2`,
+  )
+    .bind(appId, since)
+    .first<{
+      sessions: number;
+      crashed_sessions: number | null;
+      devices: number;
+      crashed_devices: number;
+    }>();
+  const totalSessions = totals?.sessions ?? 0;
+  const totalCrashedSessions = totals?.crashed_sessions ?? 0;
+  const totalDevices = totals?.devices ?? 0;
+  const totalCrashedDevices = totals?.crashed_devices ?? 0;
 
   return c.json({
     window_days: windowDays,
     since,
     totals: {
-      sessions: totals.sessions,
-      crashed_sessions: totals.crashed_sessions,
+      sessions: totalSessions,
+      crashed_sessions: totalCrashedSessions,
       crash_free_sessions_pct:
-        totals.sessions > 0
-          ? Math.round((1 - totals.crashed_sessions / totals.sessions) * 10000) / 100
+        totalSessions > 0
+          ? Math.round((1 - totalCrashedSessions / totalSessions) * 10000) / 100
+          : null,
+      devices: totalDevices,
+      crashed_devices: totalCrashedDevices,
+      crash_free_devices_pct:
+        totalDevices > 0
+          ? Math.round((1 - totalCrashedDevices / totalDevices) * 10000) / 100
           : null,
     },
     versions,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -5483,7 +5483,12 @@ describe("quiver public API v2 — scope resolution", () => {
     expect((await post({ session_id: "s1", device_id: "d1", event: "start" }, "wrong")).status).toBe(401);
     expect((await post({ session_id: "s1", device_id: "d1", event: "nope" })).status).toBe(400);
 
-    const base = { version_name: "1.2.0", version_code: 1020000, platform: "android" };
+    const base = {
+      version_name: "1.2.0",
+      version_code: 1020000,
+      channel: "main",
+      platform: "android",
+    };
     // devA: one clean session (start+end), one crashed session
     expect((await post({ ...base, session_id: "s1", device_id: "devA", event: "start" })).status).toBe(202);
     expect((await post({ ...base, session_id: "s1", device_id: "devA", event: "end", duration_ms: 60000 })).status).toBe(202);
@@ -5507,8 +5512,12 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(body.totals.sessions).toBe(5);
     expect(body.totals.crashed_sessions).toBe(2);
     expect(body.totals.crash_free_sessions_pct).toBe(60);
+    expect(body.totals.devices).toBe(4);
+    expect(body.totals.crashed_devices).toBe(2);
+    expect(body.totals.crash_free_devices_pct).toBe(50);
 
     const v12 = body.versions.find((v: any) => v.version_code === 1020000);
+    expect(v12.channel).toBe("main");
     expect(v12.sessions).toBe(4); // s1, s2, s3 (deduped start), s4
     expect(v12.crashed_sessions).toBe(1);
     expect(v12.crash_free_sessions_pct).toBe(75);


### PR DESCRIPTION
## Problem

The release-health endpoint and session table existed, but no production SDK emitted session events and the console did not render the rollup. Crash-free session/device metrics therefore remained empty.

## Changes

- add Android process session tracking with a 30-second background threshold
- persist ordered start/end/crash events before delivery and retry them after network or process failure
- mark JVM crashes synchronously and recover native-crash markers from pending `.qnc` records on the next launch
- add `trackSessions` as an opt-out flag on `Hands.install`
- add a Release Health card with crash-free sessions/devices by version and channel
- include correctly deduplicated device totals in the release-health API
- update the Android SDK and SDK parity documentation

## Follow-up

Add the same lifecycle hooks to the iOS, OHOS, and Electron SDKs so all supported clients contribute to the release-health denominator.

## Testing

- `ANDROID_HOME=/home/exedev/android-sdk gradle -p clients/android assembleRelease`
- `pnpm -w build`
- `pnpm -w test` (204 tests pass across workspaces)
- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm -w lint` remains blocked by the repository's existing Worker ESLint 9 configuration gap (`eslint.config.*` is absent)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787060835&installation_id=145465820&pr_number=319&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F319&signature=398c4dcb042cab599298df80129897ef254f871b63225cf8f4d5ed7a7df8b023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->