### PR TITLE
feat(feedback): add web app identity and idempotent submissions

### DIFF
--- a/admin/src/components/AppCreationWizard.tsx
+++ b/admin/src/components/AppCreationWizard.tsx
@@ -80,7 +80,7 @@ const DEFAULT_PRODUCT_TYPES: Array<{
   },
 ];
 
-const APP_PLATFORMS = ["android", "ios", "ohos", "electron", "node"] as const;
+const APP_PLATFORMS = ["android", "ios", "ohos", "electron", "node", "web"] as const;
 type AppPlatform = (typeof APP_PLATFORMS)[number];
 
 const DEFAULT_CHANNELS = [

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -246,14 +246,17 @@ find and rotate the key in the app's Settings tab or via
 | Field | Required | Description |
 |---|---|---|
 | `message` | Yes | Feedback text (max 10,000 chars). |
+| `submission_id` | No | Client-generated UUID for idempotent retries. Keep it fixed for one draft. An exact replay returns the original ticket; reusing it with different content returns `409`. |
 | `kind` | No | `feedback` (default), `bug`, or `crash`. |
 | `contact` | No | Reply-to handle (email, Raft name, …). |
 | `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. Crash tickets add `crash_exception_class` / `crash_top_frame` (grouping signature) and, for native crashes, `crash_native_frames` — an array of `{ index, offset, soname, build_id }` that the server symbolicates against the build's `native-symbols` asset. |
 | `attachments` | No | Inline files (multipart), up to 10 MB each, ≤9 total. |
 | `presigned` | No | JSON array of `{ r2_key, filename, content_type, size }` for files already uploaded via the presign flow (below). |
 
-Returns `201` with the full ticket UUID in `id`, plus a copyable `reference`
-and `ticket_url`, for example `{ "id": "<ticket UUID>", "status": "open",
+Returns `201` for a new ticket. An exact `submission_id` replay returns `200`
+with the same ticket and `idempotent_replay: true`. Both responses include the
+full ticket UUID in `id`, plus a copyable `reference` and `ticket_url`, for
+example `{ "id": "<ticket UUID>", "status": "open",
 "reference": "raft-android · 1.0.4 (1000400) · ticket <ticket UUID>",
 "ticket_url": "https://app.hands.build/apps/<appId>/feedback/<ticket UUID>" }`.
 Rate limit: 10 submissions per hour per app + client IP. Tickets appear in
@@ -261,6 +264,34 @@ the admin Feedback tab; a `feedback:new` webhook fires for subscribed
 endpoints (crash tickets can additionally trigger `crash:new_group` /
 `crash:spike`). The Android SDK's `HandsFeedback.submit(...)` wraps this
 endpoint and attaches device metadata automatically.
+
+### Trusted server-proxy rate identity
+
+A server that proxies many signed-in users through one egress IP can avoid a
+shared global bucket by sending both:
+
+```http
+Authorization: Bearer qvdt_...  # granted feedback:write
+X-Hands-Reporter-Id: <stable opaque base64url value>
+```
+
+The bearer must be a non-expired, non-revoked app token granted only the
+`feedback:write` permission and scoped to the same app. Scoped tokens do not
+inherit the legacy viewer/publisher role and cannot authenticate to Hands
+admin/read APIs unless a route explicitly requires one of their named
+permissions. The optional reporter id is an external subject identifier chosen
+by the integrator. It should be stable, opaque, and app/integration scoped — for
+example a random id stored in the integrator's account table or a keyed
+pseudonym — never a raw email, username, or internal database id. Hands stores
+it as the pseudonymous ticket owner and returns it through authenticated ticket
+and webhook contracts; the integrator decides whether to keep a reverse mapping
+for two-way support. Omitting the id yields anonymous, non-addressable tickets.
+Hands applies the 100/hour
+safety limit to the app + reporter id; the trusted proxy can enforce its own
+lower product limit. Supplying the reporter header without a matching app
+deploy token returns `401`; ordinary SDK submissions that omit it continue to
+use the 10/hour app + client-IP bucket. Rate-limit responses include a dynamic
+`Retry-After` header.
 
 ## Metrics Ingest
 

--- a/migrations/sql/0050_feedback_idempotency.sql
+++ b/migrations/sql/0050_feedback_idempotency.sql
@@ -1,0 +1,11 @@
+ALTER TABLE feedback_tickets ADD COLUMN submission_id TEXT;
+ALTER TABLE feedback_tickets ADD COLUMN submission_fingerprint TEXT;
+ALTER TABLE feedback_tickets ADD COLUMN reporter_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feedback_tickets_submission
+  ON feedback_tickets(app_id, submission_id)
+  WHERE submission_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_reporter
+  ON feedback_tickets(app_id, reporter_id, created_at)
+  WHERE reporter_id IS NOT NULL;

--- a/worker/src/lib/app_platform.ts
+++ b/worker/src/lib/app_platform.ts
@@ -1,4 +1,4 @@
-export const APP_PLATFORMS = ["android", "ios", "ohos", "electron", "node"] as const;
+export const APP_PLATFORMS = ["android", "ios", "ohos", "electron", "node", "web"] as const;
 
 export type AppPlatform = (typeof APP_PLATFORMS)[number];
 

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -138,8 +138,10 @@ const FeedbackSubmitResponse = z
     id: z.string(),
     status: z.string(),
     attachments: z.number().int().optional(),
+    attachment_names: z.array(z.string()).optional(),
     reference: z.string().optional(),
     ticket_url: z.string().nullable().optional(),
+    idempotent_replay: z.boolean().optional(),
   })
   .openapi("FeedbackSubmitResponse");
 
