### PR TITLE
fix(worker): preserve fixed length for simulator R2 seal

### DIFF
--- a/worker/src/routes/qa_artifacts.ts
+++ b/worker/src/routes/qa_artifacts.ts
@@ -439,6 +439,26 @@ function limitObjectBody(
   );
 }
 
+function fixedLengthSealBody(
+  body: ReadableStream<Uint8Array>,
+  expectedBytes: number,
+): { readable: ReadableStream<Uint8Array>; pump: Promise<void> } {
+  // Cloudflare R2 rejects transformed/tee'd streams whose byte length is no
+  // longer encoded in the stream type. Re-wrap the seal branch so R2 can
+  // validate Content-Length while preserving the single-snapshot tee.
+  if (typeof FixedLengthStream === "undefined") {
+    // Node/vitest does not provide this Workers runtime primitive. Tests still
+    // exercise the byte flow with an ordinary stream, and a dedicated test
+    // installs a strict polyfill that rejects non-fixed final puts.
+    return { readable: body, pump: Promise.resolve() };
+  }
+  const fixed = new FixedLengthStream(expectedBytes);
+  return {
+    readable: fixed.readable,
+    pump: body.pipeTo(fixed.writable),
+  };
+}
+
 async function transitionToVerifying(
   db: D1Database,
   row: IosSimulatorArtifactRow,
@@ -601,9 +621,11 @@ export async function handleCompleteIosSimulatorArtifact(c: AdminContext) {
   // so a still-valid presigned PUT cannot create a hash/copy TOCTOU window.
   const limitedBody = limitObjectBody(object.body, row.size_bytes);
   const [hashStream, sealStream] = limitedBody.tee();
-  const [hashResult, sealResult] = await Promise.allSettled([
+  const fixedSeal = fixedLengthSealBody(sealStream, row.size_bytes);
+  const [hashResult, pumpResult, sealResult] = await Promise.allSettled([
     hashObjectBody(hashStream),
-    c.env.APK_BUCKET.put(finalR2Key, sealStream, {
+    fixedSeal.pump,
+    c.env.APK_BUCKET.put(finalR2Key, fixedSeal.readable, {
       httpMetadata: { contentType: "application/zip" },
       customMetadata: {
         sha256: row.file_hash,
@@ -612,15 +634,22 @@ export async function handleCompleteIosSimulatorArtifact(c: AdminContext) {
       },
     }),
   ]);
-  if (hashResult.status === "rejected" || sealResult.status === "rejected") {
+  if (
+    hashResult.status === "rejected" ||
+    pumpResult.status === "rejected" ||
+    sealResult.status === "rejected"
+  ) {
+    const detail = hashResult.status === "rejected"
+      ? String(hashResult.reason)
+      : pumpResult.status === "rejected"
+        ? String(pumpResult.reason)
+        : String((sealResult as PromiseRejectedResult).reason);
     await failVerification(
       c,
       row,
       {
         verification_error: "stream_or_seal_failed",
-        detail: hashResult.status === "rejected"
-          ? String(hashResult.reason)
-          : String((sealResult as PromiseRejectedResult).reason),
+        detail,
       },
       [row.r2_key, finalR2Key],
     );

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6445,6 +6445,63 @@ describe("Hands iOS simulator QA artifacts", () => {
     );
   });
 
+  it("wraps the verified R2 put in a Workers FixedLengthStream", async () => {
+    const previousFixedLengthStream = (globalThis as any).FixedLengthStream;
+    class StrictFixedLengthStream {
+      readable: ReadableStream<Uint8Array>;
+      writable: WritableStream<Uint8Array>;
+
+      constructor(expectedBytes: number | bigint) {
+        const stream = new TransformStream<Uint8Array, Uint8Array>();
+        this.readable = stream.readable;
+        this.writable = stream.writable;
+        (this.readable as any).__expectedBytes = Number(expectedBytes);
+      }
+    }
+    (globalThis as any).FixedLengthStream = StrictFixedLengthStream;
+
+    try {
+      const { env, objects } = makeEnv();
+      const bytes = new TextEncoder().encode("fixed-length R2 fixture");
+      const createdResponse = await handleCreateIosSimulatorArtifact(
+        context(env, "POST", "/api/apps/app-ios/qa-artifacts/ios-simulator", { appId: "app-ios" }, declaration(bytes)),
+      );
+      const created = await createdResponse.json() as any;
+      const stored = await env.DB.prepare("SELECT r2_key FROM build_assets WHERE id = ?1")
+        .bind(created.asset_id)
+        .first() as { r2_key: string } | null;
+      objects.set(stored!.r2_key, bytes);
+
+      const bucket = env.APK_BUCKET as any;
+      const originalPut = bucket.put.bind(bucket);
+      let sawFixedLengthFinalPut = false;
+      bucket.put = async (key: string, value: ReadableStream, options: unknown) => {
+        if (key.includes("/qa/ios-simulator/verified/")) {
+          expect((value as any).__expectedBytes).toBe(bytes.byteLength);
+          sawFixedLengthFinalPut = true;
+        }
+        return originalPut(key, value, options);
+      };
+
+      const response = await handleCompleteIosSimulatorArtifact(
+        context(
+          env,
+          "POST",
+          `/api/apps/app-ios/qa-artifacts/ios-simulator/${created.asset_id}/complete`,
+          { appId: "app-ios", assetId: created.asset_id },
+        ),
+      );
+      expect(response.status).toBe(200);
+      expect(sawFixedLengthFinalPut).toBe(true);
+    } finally {
+      if (previousFixedLengthStream === undefined) {
+        delete (globalThis as any).FixedLengthStream;
+      } else {
+        (globalThis as any).FixedLengthStream = previousFixedLengthStream;
+      }
+    }
+  });
+
   it("rejects oversized staging objects from metadata without streaming them", async () => {
     const { env, objects } = makeEnv();
     const bytes = new TextEncoder().encode("small declaration");


### PR DESCRIPTION
## Production finding

The first real `raft-ios-simulator.app.zip` upload reached R2 successfully (HTTP 200, 37,563,642 bytes), but `complete` failed while sealing the tee/Transform output into the immutable final key. Cloudflare R2 requires transformed streams to be re-wrapped in a Workers `FixedLengthStream`; the Node mock accepted an ordinary `ReadableStream`, so this runtime contract was not covered by PR #320.

The failed production artifact (`6442c83c-03a2-491f-94af-cdf5195f9dca`) correctly became permanently `failed` and is not consumable.

## Fix

- wrap the seal branch in `FixedLengthStream(declaredSize)`
- pump the single-snapshot tee branch into the fixed-length writable while R2 consumes its readable
- wait for hash, fixed-length pump, and R2 put together; any rejection deletes staging/final and transitions `verifying -> failed`
- retain the same single-GET/same-stream integrity and concurrency protections from PR #320

## Regression

A strict test polyfills `FixedLengthStream` and rejects the immutable R2 put unless the body carries the declared fixed-length contract. This fails against the deployed #320 shape and passes with this patch.

## Validation

- Worker build ✅
- focused routes: 127/127 ✅
- full workspace build ✅
- full workspace tests: 213 ✅ (worker 175)
- lint remains the pre-existing ESLint 9 flat-config blocker

After merge/deploy I will create a new artifact and repeat the original, unmodified SHA `885b328f3a72299bd4368fd876dbcb4a8646b6f15b6e656fc8bec396a62beac8` production round-trip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/botiverse/codesmith/hands/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787084742&installation_id=145465820&pr_number=321&repository=botiverse%2Fhands&return_to=https%3A%2F%2Fgithub.com%2Fbotiverse%2Fhands%2Fpull%2F321&signature=bffcecdef4e090038a8882eda3e4965d17de35378612bd4cbc959324aa30f400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->