### PR TITLE
feat(agent): expose TestFlight upload actions

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -720,6 +720,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
       "4. Release management (app publisher): create-release from an existing build (DRAFT by default) → update-release with bilingual release_notes → after explicit human authorization, publish-release. See docs.release_guide.",
       "5. iOS simulator QA fixtures: create-ios-simulator-artifact → PUT the .app.zip to upload.url with the returned headers → complete-ios-simulator-artifact → get/presign the durable exact-byte artifact. QA artifacts can never become releases or update offers.",
+      "6. TestFlight upload (app admin): upload-testflight-build streams an existing signed Hands IPA to Apple; poll get-testflight-upload-status to COMPLETE or FAILED. Upload never assigns beta groups, notifies testers, publishes a Hands release, or submits an App Store production release.",
     ],
     auth: {
       raft_agents:
@@ -748,6 +749,8 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
         "POST /api/apps/{app_id}/qa-artifacts/ios-simulator — publisher; declares filename/size/SHA/source/version/build/bundle/GitHub run and returns a presigned PUT URL",
       complete_ios_simulator_artifact:
         "POST /api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/complete — publisher; one-shot stream verification of size/SHA-256 followed by immutable storage sealing",
+      upload_testflight_build:
+        "POST /api/apps/{app_id}/builds/{build_id}/testflight-upload — admin; streams the stored signed IPA to Apple's Build Upload API without distributing it",
     },
     docs: {
       agent_guide: `${origin}/docs/agent-cli-feedback`,
@@ -984,6 +987,33 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
           submission_id: { type: "string", in: "path", required: true, description: "Hands market submission UUID." },
+        },
+      },
+      {
+        name: "upload-testflight-build",
+        description:
+          "Upload one existing signed Hands IPA to App Store Connect/TestFlight using the app's encrypted server-side ASC credential. This upload-only action never assigns beta groups, notifies testers, activates a Hands release, or touches App Store production publishing. Requires app admin.",
+        endpoint: {
+          method: "POST",
+          path: "/api/apps/{app_id}/builds/{build_id}/testflight-upload",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Hands build UUID containing the signed installable IPA." },
+          bundle_id: { type: "string", in: "body", required: false, description: "Optional reverse-DNS identifier used only when build metadata does not contain it." },
+        },
+      },
+      {
+        name: "get-testflight-upload-status",
+        description:
+          "Poll one Apple Build Upload id returned by upload-testflight-build until state is COMPLETE or FAILED. Read-only; requires app viewer.",
+        endpoint: {
+          method: "GET",
+          path: "/api/apps/{app_id}/testflight-uploads/{build_upload_id}",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
+          build_upload_id: { type: "string", in: "path", required: true, description: "App Store Connect Build Upload id returned by upload-testflight-build." },
         },
       },
       {

--- a/worker/src/routes/testflight.ts
+++ b/worker/src/routes/testflight.ts
@@ -34,17 +34,6 @@ type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 export async function handleTestflightUpload(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const buildIdParam = c.req.param("buildId") ?? "";
-  const encKey = c.env.ASC_CRED_ENC_KEY;
-  if (!encKey) return c.json({ error: "server is missing ASC_CRED_ENC_KEY" }, 500);
-
-  const creds = await getAscCredentials(c.env.DB, encKey, appId);
-  if (!creds) {
-    return c.json(
-      { error: "no ASC credentials configured — add them in Settings → TestFlight first" },
-      400,
-    );
-  }
-
   const build = await c.env.DB.prepare(
     `SELECT id, version_name, version_code FROM builds
      WHERE app_id = ?1 AND id LIKE ?2 || '%' LIMIT 2`,
@@ -65,32 +54,58 @@ export async function handleTestflightUpload(c: AdminContext) {
     .first<{ r2_key: string; size_bytes: number; file_hash: string | null }>();
   if (!asset) return c.json({ error: "build has no installable IPA asset" }, 404);
 
-  // Bundle id: request body wins; otherwise read the build's metadata-file
-  // asset (build-metadata.json carries bundle_id since mobile#485).
+  // The immutable build metadata is authoritative. A caller may repeat the
+  // bundle id as an assertion, but cannot redirect an existing IPA to another
+  // ASC app. The body is only a fallback for older builds without metadata.
   const body = (await c.req.json().catch(() => ({}))) as { bundle_id?: unknown };
-  let bundleId = typeof body.bundle_id === "string" ? body.bundle_id.trim() : "";
-  if (!bundleId) {
-    const metaAsset = await c.env.DB.prepare(
-      `SELECT r2_key FROM build_assets
-       WHERE build_id = ?1 AND artifact_kind = 'metadata-file' LIMIT 1`,
-    )
-      .bind(b.id)
-      .first<{ r2_key: string }>();
-    if (metaAsset) {
-      const obj = await c.env.APK_BUCKET.get(metaAsset.r2_key);
-      if (obj) {
-        try {
-          const meta = (await obj.json()) as { bundle_id?: string };
-          bundleId = (meta.bundle_id ?? "").trim();
-        } catch {
-          // fall through to the error below
-        }
+  const requestedBundleId =
+    typeof body.bundle_id === "string" ? body.bundle_id.trim() : "";
+  let metadataBundleId = "";
+  const metaAsset = await c.env.DB.prepare(
+    `SELECT r2_key FROM build_assets
+     WHERE build_id = ?1 AND artifact_kind = 'metadata-file' LIMIT 1`,
+  )
+    .bind(b.id)
+    .first<{ r2_key: string }>();
+  if (metaAsset) {
+    const obj = await c.env.APK_BUCKET.get(metaAsset.r2_key);
+    if (obj) {
+      try {
+        const meta = (await obj.json()) as { bundle_id?: string };
+        metadataBundleId = (meta.bundle_id ?? "").trim();
+      } catch {
+        // fall through to the error below
       }
     }
   }
+  if (
+    metadataBundleId &&
+    requestedBundleId &&
+    metadataBundleId !== requestedBundleId
+  ) {
+    return c.json(
+      {
+        error: "bundle_id does not match the immutable build metadata",
+        code: "BUNDLE_ID_MISMATCH",
+        metadata_bundle_id: metadataBundleId,
+      },
+      400,
+    );
+  }
+  const bundleId = metadataBundleId || requestedBundleId;
   if (!bundleId) {
     return c.json(
       { error: "bundle_id not found in build metadata; pass {\"bundle_id\": …} in the body" },
+      400,
+    );
+  }
+
+  const encKey = c.env.ASC_CRED_ENC_KEY;
+  if (!encKey) return c.json({ error: "server is missing ASC_CRED_ENC_KEY" }, 500);
+  const creds = await getAscCredentials(c.env.DB, encKey, appId);
+  if (!creds) {
+    return c.json(
+      { error: "no ASC credentials configured — add them in Settings → TestFlight first" },
       400,
     );
   }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6689,6 +6689,14 @@ describe("Hands iOS simulator QA artifacts", () => {
         method: "GET",
         path: "/api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/download?presign=1",
       },
+      "upload-testflight-build": {
+        method: "POST",
+        path: "/api/apps/{app_id}/builds/{build_id}/testflight-upload",
+      },
+      "get-testflight-upload-status": {
+        method: "GET",
+        path: "/api/apps/{app_id}/testflight-uploads/{build_upload_id}",
+      },
     });
   });
 });

--- a/worker/test/testflight_upload.test.ts
+++ b/worker/test/testflight_upload.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { handleTestflightUpload } from "../src/routes/testflight";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TestFlight upload route", () => {
+  it("rejects a body bundle id that disagrees with immutable build metadata", async () => {
+    let operationWrites = 0;
+    const db = {
+      prepare(sql: string) {
+        if (sql.includes("INSERT INTO operation_logs")) operationWrites += 1;
+        return {
+          bind() {
+            return this;
+          },
+          async all() {
+            if (sql.includes("FROM builds")) {
+              return {
+                results: [
+                  { id: "build-1", version_name: "1.0.0", version_code: 1000005 },
+                ],
+              };
+            }
+            return { results: [] };
+          },
+          async first() {
+            if (
+              sql.includes("artifact_kind = 'installable'") &&
+              sql.includes("filetype = 'ipa'")
+            ) {
+              return {
+                r2_key: "apps/app-1/builds/build-1/Raft.ipa",
+                size_bytes: 48_256_623,
+                file_hash: "a".repeat(64),
+              };
+            }
+            if (sql.includes("artifact_kind = 'metadata-file'")) {
+              return { r2_key: "apps/app-1/builds/build-1/build-metadata.json" };
+            }
+            return null;
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+      },
+    };
+    const bucket = {
+      async get(key: string) {
+        if (key.endsWith("build-metadata.json")) {
+          return {
+            async json() {
+              return { bundle_id: "build.raft.app" };
+            },
+          };
+        }
+        return null;
+      },
+    };
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const app = new Hono();
+    app.post(
+      "/api/apps/:appId/builds/:buildId/testflight-upload",
+      handleTestflightUpload as any,
+    );
+    const response = await app.request(
+      "/api/apps/app-1/builds/build-1/testflight-upload",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ bundle_id: "other.example.app" }),
+      },
+      { DB: db, APK_BUCKET: bucket } as any,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "BUNDLE_ID_MISMATCH",
+      metadata_bundle_id: "build.raft.app",
+    });
+    expect(operationWrites).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- expose the existing upload-only TestFlight endpoint as `upload-testflight-build`
- expose terminal processing polling as `get-testflight-upload-status`
- document the fail-closed boundary: no groups, notifications, Hands activation, or App Store production publish

## Verification
- `pnpm --filter @botiverse/hands-worker test -- routes.test.ts` (127/127)
- `pnpm --filter @botiverse/hands-worker build:shim`
- `git diff --check`

The normal Worker typecheck requires the CI-generated `worker-configuration.d.ts`; the repository shim typecheck passes locally.