### PR TITLE
feat(worker): add exact iOS simulator QA artifacts

### DIFF
--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -139,6 +139,68 @@ downloads. `window_minutes` is also accepted for recent-report windows, but
 SDK metrics pings are throttled, so this should not be labeled as true online
 presence.
 
+### Exact iOS simulator QA artifacts
+
+Use this lane for a zipped `.app` bundle that Stamp or another agent must
+download and install into Simulator by exact byte identity. It is deliberately
+separate from iOS IPA/TestFlight publishing:
+
+- the artifact kind is `ios-simulator-app` and the build is marked QA-only;
+- `.ipa` and `.apk` filenames are rejected;
+- Hands recomputes the uploaded ZIP's size and SHA-256 before marking it ready;
+- completion is one-shot: verified bytes are copied to an immutable R2 key, so
+  reusing an unexpired upload URL cannot replace the ready artifact;
+- QA-only builds are rejected by the release-creation API and therefore never
+  enter public latest/update/history offers.
+
+The Agent Login flow is create → direct upload → complete → read/presign:
+
+```bash
+# 1. Declare the exact artifact. channel_id may be a UUID or slug and defaults
+# to the app's default/main channel for ledger grouping only.
+raft integration invoke --service <hands-service> \
+  --action create-ios-simulator-artifact \
+  --param app_id=<app-uuid> \
+  --data-json '{
+    "filename":"raft-ios-simulator.app.zip",
+    "size_bytes":37563642,
+    "sha256":"885b328f3a72299bd4368fd876dbcb4a8646b6f15b6e656fc8bec396a62beac8",
+    "source_commit":"470023f98d154e50d7ba07b01a2cd53eb4367fc9",
+    "version_name":"1.0",
+    "build_number":"1",
+    "bundle_id":"build.raft.app",
+    "github_run_id":"29700366778",
+    "github_artifact_id":"8446353537"
+  }' --json > qa-artifact-create.json
+
+# 2. PUT the bytes outside the integration transport. Use the exact method,
+# URL, and Content-Type returned in the response's upload block.
+curl --fail-with-body -X PUT \
+  -H 'Content-Type: application/zip' \
+  --upload-file raft-ios-simulator.app.zip \
+  "$(jq -r .upload.url qa-artifact-create.json)"
+
+# 3. Ask Hands to stream/hash the stored object. It becomes ready only when
+# both exact byte length and SHA-256 match the declaration.
+raft integration invoke --service <hands-service> \
+  --action complete-ios-simulator-artifact \
+  --param app_id=<app-uuid> \
+  --param asset_id="$(jq -r .asset_id qa-artifact-create.json)" --json
+
+# 4. The durable coordinate is (build_id, asset_id); download_api is a stable
+# authenticated reference. Ask for a short-lived anonymous URL for binary use.
+raft integration invoke --service <hands-service> \
+  --action presign-ios-simulator-artifact \
+  --param app_id=<app-uuid> \
+  --param asset_id="$(jq -r .asset_id qa-artifact-create.json)" --json
+```
+
+Stamp should freeze both source commit and Hands asset coordinates, then
+download the returned URL and verify the response's `server_sha256` before `ditto`
+or `simctl install`. Use `list-ios-simulator-artifacts` with
+`source_commit`, `github_run_id`, or `sha256` when recovering a coordinate;
+use `get-ios-simulator-artifact` for the complete provenance record.
+
 ### Ticket triage (feedback + crashes)
 
 ```bash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@hono/zod-openapi':
         specifier: ^1.4.0
         version: 1.4.0(hono@4.12.27)(zod@4.4.3)
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       aws4fetch:
         specifier: 1.0.20
         version: 1.0.20
@@ -940,6 +943,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -3035,6 +3042,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/hashes@1.8.0': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:

--- a/worker/package.json
+++ b/worker/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.0.30",
     "@hono/zod-openapi": "^1.4.0",
+    "@noble/hashes": "^1.8.0",
     "aws4fetch": "1.0.20",
     "hono": "^4.11.1",
     "jose": "^5.9.6",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -134,6 +134,13 @@ import {
   handleUpdateBuild,
 } from "./routes/builds";
 import {
+  handleCompleteIosSimulatorArtifact,
+  handleCreateIosSimulatorArtifact,
+  handleDownloadIosSimulatorArtifact,
+  handleGetIosSimulatorArtifact,
+  handleListIosSimulatorArtifacts,
+} from "./routes/qa_artifacts";
+import {
   handleBumpRollout,
   handleCreateRelease,
   handleCreateReleaseDraft,
@@ -651,6 +658,34 @@ admin.delete(
   "/api/apps/:appId/builds/:buildId/assets/:assetId",
   requireAppRole("admin"),
   handleDeleteBuildAsset,
+);
+
+// QA-only iOS simulator artifacts. These are immutable exact-byte fixtures
+// for agent/device validation and are deliberately outside the release model.
+admin.get(
+  "/api/apps/:appId/qa-artifacts/ios-simulator",
+  requireAppRole("viewer"),
+  handleListIosSimulatorArtifacts,
+);
+admin.post(
+  "/api/apps/:appId/qa-artifacts/ios-simulator",
+  requireAppRole("publisher"),
+  handleCreateIosSimulatorArtifact,
+);
+admin.get(
+  "/api/apps/:appId/qa-artifacts/ios-simulator/:assetId",
+  requireAppRole("viewer"),
+  handleGetIosSimulatorArtifact,
+);
+admin.post(
+  "/api/apps/:appId/qa-artifacts/ios-simulator/:assetId/complete",
+  requireAppRole("publisher"),
+  handleCompleteIosSimulatorArtifact,
+);
+admin.get(
+  "/api/apps/:appId/qa-artifacts/ios-simulator/:assetId/download",
+  requireAppRole("viewer"),
+  handleDownloadIosSimulatorArtifact,
 );
 
 admin.get("/api/apps/:appId/releases", requireAppRole("viewer"), handleListReleases);

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -75,6 +75,10 @@ export const openApiDocument = docs.getOpenAPI31Document({
       description: "Create, inspect, and download build artifacts.",
     },
     {
+      name: "QA artifacts",
+      description: "Exact-byte, non-release artifacts used by agents and device test lanes.",
+    },
+    {
       name: "Releases",
       description: "Draft, publish, scope, and operate releases.",
     },

--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -16,6 +16,7 @@ import {
 
 const AppBuildParams = AppIdParam.merge(BuildIdParam);
 const AppBuildAssetParams = AppBuildParams.merge(AssetIdParam);
+const AppQaArtifactParams = AppIdParam.merge(AssetIdParam);
 
 const BuildInput = z
   .object({
@@ -76,6 +77,25 @@ const ExternalBuildVersionInput = z
     provenance_json: z.record(z.string(), z.unknown()).optional(),
   })
   .openapi("ExternalBuildVersionInput");
+
+const IosSimulatorQaArtifactInput = z
+  .object({
+    channel_id: z.string().optional(),
+    filename: z.string().regex(/\.app\.zip$/i),
+    size_bytes: z.number().int().positive().max(500 * 1024 * 1024),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/i),
+    source_commit: z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i),
+    version_name: z.string().min(1),
+    build_number: z.union([z.string().min(1), z.number().int().nonnegative()]),
+    bundle_id: z.string().min(3),
+    github_run_id: z.union([z.string().min(1), z.number().int().nonnegative()]),
+    github_artifact_id: z.union([z.string().min(1), z.number().int().nonnegative()]).nullable().optional(),
+    github_repository: z.string().nullable().optional(),
+    github_job_id: z.union([z.string().min(1), z.number().int().nonnegative()]).nullable().optional(),
+    source_ref: z.string().nullable().optional(),
+    metadata_json: z.record(z.string(), z.unknown()).optional(),
+  })
+  .openapi("IosSimulatorQaArtifactInput");
 
 export function registerBuildRoutes(registry: OpenApiRegistry) {
   register(registry, {
@@ -180,6 +200,104 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
       200: success("Deleted build.", GenericObject),
       403: error("Current principal cannot delete this build."),
       404: error("Build was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/qa-artifacts/ios-simulator",
+    tags: ["QA artifacts"],
+    summary: "List exact iOS simulator QA artifacts",
+    description:
+      "Lists QA-only .app.zip fixtures. These records are not releases and are never eligible for update offers.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      query: z.object({
+        source_commit: z.string().optional(),
+        github_run_id: z.string().optional(),
+        sha256: z.string().optional(),
+      }),
+    },
+    responses: {
+      200: success("QA artifact list.", z.object({ artifacts: z.array(GenericObject) })),
+      403: error("Current principal cannot view QA artifacts."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/qa-artifacts/ios-simulator",
+    tags: ["QA artifacts"],
+    summary: "Create an exact iOS simulator QA artifact upload",
+    description:
+      "Creates a QA-only build/asset ledger entry and returns a one-hour presigned PUT URL. The filename must end in .app.zip; IPA/APK release publishing is intentionally not used.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      body: { content: json(IosSimulatorQaArtifactInput), required: true },
+    },
+    responses: {
+      201: success("Created pending QA artifact and upload URL.", GenericObject),
+      400: error("Invalid QA artifact declaration."),
+      403: error("Current principal cannot create QA artifacts."),
+      503: error("Direct R2 upload signing is unavailable."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}",
+    tags: ["QA artifacts"],
+    summary: "Read one exact iOS simulator QA artifact",
+    security: auth,
+    request: { params: AppQaArtifactParams },
+    responses: {
+      200: success("QA artifact with build/asset ids and full provenance.", GenericObject),
+      403: error("Current principal cannot view QA artifacts."),
+      404: error("QA artifact was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/complete",
+    tags: ["QA artifacts"],
+    summary: "Verify and complete an iOS simulator QA artifact upload",
+    description:
+      "One-shot completion: streams the uploaded object through SHA-256, compares exact size and digest, then copies verified bytes to an immutable R2 key before marking ready.",
+    security: auth,
+    request: { params: AppQaArtifactParams },
+    responses: {
+      200: success("Verified exact bytes; QA artifact is ready.", GenericObject),
+      403: error("Current principal cannot complete QA artifacts."),
+      404: error("QA artifact or uploaded object was not found."),
+      409: error("Upload is not present yet."),
+      422: error("Uploaded bytes do not match the declared size/SHA-256."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/download",
+    tags: ["QA artifacts"],
+    summary: "Download an exact iOS simulator QA artifact",
+    description:
+      "The authenticated API path is the durable reference. Add ?presign=1 to receive a short-lived anonymous object URL for curl, ditto, simctl, or Stamp.",
+    security: auth,
+    request: { params: AppQaArtifactParams },
+    responses: {
+      200: {
+        description: "Binary .app.zip stream, or JSON containing download_url when presign=1.",
+        content: {
+          ...binary(),
+          "application/json": { schema: GenericObject },
+          "application/zip": { schema: z.string().openapi({ format: "binary" }) },
+        },
+      },
+      403: error("Current principal cannot download QA artifacts."),
+      404: error("QA artifact or stored object was not found."),
+      409: error("QA artifact has not completed exact-byte verification."),
     },
   });
 

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -719,6 +719,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       "2. Crash triage: list-feedback (kind=crash) → get-feedback (device context + attachments) → presign-feedback-attachment, then curl the returned download_url yourself (raw-bytes endpoints get corrupted through agent transports).",
       "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
       "4. Release management (app publisher): create-release from an existing build (DRAFT by default) → update-release with bilingual release_notes → after explicit human authorization, publish-release. See docs.release_guide.",
+      "5. iOS simulator QA fixtures: create-ios-simulator-artifact → PUT the .app.zip to upload.url with the returned headers → complete-ios-simulator-artifact → get/presign the durable exact-byte artifact. QA artifacts can never become releases or update offers.",
     ],
     auth: {
       raft_agents:
@@ -743,6 +744,10 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
         "PATCH /api/apps/{app_id}/releases/{release_id} — body: {changelog?, release_notes?, hidden?} — publisher",
       publish_release:
         "POST /api/apps/{app_id}/releases/{release_id}/publish — publisher; live-facing, needs explicit human authorization",
+      create_ios_simulator_artifact:
+        "POST /api/apps/{app_id}/qa-artifacts/ios-simulator — publisher; declares filename/size/SHA/source/version/build/bundle/GitHub run and returns a presigned PUT URL",
+      complete_ios_simulator_artifact:
+        "POST /api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/complete — publisher; one-shot stream verification of size/SHA-256 followed by immutable storage sealing",
     },
     docs: {
       agent_guide: `${origin}/docs/agent-cli-feedback`,
@@ -1003,6 +1008,70 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           build_id: { type: "string", in: "path", required: true, description: "Build UUID." },
           asset_id: { type: "string", in: "path", required: true, description: "Build asset UUID." },
+        },
+      },
+      {
+        name: "list-ios-simulator-artifacts",
+        description:
+          "List exact-byte iOS simulator .app.zip QA fixtures. Optional source_commit, github_run_id, and sha256 filters select the exact provenance coordinate. Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/qa-artifacts/ios-simulator" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          source_commit: { type: "string", in: "query", required: false, description: "Full source commit." },
+          github_run_id: { type: "string", in: "query", required: false, description: "GitHub Actions run id." },
+          sha256: { type: "string", in: "query", required: false, description: "Exact artifact SHA-256." },
+        },
+      },
+      {
+        name: "create-ios-simulator-artifact",
+        description:
+          "Create a QA-only iOS simulator artifact declaration and one-hour direct R2 PUT URL. Upload only a .app.zip using upload.method/url/headers, then call complete-ios-simulator-artifact. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/qa-artifacts/ios-simulator" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          channel_id: { type: "string", in: "body", required: false, description: "Channel UUID or slug for ledger grouping; defaults to the app default/main channel." },
+          filename: { type: "string", in: "body", required: true, description: "Original filename ending in .app.zip." },
+          size_bytes: { type: "number", in: "body", required: true, description: "Exact ZIP byte length." },
+          sha256: { type: "string", in: "body", required: true, description: "Exact ZIP SHA-256 hex digest." },
+          source_commit: { type: "string", in: "body", required: true, description: "Full 40- or 64-character git object id." },
+          version_name: { type: "string", in: "body", required: true, description: "CFBundleShortVersionString." },
+          build_number: { type: "string", in: "body", required: true, description: "CFBundleVersion." },
+          bundle_id: { type: "string", in: "body", required: true, description: "Simulator app bundle identifier." },
+          github_run_id: { type: "string", in: "body", required: true, description: "GitHub Actions run id." },
+          github_artifact_id: { type: "string", in: "body", required: false, description: "GitHub Actions artifact id." },
+          github_repository: { type: "string", in: "body", required: false, description: "owner/repository source." },
+          github_job_id: { type: "string", in: "body", required: false, description: "GitHub Actions verifier/build job id." },
+          source_ref: { type: "string", in: "body", required: false, description: "Branch or tag ref." },
+        },
+      },
+      {
+        name: "complete-ios-simulator-artifact",
+        description:
+          "After the presigned PUT finishes, stream the stored object through SHA-256 and seal it under an immutable key only if size and digest exactly match. Completion is one-shot. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/complete" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          asset_id: { type: "string", in: "path", required: true, description: "QA build asset UUID." },
+        },
+      },
+      {
+        name: "get-ios-simulator-artifact",
+        description:
+          "Read a QA artifact by asset id, including kind/qa_only, build id, exact filename/size/server SHA-256, source commit, version/version_code/bundle/build run, verification state, and durable download_api. Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          asset_id: { type: "string", in: "path", required: true, description: "QA build asset UUID." },
+        },
+      },
+      {
+        name: "presign-ios-simulator-artifact",
+        description:
+          "Return a short-lived anonymous download URL plus exact filename/size/SHA-256 for a ready simulator QA artifact. The authenticated endpoint itself is the durable reference. Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/download?presign=1" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          asset_id: { type: "string", in: "path", required: true, description: "QA build asset UUID." },
         },
       },
       {

--- a/worker/src/routes/history.ts
+++ b/worker/src/routes/history.ts
@@ -133,6 +133,7 @@ const HISTORY_SQL = `
   JOIN builds b ON b.id = r.build_id
   JOIN channels ch ON ch.id = r.channel_id
   WHERE r.app_id = ?1 AND r.hidden = 0 AND r.status IN ('active', 'superseded')