@@ -333,20 +335,26 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     tags: ["Public feedback"],
     summary: "Submit feedback or crash report",
     description:
-      "Accepts SDK/client feedback, bug reports, and crash reports. Requires the app client key in X-Hands-Client-Key or client_key.",
+      "Accepts SDK/client feedback, bug reports, and crash reports. Requires the app client key in X-Hands-Client-Key or client_key. An optional multipart submission_id UUID makes retries idempotent: an exact replay returns the existing ticket, while reusing the UUID for a different payload returns 409. Trusted server proxies may send an optional opaque, integration-scoped X-Hands-Reporter-Id together with an app-scoped bearer token granted feedback:write; Hands persists the external subject as the pseudonymous ticket owner and rate-limits by reporter instead of the proxy's shared IP.",
     request: {
       params: SlugParam,
       query: z.object({ client_key: z.string().optional() }),
-      headers: z.object({ "X-Hands-Client-Key": z.string().optional() }),
+      headers: z.object({
+        "X-Hands-Client-Key": z.string().optional(),
+        "X-Hands-Reporter-Id": z.string().optional(),
+        Authorization: z.string().optional(),
+      }),
       body: {
         content: multipart(),
         required: true,
       },
     },
     responses: {
+      200: success("Returned an existing ticket for an idempotent replay.", FeedbackSubmitResponse),
       201: success("Created feedback ticket.", FeedbackSubmitResponse),
       400: error("Invalid feedback payload."),
       401: error("Missing or invalid client key."),
+      409: error("Submission id was already used for a different payload."),
       413: error("Attachment is too large."),
       429: error("Rate limit exceeded."),
     },

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -13,6 +13,7 @@ import { emitWebhookEvent } from "./webhooks";
 import { presignR2UploadUrl } from "../lib/r2_presign";
 import { generateSignedR2Url } from "./public_v2";
 import { dashboardOrigin, requestOrigin } from "../lib/origin";
+import { loadDeployToken, resolveDeployTokenPermissions } from "../lib/deploy_tokens";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -21,10 +22,21 @@ const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // inline multipart cap (through 
 const MAX_PRESIGNED_BYTES = 200 * 1024 * 1024; // direct-to-R2 cap
 const PRESIGN_TTL_SECONDS = 900;
 const MAX_MESSAGE_CHARS = 10_000;
-const RATE_LIMIT_PER_HOUR = 10;
+const DIRECT_RATE_LIMIT_PER_HOUR = 10;
+const TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR = 100;
 
 const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
 const TICKET_KINDS = ["feedback", "bug", "crash"] as const;