+    AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
   ORDER BY b.version_code DESC, released_at DESC
   LIMIT 50`;
 
@@ -156,6 +157,7 @@ const LATEST_LANDING_SQL = `
   JOIN channels ch ON ch.id = r.channel_id
   JOIN build_assets ba ON ba.build_id = b.id AND ba.artifact_kind = 'installable'
   WHERE r.app_id = ?1 AND r.hidden = 0 AND r.status = 'active'
+    AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
     AND (?2 IS NULL OR ch.slug = ?2)
   ORDER BY CASE WHEN ?2 IS NULL AND ch.slug = 'main' THEN 0 ELSE 1 END,
            b.version_code DESC, released_at DESC,
@@ -230,6 +232,7 @@ const NOTES_SQL = `
     r.status IN ('active', 'superseded')
     OR (r.status = 'draft' AND b.version_code = ?2)
   )
+    AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
   ORDER BY b.version_code DESC, released_at DESC
   LIMIT 50`;
 
@@ -355,8 +358,10 @@ export async function handlePublicAppHistoryDownload(
   }
   const asset = await c.env.DB.prepare(
     `SELECT ba.r2_key FROM releases r
+     JOIN builds b ON b.id = r.build_id
      JOIN build_assets ba ON ba.build_id = r.build_id
      WHERE r.app_id = ?1 AND r.id = ?2 AND r.hidden = 0 AND r.status IN ('active', 'superseded')
+       AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
        AND ba.artifact_kind = 'installable'
      ORDER BY ba.created_at LIMIT 1`,
   )

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -111,16 +111,20 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   // Candidates: active releases on (channel, [product_type]). No time window:
   // an active release must stay resolvable no matter how old it is.
   const candidateSql = productType