+const SUBMISSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const REPORTER_ID_PATTERN = /^[A-Za-z0-9_-]{16,200}$/;
+
+type FeedbackApp = {
+  id: string;
+  org_id: string | null;
+  slug: string;
+  client_key: string | null;
+  platform: string | null;
+};
 
 /**
  * Presigned direct-to-R2 upload for large feedback attachments. Client-key
@@ -101,13 +113,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     "SELECT id, org_id, slug, client_key, platform FROM apps WHERE slug = ?1 AND archived = 0",
   )
     .bind(slug)
-    .first<{
-      id: string;
-      org_id: string | null;
-      slug: string;
-      client_key: string | null;
-      platform: string | null;
-    }>();
+    .first<FeedbackApp>();
   if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
 
   // Client-key gate (Sentry-DSN model): always required. Apps predating the
@@ -134,6 +140,11 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   const kindRaw = String(form.get("kind") ?? "feedback");
   const kind = (TICKET_KINDS as readonly string[]).includes(kindRaw) ? kindRaw : "feedback";
   const contact = String(form.get("contact") ?? "").trim() || null;
+  const submissionIdRaw = String(form.get("submission_id") ?? "").trim() || null;
+  if (submissionIdRaw && !SUBMISSION_ID_PATTERN.test(submissionIdRaw)) {
+    return c.json({ error: "submission_id must be a UUID" }, 400);
+  }
+  const submissionId = submissionIdRaw?.toLowerCase() ?? null;
 
   let metadata: Record<string, unknown> = {};
   const metadataRaw = form.get("metadata");
@@ -156,21 +167,70 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       ? Math.trunc(versionCodeRaw)
       : null;
 
-  // Rate limit per app + hashed client ip.
+  // Direct SDK clients are rate-limited by client IP. A trusted server proxy
+  // may instead provide a stable pseudonymous reporter id, but only while
+  // authenticating with an app-scoped token whose sole effective permission is
+  // feedback:write for this app. This
+  // prevents public clients from rotating a spoofed forwarded identity to
+  // bypass the IP bucket.
   const clientIp =
     (c.req.raw?.cf as { clientIp?: string } | undefined)?.clientIp ??
     c.req.header("cf-connecting-ip") ??
     "unknown";
-  const clientIpHash = await sha256Hex(`feedback:${app.id}:${clientIp}`);
+  const reporterId = (c.req.header("X-Hands-Reporter-Id") ?? "").trim();
+  let rateLimitHashInput = `feedback:${app.id}:${clientIp}`;
+  let rateLimitPerHour = DIRECT_RATE_LIMIT_PER_HOUR;
+  if (reporterId) {
+    if (!REPORTER_ID_PATTERN.test(reporterId)) {
+      return c.json({ error: "X-Hands-Reporter-Id must be a 16-200 character opaque base64url value" }, 400);
+    }
+    const authorization = c.req.header("authorization") ?? "";
+    const bearerToken = authorization.startsWith("Bearer ")
+      ? authorization.slice("Bearer ".length).trim()
+      : "";
+    const deployToken = await loadDeployToken(c.env, bearerToken);
+    const effectivePermissions = deployToken
+      ? resolveDeployTokenPermissions(deployToken)
+      : new Set();
+    if (
+      !deployToken
+      || deployToken.app_id !== app.id
+      || deployToken.app_role !== null
+      || effectivePermissions.size !== 1
+      || !effectivePermissions.has("feedback:write")
+    ) {
+      return c.json({ error: "trusted reporter identity requires feedback:write permission for this app" }, 401);
+    }
+    rateLimitHashInput = `feedback:${app.id}:reporter:${reporterId}`;
+    rateLimitPerHour = TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR;
+  }
+  const clientIpHash = await sha256Hex(rateLimitHashInput);
   const oneHourAgo = Date.now() - 3600_000;
-  const recent = await c.env.DB.prepare(
-    `SELECT COUNT(*) AS count FROM feedback_tickets
-     WHERE app_id = ?1 AND client_ip_hash = ?2 AND created_at > ?3`,
-  )
-    .bind(app.id, clientIpHash, oneHourAgo)
-    .first<{ count: number }>();
-  if ((recent?.count ?? 0) >= RATE_LIMIT_PER_HOUR) {
-    return c.json({ error: "too many feedback submissions; try again later" }, 429);
+  // A cheap indexed lookup happens before attachment hashing/R2 HEAD work.
+  // Only a known idempotency key may bypass the rate-limit count so a lost
+  // response remains recoverable; a new key is rejected before expensive
+  // attachment processing once the subject is over quota.
+  const existingSubmission = submissionId
+    ? await findFeedbackSubmission(c.env.DB, app.id, submissionId)
+    : null;
+  if (existingSubmission && existingSubmission.reporter_id !== (reporterId || null)) {
+    return c.json({ error: "submission_id already used by a different reporter" }, 409);
+  }
+  if (!existingSubmission) {
+    const recent = await c.env.DB.prepare(
+      `SELECT COUNT(*) AS count, MIN(created_at) AS oldest_created_at FROM feedback_tickets
+       WHERE app_id = ?1 AND client_ip_hash = ?2 AND created_at > ?3`,
+    )
+      .bind(app.id, clientIpHash, oneHourAgo)
+      .first<{ count: number; oldest_created_at: number | null }>();
+    if ((recent?.count ?? 0) >= rateLimitPerHour) {
+      const retryAfter = Math.max(
+        1,
+        Math.ceil(((recent?.oldest_created_at ?? Date.now()) + 3600_000 - Date.now()) / 1000),
+      );
+      c.header("Retry-After", String(retryAfter));
+      return c.json({ error: "too many feedback submissions; try again later" }, 429);
+    }
   }
 
   // Collect attachments before writing anything.
@@ -191,33 +251,32 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     files.push(file);
   }
 
-  // Crash tickets get a grouping signature from their exception class + top
-  // app frame (populated by the SDK). Non-crash tickets have no signature.
-  const signature =
-    kind === "crash" ? crashSignature(metadata) : null;
-
-  const now = Date.now();
-  const ticketId = crypto.randomUUID();
-
   const attachmentRows: Array<{
     id: string;
     r2Key: string;
     filename: string;
     contentType: string | null;
     sizeBytes: number;
+    inlineFile?: File;
+    fingerprint: Record<string, unknown>;
   }> = [];
   for (const [index, file] of files.entries()) {
     const safeName = file.name.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) || `attachment-${index}`;
-    const r2Key = `feedback/${app.id}/${ticketId}/${index}-${safeName}`;
-    await c.env.APK_BUCKET.put(r2Key, await file.arrayBuffer(), {
-      httpMetadata: { contentType: file.type || "application/octet-stream" },
-    });
     attachmentRows.push({
       id: crypto.randomUUID(),
-      r2Key,
+      r2Key: "",
       filename: safeName,
       contentType: file.type || null,
       sizeBytes: file.size,
+      inlineFile: file,
+      fingerprint: {
+        source: "inline",
+        index,
+        filename: safeName,
+        content_type: file.type || null,
+        size_bytes: file.size,
+        sha256: await sha256BufferHex(await file.arrayBuffer()),
+      },
     });
   }
 
@@ -255,8 +314,51 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
         filename,
         contentType: (item.content_type ? String(item.content_type).slice(0, 100) : null),
         sizeBytes: head.size ?? (typeof item.size === "number" ? item.size : 0),
+        fingerprint: {
+          source: "presigned",
+          index: attachmentRows.length,
+          r2_key: r2Key,
+          filename,
+          content_type: item.content_type ? String(item.content_type).slice(0, 100) : null,
+          size_bytes: head.size ?? (typeof item.size === "number" ? item.size : 0),
+          etag: head.etag,
+        },
       });
     }
+  }
+
+  const submissionFingerprint = submissionId
+    ? await sha256Hex(stableJson({
+        message,
+        kind,
+        contact,
+        metadata,
+        reporter_id: reporterId || null,
+        attachments: attachmentRows.map((attachment) => attachment.fingerprint),
+      }))
+    : null;
+
+  if (existingSubmission && submissionFingerprint) {
+    if (existingSubmission.submission_fingerprint !== submissionFingerprint) {
+      return c.json({ error: "submission_id already used with a different payload" }, 409);
+    }
+    return feedbackSubmitResponse(c, app, existingSubmission.id, 200, true);
+  }
+
+  // Crash tickets get a grouping signature from their exception class + top
+  // app frame (populated by the SDK). Non-crash tickets have no signature.
+  const signature =
+    kind === "crash" ? crashSignature(metadata) : null;
+
+  const now = Date.now();
+  const ticketId = crypto.randomUUID();
+
+  for (const [index, attachment] of attachmentRows.entries()) {
+    if (!attachment.inlineFile) continue;
+    attachment.r2Key = `feedback/${app.id}/${ticketId}/${index}-${attachment.filename}`;
+    await c.env.APK_BUCKET.put(attachment.r2Key, await attachment.inlineFile.arrayBuffer(), {
+      httpMetadata: { contentType: attachment.contentType || "application/octet-stream" },
+    });
   }
 
   const statements = [
@@ -264,8 +366,9 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       `INSERT INTO feedback_tickets
        (id, app_id, kind, status, message, contact, version_name, version_code,
         channel, device_id, device_model, os_version, arch, locale,
-        metadata_json, client_ip_hash, signature, created_at, updated_at)
-       VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)`,
+        metadata_json, client_ip_hash, signature, submission_id,
+        submission_fingerprint, reporter_id, created_at, updated_at)
+       VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)`,
     ).bind(
       ticketId,
       app.id,
@@ -283,6 +386,9 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       JSON.stringify(metadata),
       clientIpHash,
       signature,
+      submissionId,
+      submissionFingerprint,
+      reporterId || null,
       now,
       now,
     ),
@@ -294,7 +400,30 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       ).bind(a.id, ticketId, a.r2Key, a.filename, a.contentType, a.sizeBytes, now),
     ),
   ];
-  await c.env.DB.batch(statements);
+  const cleanupInlineUploads = () => Promise.allSettled(
+    attachmentRows
+      .filter((attachment) => attachment.inlineFile)
+      .map((attachment) => c.env.APK_BUCKET.delete(attachment.r2Key)),
+  );
+  try {
+    await c.env.DB.batch(statements);
+  } catch (error) {
+    if (submissionId && submissionFingerprint) {
+      const existing = await findFeedbackSubmission(c.env.DB, app.id, submissionId);
+      if (existing) {
+        await cleanupInlineUploads();
+        if (
+          existing.reporter_id !== (reporterId || null)
+          || existing.submission_fingerprint !== submissionFingerprint
+        ) {
+          return c.json({ error: "submission_id already used with a different payload" }, 409);
+        }
+        return feedbackSubmitResponse(c, app, existing.id, 200, true);
+      }
+    }
+    await cleanupInlineUploads();
+    throw error;
+  }
 
   // Crash tickets: symbolicate in the background (retrace / native / OHOS / dSYM
   // lanes) and record the result on the ticket's symbolicated_stack /
@@ -385,28 +514,62 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
         version_name: meta("version_name"),
         version_code: versionCode,
         attachments: attachmentRows.length,
+        reporter_id: reporterId || null,
       },
     }).catch(() => {
       // webhook fan-out must never fail the submission
     });
   }
 
-  // A ready-to-copy reference so a pasted ticket can be located by an agent:
-  // slug + version + full id, plus a direct admin link. Keep the full UUID
-  // here because detail/attachment API routes require it.
-  const versionName = meta("version_name");
-  const versionLabel = versionName
-    ? versionCode != null
-      ? `${versionName} (${versionCode})`
-      : versionName
-    : versionCode != null
-      ? String(versionCode)
+  return feedbackSubmitResponse(c, app, ticketId, 201, false);
+}
+
+async function findFeedbackSubmission(db: D1Database, appId: string, submissionId: string) {
+  return db.prepare(
+    `SELECT id, submission_fingerprint, reporter_id
+     FROM feedback_tickets
+     WHERE app_id = ?1 AND submission_id = ?2`,
+  )
+    .bind(appId, submissionId)
+    .first<{
+      id: string;
+      submission_fingerprint: string | null;
+      reporter_id: string | null;
+    }>();
+}
+
+async function feedbackSubmitResponse(
+  c: Context<{ Bindings: Env }>,
+  app: FeedbackApp,
+  ticketId: string,
+  httpStatus: 200 | 201,
+  idempotentReplay: boolean,
+) {
+  const ticket = await c.env.DB.prepare(
+    `SELECT status, version_name, version_code
+     FROM feedback_tickets
+     WHERE app_id = ?1 AND id = ?2`,
+  )
+    .bind(app.id, ticketId)
+    .first<{ status: string; version_name: string | null; version_code: number | null }>();
+  if (!ticket) return c.json({ error: "feedback ticket not found" }, 500);
+
+  const attachments = await c.env.DB.prepare(
+    `SELECT filename
+     FROM feedback_attachments
+     WHERE ticket_id = ?1
+     ORDER BY created_at, id`,
+  )
+    .bind(ticketId)
+    .all<{ filename: string }>();
+  const attachmentNames = attachments.results.map((attachment) => attachment.filename).filter(Boolean);
+  const versionLabel = ticket.version_name
+    ? ticket.version_code != null
+      ? `${ticket.version_name} (${ticket.version_code})`
+      : ticket.version_name
+    : ticket.version_code != null
+      ? String(ticket.version_code)
       : null;
-  const ticketUrl = `${dashboardOrigin(c.env)}/apps/${app.id}/feedback/${ticketId}`;
-  // List attachment filenames in the copyable reference — one per line — so an
-  // agent reading a pasted ticket knows it carries images/files and will fetch
-  // them.
-  const attachmentNames = attachmentRows.map((a) => a.filename).filter(Boolean);
   const referenceLine = [app.slug, versionLabel, `ticket ${ticketId}`]
     .filter(Boolean)
     .join(" · ");
@@ -417,14 +580,28 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   return c.json(
     {
       id: ticketId,
-      status: "open",
-      attachments: attachmentRows.length,
+      status: ticket.status,
+      attachments: attachmentNames.length,
       attachment_names: attachmentNames,
       reference,
-      ticket_url: ticketUrl,
+      ticket_url: `${dashboardOrigin(c.env)}/apps/${app.id}/feedback/${ticketId}`,
+      idempotent_replay: idempotentReplay,
     },
-    201,
+    httpStatus,
   );
+}
+
+function stableJson(value: unknown): string {
+  const sort = (entry: unknown): unknown => {
+    if (Array.isArray(entry)) return entry.map(sort);
+    if (!entry || typeof entry !== "object") return entry;
+    return Object.fromEntries(
+      Object.entries(entry as Record<string, unknown>)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, child]) => [key, sort(child)]),
+    );
+  };
+  return JSON.stringify(sort(value));
 }
 
 const MINIDUMP_MAX_BYTES = 64 * 1024 * 1024; // Crashpad dumps are usually < a few MB
@@ -515,7 +692,7 @@ export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) 
   )
     .bind(app.id, clientIpHash, Date.now() - 3600_000)
     .first<{ count: number }>();
-  if ((recent?.count ?? 0) >= RATE_LIMIT_PER_HOUR) {
+  if ((recent?.count ?? 0) >= DIRECT_RATE_LIMIT_PER_HOUR) {
     return c.json({ error: "too many crash reports; try again later" }, 429);
   }
 
@@ -581,6 +758,7 @@ export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) 
         version_name: versionName,
         version_code: versionCode,
         attachments: 1,
+        reporter_id: null,
       },
     }).catch(() => {});
   }
@@ -1747,6 +1925,13 @@ export async function handleDownloadFeedbackAttachment(c: AdminContext) {
 
 async function sha256Hex(input: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function sha256BufferHex(input: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input);
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");

--- a/worker/test/external_builds.test.ts
+++ b/worker/test/external_builds.test.ts
@@ -142,7 +142,7 @@ function declaration(target = "darwin-arm64") {
 describe("external Node build declarations", () => {
   it("rejects app platform values outside the shared closed set", async () => {
     const response = await handleCreateApp(
-      jsonContext(makeDb(), {}, { slug: "bad", name: "Bad", platform: "web" }),
+      jsonContext(makeDb(), {}, { slug: "bad", name: "Bad", platform: "desktop" }),
     );
 
     expect(response.status).toBe(400);
@@ -151,6 +151,7 @@ describe("external Node build declarations", () => {
       code: "UNSUPPORTED_APP_PLATFORM",
       supported_platforms: APP_PLATFORMS,
     });
+    expect(APP_PLATFORMS).toContain("web");
   });
 
   it("publishes immutable per-target evidence and replays the same declaration", async () => {

--- a/worker/test/feedback_idempotency_migration.test.ts
+++ b/worker/test/feedback_idempotency_migration.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0050_feedback_idempotency.sql", import.meta.url),
+);
+
+describe("feedback idempotency migration", () => {
+  it("adds nullable submission fields and enforces one id per app", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE feedback_tickets (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        message TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO feedback_tickets (id, app_id, message, created_at)
+      VALUES ('legacy', 'app-1', 'legacy ticket', 1);
+    `);
+
+    db.exec(readFileSync(migrationPath, "utf8"));
+
+    expect(db.prepare(
+      "SELECT submission_id, submission_fingerprint, reporter_id FROM feedback_tickets WHERE id = 'legacy'",
+    ).get()).toEqual({
+      submission_id: null,
+      submission_fingerprint: null,
+      reporter_id: null,
+    });
+
+    const insert = db.prepare(`
+      INSERT INTO feedback_tickets
+        (id, app_id, message, created_at, submission_id, submission_fingerprint, reporter_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    insert.run("first", "app-1", "first", 2, "submission-1", "fingerprint-1", "reporter-1");
+    expect(() => insert.run(
+      "duplicate",
+      "app-1",
+      "duplicate",
+      3,
+      "submission-1",
+      "fingerprint-2",
+      "reporter-1",
+    )).toThrow();
+    expect(() => insert.run(
+      "other-app",
+      "app-2",
+      "other app",
+      4,
+      "submission-1",
+      "fingerprint-3",
+      "reporter-2",
+    )).not.toThrow();
+    expect(() => insert.run("legacy-2", "app-1", "no id", 5, null, null, null)).not.toThrow();
+
+    const indexes = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'feedback_tickets'",
+    ).all() as Array<{ name: string }>;
+    expect(indexes.map((index) => index.name)).toContain("idx_feedback_tickets_reporter");
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -389,12 +389,21 @@ function makeMockDb() {
       client_ip_hash TEXT,
       assignee TEXT,
       signature TEXT,
+      submission_id TEXT,
+      submission_fingerprint TEXT,
+      reporter_id TEXT,
       symbolication_status TEXT,
       symbolicated_stack TEXT,
       symbolicated_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
+    CREATE UNIQUE INDEX idx_feedback_tickets_submission
+      ON feedback_tickets(app_id, submission_id)
+      WHERE submission_id IS NOT NULL;
+    CREATE INDEX idx_feedback_tickets_reporter
+      ON feedback_tickets(app_id, reporter_id, created_at)
+      WHERE reporter_id IS NOT NULL;
     CREATE TABLE device_pings (
       app_id TEXT NOT NULL,
       device_id TEXT NOT NULL,
@@ -4111,6 +4120,12 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(draftPayload.artifact.download_api).toBe(
       `/api/apps/app-scope/builds/${build.id}/assets/${draftPayload.artifact.asset_id}/download?presign=1`,
     );
+    const feedbackDelivery = (await env.DB.prepare(
+      "SELECT payload_json FROM webhook_deliveries WHERE webhook_id = ?1 AND event_type = 'feedback:new'",
+    )
+      .bind("wh-e2e")
+      .first()) as { payload_json: string };
+    expect(JSON.parse(feedbackDelivery.payload_json).payload.reporter_id).toBeNull();
   });
 
   it("external-target gate: freeze on publish, set assertion, replay re-assert, dl routes", async () => {
@@ -6477,6 +6492,344 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(ok.status).toBe(201);
     const body = await responseJson<any>(ok);
     expect(body.attachments).toBe(1);
+  });
+
+  it("feedback: submission_id replays the original ticket and rejects payload conflicts", async () => {
+    const env = makeEnv();
+    const putCalls: string[] = [];
+    const deleted: string[] = [];
+    env.APK_BUCKET = {
+      put: async (key: string) => { putCalls.push(key); },
+      delete: async (key: string) => { deleted.push(key); },
+      get: async () => null,
+      head: async () => null,
+    };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    const submissionId = "11111111-1111-4111-8111-111111111111";
+
+    const submit = (opts: {
+      message?: string;
+      metadata?: Record<string, unknown>;
+      bytes?: number[];
+      submissionId?: string;
+    } = {}) => {
+      const form = new FormData();
+      form.set("message", opts.message ?? "Please add compact mode");
+      form.set("kind", "feedback");
+      form.set("submission_id", opts.submissionId ?? submissionId);
+      form.set("metadata", JSON.stringify(opts.metadata ?? { feedback_type: "idea", locale: "zh-CN" }));
+      if (opts.bytes) {
+        form.append("attachments", new File([new Uint8Array(opts.bytes)], "screen.png", { type: "image/png" }));
+      }
+      return handlePublicFeedbackSubmit({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        req: {
+          param: (name: string) => (name === "slug" ? "scope-app" : ""),
+          header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.71" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+    };
+
+    const first = await submit({ bytes: [1, 2, 3] });
+    expect(first.status).toBe(201);
+    const firstBody = await responseJson<any>(first);
+    expect(firstBody.idempotent_replay).toBe(false);
+
+    const replay = await submit({
+      metadata: { locale: "zh-CN", feedback_type: "idea" },
+      bytes: [1, 2, 3],
+      submissionId: submissionId.toUpperCase(),
+    });
+    expect(replay.status).toBe(200);
+    const replayBody = await responseJson<any>(replay);
+    expect(replayBody.id).toBe(firstBody.id);
+    expect(replayBody.reference).toBe(firstBody.reference);
+    expect(replayBody.idempotent_replay).toBe(true);
+    expect(putCalls).toHaveLength(1);
+
+    expect((await submit({ message: "Different draft", bytes: [1, 2, 3] })).status).toBe(409);
+    expect((await submit({ bytes: [3, 2, 1] })).status).toBe(409);
+    expect(deleted).toEqual([]);
+
+    const rows = await env.DB.prepare(
+      "SELECT id, submission_id, submission_fingerprint FROM feedback_tickets WHERE app_id = ?1 AND submission_id = ?2",
+    ).bind("app-scope", submissionId).all();
+    expect(rows.results).toHaveLength(1);
+    expect((rows.results[0] as any).submission_fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("feedback: over-limit new submissions stop before R2 HEAD while known replays remain recoverable", async () => {
+    const env = makeEnv();
+    let headCalls = 0;
+    env.APK_BUCKET = {
+      put: async () => {},
+      get: async () => null,
+      head: async () => {
+        headCalls += 1;
+        return { size: 3, etag: "etag-screen" };
+      },
+    };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    const existingId = "33333333-3333-4333-8333-333333333333";
+    const presigned = [{
+      r2_key: "feedback/app-scope/presigned/screen.png",
+      filename: "screen.png",
+      content_type: "image/png",
+      size: 3,
+    }];
+    const submit = (submissionId?: string, includePresigned = false) => {
+      const responseHeaders = new Headers();
+      const form = new FormData();
+      form.set("message", "Rate boundary");
+      if (submissionId) form.set("submission_id", submissionId);
+      if (includePresigned) form.set("presigned", JSON.stringify(presigned));
+      return handlePublicFeedbackSubmit({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        header: (name: string, value: string) => { responseHeaders.set(name, value); },
+        req: {
+          param: (name: string) => (name === "slug" ? "scope-app" : ""),
+          header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.74" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
+          status,
+          headers: responseHeaders,
+        }),
+      } as any);
+    };
+
+    expect((await submit(existingId, true)).status).toBe(201);
+    for (let index = 0; index < 9; index += 1) expect((await submit()).status).toBe(201);
+    headCalls = 0;
+
+    const overLimit = await submit("44444444-4444-4444-8444-444444444444", true);
+    expect(overLimit.status).toBe(429);
+    expect(Number(overLimit.headers.get("retry-after"))).toBeGreaterThan(0);
+    expect(headCalls).toBe(0);
+
+    const replay = await submit(existingId.toUpperCase(), true);
+    expect(replay.status).toBe(200);
+    expect(headCalls).toBe(1);
+  });
+
+  it("feedback: concurrent identical submission_id requests converge on one ticket", async () => {
+    const env = makeEnv();
+    const deleted: string[] = [];
+    env.APK_BUCKET = {
+      put: async () => {},
+      delete: async (key: string) => { deleted.push(key); },
+      get: async () => null,
+      head: async () => null,
+    };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    const submit = () => {
+      const form = new FormData();
+      form.set("message", "Concurrent retry");
+      form.set("submission_id", "22222222-2222-4222-8222-222222222222");
+      form.append("attachments", new File([new Uint8Array([9])], "same.txt", { type: "text/plain" }));
+      return handlePublicFeedbackSubmit({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        req: {
+          param: (name: string) => (name === "slug" ? "scope-app" : ""),
+          header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.72" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+    };
+
+    const responses = await Promise.all([submit(), submit()]);
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 201]);
+    const bodies = await Promise.all(responses.map((response) => responseJson<any>(response)));
+    expect(new Set(bodies.map((body) => body.id)).size).toBe(1);
+    expect(deleted.length).toBeLessThanOrEqual(1);
+
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_tickets WHERE app_id = ?1 AND submission_id = ?2",
+    ).bind("app-scope", "22222222-2222-4222-8222-222222222222").first() as { count: number } | null;
+    expect(count?.count).toBe(1);
+  });
+
+  it("feedback: trusted server proxy persists and rate-limits by pseudonymous reporter id", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = { put: async () => {}, get: async () => null };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
+    const credential = generateDeployToken();
+    const publisherCredential = generateDeployToken();
+    const broadCredential = generateDeployToken();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by_actor, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, NULL, '["feedback:write"]', ?6, ?7)`,
+    ).bind(
+      "proxy-token",
+      "app-scope",
+      "feedback proxy",
+      credential.token_prefix,
+      await hashDeployToken(credential.token),
+      "test",
+      Date.now(),
+    ).run();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by_actor, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, 'publisher', NULL, ?6, ?7)`,
+    ).bind(
+      "publisher-token",
+      "app-scope",
+      "publisher token",
+      publisherCredential.token_prefix,
+      await hashDeployToken(publisherCredential.token),
+      "test",
+      Date.now(),
+    ).run();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by_actor, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, NULL, '["feedback:write","app:read"]', ?6, ?7)`,
+    ).bind(
+      "broad-token",
+      "app-scope",
+      "broad custom token",
+      broadCredential.token_prefix,
+      await hashDeployToken(broadCredential.token),
+      "test",
+      Date.now(),
+    ).run();
+
+    const submit = (
+      reporterId: string,
+      bearer = credential.token,
+      submissionId?: string,
+    ) => {
+      const responseHeaders = new Headers();
+      const form = new FormData();
+      form.set("message", "Proxy feedback");
+      if (submissionId) form.set("submission_id", submissionId);
+      return handlePublicFeedbackSubmit({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        header: (name: string, value: string) => { responseHeaders.set(name, value); },
+        req: {
+          param: (name: string) => (name === "slug" ? "scope-app" : ""),
+          header: (name: string) => {
+            if (name === "X-Quiver-Client-Key") return "qk_test";
+            if (name === "X-Hands-Reporter-Id") return reporterId;
+            if (name === "authorization") return bearer ? `Bearer ${bearer}` : undefined;
+            return undefined;
+          },
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.80" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
+          status,
+          headers: responseHeaders,
+        }),
+      } as any);
+    };
+
+    const reporterA = "a".repeat(64);
+    for (let index = 0; index < 100; index += 1) expect((await submit(reporterA)).status).toBe(201);
+    const limited = await submit(reporterA);
+    expect(limited.status).toBe(429);
+    expect(Number(limited.headers.get("retry-after"))).toBeGreaterThan(0);
+    expect((await submit("b".repeat(64))).status).toBe(201);
+    expect((await submit("c".repeat(64), "")).status).toBe(401);
+    expect((await submit("d".repeat(64), publisherCredential.token)).status).toBe(401);
+    expect((await submit("e".repeat(64), broadCredential.token)).status).toBe(401);
+    expect((await submit("raw account id", credential.token)).status).toBe(400);
+
+    await env.DB.prepare(
+      `INSERT INTO webhooks
+       (id, org_id, app_id, url, secret, events_json, enabled, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8)`,
+    ).bind(
+      "trusted-feedback-webhook",
+      "default",
+      "app-scope",
+      "https://example.test/trusted-feedback",
+      "secret",
+      JSON.stringify(["feedback:new"]),
+      Date.now(),
+      Date.now(),
+    ).run();
+    const ownedSubmission = "55555555-5555-4555-8555-555555555555";
+    expect((await submit("g".repeat(64), credential.token, ownedSubmission)).status).toBe(201);
+    expect((await submit("h".repeat(64), credential.token, ownedSubmission)).status).toBe(409);
+
+    const trustedDelivery = (await env.DB.prepare(
+      `SELECT payload_json
+       FROM webhook_deliveries
+       WHERE webhook_id = ?1 AND event_type = 'feedback:new'`,
+    ).bind("trusted-feedback-webhook").first()) as { payload_json: string };
+    expect(JSON.parse(trustedDelivery.payload_json).payload.reporter_id).toBe("g".repeat(64));
+
+    const reporterRows = await env.DB.prepare(
+      `SELECT DISTINCT reporter_id
+       FROM feedback_tickets
+       WHERE app_id = ?1 AND reporter_id IS NOT NULL`,
+    ).bind("app-scope").all();
+    const storedReporterIds = reporterRows.results.map((row: any) => row.reporter_id);
+    expect(storedReporterIds).toContain(reporterA);
+    expect(storedReporterIds).toContain("b".repeat(64));
+    expect(storedReporterIds).toContain("g".repeat(64));
+  });
+
+  it("feedback: legacy submissions without submission_id remain non-idempotent", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = { put: async () => {}, get: async () => null };
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    const submit = () => {
+      const form = new FormData();
+      form.set("message", "Legacy client");
+      return handlePublicFeedbackSubmit({
+        env,
+        executionCtx: { waitUntil: () => {} },
+        req: {
+          param: (name: string) => (name === "slug" ? "scope-app" : ""),
+          header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.73" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+    };
+    const first = await responseJson<any>(await submit());
+    const second = await responseJson<any>(await submit());
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it("feedback: rejects malformed submission_id", async () => {
+    const env = makeEnv();
+    const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
+    const form = new FormData();
+    form.set("message", "Bad id");
+    form.set("submission_id", "not-a-uuid");
+    const response = await handlePublicFeedbackSubmit({
+      env,
+      req: {
+        param: (name: string) => (name === "slug" ? "scope-app" : ""),
+        header: (name: string) => (name === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+        query: () => undefined,
+        formData: async () => form,
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    expect(response.status).toBe(400);
   });
 
   it("feedback: client key is always required", async () => {


### PR DESCRIPTION
## Summary

- add `web` to the supported app-platform contract and app creation wizard
- add optional UUID `submission_id` support to public feedback submissions
- persist a normalized payload fingerprint and enforce one canonical lowercase submission id per app
- return the existing ticket on exact retries and reject conflicting reuse with `409`
- persist an optional, opaque external `reporter_id` for trusted server-proxy submissions
- include `reporter_id` in the existing authenticated `feedback:new` webhook payload (`null` for anonymous submissions)
- rate trusted proxies by app + reporter identity authenticated by a custom token whose sole effective permission is `feedback:write`
- preserve existing behavior for SDKs that do not send a submission id or reporter identity

Inline attachment fingerprints include their SHA-256 content digest. Presigned attachments bind the R2 key, normalized metadata, size, and ETag. Concurrent retries converge through the database unique index; losing inline uploads are cleaned up.

## API behavior

- new submission: `201`, `idempotent_replay: false`
- exact replay: `200`, same ticket/reference, `idempotent_replay: true`
- same `submission_id`, different normalized payload or reporter identity: `409`
- malformed `submission_id` or reporter identity: `400`
- UUID casing is canonicalized before lookup/insert
- direct SDK limit: 10/hour/app+IP
- trusted server-proxy limit: 100/hour/app+reporter with dynamic `Retry-After`

Trusted proxy submissions send an app-scoped custom token granted only `feedback:write`, plus an optional `X-Hands-Reporter-Id`. Role tokens and custom tokens with additional permissions are rejected for this path.

`reporter_id` is an external subject identifier chosen by the integrator. It must be stable, opaque, and app/integration scoped, never a raw email, username, or internal database id. An integrator may store a random id with a reverse mapping for two-way support, use a keyed non-reversible pseudonym for anonymous correlation, or omit it for anonymous non-addressable feedback. Hands stores the value on the ticket and returns it in the authenticated `feedback:new` webhook contract so an integrator that retains a reverse map can route the event to its local user.

Rate-limit lookup runs before attachment hashing or R2 HEAD work for new submission ids. Known idempotency keys can still reconstruct an exact replay after the rate bucket fills.

## Verification

- Worker TypeScript build and shim build
- Worker tests: 215/215
- Admin TypeScript typecheck
- Admin tests: 5/5
- Admin production build
- SQLite feedback-idempotency migration test, including the reporter column and index
- trusted and anonymous `feedback:new` reporter payload assertions
- `git diff --check`

The repository's current Worker lint command remains unavailable because ESLint 9 is configured without a flat `eslint.config.*`; this is unchanged by the PR.