-    ? `SELECT id, build_id, created_at, product_type, rollout_cohort_count, changelog
-       FROM releases
-       WHERE app_id = ?1 AND channel_id = ?2 AND product_type = ?3
-         AND status = 'active'
-       ORDER BY created_at DESC`
-    : `SELECT id, build_id, created_at, product_type, rollout_cohort_count, changelog
-       FROM releases
-       WHERE app_id = ?1 AND channel_id = ?2
-         AND status = 'active'
-       ORDER BY created_at DESC`;
+    ? `SELECT r.id, r.build_id, r.created_at, r.product_type, r.rollout_cohort_count, r.changelog
+       FROM releases r
+       JOIN builds b ON b.id = r.build_id
+       WHERE r.app_id = ?1 AND r.channel_id = ?2 AND r.product_type = ?3
+         AND r.status = 'active'
+         AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
+       ORDER BY r.created_at DESC`
+    : `SELECT r.id, r.build_id, r.created_at, r.product_type, r.rollout_cohort_count, r.changelog
+       FROM releases r
+       JOIN builds b ON b.id = r.build_id
+       WHERE r.app_id = ?1 AND r.channel_id = ?2
+         AND r.status = 'active'
+         AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
+       ORDER BY r.created_at DESC`;
   const candidateStmt = c.env.DB.prepare(candidateSql);
   const allCandidates = await (productType
     ? candidateStmt.bind(app.id, channelRow.id, productType)
@@ -918,6 +922,7 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
      JOIN releases r ON r.build_id = b.id
      WHERE ba.r2_key = ?1
        AND ba.artifact_kind = 'installable'
+       AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
        AND r.status IN ('active', 'draft')
      LIMIT 1`,
   )

--- a/worker/src/routes/qa_artifacts.ts
+++ b/worker/src/routes/qa_artifacts.ts
@@ -176,11 +176,24 @@ function parseJsonObject(value: string): JsonObject {
   }
 }
 
-function artifactState(row: IosSimulatorArtifactRow): "pending_upload" | "ready" | "failed" {
+type ArtifactState = "pending_upload" | "verifying" | "ready" | "failed";
+
+function artifactState(row: IosSimulatorArtifactRow): ArtifactState {
   const metadata = parseJsonObject(row.asset_metadata_json);
+  if (metadata.upload_state === "verifying") return "verifying";
   if (metadata.upload_state === "ready") return "ready";
   if (metadata.upload_state === "failed") return "failed";
   return "pending_upload";
+}
+
+function completionConflict(c: Context<any>, state: ArtifactState) {
+  if (state === "ready") {
+    return c.json({ error: "QA artifact is already complete", code: "QA_ARTIFACT_ALREADY_COMPLETED" }, 409);
+  }
+  if (state === "failed") {
+    return c.json({ error: "QA artifact verification has already failed", code: "QA_ARTIFACT_VERIFICATION_FAILED" }, 409);
+  }
+  return c.json({ error: "QA artifact verification is already in progress", code: "QA_ARTIFACT_VERIFICATION_IN_PROGRESS" }, 409);
 }
 
 function artifactResponse(c: Context<any>, row: IosSimulatorArtifactRow) {
@@ -408,43 +421,228 @@ async function hashObjectBody(body: ReadableStream<Uint8Array>): Promise<{ sha25
   return { sha256: bytesToHex(digest.digest()), size };
 }
 
+function limitObjectBody(
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): ReadableStream<Uint8Array> {
+  let seen = 0;
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        seen += chunk.byteLength;
+        if (seen > maxBytes || seen > MAX_ARTIFACT_BYTES) {
+          throw new Error("QA artifact stream exceeds the declared or maximum byte limit");
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+}
+
+async function transitionToVerifying(
+  db: D1Database,
+  row: IosSimulatorArtifactRow,
+): Promise<boolean> {
+  const metadata = {
+    ...parseJsonObject(row.asset_metadata_json),
+    upload_state: "verifying",
+    verifying_started_at: Date.now(),
+  };
+  const result = await db
+    .prepare(
+      `UPDATE build_assets
+       SET metadata_json = ?1
+       WHERE id = ?2 AND build_id = ?3
+         AND json_extract(metadata_json, '$.upload_state') = 'pending_upload'`,
+    )
+    .bind(JSON.stringify(metadata), row.asset_id, row.build_id)
+    .run();
+  return Number(result.meta?.changes ?? 0) === 1;
+}
+
+async function transitionFromVerifying(
+  db: D1Database,
+  row: IosSimulatorArtifactRow,
+  state: "ready" | "failed",
+  metadata: JsonObject,
+  finalR2Key?: string,
+): Promise<boolean> {
+  const now = Date.now();
+  const assetUpdate = state === "ready"
+    ? db.prepare(
+        `UPDATE build_assets
+         SET r2_key = ?1, metadata_json = ?2
+         WHERE id = ?3 AND build_id = ?4
+           AND json_extract(metadata_json, '$.upload_state') = 'verifying'`,
+      ).bind(finalR2Key, JSON.stringify(metadata), row.asset_id, row.build_id)
+    : db.prepare(
+        `UPDATE build_assets
+         SET metadata_json = ?1
+         WHERE id = ?2 AND build_id = ?3
+           AND json_extract(metadata_json, '$.upload_state') = 'verifying'`,
+      ).bind(JSON.stringify(metadata), row.asset_id, row.build_id);
+  const buildUpdate = db.prepare(
+    `UPDATE builds
+     SET status = ?1, updated_at = ?2, completed_at = ?2
+     WHERE id = ?3 AND app_id = ?4
+       AND EXISTS (
+         SELECT 1 FROM build_assets
+         WHERE id = ?5 AND build_id = ?3
+           AND json_extract(metadata_json, '$.upload_state') = ?6
+       )`,
+  ).bind(state === "ready" ? "succeeded" : "failed", now, row.build_id, row.app_id, row.asset_id, state);
+  const results = await db.batch([assetUpdate, buildUpdate]);
+  return Number(results[0]?.meta?.changes ?? 0) === 1 && Number(results[1]?.meta?.changes ?? 0) === 1;
+}
+
+async function failVerification(
+  c: AdminContext,
+  row: IosSimulatorArtifactRow,
+  details: JsonObject,
+  keysToDelete: string[],
+) {
+  await Promise.all(keysToDelete.map((key) => c.env.APK_BUCKET.delete(key).catch(() => {})));
+  const metadata = {
+    ...parseJsonObject(row.asset_metadata_json),
+    upload_state: "failed",
+    ...details,
+    verified_at: Date.now(),
+  };
+  const changed = await transitionFromVerifying(c.env.DB, row, "failed", metadata);
+  if (changed) {
+    await insertAuditLog(c.env.DB, row.app_id, "qa_artifact.verify_failed", currentActor(c), {
+      build_id: row.build_id,
+      asset_id: row.asset_id,
+      ...details,
+    });
+  }
+}
+
 export async function handleCompleteIosSimulatorArtifact(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const assetId = c.req.param("assetId") ?? "";
   const row = await getArtifactRow(c.env.DB, appId, assetId);
   if (!row) return c.json({ error: "QA artifact not found" }, 404);
-  const state = artifactState(row);
-  if (state === "ready") {
-    return c.json({ error: "QA artifact is already complete", code: "QA_ARTIFACT_ALREADY_COMPLETED" }, 409);
+  if (artifactState(row) !== "pending_upload") return completionConflict(c, artifactState(row));
+  if (!(await transitionToVerifying(c.env.DB, row))) {
+    const latest = await getArtifactRow(c.env.DB, appId, assetId);
+    return completionConflict(c, latest ? artifactState(latest) : "verifying");
   }
-  if (state === "failed") {
-    return c.json({ error: "QA artifact verification has already failed", code: "QA_ARTIFACT_VERIFICATION_FAILED" }, 409);
+
+  const head = await c.env.APK_BUCKET.head(row.r2_key);
+  if (!head) {
+    await failVerification(c, row, { verification_error: "upload_not_found" }, []);
+    return c.json({ error: "uploaded object not found", code: "QA_UPLOAD_NOT_FOUND" }, 409);
+  }
+  if (head.size !== row.size_bytes || head.size > MAX_ARTIFACT_BYTES) {
+    await failVerification(
+      c,
+      row,
+      {
+        verification_error: head.size > MAX_ARTIFACT_BYTES ? "object_too_large" : "size_mismatch",
+        expected_size_bytes: row.size_bytes,
+        actual_size_bytes: head.size,
+      },
+      [row.r2_key],
+    );
+    return c.json(
+      {
+        error: "uploaded artifact size does not match the declaration",
+        code: "QA_ARTIFACT_INTEGRITY_MISMATCH",
+        expected: { sha256: row.file_hash, size_bytes: row.size_bytes },
+        actual: { sha256: null, size_bytes: head.size },
+      },
+      422,
+    );
   }
 
   const object = await c.env.APK_BUCKET.get(row.r2_key);
-  if (!object) return c.json({ error: "uploaded object not found", code: "QA_UPLOAD_NOT_FOUND" }, 409);
+  if (!object) {
+    await failVerification(c, row, { verification_error: "upload_disappeared" }, []);
+    return c.json({ error: "uploaded object disappeared", code: "QA_UPLOAD_NOT_FOUND" }, 409);
+  }
+  if (object.size !== row.size_bytes || object.size > MAX_ARTIFACT_BYTES) {
+    await failVerification(
+      c,
+      row,
+      {
+        verification_error: object.size > MAX_ARTIFACT_BYTES ? "object_too_large" : "size_mismatch",
+        expected_size_bytes: row.size_bytes,
+        actual_size_bytes: object.size,
+      },
+      [row.r2_key],
+    );
+    return c.json(
+      {
+        error: "uploaded artifact size changed before verification",
+        code: "QA_ARTIFACT_INTEGRITY_MISMATCH",
+        expected: { sha256: row.file_hash, size_bytes: row.size_bytes },
+        actual: { sha256: null, size_bytes: object.size },
+      },
+      422,
+    );
+  }
 
-  const actual = await hashObjectBody(object.body);
+  const existingMetadata = parseJsonObject(row.asset_metadata_json);
+  const finalR2Key = typeof existingMetadata.final_r2_key === "string"
+    ? existingMetadata.final_r2_key
+    : null;
+  if (!finalR2Key || !finalR2Key.startsWith(`apps/${appId}/qa/ios-simulator/verified/${row.build_id}/${assetId}/`)) {
+    await failVerification(c, row, { verification_error: "invalid_final_storage_key" }, [row.r2_key]);
+    return c.json({ error: "QA artifact final storage key is invalid", code: "QA_ARTIFACT_STORAGE_INVALID" }, 500);
+  }
+  if (await c.env.APK_BUCKET.head(finalR2Key)) {
+    await failVerification(c, row, { verification_error: "immutable_key_conflict" }, [row.r2_key]);
+    return c.json({ error: "QA artifact immutable storage key already exists", code: "QA_ARTIFACT_IMMUTABLE_CONFLICT" }, 409);
+  }
+
+  // Hash and seal the exact same R2 object-body snapshot. `tee()` duplicates
+  // one byte stream; we never re-read the mutable staging key after hashing,
+  // so a still-valid presigned PUT cannot create a hash/copy TOCTOU window.
+  const limitedBody = limitObjectBody(object.body, row.size_bytes);
+  const [hashStream, sealStream] = limitedBody.tee();
+  const [hashResult, sealResult] = await Promise.allSettled([
+    hashObjectBody(hashStream),
+    c.env.APK_BUCKET.put(finalR2Key, sealStream, {
+      httpMetadata: { contentType: "application/zip" },
+      customMetadata: {
+        sha256: row.file_hash,
+        build_id: row.build_id,
+        asset_id: assetId,
+      },
+    }),
+  ]);
+  if (hashResult.status === "rejected" || sealResult.status === "rejected") {
+    await failVerification(
+      c,
+      row,
+      {
+        verification_error: "stream_or_seal_failed",
+        detail: hashResult.status === "rejected"
+          ? String(hashResult.reason)
+          : String((sealResult as PromiseRejectedResult).reason),
+      },
+      [row.r2_key, finalR2Key],
+    );
+    return c.json({ error: "failed to verify and seal QA artifact", code: "QA_ARTIFACT_SEAL_FAILED" }, 422);
+  }
+
+  const actual = hashResult.value;
   if (actual.size !== row.size_bytes || actual.sha256 !== row.file_hash.toLowerCase()) {
-    const metadata = {
-      ...parseJsonObject(row.asset_metadata_json),
-      upload_state: "failed",
-      verification_error: actual.size !== row.size_bytes ? "size_mismatch" : "sha256_mismatch",
-      verified_size_bytes: actual.size,
-      verified_sha256: actual.sha256,
-      verified_at: Date.now(),
-    };
-    await c.env.DB.prepare("UPDATE build_assets SET metadata_json = ?1 WHERE id = ?2").bind(JSON.stringify(metadata), assetId).run();
-    await c.env.DB.prepare("UPDATE builds SET status = 'failed', updated_at = ?1, completed_at = ?1 WHERE id = ?2").bind(Date.now(), row.build_id).run();
-    await c.env.APK_BUCKET.delete(row.r2_key);
-    await insertAuditLog(c.env.DB, appId, "qa_artifact.verify_failed", currentActor(c), {
-      build_id: row.build_id,
-      asset_id: assetId,
-      expected_sha256: row.file_hash,
-      actual_sha256: actual.sha256,
-      expected_size_bytes: row.size_bytes,
-      actual_size_bytes: actual.size,
-    });
+    await failVerification(
+      c,
+      row,
+      {
+        verification_error: actual.size !== row.size_bytes ? "size_mismatch" : "sha256_mismatch",
+        expected_sha256: row.file_hash,
+        actual_sha256: actual.sha256,
+        expected_size_bytes: row.size_bytes,
+        actual_size_bytes: actual.size,
+        verified_size_bytes: actual.size,
+        verified_sha256: actual.sha256,
+      },
+      [row.r2_key, finalR2Key],
+    );
     return c.json(
       {
         error: "uploaded artifact does not match the declared exact bytes",
@@ -457,29 +655,18 @@ export async function handleCompleteIosSimulatorArtifact(c: AdminContext) {
   }
 
   const now = Date.now();
-  const existingMetadata = parseJsonObject(row.asset_metadata_json);
-  const finalR2Key = typeof existingMetadata.final_r2_key === "string"
-    ? existingMetadata.final_r2_key
-    : null;
-  if (!finalR2Key || !finalR2Key.startsWith(`apps/${appId}/qa/ios-simulator/verified/${row.build_id}/${assetId}/`)) {
-    return c.json({ error: "QA artifact final storage key is invalid", code: "QA_ARTIFACT_STORAGE_INVALID" }, 500);
-  }
-  if (await c.env.APK_BUCKET.head(finalR2Key)) {
-    return c.json({ error: "QA artifact immutable storage key already exists", code: "QA_ARTIFACT_IMMUTABLE_CONFLICT" }, 409);
-  }
-  const copySource = await c.env.APK_BUCKET.get(row.r2_key);
-  if (!copySource) return c.json({ error: "uploaded object disappeared", code: "QA_UPLOAD_NOT_FOUND" }, 409);
-  await c.env.APK_BUCKET.put(finalR2Key, copySource.body, {
-    httpMetadata: { contentType: "application/zip" },
-    customMetadata: {
-      sha256: actual.sha256,
-      build_id: row.build_id,
-      asset_id: assetId,
-    },
-  });
   const finalHead = await c.env.APK_BUCKET.head(finalR2Key);
   if (!finalHead || finalHead.size !== actual.size) {
-    await c.env.APK_BUCKET.delete(finalR2Key);
+    await failVerification(
+      c,
+      row,
+      {
+        verification_error: "sealed_size_mismatch",
+        expected_size_bytes: actual.size,
+        actual_size_bytes: finalHead?.size ?? null,
+      },
+      [row.r2_key, finalR2Key],
+    );
     return c.json({ error: "failed to seal immutable QA artifact", code: "QA_ARTIFACT_SEAL_FAILED" }, 500);
   }
   const metadata = {
@@ -489,10 +676,11 @@ export async function handleCompleteIosSimulatorArtifact(c: AdminContext) {
     verified_sha256: actual.sha256,
     verified_at: now,
   };
-  await c.env.DB.batch([
-    c.env.DB.prepare("UPDATE build_assets SET r2_key = ?1, metadata_json = ?2 WHERE id = ?3").bind(finalR2Key, JSON.stringify(metadata), assetId),
-    c.env.DB.prepare("UPDATE builds SET status = 'succeeded', updated_at = ?1, completed_at = ?1 WHERE id = ?2").bind(now, row.build_id),
-  ]);
+  const ready = await transitionFromVerifying(c.env.DB, row, "ready", metadata, finalR2Key);
+  if (!ready) {
+    await Promise.all([c.env.APK_BUCKET.delete(row.r2_key), c.env.APK_BUCKET.delete(finalR2Key)]);
+    return c.json({ error: "QA artifact verification state changed unexpectedly", code: "QA_ARTIFACT_STATE_CONFLICT" }, 409);
+  }
   await c.env.APK_BUCKET.delete(row.r2_key);
   await insertAuditLog(c.env.DB, appId, "qa_artifact.complete", currentActor(c), {
     build_id: row.build_id,

--- a/worker/src/routes/qa_artifacts.ts
+++ b/worker/src/routes/qa_artifacts.ts
@@ -1,0 +1,605 @@
+import type { Context } from "hono";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import { currentActor, type AdminEnv } from "../middleware/auth";
+import { requestOrigin } from "../lib/origin";
+import { presignR2DownloadUrl, presignR2UploadUrl } from "../lib/r2_presign";
+import { createBuild, createBuildAsset, resolveChannelId } from "./builds";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+type JsonObject = Record<string, unknown>;
+
+export const IOS_SIMULATOR_QA_PRODUCT_TYPE = "ios-simulator-qa";
+export const IOS_SIMULATOR_ARTIFACT_KIND = "ios-simulator-app";
+const IOS_SIMULATOR_SCHEMA = "hands.qa-artifact.ios-simulator.v1";
+const MAX_ARTIFACT_BYTES = 500 * 1024 * 1024;
+const UPLOAD_TTL_SECONDS = 3600;
+
+interface CreateIosSimulatorArtifactInput {
+  channel_id?: string;
+  filename: string;
+  size_bytes: number;
+  sha256: string;
+  source_commit: string;
+  version_name: string;
+  build_number: string | number;
+  bundle_id: string;
+  github_run_id: string | number;
+  github_artifact_id?: string | number | null;
+  github_repository?: string | null;
+  github_job_id?: string | number | null;
+  source_ref?: string | null;
+  metadata_json?: JsonObject;
+}
+
+interface IosSimulatorArtifactRow {
+  app_id: string;
+  app_slug: string;
+  build_id: string;
+  asset_id: string;
+  channel_id: string | null;
+  channel: string | null;
+  build_status: string;
+  version_name: string;
+  version_code: number;
+  build_metadata_json: string;
+  provenance_json: string;
+  artifact_kind: string;
+  platform: string;
+  arch: string | null;
+  variant: string | null;
+  filetype: string;
+  r2_key: string;
+  file_hash: string;
+  size_bytes: number;
+  asset_metadata_json: string;
+  download_count: number;
+  created_at: number;
+  completed_at: number | null;
+}
+
+function asTrimmedString(value: unknown, field: string, maxLength = 512): string {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) throw new Error(`${field} required`);
+  if (normalized.length > maxLength) throw new Error(`${field} is too long`);
+  return normalized;
+}
+
+function normalizeFilename(value: unknown): string {
+  const filename = asTrimmedString(value, "filename", 255);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._ -]*\.app\.zip$/i.test(filename)) {
+    throw new Error("filename must be a safe basename ending with .app.zip");
+  }
+  return filename;
+}
+
+function normalizeSha256(value: unknown): string {
+  const digest = asTrimmedString(value, "sha256", 64).toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(digest)) throw new Error("sha256 must be a 64-character hex digest");
+  return digest;
+}
+
+function normalizeSourceCommit(value: unknown): string {
+  const commit = asTrimmedString(value, "source_commit", 64).toLowerCase();
+  if (!/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(commit)) {
+    throw new Error("source_commit must be a full 40- or 64-character git object id");
+  }
+  return commit;
+}
+
+function normalizeSize(value: unknown): number {
+  const size = Number(value);
+  if (!Number.isSafeInteger(size) || size <= 0) throw new Error("size_bytes must be a positive integer");
+  if (size > MAX_ARTIFACT_BYTES) throw new Error("size_bytes exceeds the 500 MiB QA artifact limit");
+  return size;
+}
+
+function normalizeBuildNumber(value: unknown): string {
+  const buildNumber = asTrimmedString(value, "build_number", 128);
+  if (!/^[A-Za-z0-9._+-]+$/.test(buildNumber)) {
+    throw new Error("build_number contains unsupported characters");
+  }
+  return buildNumber;
+}
+
+function numericVersionCode(buildNumber: string): number {
+  if (!/^\d+$/.test(buildNumber)) return 0;
+  const value = Number(buildNumber);
+  return Number.isSafeInteger(value) ? value : 0;
+}
+
+function normalizeInput(input: CreateIosSimulatorArtifactInput) {
+  const filename = normalizeFilename(input.filename);
+  const buildNumber = normalizeBuildNumber(input.build_number);
+  const bundleId = asTrimmedString(input.bundle_id, "bundle_id", 255);
+  if (!/^[A-Za-z0-9][A-Za-z0-9.-]+$/.test(bundleId) || !bundleId.includes(".")) {
+    throw new Error("bundle_id must be a reverse-DNS identifier");
+  }
+  return {
+    channel: input.channel_id ? asTrimmedString(input.channel_id, "channel_id", 128) : null,
+    filename,
+    sizeBytes: normalizeSize(input.size_bytes),
+    sha256: normalizeSha256(input.sha256),
+    sourceCommit: normalizeSourceCommit(input.source_commit),
+    versionName: asTrimmedString(input.version_name, "version_name", 128),
+    buildNumber,
+    bundleId,
+    githubRunId: asTrimmedString(input.github_run_id, "github_run_id", 128),
+    githubArtifactId:
+      input.github_artifact_id === undefined || input.github_artifact_id === null
+        ? null
+        : asTrimmedString(input.github_artifact_id, "github_artifact_id", 128),
+    githubRepository: input.github_repository
+      ? asTrimmedString(input.github_repository, "github_repository", 255)
+      : null,
+    githubJobId:
+      input.github_job_id === undefined || input.github_job_id === null
+        ? null
+        : asTrimmedString(input.github_job_id, "github_job_id", 128),
+    sourceRef: input.source_ref ? asTrimmedString(input.source_ref, "source_ref", 255) : null,
+    metadata: input.metadata_json && typeof input.metadata_json === "object" && !Array.isArray(input.metadata_json)
+      ? input.metadata_json
+      : {},
+  };
+}
+
+async function resolveQaChannel(db: D1Database, appId: string, requested: string | null): Promise<string | null> {
+  if (requested) return resolveChannelId(db, appId, requested);
+  const app = await db
+    .prepare("SELECT default_channel_id FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ default_channel_id: string | null }>();
+  if (!app) return null;
+  if (app.default_channel_id) return app.default_channel_id;
+  const channel = await db
+    .prepare(
+      `SELECT id FROM channels
+       WHERE app_id = ?1
+       ORDER BY CASE slug WHEN 'main' THEN 0 ELSE 1 END, created_at ASC
+       LIMIT 1`,
+    )
+    .bind(appId)
+    .first<{ id: string }>();
+  return channel?.id ?? null;
+}
+
+function safeR2Filename(filename: string): string {
+  return filename.replace(/[^A-Za-z0-9._-]+/g, "-");
+}
+
+function parseJsonObject(value: string): JsonObject {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function artifactState(row: IosSimulatorArtifactRow): "pending_upload" | "ready" | "failed" {
+  const metadata = parseJsonObject(row.asset_metadata_json);
+  if (metadata.upload_state === "ready") return "ready";
+  if (metadata.upload_state === "failed") return "failed";
+  return "pending_upload";
+}
+
+function artifactResponse(c: Context<any>, row: IosSimulatorArtifactRow) {
+  const origin = requestOrigin(c);
+  const basePath = `/api/apps/${row.app_id}/qa-artifacts/ios-simulator/${row.asset_id}`;
+  const provenance = parseJsonObject(row.provenance_json);
+  const buildMetadata = parseJsonObject(row.build_metadata_json);
+  const assetMetadata = parseJsonObject(row.asset_metadata_json);
+  return {
+    schema: IOS_SIMULATOR_SCHEMA,
+    app_id: row.app_id,
+    app_slug: row.app_slug,
+    build_id: row.build_id,
+    asset_id: row.asset_id,
+    kind: row.artifact_kind,
+    artifact_kind: row.artifact_kind,
+    qa_only: true,
+    release_offer_eligible: false,
+    status: artifactState(row),
+    channel_id: row.channel_id,
+    channel: row.channel,
+    filename: assetMetadata.filename,
+    content_type: assetMetadata.content_type ?? "application/zip",
+    size_bytes: row.size_bytes,
+    sha256: row.file_hash,
+    server_sha256: assetMetadata.verified_sha256 ?? null,
+    source_commit: provenance.source_commit,
+    source_ref: provenance.source_ref ?? null,
+    version_name: row.version_name,
+    version: row.version_name,
+    version_code: row.version_code,
+    build_number: buildMetadata.build_number,
+    build_run_id: provenance.github_run_id,
+    bundle_id: buildMetadata.bundle_id,
+    github: {
+      repository: provenance.github_repository ?? null,
+      run_id: provenance.github_run_id,
+      artifact_id: provenance.github_artifact_id ?? null,
+      job_id: provenance.github_job_id ?? null,
+    },
+    verification: {
+      verified_at: assetMetadata.verified_at ?? null,
+      verified_sha256: assetMetadata.verified_sha256 ?? null,
+      verified_size_bytes: assetMetadata.verified_size_bytes ?? null,
+    },
+    metadata: assetMetadata.metadata ?? {},
+    created_at: row.created_at,
+    completed_at: row.completed_at,
+    download_count: row.download_count,
+    artifact_api: `${origin}${basePath}`,
+    download_api: `${origin}${basePath}/download`,
+  };
+}
+
+async function getArtifactRow(
+  db: D1Database,
+  appId: string,
+  assetId: string,
+): Promise<IosSimulatorArtifactRow | null> {
+  return db
+    .prepare(
+      `SELECT a.id AS app_id, a.slug AS app_slug,
+              b.id AS build_id, ba.id AS asset_id,
+              b.channel_id, c.slug AS channel, b.status AS build_status,
+              b.version_name, b.version_code, b.build_metadata_json, b.provenance_json,
+              ba.artifact_kind, ba.platform, ba.arch, ba.variant, ba.filetype,
+              ba.r2_key, ba.file_hash, ba.size_bytes,
+              ba.metadata_json AS asset_metadata_json,
+              ba.download_count, ba.created_at, b.completed_at
+       FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       JOIN apps a ON a.id = b.app_id
+       LEFT JOIN channels c ON c.id = b.channel_id
+       WHERE a.id = ?1 AND ba.id = ?2
+         AND b.product_type = ?3
+         AND ba.artifact_kind = ?4
+       LIMIT 1`,
+    )
+    .bind(appId, assetId, IOS_SIMULATOR_QA_PRODUCT_TYPE, IOS_SIMULATOR_ARTIFACT_KIND)
+    .first<IosSimulatorArtifactRow>();
+}
+
+async function insertAuditLog(
+  db: D1Database,
+  appId: string,
+  action: string,
+  actor: string,
+  payload: unknown,
+) {
+  await db
+    .prepare(
+      "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    )
+    .bind(crypto.randomUUID(), appId, action, actor, JSON.stringify(payload), Date.now())
+    .run();
+}
+
+export async function handleCreateIosSimulatorArtifact(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  let input: ReturnType<typeof normalizeInput>;
+  try {
+    input = normalizeInput((await c.req.json()) as CreateIosSimulatorArtifactInput);
+  } catch (error) {
+    return c.json({ error: (error as Error).message, code: "INVALID_QA_ARTIFACT" }, 400);
+  }
+
+  const app = await c.env.DB
+    .prepare("SELECT id, slug FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ id: string; slug: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+
+  const channelId = await resolveQaChannel(c.env.DB, appId, input.channel);
+  if (!channelId) {
+    return c.json(
+      { error: input.channel ? "channel_id not found for app" : "app has no channel", code: "QA_CHANNEL_REQUIRED" },
+      400,
+    );
+  }
+
+  const buildId = crypto.randomUUID();
+  const assetId = crypto.randomUUID();
+  const safeFilename = safeR2Filename(input.filename);
+  const stagingR2Key = `apps/${appId}/qa/ios-simulator/pending/${buildId}/${assetId}/${safeFilename}`;
+  const finalR2Key = `apps/${appId}/qa/ios-simulator/verified/${buildId}/${assetId}/${safeFilename}`;
+  const uploadUrl = await presignR2UploadUrl(c.env, stagingR2Key, "application/zip", UPLOAD_TTL_SECONDS);
+  if (!uploadUrl) {
+    return c.json({ error: "direct artifact uploads are unavailable", code: "QA_UPLOAD_UNAVAILABLE" }, 503);
+  }
+
+  const provenance = {
+    schema: IOS_SIMULATOR_SCHEMA,
+    source_commit: input.sourceCommit,
+    source_ref: input.sourceRef,
+    github_repository: input.githubRepository,
+    github_run_id: input.githubRunId,
+    github_artifact_id: input.githubArtifactId,
+    github_job_id: input.githubJobId,
+  };
+  const buildMetadata = {
+    schema: IOS_SIMULATOR_SCHEMA,
+    qa_only: true,
+    release_offer_eligible: false,
+    bundle_id: input.bundleId,
+    build_number: input.buildNumber,
+  };
+  const assetMetadata = {
+    schema: IOS_SIMULATOR_SCHEMA,
+    upload_state: "pending_upload",
+    filename: input.filename,
+    content_type: "application/zip",
+    final_r2_key: finalR2Key,
+    metadata: input.metadata,
+  };
+
+  try {
+    await createBuild(
+      c.env.DB,
+      appId,
+      {
+        channel_id: channelId,
+        product_type: IOS_SIMULATOR_QA_PRODUCT_TYPE,
+        release_type: "qa",
+        version_name: input.versionName,
+        version_code: numericVersionCode(input.buildNumber),
+        source: "qa-artifact",
+        status: "pending",
+        build_metadata_json: buildMetadata,
+        provenance_json: provenance,
+      },
+      currentActor(c),
+      buildId,
+    );
+    await createBuildAsset(
+      c.env.DB,
+      appId,
+      buildId,
+      {
+        artifact_kind: IOS_SIMULATOR_ARTIFACT_KIND,
+        platform: "ios-simulator",
+        arch: "universal",
+        variant: "app-bundle",
+        filetype: "zip",
+        r2_key: stagingR2Key,
+        file_hash: input.sha256,
+        size_bytes: input.sizeBytes,
+        metadata_json: assetMetadata,
+      },
+      currentActor(c),
+      assetId,
+    );
+  } catch (error) {
+    await c.env.DB.prepare("DELETE FROM builds WHERE id = ?1 AND app_id = ?2").bind(buildId, appId).run();
+    return c.json({ error: (error as Error).message, code: "QA_ARTIFACT_CREATE_FAILED" }, 400);
+  }
+
+  const row = await getArtifactRow(c.env.DB, appId, assetId);
+  if (!row) return c.json({ error: "artifact creation failed" }, 500);
+  return c.json(
+    {
+      ...artifactResponse(c, row),
+      upload: {
+        method: "PUT",
+        url: uploadUrl,
+        headers: { "content-type": "application/zip" },
+        expires_in_seconds: UPLOAD_TTL_SECONDS,
+      },
+      complete_api: `${requestOrigin(c)}/api/apps/${appId}/qa-artifacts/ios-simulator/${assetId}/complete`,
+    },
+    201,
+  );
+}
+
+async function hashObjectBody(body: ReadableStream<Uint8Array>): Promise<{ sha256: string; size: number }> {
+  const digest = sha256.create();
+  let size = 0;
+  const reader = body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    size += value.byteLength;
+    digest.update(value);
+  }
+  return { sha256: bytesToHex(digest.digest()), size };
+}
+
+export async function handleCompleteIosSimulatorArtifact(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const assetId = c.req.param("assetId") ?? "";
+  const row = await getArtifactRow(c.env.DB, appId, assetId);
+  if (!row) return c.json({ error: "QA artifact not found" }, 404);
+  const state = artifactState(row);
+  if (state === "ready") {
+    return c.json({ error: "QA artifact is already complete", code: "QA_ARTIFACT_ALREADY_COMPLETED" }, 409);
+  }
+  if (state === "failed") {
+    return c.json({ error: "QA artifact verification has already failed", code: "QA_ARTIFACT_VERIFICATION_FAILED" }, 409);
+  }
+
+  const object = await c.env.APK_BUCKET.get(row.r2_key);
+  if (!object) return c.json({ error: "uploaded object not found", code: "QA_UPLOAD_NOT_FOUND" }, 409);
+
+  const actual = await hashObjectBody(object.body);
+  if (actual.size !== row.size_bytes || actual.sha256 !== row.file_hash.toLowerCase()) {
+    const metadata = {
+      ...parseJsonObject(row.asset_metadata_json),
+      upload_state: "failed",
+      verification_error: actual.size !== row.size_bytes ? "size_mismatch" : "sha256_mismatch",
+      verified_size_bytes: actual.size,
+      verified_sha256: actual.sha256,
+      verified_at: Date.now(),
+    };
+    await c.env.DB.prepare("UPDATE build_assets SET metadata_json = ?1 WHERE id = ?2").bind(JSON.stringify(metadata), assetId).run();
+    await c.env.DB.prepare("UPDATE builds SET status = 'failed', updated_at = ?1, completed_at = ?1 WHERE id = ?2").bind(Date.now(), row.build_id).run();
+    await c.env.APK_BUCKET.delete(row.r2_key);
+    await insertAuditLog(c.env.DB, appId, "qa_artifact.verify_failed", currentActor(c), {
+      build_id: row.build_id,
+      asset_id: assetId,
+      expected_sha256: row.file_hash,
+      actual_sha256: actual.sha256,
+      expected_size_bytes: row.size_bytes,
+      actual_size_bytes: actual.size,
+    });
+    return c.json(
+      {
+        error: "uploaded artifact does not match the declared exact bytes",
+        code: "QA_ARTIFACT_INTEGRITY_MISMATCH",
+        expected: { sha256: row.file_hash, size_bytes: row.size_bytes },
+        actual: { sha256: actual.sha256, size_bytes: actual.size },
+      },
+      422,
+    );
+  }
+
+  const now = Date.now();
+  const existingMetadata = parseJsonObject(row.asset_metadata_json);
+  const finalR2Key = typeof existingMetadata.final_r2_key === "string"
+    ? existingMetadata.final_r2_key
+    : null;
+  if (!finalR2Key || !finalR2Key.startsWith(`apps/${appId}/qa/ios-simulator/verified/${row.build_id}/${assetId}/`)) {
+    return c.json({ error: "QA artifact final storage key is invalid", code: "QA_ARTIFACT_STORAGE_INVALID" }, 500);
+  }
+  if (await c.env.APK_BUCKET.head(finalR2Key)) {
+    return c.json({ error: "QA artifact immutable storage key already exists", code: "QA_ARTIFACT_IMMUTABLE_CONFLICT" }, 409);
+  }
+  const copySource = await c.env.APK_BUCKET.get(row.r2_key);
+  if (!copySource) return c.json({ error: "uploaded object disappeared", code: "QA_UPLOAD_NOT_FOUND" }, 409);
+  await c.env.APK_BUCKET.put(finalR2Key, copySource.body, {
+    httpMetadata: { contentType: "application/zip" },
+    customMetadata: {
+      sha256: actual.sha256,
+      build_id: row.build_id,
+      asset_id: assetId,
+    },
+  });
+  const finalHead = await c.env.APK_BUCKET.head(finalR2Key);
+  if (!finalHead || finalHead.size !== actual.size) {
+    await c.env.APK_BUCKET.delete(finalR2Key);
+    return c.json({ error: "failed to seal immutable QA artifact", code: "QA_ARTIFACT_SEAL_FAILED" }, 500);
+  }
+  const metadata = {
+    ...existingMetadata,
+    upload_state: "ready",
+    verified_size_bytes: actual.size,
+    verified_sha256: actual.sha256,
+    verified_at: now,
+  };
+  await c.env.DB.batch([
+    c.env.DB.prepare("UPDATE build_assets SET r2_key = ?1, metadata_json = ?2 WHERE id = ?3").bind(finalR2Key, JSON.stringify(metadata), assetId),
+    c.env.DB.prepare("UPDATE builds SET status = 'succeeded', updated_at = ?1, completed_at = ?1 WHERE id = ?2").bind(now, row.build_id),
+  ]);
+  await c.env.APK_BUCKET.delete(row.r2_key);
+  await insertAuditLog(c.env.DB, appId, "qa_artifact.complete", currentActor(c), {
+    build_id: row.build_id,
+    asset_id: assetId,
+    sha256: actual.sha256,
+    size_bytes: actual.size,
+  });
+  const completed = await getArtifactRow(c.env.DB, appId, assetId);
+  return c.json(artifactResponse(c, completed!));
+}
+
+export async function handleGetIosSimulatorArtifact(c: Context<{ Bindings: Env }>) {
+  const row = await getArtifactRow(
+    c.env.DB,
+    c.req.param("appId") ?? "",
+    c.req.param("assetId") ?? "",
+  );
+  if (!row) return c.json({ error: "QA artifact not found" }, 404);
+  return c.json(artifactResponse(c, row));
+}
+
+export async function handleListIosSimulatorArtifacts(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const conditions = ["a.id = ?1", "b.product_type = ?2", "ba.artifact_kind = ?3"];
+  const binds: Array<string | number> = [appId, IOS_SIMULATOR_QA_PRODUCT_TYPE, IOS_SIMULATOR_ARTIFACT_KIND];
+  const sourceCommit = c.req.query("source_commit")?.trim().toLowerCase();
+  const githubRunId = c.req.query("github_run_id")?.trim();
+  const declaredSha = c.req.query("sha256")?.trim().toLowerCase();
+  if (sourceCommit) {
+    conditions.push(`json_extract(b.provenance_json, '$.source_commit') = ?${binds.length + 1}`);
+    binds.push(sourceCommit);
+  }
+  if (githubRunId) {
+    conditions.push(`json_extract(b.provenance_json, '$.github_run_id') = ?${binds.length + 1}`);
+    binds.push(githubRunId);
+  }
+  if (declaredSha) {
+    conditions.push(`ba.file_hash = ?${binds.length + 1}`);
+    binds.push(declaredSha);
+  }
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT a.id AS app_id, a.slug AS app_slug,
+              b.id AS build_id, ba.id AS asset_id,
+              b.channel_id, c.slug AS channel, b.status AS build_status,
+              b.version_name, b.version_code, b.build_metadata_json, b.provenance_json,
+              ba.artifact_kind, ba.platform, ba.arch, ba.variant, ba.filetype,
+              ba.r2_key, ba.file_hash, ba.size_bytes,
+              ba.metadata_json AS asset_metadata_json,
+              ba.download_count, ba.created_at, b.completed_at
+       FROM build_assets ba
+       JOIN builds b ON b.id = ba.build_id
+       JOIN apps a ON a.id = b.app_id
+       LEFT JOIN channels c ON c.id = b.channel_id
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY ba.created_at DESC
+       LIMIT 100`,
+    )
+    .bind(...binds)
+    .all<IosSimulatorArtifactRow>();
+  return c.json({ artifacts: results.map((row) => artifactResponse(c, row)) });
+}
+
+export async function handleDownloadIosSimulatorArtifact(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const assetId = c.req.param("assetId") ?? "";
+  const row = await getArtifactRow(c.env.DB, appId, assetId);
+  if (!row) return c.json({ error: "QA artifact not found" }, 404);
+  if (artifactState(row) !== "ready") {
+    return c.json({ error: "QA artifact is not ready", code: "QA_ARTIFACT_NOT_READY" }, 409);
+  }
+  const metadata = parseJsonObject(row.asset_metadata_json);
+  const filename = typeof metadata.filename === "string" ? metadata.filename : `${assetId}.app.zip`;
+  const disposition = `attachment; filename="${filename.replace(/["\\]/g, "_")}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+  const objectHead = await c.env.APK_BUCKET.head(row.r2_key);
+  if (!objectHead) return c.json({ error: "stored object not found" }, 404);
+
+  if (c.req.query("presign") === "1") {
+    const ttl = Number(c.env.R2_PRESIGNED_DOWNLOAD_TTL_SECONDS ?? c.env.SIGNED_URL_TTL_SECONDS ?? "3600");
+    const url = await presignR2DownloadUrl(c.env, {
+      key: row.r2_key,
+      filetype: "zip",
+      contentDisposition: disposition,
+    }, ttl);
+    if (!url) return c.json({ error: "presigned downloads are unavailable" }, 503);
+    return c.json({
+      build_id: row.build_id,
+      asset_id: row.asset_id,
+      filename,
+      size_bytes: row.size_bytes,
+      sha256: row.file_hash,
+      download_url: url,
+    });
+  }
+
+  const object = await c.env.APK_BUCKET.get(row.r2_key);
+  if (!object) return c.json({ error: "stored object not found" }, 404);
+  await c.env.DB
+    .prepare("UPDATE build_assets SET download_count = download_count + 1 WHERE id = ?1")
+    .bind(assetId)
+    .run();
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+  headers.set("content-type", "application/zip");
+  headers.set("content-length", String(row.size_bytes));
+  headers.set("content-disposition", disposition);
+  headers.set("cache-control", "private, max-age=0, no-store");
+  headers.set("etag", object.httpEtag);
+  return new Response(object.body, { headers });
+}

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -148,6 +148,9 @@ export async function createRelease(
   if (!input.build_id) throw new Error("build_id required");
   const build = await getBuildForApp(db, appId, input.build_id);
   if (!build) throw new Error("build not found");
+  if (build.product_type === "ios-simulator-qa" || build.release_type === "qa") {
+    throw new Error("QA-only builds cannot be attached to releases");
+  }
 
   const channelId = input.channel_id ?? build.channel_id;
   if (!channelId) throw new Error("channel_id required");

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6342,6 +6342,158 @@ describe("Hands iOS simulator QA artifacts", () => {
     await expect(retry.json()).resolves.toMatchObject({ code: "QA_ARTIFACT_VERIFICATION_FAILED" });
   });
 
+  it("allows exactly one concurrent complete request to enter verifying", async () => {
+    const { env, objects } = makeEnv();
+    const bytes = new TextEncoder().encode("concurrent complete fixture");
+    const createdResponse = await handleCreateIosSimulatorArtifact(
+      context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, declaration(bytes)),
+    );
+    const created = await createdResponse.json() as any;
+    const stored = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+      .bind(created.asset_id)
+      .first() as { r2_key: string } | null;
+    objects.set(stored!.r2_key, bytes);
+
+    const bucket = env.APK_BUCKET as any;
+    const originalHead = bucket.head.bind(bucket);
+    let releaseFirstHead!: () => void;
+    const firstHeadBlocked = new Promise<void>((resolveBlocked) => {
+      bucket.head = async (key: string) => {
+        if (key === stored!.r2_key) {
+          await new Promise<void>((resolveRelease) => {
+            releaseFirstHead = resolveRelease;
+            resolveBlocked();
+          });
+        }
+        return originalHead(key);
+      };
+    });
+
+    const first = handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    await firstHeadBlocked;
+    const loser = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(loser.status).toBe(409);
+    await expect(loser.json()).resolves.toMatchObject({ code: "QA_ARTIFACT_VERIFICATION_IN_PROGRESS" });
+    releaseFirstHead();
+    const winner = await first;
+    expect(winner.status).toBe(200);
+    await expect(winner.json()).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it("hashes and seals the same staging byte stream even if the upload key is overwritten during complete", async () => {
+    const { env, objects } = makeEnv();
+    const original = new TextEncoder().encode("original-stream");
+    const overwritten = new TextEncoder().encode("tampered-stream");
+    expect(overwritten.byteLength).toBe(original.byteLength);
+    const createdResponse = await handleCreateIosSimulatorArtifact(
+      context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, declaration(original)),
+    );
+    const created = await createdResponse.json() as any;
+    const stored = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+      .bind(created.asset_id)
+      .first() as { r2_key: string } | null;
+    objects.set(stored!.r2_key, original);
+
+    const bucket = env.APK_BUCKET as any;
+    const originalGet = bucket.get.bind(bucket);
+    let overwrittenOnce = false;
+    bucket.get = async (key: string) => {
+      const snapshot = await originalGet(key);
+      if (key === stored!.r2_key && !overwrittenOnce) {
+        overwrittenOnce = true;
+        objects.set(key, overwritten);
+      }
+      return snapshot;
+    };
+
+    const complete = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(complete.status).toBe(200);
+    const completed = await complete.json() as any;
+    expect(completed.server_sha256).toBe(declaration(original).sha256);
+
+    const download = await handleDownloadIosSimulatorArtifact(
+      context(env, "GET", `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/download`, {
+        appId: "app-ios",
+        assetId: created.asset_id,
+      }),
+    );
+    const downloaded = new Uint8Array(await download.arrayBuffer());
+    expect(createHash("sha256").update(downloaded).digest("hex")).toBe(declaration(original).sha256);
+    expect(createHash("sha256").update(downloaded).digest("hex")).not.toBe(
+      createHash("sha256").update(overwritten).digest("hex"),
+    );
+  });
+
+  it("rejects oversized staging objects from metadata without streaming them", async () => {
+    const { env, objects } = makeEnv();
+    const bytes = new TextEncoder().encode("small declaration");
+    const createdResponse = await handleCreateIosSimulatorArtifact(
+      context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, declaration(bytes)),
+    );
+    const created = await createdResponse.json() as any;
+    const stored = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+      .bind(created.asset_id)
+      .first() as { r2_key: string } | null;
+    objects.set(stored!.r2_key, bytes);
+
+    const bucket = env.APK_BUCKET as any;
+    const originalHead = bucket.head.bind(bucket);
+    const originalGet = bucket.get.bind(bucket);
+    let getCalls = 0;
+    bucket.head = async (key: string) => key === stored!.r2_key
+      ? { size: 500 * 1024 * 1024 + 1, httpEtag: '"oversized"', writeHttpMetadata: () => undefined }
+      : originalHead(key);
+    bucket.get = async (key: string) => {
+      getCalls += 1;
+      return originalGet(key);
+    };
+
+    const response = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "QA_ARTIFACT_INTEGRITY_MISMATCH",
+      actual: { size_bytes: 500 * 1024 * 1024 + 1 },
+    });
+    expect(getCalls).toBe(0);
+    expect(objects.has(stored!.r2_key)).toBe(false);
+
+    const readback = await handleGetIosSimulatorArtifact(
+      context(env, "GET", `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}`, {
+        appId: "app-ios",
+        assetId: created.asset_id,
+      }),
+    );
+    await expect(readback.json()).resolves.toMatchObject({ status: "failed" });
+  });
+
   it("explicitly excludes QA-only builds from public latest, update offers, and latest landing", async () => {
     const { env } = makeEnv();
     const now = Date.now();

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -37,6 +37,13 @@ import { openApiDocument } from "../src/openapi";
 import { handleCreateApp, handleListApps, handleUpdateFeatureFlag } from "../src/routes/apps";
 import { createSignedJwt, handleAuthLogin, handleAuthMe, handleDashboardRedirect } from "../src/routes/auth";
 import { handleListOrgs } from "../src/routes/orgs";
+import {
+  handleCompleteIosSimulatorArtifact,
+  handleCreateIosSimulatorArtifact,
+  handleDownloadIosSimulatorArtifact,
+  handleGetIosSimulatorArtifact,
+  handleListIosSimulatorArtifacts,
+} from "../src/routes/qa_artifacts";
 
 // ---------- Test harness ----------
 
@@ -80,6 +87,10 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/builds",
       "/api/apps/{appId}/builds/publish-version",
       "/api/apps/{appId}/builds/{buildId}/external-targets",
+      "/api/apps/{appId}/qa-artifacts/ios-simulator",
+      "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}",
+      "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/complete",
+      "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/download",
       "/api/apps/{appId}/releases/{releaseId}/publish",
       "/api/apps/{appId}/feedback/{ticketId}/comments",
       "/api/apps/{appId}/client-key",
@@ -6049,5 +6060,426 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(response.status).toBe(404);
     const body = await responseJson<any>(response);
     expect(body.error).toBe("matched release has no compatible asset");
+  });
+});
+
+// =============================================================================
+// QA-only exact iOS simulator artifacts
+// =============================================================================
+
+describe("Hands iOS simulator QA artifacts", () => {
+  function makeEnv() {
+    const env = makeMockEnv();
+    env.R2_ACCOUNT_ID = "test-account";
+    env.R2_BUCKET_NAME = "hands-artifacts";
+    env.R2_S3_ACCESS_KEY_ID = "test-access-key";
+    env.R2_S3_SECRET_ACCESS_KEY = "test-secret-key";
+    env.R2_PRESIGNED_DOWNLOAD_TTL_SECONDS = "600";
+    env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).bind("app-ios", "default", "raft-ios", "Raft iOS", "ios", 1).run();
+    env.DB.prepare(
+      `INSERT INTO channels (id, app_id, slug, name, enabled_product_types_json, metadata_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).bind("ch-ios-main", "app-ios", "main", "Main", "[]", "{}", 1).run();
+
+    const objects = new Map<string, Uint8Array>();
+    env.APK_BUCKET = {
+      put: async (key: string, value: ArrayBuffer | ArrayBufferView | ReadableStream | string) => {
+        const bytes = typeof value === "string"
+          ? new TextEncoder().encode(value)
+          : value instanceof ReadableStream
+            ? new Uint8Array(await new Response(value).arrayBuffer())
+            : value instanceof ArrayBuffer
+              ? new Uint8Array(value)
+              : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+        objects.set(key, new Uint8Array(bytes));
+      },
+      head: async (key: string) => {
+        const bytes = objects.get(key);
+        return bytes
+          ? { size: bytes.byteLength, httpEtag: `"${key}"`, writeHttpMetadata: () => undefined }
+          : null;
+      },
+      get: async (key: string) => {
+        const bytes = objects.get(key);
+        if (!bytes) return null;
+        return {
+          body: new Response(bytes).body!,
+          size: bytes.byteLength,
+          httpEtag: `"${key}"`,
+          writeHttpMetadata(headers: Headers) {
+            headers.set("content-type", "application/zip");
+          },
+        };
+      },
+      delete: async (key: string) => {
+        objects.delete(key);
+      },
+    };
+    return { env, objects };
+  }
+
+  function context(
+    env: MockEnv,
+    method: string,
+    path: string,
+    params: Record<string, string>,
+    body?: unknown,
+  ) {
+    const url = new URL(`https://hands.test${path}`);
+    return {
+      env,
+      req: {
+        url: url.toString(),
+        raw: new Request(url, { method }),
+        param: (name: string) => params[name] ?? "",
+        query: (name: string) => url.searchParams.get(name) ?? undefined,
+        header: (_name: string) => undefined,
+        json: async () => body,
+      },
+      get: (name: string) => (name === "admin_actor" ? "raft:test-agent@test" : undefined),
+      header: (_name: string, _value: string) => undefined,
+      json: (data: unknown, status = 200) => Response.json(data, { status }),
+    } as any;
+  }
+
+  const declaration = (bytes: Uint8Array) => ({
+    filename: "raft-ios-simulator.app.zip",
+    size_bytes: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    source_commit: "470023f98d154e50d7ba07b01a2cd53eb4367fc9",
+    version_name: "1.0",
+    build_number: "1",
+    bundle_id: "build.raft.app",
+    github_run_id: "29700366778",
+    github_artifact_id: "8446353537",
+    github_job_id: "88230185690",
+    github_repository: "botiverse/mobile",
+  });
+
+  it("round-trips exact bytes with durable build/asset coordinates and full provenance", async () => {
+    const { env, objects } = makeEnv();
+    const bytes = new TextEncoder().encode("exact iOS simulator .app.zip fixture");
+
+    const createdResponse = await handleCreateIosSimulatorArtifact(
+      context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, declaration(bytes)),
+    );
+    expect(createdResponse.status).toBe(201);
+    const created = await createdResponse.json() as any;
+    expect(created).toMatchObject({
+      kind: "ios-simulator-app",
+      artifact_kind: "ios-simulator-app",
+      qa_only: true,
+      release_offer_eligible: false,
+      status: "pending_upload",
+      filename: "raft-ios-simulator.app.zip",
+      source_commit: declaration(bytes).source_commit,
+      version_name: "1.0",
+      version: "1.0",
+      version_code: 1,
+      build_number: "1",
+      build_run_id: "29700366778",
+      bundle_id: "build.raft.app",
+      github: {
+        run_id: "29700366778",
+        artifact_id: "8446353537",
+        job_id: "88230185690",
+      },
+    });
+    expect(created.build_id).toMatch(/[0-9a-f-]{36}/);
+    expect(created.asset_id).toMatch(/[0-9a-f-]{36}/);
+    expect(created.upload).toMatchObject({ method: "PUT", headers: { "content-type": "application/zip" } });
+    expect(created.upload.url).toContain("test-account.r2.cloudflarestorage.com");
+    expect(created.download_api).toBe(
+      `https://hands.test/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/download`,
+    );
+
+    const stored = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+      .bind(created.asset_id)
+      .first() as { r2_key: string } | null;
+    objects.set(stored!.r2_key, bytes);
+
+    const completeResponse = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(completeResponse.status).toBe(200);
+    const completed = await completeResponse.json() as any;
+    expect(completed.status).toBe("ready");
+    expect(completed.verification).toMatchObject({
+      verified_sha256: declaration(bytes).sha256,
+      verified_size_bytes: bytes.byteLength,
+    });
+    expect(completed.server_sha256).toBe(declaration(bytes).sha256);
+    const sealed = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+      .bind(created.asset_id)
+      .first() as { r2_key: string } | null;
+    expect(sealed!.r2_key).toContain("/qa/ios-simulator/verified/");
+    expect(objects.has(stored!.r2_key)).toBe(false);
+    expect(objects.has(sealed!.r2_key)).toBe(true);
+
+    // A still-valid stale PUT URL can only recreate the pending key; the
+    // completed asset points at a separate sealed key and cannot be replaced.
+    objects.set(stored!.r2_key, new TextEncoder().encode("late overwrite attempt"));
+    const secondComplete = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(secondComplete.status).toBe(409);
+    await expect(secondComplete.json()).resolves.toMatchObject({ code: "QA_ARTIFACT_ALREADY_COMPLETED" });
+
+    const getResponse = await handleGetIosSimulatorArtifact(
+      context(env, "GET", `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}`, {
+        appId: "app-ios",
+        assetId: created.asset_id,
+      }),
+    );
+    expect(await getResponse.json()).toMatchObject({
+      build_id: created.build_id,
+      asset_id: created.asset_id,
+      sha256: declaration(bytes).sha256,
+      server_sha256: declaration(bytes).sha256,
+      status: "ready",
+    });
+
+    const listResponse = await handleListIosSimulatorArtifacts(
+      context(
+        env,
+        "GET",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator?source_commit=${declaration(bytes).source_commit}&github_run_id=29700366778`,
+        { appId: "app-ios" },
+      ),
+    );
+    const listed = await listResponse.json() as any;
+    expect(listed.artifacts).toHaveLength(1);
+    expect(listed.artifacts[0].asset_id).toBe(created.asset_id);
+
+    const presignResponse = await handleDownloadIosSimulatorArtifact(
+      context(
+        env,
+        "GET",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/download?presign=1`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    const presigned = await presignResponse.json() as any;
+    expect(presigned).toMatchObject({
+      build_id: created.build_id,
+      asset_id: created.asset_id,
+      filename: "raft-ios-simulator.app.zip",
+      sha256: declaration(bytes).sha256,
+      size_bytes: bytes.byteLength,
+    });
+    expect(presigned.download_url).toContain("X-Amz-Signature=");
+
+    const downloadResponse = await handleDownloadIosSimulatorArtifact(
+      context(env, "GET", `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/download`, {
+        appId: "app-ios",
+        assetId: created.asset_id,
+      }),
+    );
+    expect(downloadResponse.status).toBe(200);
+    const downloaded = new Uint8Array(await downloadResponse.arrayBuffer());
+    expect(createHash("sha256").update(downloaded).digest("hex")).toBe(declaration(bytes).sha256);
+    expect(downloadResponse.headers.get("content-disposition")).toContain("raft-ios-simulator.app.zip");
+
+    const { createRelease } = await import("../src/routes/releases");
+    await expect(
+      createRelease(env.DB as any, "app-ios", { build_id: created.build_id, status: "draft" }, "tester"),
+    ).rejects.toThrow("QA-only builds cannot be attached to releases");
+  });
+
+  it("fails closed and deletes uploaded bytes when exact SHA-256 does not match", async () => {
+    const { env, objects } = makeEnv();
+    const declared = new TextEncoder().encode("declared bytes");
+    const createdResponse = await handleCreateIosSimulatorArtifact(
+      context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, declaration(declared)),
+    );
+    const created = await createdResponse.json() as any;
+    const stored = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+      .bind(created.asset_id)
+      .first() as { r2_key: string } | null;
+    objects.set(stored!.r2_key, new TextEncoder().encode("tampered bytes"));
+
+    const response = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({ code: "QA_ARTIFACT_INTEGRITY_MISMATCH" });
+    expect(objects.has(stored!.r2_key)).toBe(false);
+
+    const getResponse = await handleGetIosSimulatorArtifact(
+      context(env, "GET", `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}`, {
+        appId: "app-ios",
+        assetId: created.asset_id,
+      }),
+    );
+    await expect(getResponse.json()).resolves.toMatchObject({ status: "failed" });
+
+    const retry = await handleCompleteIosSimulatorArtifact(
+      context(
+        env,
+        "POST",
+        `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+        { appId: "app-ios", assetId: created.asset_id },
+      ),
+    );
+    expect(retry.status).toBe(409);
+    await expect(retry.json()).resolves.toMatchObject({ code: "QA_ARTIFACT_VERIFICATION_FAILED" });
+  });
+
+  it("explicitly excludes QA-only builds from public latest, update offers, and latest landing", async () => {
+    const { env } = makeEnv();
+    const now = Date.now();
+    await env.DB.prepare("UPDATE apps SET public_history = 1 WHERE id = ?1").bind("app-ios").run();
+    await env.DB.prepare(
+      `INSERT INTO builds
+       (id, app_id, channel_id, product_type, release_type, version_name, version_code,
+        source, status, build_metadata_json, parsed_metadata_json, provenance_json,
+        created_at, updated_at, completed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      "qa-public-build",
+      "app-ios",
+      "ch-ios-main",
+      "ios-simulator-qa",
+      "qa",
+      "9.9",
+      99,
+      "qa-artifact",
+      "succeeded",
+      '{"qa_only":true}',
+      "{}",
+      "{}",
+      now,
+      now,
+      now,
+    ).run();
+    // Deliberately attach an installable-shaped asset and inject an active
+    // release directly, bypassing createRelease, to prove public queries keep
+    // their own defense-in-depth exclusion.
+    await env.DB.prepare(
+      `INSERT INTO build_assets
+       (id, build_id, artifact_kind, platform, arch, variant, filetype, r2_key,
+        file_hash, size_bytes, metadata_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      "qa-malicious-installable",
+      "qa-public-build",
+      "installable",
+      "ios",
+      "arm64",
+      "simulator",
+      "ipa",
+      "apps/app-ios/qa-malicious.ipa",
+      "deadbeef",
+      42,
+      "{}",
+      now,
+    ).run();
+    await env.DB.prepare(
+      `INSERT INTO releases
+       (id, app_id, build_id, channel_id, product_type, release_type, status,
+        is_full, changelog, created_by, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      "qa-malicious-release",
+      "app-ios",
+      "qa-public-build",
+      "ch-ios-main",
+      "ios-simulator-qa",
+      "qa",
+      "active",
+      1,
+      "must stay private",
+      "tester",
+      now,
+      now,
+    ).run();
+    await env.DB.prepare(
+      "INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).bind("qa-malicious-scope", "qa-malicious-release", "full", "all", now).run();
+
+    const { handlePublicV2Latest, handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    const latest = await handlePublicV2Latest(
+      context(env, "GET", "/public/v2/apps/raft-ios/latest?channel=main", { slug: "raft-ios" }),
+    );
+    expect(latest.status).toBe(404);
+
+    const update = await handlePublicV2UpdateCheck(
+      context(
+        env,
+        "GET",
+        "/public/v2/apps/raft-ios/updates/check?channel=main&current_version_code=1&platform=ios&filetype=ipa",
+        { slug: "raft-ios" },
+      ),
+    );
+    expect(update.status).toBe(404);
+
+    const { handlePublicLatestReleaseLanding } = await import("../src/routes/history");
+    const landing = await handlePublicLatestReleaseLanding(
+      context(env, "GET", "/apps/raft-ios/latest?channel=main", { slug: "raft-ios" }),
+    );
+    expect(landing.status).toBe(404);
+    await expect(landing.text()).resolves.toBe("No active release");
+  });
+
+  it("rejects IPA-shaped declarations instead of treating them as simulator QA artifacts", async () => {
+    const { env } = makeEnv();
+    const bytes = new TextEncoder().encode("fixture");
+    const response = await handleCreateIosSimulatorArtifact(
+      context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, {
+        ...declaration(bytes),
+        filename: "raft-ios.ipa",
+      }),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: "INVALID_QA_ARTIFACT" });
+  });
+
+  it("publishes the full create/upload/complete/read/download Agent Login action surface", async () => {
+    const { env } = makeEnv();
+    const { handleAgentManifest } = await import("../src/routes/auth");
+    const response = await handleAgentManifest(
+      context(env, "GET", "/.well-known/raft-agent-manifest.json", {}),
+    );
+    const manifest = await response.json() as any;
+    const actions = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action.endpoint]));
+    expect(actions).toMatchObject({
+      "list-ios-simulator-artifacts": {
+        method: "GET",
+        path: "/api/apps/{app_id}/qa-artifacts/ios-simulator",
+      },
+      "create-ios-simulator-artifact": {
+        method: "POST",
+        path: "/api/apps/{app_id}/qa-artifacts/ios-simulator",
+      },
+      "complete-ios-simulator-artifact": {
+        method: "POST",
+        path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/complete",
+      },
+      "get-ios-simulator-artifact": {
+        method: "GET",
+        path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}",
+      },
+      "presign-ios-simulator-artifact": {
+        method: "GET",
+        path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/download?presign=1",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add a QA-only `ios-simulator-app` artifact flow backed by the existing Hands build/asset ledger and R2
- expose Agent Login actions for create, complete, list/read, and durable authenticated/presigned download
- persist filename, declared/server SHA-256, size, source commit/ref, version/version code/build number, bundle id, GitHub repository/run/artifact/job provenance
- make completion one-shot: verify the staging object by streaming SHA-256, seal exact bytes to a separate immutable R2 key, then delete staging
- reject QA-only builds from release creation and explicitly exclude them from public latest/update/history/download queries
- document the Stamp/agent create → PUT → complete → download workflow

## Contract

- input must be a safe `*.app.zip`; IPA/APK shapes are rejected
- response exposes `kind=ios-simulator-app`, `qa_only=true`, `release_offer_eligible=false`, `build_id`, `asset_id`, `server_sha256`, `build_run_id`, provenance, and stable `artifact_api` / `download_api`
- a stale presigned PUT can only recreate the discarded staging key; it cannot replace the verified object referenced by the ready asset
- mismatch returns `422 QA_ARTIFACT_INTEGRITY_MISMATCH`, deletes uploaded bytes, and permanently leaves the artifact non-consumable

## Validation

- `pnpm -w build` ✅
- `pnpm -w test` ✅ — 209 tests
- focused route suite ✅ — 123 tests, including:
  - exact create/upload/complete/read/list/download round-trip
  - server SHA/size verification
  - one-shot completion + stale-upload overwrite isolation
  - tampered upload fail-closed behavior
  - Agent Login action manifest
  - create-release rejection
  - explicit public latest/update/landing exclusion even when a QA release row is injected directly
- `pnpm -w lint` remains blocked by the pre-existing ESLint 9 missing `eslint.config.*`

## Fixture readiness

Downloaded the canonical GitHub Actions fixture locally and independently confirmed:

- `raft-ios-simulator.app.zip`
- 37,563,642 bytes
- SHA-256 `885b328f3a72299bd4368fd876dbcb4a8646b6f15b6e656fc8bec396a62beac8`
- Actions artifact `8446353537`, run `29700366778`

The required real Hands upload → complete → download round-trip must run after this Worker change is merged and deployed; that production evidence is the remaining acceptance step for task #166.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787083561&installation_id=145465820&pr_number=320&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F320&signature=68f05a2a793f1649de406dd20a01c41573c98c50d26b22ddc008177e557405ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->