### PR TITLE
feat(releases): add exact device group rollout

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -232,9 +232,27 @@ export interface Release {
 export interface ReleaseScope {
   id: string;
   release_id: string;
-  scope_type: string;         // 'full' | 'platform' | 'ip_range' | 'user_cohort'
+  scope_type: string;         // 'full' | 'platform' | 'ip_range' | 'user_cohort' | 'device_group'
   scope_value: string;
   created_at: number;
+}
+
+export interface DeviceGroupMember {
+  group_id: string;
+  device_id: string;
+  label: string | null;
+  created_at: number;
+}
+
+export interface DeviceGroup {
+  id: string;
+  app_id: string;
+  name: string;
+  description: string | null;
+  member_count: number;
+  members: DeviceGroupMember[];
+  created_at: number;
+  updated_at: number;
 }
 
 export interface Channel {
@@ -1150,6 +1168,48 @@ export const getBuildAssetDownloadUrl = (
 
 export const listReleases = (appId: string) =>
   request<{ releases: Release[] }>(`/api/apps/${appId}/releases`, { admin: true });
+
+export const listDeviceGroups = (appId: string) =>
+  request<{ groups: DeviceGroup[] }>(`/api/apps/${appId}/device-groups`, { admin: true });
+
+export const createDeviceGroup = (appId: string, input: { name: string; description?: string }) =>
+  request<DeviceGroup>(`/api/apps/${appId}/device-groups`, {
+    method: "POST",
+    admin: true,
+    body: JSON.stringify(input),
+  });
+
+export const updateDeviceGroup = (
+  appId: string,
+  groupId: string,
+  input: { name?: string; description?: string | null },
+) => request<DeviceGroup>(`/api/apps/${appId}/device-groups/${groupId}`, {
+  method: "PATCH",
+  admin: true,
+  body: JSON.stringify(input),
+});
+
+export const deleteDeviceGroup = (appId: string, groupId: string) =>
+  request<{ ok: boolean; id: string }>(`/api/apps/${appId}/device-groups/${groupId}`, {
+    method: "DELETE",
+    admin: true,
+  });
+
+export const addDeviceGroupMember = (
+  appId: string,
+  groupId: string,
+  input: { device_id: string; label?: string },
+) => request<DeviceGroupMember>(`/api/apps/${appId}/device-groups/${groupId}/members`, {
+  method: "POST",
+  admin: true,
+  body: JSON.stringify(input),
+});
+
+export const removeDeviceGroupMember = (appId: string, groupId: string, deviceId: string) =>
+  request<{ ok: boolean }>(
+    `/api/apps/${appId}/device-groups/${groupId}/members/${encodeURIComponent(deviceId)}`,
+    { method: "DELETE", admin: true },
+  );
 
 export interface ReleaseCheck {
   id: string;

--- a/admin/src/lib/deviceGroupForm.test.ts
+++ b/admin/src/lib/deviceGroupForm.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { deviceGroupUpdatePayload } from "./deviceGroupForm";
+
+describe("device-group form contract", () => {
+  it("trims renamed groups and explicitly clears an empty description", () => {
+    expect(deviceGroupUpdatePayload("  QA tablets  ", "   ")).toEqual({
+      name: "QA tablets",
+      description: null,
+    });
+    expect(deviceGroupUpdatePayload("QA phones", " physical devices ")).toEqual({
+      name: "QA phones",
+      description: "physical devices",
+    });
+  });
+});

--- a/admin/src/lib/deviceGroupForm.ts
+++ b/admin/src/lib/deviceGroupForm.ts
@@ -1,0 +1,6 @@
+export function deviceGroupUpdatePayload(name: string, description: string) {
+  return {
+    name: name.trim(),
+    description: description.trim() || null,
+  };
+}

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -56,9 +56,17 @@ import {
   deleteAgcCredentials,
   verifyAgcCredentials,
   getAppStoreReview,
+  addDeviceGroupMember,
+  createDeviceGroup,
+  deleteDeviceGroup,
+  listDeviceGroups,
+  removeDeviceGroupMember,
+  updateDeviceGroup,
+  type DeviceGroup,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
+import { deviceGroupUpdatePayload } from "../lib/deviceGroupForm";
 
 export function AppDetail({ appId }: { appId: string }) {
   const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
@@ -375,6 +383,172 @@ function ClientKeyPanel({ appId }: { appId: string }) {
           }}
         >
           {rotate.isPending ? "…" : key ? "Rotate" : "Generate"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DeviceGroupsPanel({ appId }: { appId: string }) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const groups = useQuery({
+    queryKey: ["device-groups", appId],
+    queryFn: () => listDeviceGroups(appId),
+  });
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const create = useMutation({
+    mutationFn: () => createDeviceGroup(appId, {
+      name: name.trim(),
+      ...(description.trim() ? { description: description.trim() } : {}),
+    }),
+    onSuccess: () => {
+      setName("");
+      setDescription("");
+      void queryClient.invalidateQueries({ queryKey: ["device-groups", appId] });
+      toast.show({ kind: "success", title: "Device group created" });
+    },
+    onError: (error) => toast.show({ kind: "error", title: "Create failed", description: (error as Error).message }),
+  });
+
+  return (
+    <div className="border-t border-slate-100 pt-3 space-y-3">
+      <div>
+        <div className="text-sm font-medium">Device groups</div>
+        <p className="text-xs text-slate-500">
+          Exact rollout groups use the stable installation device id sent by the Hands update SDK.
+        </p>
+      </div>
+      <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
+        <Input value={name} onChange={(event) => setName(event.target.value)} placeholder="Artin test devices" />
+        <Input value={description} onChange={(event) => setDescription(event.target.value)} placeholder="Operator note (optional)" />
+        <Button variant="outline" disabled={!name.trim() || create.isPending} onClick={() => create.mutate()}>
+          Create group
+        </Button>
+      </div>
+      {groups.isLoading && <p className="text-xs text-slate-500">Loading device groups…</p>}
+      {groups.error && <p className="text-xs text-red-700">{(groups.error as Error).message}</p>}
+      {(groups.data?.groups ?? []).map((group) => (
+        <DeviceGroupCard key={group.id} appId={appId} group={group} />
+      ))}
+    </div>
+  );
+}
+
+function DeviceGroupCard({ appId, group }: { appId: string; group: DeviceGroup }) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [deviceId, setDeviceId] = useState("");
+  const [label, setLabel] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [groupName, setGroupName] = useState(group.name);
+  const [groupDescription, setGroupDescription] = useState(group.description ?? "");
+  useEffect(() => {
+    if (!editing) {
+      setGroupName(group.name);
+      setGroupDescription(group.description ?? "");
+    }
+  }, [editing, group.description, group.name]);
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["device-groups", appId] });
+  const update = useMutation({
+    mutationFn: () => updateDeviceGroup(appId, group.id, deviceGroupUpdatePayload(groupName, groupDescription)),
+    onSuccess: () => {
+      setEditing(false);
+      void refresh();
+      toast.show({ kind: "success", title: "Device group updated" });
+    },
+    onError: (error) => toast.show({ kind: "error", title: "Update failed", description: (error as Error).message }),
+  });
+  const add = useMutation({
+    mutationFn: () => addDeviceGroupMember(appId, group.id, {
+      device_id: deviceId.trim(),
+      ...(label.trim() ? { label: label.trim() } : {}),
+    }),
+    onSuccess: () => {
+      setDeviceId("");
+      setLabel("");
+      void refresh();
+      toast.show({ kind: "success", title: "Device added" });
+    },
+    onError: (error) => toast.show({ kind: "error", title: "Add failed", description: (error as Error).message }),
+  });
+  const remove = useMutation({
+    mutationFn: (memberDeviceId: string) => removeDeviceGroupMember(appId, group.id, memberDeviceId),
+    onSuccess: () => void refresh(),
+    onError: (error) => toast.show({ kind: "error", title: "Remove failed", description: (error as Error).message }),
+  });
+  const destroy = useMutation({
+    mutationFn: () => deleteDeviceGroup(appId, group.id),
+    onSuccess: () => {
+      void refresh();
+      toast.show({ kind: "success", title: "Device group deleted" });
+    },
+    onError: (error) => toast.show({ kind: "error", title: "Delete failed", description: (error as Error).message }),
+  });
+
+  return (
+    <div className="rounded-md border border-slate-200 p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          {editing ? (
+            <div className="space-y-2">
+              <Input value={groupName} onChange={(event) => setGroupName(event.target.value)} placeholder="Group name" />
+              <Input
+                value={groupDescription}
+                onChange={(event) => setGroupDescription(event.target.value)}
+                placeholder="Operator note"
+              />
+            </div>
+          ) : (
+            <>
+              <div className="text-sm font-medium">{group.name}</div>
+              {group.description && <div className="text-xs text-slate-500">{group.description}</div>}
+            </>
+          )}
+          <div className="text-[11px] font-mono text-slate-400">{group.id}</div>
+        </div>
+        <div className="flex gap-2">
+          {editing ? (
+            <>
+              <Button variant="outline" disabled={!groupName.trim() || update.isPending} onClick={() => update.mutate()}>
+                Save
+              </Button>
+              <Button variant="outline" disabled={update.isPending} onClick={() => setEditing(false)}>
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" onClick={() => setEditing(true)}>Edit</Button>
+          )}
+          <Button
+            variant="outline"
+            disabled={destroy.isPending || editing}
+            onClick={() => { if (window.confirm(`Delete device group '${group.name}'?`)) destroy.mutate(); }}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+      <div className="space-y-1">
+        {group.members.length === 0 && <p className="text-xs text-slate-500">No devices yet.</p>}
+        {group.members.map((member) => (
+          <div key={member.device_id} className="flex items-center justify-between gap-2 text-xs">
+            <span className="min-w-0 truncate">
+              <span className="font-medium">{member.label || "Device"}</span>{" "}
+              <span className="font-mono text-slate-500">{member.device_id}</span>
+            </span>
+            <Button variant="outline" onClick={() => remove.mutate(member.device_id)} disabled={remove.isPending}>
+              Remove
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-[1fr_160px_auto] gap-2">
+        <Input value={deviceId} onChange={(event) => setDeviceId(event.target.value)} placeholder="Installation device id" />
+        <Input value={label} onChange={(event) => setLabel(event.target.value)} placeholder="Label" />
+        <Button variant="outline" disabled={!deviceId.trim() || add.isPending} onClick={() => add.mutate()}>
+          Add
         </Button>
       </div>
     </div>
@@ -1147,6 +1321,9 @@ export function AppSettings({ appId }: { appId: string }) {
 
         {/* Client key (feedback/crash reporting auth) */}
         <ClientKeyPanel appId={appId} />
+
+        {/* Exact per-installation rollout groups */}
+        <DeviceGroupsPanel appId={appId} />
 
         {/* TestFlight upload credentials — iOS apps only */}
         {app.platform === "ios" && <TestFlightPanel appId={appId} />}

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -16,6 +16,7 @@ import {
   getRelease,
   listApps,
   listChannels,
+  listDeviceGroups,
   listProductTypes,
   listReleases,
   publishRelease,
@@ -706,7 +707,11 @@ function EditReleaseDialog({
 }) {
   const toast = useToast();
   const [changelog, setChangelog] = useState(release.changelog ?? "");
-  const [scopeType, setScopeType] = useState<"full" | "platform" | "user_cohort" | "ip_range">("full");
+  const deviceGroups = useQuery({
+    queryKey: ["device-groups", appId],
+    queryFn: () => listDeviceGroups(appId),
+  });
+  const [scopeType, setScopeType] = useState<"full" | "platform" | "user_cohort" | "ip_range" | "device_group">("full");
   const [scopeValue, setScopeValue] = useState("all");
   const [shouldForceUpdate, setShouldForceUpdate] = useState(Boolean(release.should_force_update));
   const [rolloutPercent, setRolloutPercent] = useState<number>(release.rollout_cohort_count ?? 100);
@@ -722,7 +727,8 @@ function EditReleaseDialog({
       (firstScope.scope_type === "full" ||
         firstScope.scope_type === "platform" ||
         firstScope.scope_type === "user_cohort" ||
-        firstScope.scope_type === "ip_range")
+        firstScope.scope_type === "ip_range" ||
+        firstScope.scope_type === "device_group")
     ) {
       setScopeType(firstScope.scope_type);
       setScopeValue(firstScope.scope_value);
@@ -784,6 +790,7 @@ function EditReleaseDialog({
                   platform: "Platform",
                   user_cohort: "User cohort",
                   ip_range: "IP range",
+                  device_group: "Device group",
                 }}
                 value={scopeType}
                 onValueChange={(v) => {
@@ -801,17 +808,33 @@ function EditReleaseDialog({
                   <SelectItem value="platform">Platform</SelectItem>
                   <SelectItem value="user_cohort">User cohort</SelectItem>
                   <SelectItem value="ip_range">IP range</SelectItem>
+                  <SelectItem value="device_group">Device group</SelectItem>
                 </SelectContent>
               </Select>
             </div>
             <div>
               <label className="label">Scope value</label>
-              <Input
-                value={scopeValue}
-                disabled={scopeType === "full"}
-                onChange={(e) => setScopeValue(e.target.value)}
-                placeholder={scopeType === "full" ? "all" : "android-arm64-v8a"}
-              />
+              {scopeType === "device_group" ? (
+                <Select
+                  items={Object.fromEntries((deviceGroups.data?.groups ?? []).map((group) => [group.id, group.name]))}
+                  value={scopeValue}
+                  onValueChange={(value) => setScopeValue(value as string)}
+                >
+                  <SelectTrigger><SelectValue placeholder="Choose group" /><SelectIcon /></SelectTrigger>
+                  <SelectContent>
+                    {(deviceGroups.data?.groups ?? []).map((group) => (
+                      <SelectItem key={group.id} value={group.id}>{group.name} ({group.member_count})</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  value={scopeValue}
+                  disabled={scopeType === "full"}
+                  onChange={(e) => setScopeValue(e.target.value)}
+                  placeholder={scopeType === "full" ? "all" : "android-arm64-v8a"}
+                />
+              )}
             </div>
           </div>
           <label className="flex items-center gap-2 text-xs">
@@ -866,6 +889,10 @@ function NewReleaseDialog({
     queryKey: ["product-types", appId],
     queryFn: () => listProductTypes(appId),
   });
+  const deviceGroups = useQuery({
+    queryKey: ["device-groups", appId],
+    queryFn: () => listDeviceGroups(appId),
+  });
 
   // Pre-fill the channel with the app's default release channel (set in
   // AppDetail Settings). Falls back to first channel if no default.
@@ -888,7 +915,7 @@ function NewReleaseDialog({
   const [versionName, setVersionName] = useState<string>("");
   const [versionCode, setVersionCode] = useState<string>("");
   const [changelog, setChangelog] = useState<string>("");
-  const [scopeType, setScopeType] = useState<"full" | "platform" | "user_cohort" | "ip_range">(
+  const [scopeType, setScopeType] = useState<"full" | "platform" | "user_cohort" | "ip_range" | "device_group">(
     "full",
   );
   const [scopeValue, setScopeValue] = useState<string>("all");
@@ -1253,10 +1280,57 @@ function NewReleaseDialog({
                     setShowAdvanced((v) => !v);
                   }}
                 >
-                  {showAdvanced ? "▾" : "▸"} Advanced options (force update, rollout %)
+                  {showAdvanced ? "▾" : "▸"} Advanced options (scope, force update, rollout %)
                 </summary>
                 {showAdvanced && (
                   <div className="mt-2 p-3 border border-slate-200 rounded-sm space-y-2">
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="label">Release scope</label>
+                        <Select
+                          items={{ full: "Full", platform: "Platform", user_cohort: "User cohort", ip_range: "IP range", device_group: "Device group" }}
+                          value={scopeType}
+                          onValueChange={(value) => {
+                            const next = value as typeof scopeType;
+                            setScopeType(next);
+                            setScopeValue(next === "full" ? "all" : "");
+                          }}
+                        >
+                          <SelectTrigger><SelectValue /><SelectIcon /></SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="full">Full</SelectItem>
+                            <SelectItem value="platform">Platform</SelectItem>
+                            <SelectItem value="user_cohort">User cohort</SelectItem>
+                            <SelectItem value="ip_range">IP range</SelectItem>
+                            <SelectItem value="device_group">Device group</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div>
+                        <label className="label">Scope value</label>
+                        {scopeType === "device_group" ? (
+                          <Select
+                            items={Object.fromEntries((deviceGroups.data?.groups ?? []).map((group) => [group.id, group.name]))}
+                            value={scopeValue}
+                            onValueChange={(value) => setScopeValue(value as string)}
+                          >
+                            <SelectTrigger><SelectValue placeholder="Choose group" /><SelectIcon /></SelectTrigger>
+                            <SelectContent>
+                              {(deviceGroups.data?.groups ?? []).map((group) => (
+                                <SelectItem key={group.id} value={group.id}>{group.name} ({group.member_count})</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Input
+                            value={scopeValue}
+                            disabled={scopeType === "full"}
+                            onChange={(event) => setScopeValue(event.target.value)}
+                            placeholder={scopeType === "full" ? "all" : "android-arm64-v8a"}
+                          />
+                        )}
+                      </div>
+                    </div>
                     <label className="flex items-center gap-2 text-xs">
                       <Checkbox
                         checked={shouldForceUpdate}

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -338,6 +338,27 @@ Bilingual changelogs are stored per language; clients receive the language
 matching their locale (`zh` normalizes to `zh-CN`; plain single-value
 changelogs are served as-is).
 
+### Exact device-group rollout
+
+Create a named group, add stable installation ids reported by the Hands update
+SDK, then bind a draft release to that group:
+
+```bash
+hands device-groups create raft-android --name "Artin test devices"
+hands device-groups add-member raft-android <group-id> \
+  --device-id <installation-device-id> --label "Huawei test tablet"
+hands device-groups update raft-android <group-id> \
+  --name "Artin test tablets" --description "Physical acceptance devices"
+hands releases update raft-android <release-id> --device-group <group-id>
+hands releases publish raft-android <release-id>
+```
+
+The final publish remains an explicit authorization step. Only exact group
+members receive the release; other devices fall back to the prior active
+release. List groups with `hands device-groups list <app>` and remove members
+with `device-groups remove-member`. Rename or change the operator note with
+`device-groups update`. Do not use IMEI or hardware serial numbers.
+
 ## Share Links
 
 ```bash

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -43,6 +43,13 @@ while the percentage climbs. Clients that send no device id only ever see
 fully rolled-out releases; gated-out clients fall through to the previous
 active release. The Android SDK sends the header automatically.
 
+For exact QA or customer-device targeting, publishers can create an app-scoped
+device group and use a `device_group` release scope. Membership is evaluated
+server-side against the same stable installation `device_id`; the client never
+receives or chooses the group name. A non-member falls through to the previous
+matching active release. Device groups use installation identifiers, not IMEI,
+hardware serial numbers, or account identities.
+
 ### Update Available
 
 ```json

--- a/migrations/sql/0049_device_groups.sql
+++ b/migrations/sql/0049_device_groups.sql
@@ -1,0 +1,64 @@
+CREATE TABLE IF NOT EXISTS device_groups (
+  id          TEXT PRIMARY KEY,
+  app_id      TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  description TEXT,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_device_groups_app_name
+  ON device_groups(app_id, name COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS device_group_members (
+  group_id   TEXT NOT NULL REFERENCES device_groups(id) ON DELETE CASCADE,
+  device_id  TEXT NOT NULL,
+  label      TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (group_id, device_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_group_members_device
+  ON device_group_members(device_id, group_id);
+
+-- release_scopes cannot use a normal foreign key because scope_value is
+-- polymorphic. Enforce the device-group branch in the database so concurrent
+-- create/update/delete requests cannot leave a dangling or cross-app scope.
+CREATE TRIGGER IF NOT EXISTS trg_release_scopes_device_group_insert
+BEFORE INSERT ON release_scopes
+WHEN NEW.scope_type = 'device_group'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM releases r
+    JOIN device_groups g ON g.id = NEW.scope_value
+    WHERE r.id = NEW.release_id AND r.app_id = g.app_id
+  ) THEN RAISE(ABORT, 'device_group scope must reference a group in the release app') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_release_scopes_device_group_update
+BEFORE UPDATE OF release_id, scope_type, scope_value ON release_scopes
+WHEN NEW.scope_type = 'device_group'
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM releases r
+    JOIN device_groups g ON g.id = NEW.scope_value
+    WHERE r.id = NEW.release_id AND r.app_id = g.app_id
+  ) THEN RAISE(ABORT, 'device_group scope must reference a group in the release app') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_device_groups_live_release_delete
+BEFORE DELETE ON device_groups
+WHEN EXISTS (SELECT 1 FROM apps WHERE id = OLD.app_id)
+  AND EXISTS (
+    SELECT 1
+    FROM release_scopes s
+    JOIN releases r ON r.id = s.release_id
+    WHERE s.scope_type = 'device_group'
+      AND s.scope_value = OLD.id
+      AND r.status IN ('draft', 'active')
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'device group is used by a draft or active release');
+END;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.10 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.11 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -125,6 +125,98 @@ describe("apiRequest", () => {
   });
 });
 
+describe("device-group rollout commands", () => {
+  it("creates and updates a device group, then applies it as a release scope", async () => {
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      if (req.url === "/api/apps/app-1/device-groups" && req.method === "POST") {
+        return res.end(JSON.stringify({ id: "group-1", name: "Artin test devices", member_count: 0, members: [] }));
+      }
+      if (req.url === "/api/apps/app-1/device-groups/group-1" && req.method === "PATCH") {
+        return res.end(JSON.stringify({
+          id: "group-1",
+          name: "Artin test tablets",
+          description: "Physical acceptance devices",
+          member_count: 0,
+          members: [],
+        }));
+      }
+      if (req.url === "/api/apps/app-1/releases/release-1" && req.method === "PATCH") {
+        return res.end(JSON.stringify({ id: "release-1", status: "draft" }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { registerDeviceGroupCommands } = await import("../src/commands/device_groups.js");
+      const { registerReleaseCommands } = await import("../src/commands/releases.js");
+
+      const groupsProgram = new Command();
+      registerDeviceGroupCommands(groupsProgram);
+      await groupsProgram.parseAsync([
+        "node", "hands", "device-groups", "create", "raft-android",
+        "--name", "Artin test devices",
+      ]);
+      const updateProgram = new Command();
+      registerDeviceGroupCommands(updateProgram);
+      await updateProgram.parseAsync([
+        "node", "hands", "device-groups", "update", "raft-android", "group-1",
+        "--name", "Artin test tablets",
+        "--description", "Physical acceptance devices",
+      ]);
+
+      const releasesProgram = new Command();
+      registerReleaseCommands(releasesProgram);
+      await releasesProgram.parseAsync([
+        "node", "hands", "releases", "update", "raft-android", "release-1",
+        "--device-group", "group-1",
+      ]);
+
+      expect(requests.find((request) => request.url.endsWith("/device-groups"))).toMatchObject({
+        method: "POST",
+        body: { name: "Artin test devices" },
+      });
+      expect(requests.find((request) => request.url.endsWith("/device-groups/group-1"))).toMatchObject({
+        method: "PATCH",
+        body: {
+          name: "Artin test tablets",
+          description: "Physical acceptance devices",
+        },
+      });
+      expect(requests.find((request) => request.url.endsWith("/releases/release-1"))).toMatchObject({
+        method: "PATCH",
+        body: { scopes: [{ scope_type: "device_group", scope_value: "group-1" }] },
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
 describe("electron build helpers", () => {
   it("infers Electron platforms from metadata and artifact filenames", async () => {
     const { inferElectronPlatform } = await import("../src/commands/builds.js");

--- a/packages/cli/src/commands/device_groups.ts
+++ b/packages/cli/src/commands/device_groups.ts
@@ -1,0 +1,101 @@
+import type { Command } from "commander";
+import { apiRequest } from "../lib/api.js";
+
+type AppRow = { id: string; slug: string };
+type DeviceGroup = {
+  id: string;
+  name: string;
+  description: string | null;
+  member_count: number;
+  members: Array<{ device_id: string; label: string | null }>;
+};
+
+export function registerDeviceGroupCommands(program: Command): void {
+  const groups = program.command("device-groups").description("Manage exact-rollout installation device groups.");
+
+  groups.command("list <appIdOrSlug>").option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<{ groups: DeviceGroup[] }>(`/api/apps/${appId}/device-groups`);
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      if (result.groups.length === 0) return console.log("No device groups.");
+      for (const group of result.groups) console.log(`${group.id}  ${group.name}  members=${group.member_count}`);
+    });
+
+  groups.command("create <appIdOrSlug>").requiredOption("--name <name>", "Group name.")
+    .option("--description <text>", "Operator note.").option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: { name: string; description?: string; json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<DeviceGroup>(`/api/apps/${appId}/device-groups`, {
+        method: "POST", body: { name: opts.name, description: opts.description },
+      });
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(`Created device group ${result.id} (${result.name}).`);
+    });
+
+  groups.command("update <appIdOrSlug> <groupId>")
+    .option("--name <name>", "New group name.")
+    .option("--description <text>", "New operator note; pass an empty string to clear it.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      groupId: string,
+      opts: { name?: string; description?: string; json?: boolean },
+    ) => {
+      if (opts.name === undefined && opts.description === undefined) {
+        throw new Error("nothing to update: pass --name or --description");
+      }
+      const appId = await resolveAppId(appIdOrSlug);
+      const body: Record<string, unknown> = {};
+      if (opts.name !== undefined) body.name = opts.name;
+      if (opts.description !== undefined) body.description = opts.description;
+      const result = await apiRequest<DeviceGroup>(`/api/apps/${appId}/device-groups/${groupId}`, {
+        method: "PATCH", body,
+      });
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(`Updated device group ${result.id} (${result.name}).`);
+    });
+
+  groups.command("add-member <appIdOrSlug> <groupId>")
+    .requiredOption("--device-id <id>", "Stable Hands installation device id.")
+    .option("--label <label>", "Human-readable device label.").option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, groupId: string, opts: { deviceId: string; label?: string; json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<Record<string, unknown>>(`/api/apps/${appId}/device-groups/${groupId}/members`, {
+        method: "POST", body: { device_id: opts.deviceId, label: opts.label },
+      });
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(`Added device to group ${groupId}.`);
+    });
+
+  groups.command("remove-member <appIdOrSlug> <groupId>")
+    .requiredOption("--device-id <id>", "Stable Hands installation device id.")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, groupId: string, opts: { deviceId: string; json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<Record<string, unknown>>(
+        `/api/apps/${appId}/device-groups/${groupId}/members/${encodeURIComponent(opts.deviceId)}`,
+        { method: "DELETE" },
+      );
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(`Removed device from group ${groupId}.`);
+    });
+
+  groups.command("delete <appIdOrSlug> <groupId>").option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, groupId: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<Record<string, unknown>>(`/api/apps/${appId}/device-groups/${groupId}`, {
+        method: "DELETE",
+      });
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(`Deleted device group ${groupId}.`);
+    });
+}
+
+async function resolveAppId(input: string): Promise<string> {
+  if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(input)) return input;
+  const { apps } = await apiRequest<{ apps: AppRow[] }>("/api/apps");
+  const app = apps.find((item) => item.slug === input);
+  if (!app) throw new Error(`App not found: ${input}`);
+  return app.id;
+}

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -67,6 +67,7 @@ export function registerReleaseCommands(program: Command): void {
       "Changelog file. Repeatable with lang=path, e.g. --changelog-file zh=zh.md --changelog-file en=en.md.",
       (value: string, prev: string[] = []) => [...prev, value],
     )
+    .option("--device-group <groupId>", "Replace release scope with one exact-rollout device group UUID.")
     .option("--json", "Output JSON.", false)
     .action(
       async (
@@ -75,6 +76,7 @@ export function registerReleaseCommands(program: Command): void {
         opts: {
           changelog?: string[];
           changelogFile?: string[];
+          deviceGroup?: string;
           json?: boolean;
         },
       ) => {
@@ -108,21 +110,26 @@ export function registerReleaseCommands(program: Command): void {
         } else if (plain !== undefined) {
           changelog = plain;
         }
-        if (changelog === undefined) {
+        if (changelog === undefined && !opts.deviceGroup) {
           throw new Error(
-            "nothing to update: pass --changelog(-file) [lang=]value, e.g. --changelog-file zh=zh.md --changelog-file en=en.md",
+            "nothing to update: pass --changelog(-file) or --device-group",
           );
+        }
+        const body: Record<string, unknown> = {};
+        if (changelog !== undefined) body.changelog = changelog;
+        if (opts.deviceGroup) {
+          body.scopes = [{ scope_type: "device_group", scope_value: opts.deviceGroup }];
         }
         const updated = await apiRequest<Record<string, unknown>>(
           `/api/apps/${appId}/releases/${releaseId}`,
-          { method: "PATCH", body: { changelog } },
+          { method: "PATCH", body },
         );
         if (opts.json) {
           console.log(JSON.stringify(updated, null, 2));
           return;
         }
         console.log(
-          `Updated release ${releaseId} changelog${langs.length ? ` (${langs.join(", ")})` : ""}.`,
+          `Updated release ${releaseId}${changelog !== undefined ? ` changelog${langs.length ? ` (${langs.join(", ")})` : ""}` : ""}${opts.deviceGroup ? ` scope=device_group:${opts.deviceGroup}` : ""}.`,
         );
       },
     );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import { registerFeedbackCommands } from "./commands/feedback.js";
 import { registerDeployTokenCommands } from "./commands/deploy_tokens.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerLogsCommands } from "./commands/logs.js";
+import { registerDeviceGroupCommands } from "./commands/device_groups.js";
 import { getConfig } from "./lib/config.js";
 import { readEnv } from "./lib/env.js";
 import { setApiBase } from "./lib/api.js";
@@ -35,7 +36,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.10")
+  .version("0.5.11")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",
@@ -83,6 +84,7 @@ registerWhoamiCommand(program);
 registerAppCommands(program);
 registerBuildCommands(program);
 registerReleaseCommands(program);
+registerDeviceGroupCommands(program);
 registerFeedbackCommands(program);
 registerDeployTokenCommands(program);
 registerLogsCommands(program);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -155,6 +155,14 @@ import {
   handleListReleaseChecks,
 } from "./routes/releases";
 import { handleListChannels, handleCreateChannel, handleUpdateChannel, handleDeleteChannel } from "./routes/channels";
+import {
+  handleAddDeviceGroupMember,
+  handleCreateDeviceGroup,
+  handleDeleteDeviceGroup,
+  handleListDeviceGroups,
+  handleRemoveDeviceGroupMember,
+  handleUpdateDeviceGroup,
+} from "./routes/device_groups";
 import { handleListProductTypes, handleCreateProductType, handleUpdateProductType, handleDeleteProductType } from "./routes/product_types";
 import { handleListReleaseTypes, handleCreateReleaseType, handleUpdateReleaseType, handleDeleteReleaseType } from "./routes/release_types";
 import { handleListAuditLogs, handleListUserAudit } from "./routes/audit";
@@ -838,6 +846,21 @@ admin.get("/api/apps/:appId/channels", requireAppRole("viewer"), handleListChann
 admin.post("/api/apps/:appId/channels", requireAppRole("admin"), handleCreateChannel);
 admin.patch("/api/apps/:appId/channels/:channelId", requireAppRole("admin"), handleUpdateChannel);
 admin.delete("/api/apps/:appId/channels/:channelId", requireAppRole("admin"), handleDeleteChannel);
+
+admin.get("/api/apps/:appId/device-groups", requireAppRole("publisher"), handleListDeviceGroups);
+admin.post("/api/apps/:appId/device-groups", requireAppRole("publisher"), handleCreateDeviceGroup);
+admin.patch("/api/apps/:appId/device-groups/:groupId", requireAppRole("publisher"), handleUpdateDeviceGroup);
+admin.delete("/api/apps/:appId/device-groups/:groupId", requireAppRole("publisher"), handleDeleteDeviceGroup);
+admin.post(
+  "/api/apps/:appId/device-groups/:groupId/members",
+  requireAppRole("publisher"),
+  handleAddDeviceGroupMember,
+);
+admin.delete(
+  "/api/apps/:appId/device-groups/:groupId/members/:deviceId",
+  requireAppRole("publisher"),
+  handleRemoveDeviceGroupMember,
+);
 
 admin.get("/api/apps/:appId/product-types", requireAppRole("viewer"), handleListProductTypes);
 admin.post("/api/apps/:appId/product-types", requireAppRole("admin"), handleCreateProductType);

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -25,7 +25,7 @@ const PublicApp = z
 
 const PublicScope = z
   .object({
-    scope_type: z.enum(["full", "platform", "user_cohort", "ip_range"]),
+    scope_type: z.enum(["full", "platform", "user_cohort", "ip_range", "device_group"]),
     scope_value: z.string(),
     release_id: z.string(),
     rollout_cohort_count: z.number().int().nullable().optional(),

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -820,6 +820,65 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           "Create a release channel on an app (channels are never auto-created by publish). Requires app admin. Creating a channel activates nothing.",
       },
       {
+        name: "list-device-groups",
+        description: "List app-scoped rollout device groups and their installation device ids. Requires app publisher.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/device-groups" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+        },
+      },
+      {
+        name: "create-device-group",
+        description: "Create an app-scoped device group for exact release targeting. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/device-groups" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          name: { type: "string", in: "body", required: true, description: "Display name." },
+          description: { type: "string", in: "body", required: false, description: "Optional operator note." },
+        },
+      },
+      {
+        name: "update-device-group",
+        description: "Rename or update the operator note for an app-scoped device group. Requires app publisher.",
+        endpoint: { method: "PATCH", path: "/api/apps/{app_id}/device-groups/{group_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          group_id: { type: "string", in: "path", required: true, description: "Device-group UUID." },
+          name: { type: "string", in: "body", required: false, description: "New display name." },
+          description: { type: "string", in: "body", required: false, description: "New operator note; empty clears it." },
+        },
+      },
+      {
+        name: "add-device-group-member",
+        description: "Add or relabel one stable Hands installation device id in a device group. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/device-groups/{group_id}/members" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          group_id: { type: "string", in: "path", required: true, description: "Device-group UUID." },
+          device_id: { type: "string", in: "body", required: true, description: "Stable per-installation id reported by the Hands update SDK." },
+          label: { type: "string", in: "body", required: false, description: "Human-readable member label." },
+        },
+      },
+      {
+        name: "remove-device-group-member",
+        description: "Remove one installation device id from a device group. Requires app publisher.",
+        endpoint: { method: "DELETE", path: "/api/apps/{app_id}/device-groups/{group_id}/members/{device_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          group_id: { type: "string", in: "path", required: true, description: "Device-group UUID." },
+          device_id: { type: "string", in: "path", required: true, description: "URL-encoded installation device id." },
+        },
+      },
+      {
+        name: "delete-device-group",
+        description: "Delete an unused device group. Draft/active release references fail closed. Requires app publisher.",
+        endpoint: { method: "DELETE", path: "/api/apps/{app_id}/device-groups/{group_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          group_id: { type: "string", in: "path", required: true, description: "Device-group UUID." },
+        },
+      },
+      {
         name: "list-releases",
         description: "List an app's releases (id, status, channel, version, rollout). Requires app viewer.",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/releases" },
@@ -847,6 +906,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           channel_id: { type: "string", in: "body", required: false, description: "Channel UUID (defaults to the build's channel)." },
           changelog: { type: "string", in: "body", required: false, description: "Changelog text (single-language fallback)." },
           release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes, e.g. {\"en\": \"...\", \"zh-CN\": \"...\"}." },
+          scopes: { type: "array", in: "body", required: false, description: "Release scopes. Exact device targeting uses [{\"scope_type\":\"device_group\",\"scope_value\":\"<group UUID>\"}]." },
         },
       },
       {
@@ -860,6 +920,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           changelog: { type: "string", in: "body", required: false, description: "Changelog text." },
           release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes object." },
           hidden: { type: "boolean", in: "body", required: false, description: "Hide/show on public history without deleting." },
+          scopes: { type: "array", in: "body", required: false, description: "Replace release scopes. Exact device targeting uses device_group with a same-app group UUID." },
         },
       },
       {

--- a/worker/src/routes/device_groups.ts
+++ b/worker/src/routes/device_groups.ts
@@ -1,0 +1,203 @@
+import type { Context } from "hono";
+import { currentActor } from "../middleware/auth";
+
+type DeviceGroupRow = {
+  id: string;
+  app_id: string;
+  name: string;
+  description: string | null;
+  created_at: number;
+  updated_at: number;
+  member_count?: number;
+};
+
+function normalizeName(value: unknown): string {
+  const name = String(value ?? "").trim();
+  if (!name) throw new Error("name required");
+  if (name.length > 80) throw new Error("name too long (max 80 chars)");
+  return name;
+}
+
+function normalizeDescription(value: unknown): string | null {
+  const description = String(value ?? "").trim();
+  if (description.length > 500) throw new Error("description too long (max 500 chars)");
+  return description || null;
+}
+
+function normalizeDeviceId(value: unknown): string {
+  const deviceId = String(value ?? "").trim();
+  if (!deviceId) throw new Error("device_id required");
+  if (deviceId.length > 256) throw new Error("device_id too long (max 256 chars)");
+  return deviceId;
+}
+
+function normalizeLabel(value: unknown): string | null {
+  const label = String(value ?? "").trim();
+  if (label.length > 120) throw new Error("label too long (max 120 chars)");
+  return label || null;
+}
+
+async function getGroup(db: D1Database, appId: string, groupId: string) {
+  return db.prepare(
+    `SELECT id, app_id, name, description, created_at, updated_at
+     FROM device_groups WHERE id = ?1 AND app_id = ?2`,
+  ).bind(groupId, appId).first<DeviceGroupRow>();
+}
+
+async function audit(
+  db: D1Database,
+  appId: string,
+  action: string,
+  actor: string,
+  payload: unknown,
+  now = Date.now(),
+) {
+  await db.prepare(
+    "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+  ).bind(crypto.randomUUID(), appId, action, actor, JSON.stringify(payload), now).run();
+}
+
+export async function handleListDeviceGroups(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const { results: groups } = await c.env.DB.prepare(
+    `SELECT g.id, g.app_id, g.name, g.description, g.created_at, g.updated_at,
+            COUNT(m.device_id) AS member_count
+     FROM device_groups g
+     LEFT JOIN device_group_members m ON m.group_id = g.id
+     WHERE g.app_id = ?1
+     GROUP BY g.id
+     ORDER BY lower(g.name), g.id`,
+  ).bind(appId).all<DeviceGroupRow>();
+  const { results: members } = await c.env.DB.prepare(
+    `SELECT m.group_id, m.device_id, m.label, m.created_at
+     FROM device_group_members m
+     JOIN device_groups g ON g.id = m.group_id
+     WHERE g.app_id = ?1
+     ORDER BY m.created_at, m.device_id`,
+  ).bind(appId).all<{ group_id: string; device_id: string; label: string | null; created_at: number }>();
+  return c.json({
+    groups: groups.map((group) => ({
+      ...group,
+      member_count: Number(group.member_count ?? 0),
+      members: members.filter((member) => member.group_id === group.id),
+    })),
+  });
+}
+
+export async function handleCreateDeviceGroup(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const body = await c.req.json().catch(() => ({})) as { name?: unknown; description?: unknown };
+  try {
+    const id = crypto.randomUUID();
+    const name = normalizeName(body.name);
+    const description = normalizeDescription(body.description);
+    const now = Date.now();
+    await c.env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?5)`,
+    ).bind(id, appId, name, description, now).run();
+    await audit(c.env.DB, appId, "device_group.create", currentActor(c), { group_id: id, name, description }, now);
+    return c.json({ id, app_id: appId, name, description, member_count: 0, members: [] }, 201);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message.includes("UNIQUE") ? "device group name already exists" : message }, message.includes("UNIQUE") ? 409 : 400);
+  }
+}
+
+export async function handleUpdateDeviceGroup(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const groupId = c.req.param("groupId") ?? "";
+  const group = await getGroup(c.env.DB, appId, groupId);
+  if (!group) return c.json({ error: "device group not found" }, 404);
+  const body = await c.req.json().catch(() => ({})) as { name?: unknown; description?: unknown };
+  try {
+    const name = body.name === undefined ? group.name : normalizeName(body.name);
+    const description = body.description === undefined ? group.description : normalizeDescription(body.description);
+    const now = Date.now();
+    await c.env.DB.prepare(
+      `UPDATE device_groups SET name = ?1, description = ?2, updated_at = ?3
+       WHERE id = ?4 AND app_id = ?5`,
+    ).bind(name, description, now, groupId, appId).run();
+    await audit(c.env.DB, appId, "device_group.update", currentActor(c), { group_id: groupId, name, description }, now);
+    return c.json({ id: groupId, app_id: appId, name, description });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message.includes("UNIQUE") ? "device group name already exists" : message }, message.includes("UNIQUE") ? 409 : 400);
+  }
+}
+
+export async function handleDeleteDeviceGroup(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const groupId = c.req.param("groupId") ?? "";
+  const group = await getGroup(c.env.DB, appId, groupId);
+  if (!group) return c.json({ error: "device group not found" }, 404);
+  const usage = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS count
+     FROM release_scopes s
+     JOIN releases r ON r.id = s.release_id
+     WHERE r.app_id = ?1 AND s.scope_type = 'device_group' AND s.scope_value = ?2
+       AND r.status IN ('draft', 'active')`,
+  ).bind(appId, groupId).first<{ count: number }>();
+  if (Number(usage?.count ?? 0) > 0) {
+    return c.json({ error: "device group is used by a draft or active release" }, 409);
+  }
+  const now = Date.now();
+  try {
+    await c.env.DB.prepare("DELETE FROM device_groups WHERE id = ?1 AND app_id = ?2").bind(groupId, appId).run();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("device group is used by a draft or active release")) {
+      return c.json({ error: "device group is used by a draft or active release" }, 409);
+    }
+    throw error;
+  }
+  await audit(c.env.DB, appId, "device_group.delete", currentActor(c), { group_id: groupId, name: group.name }, now);
+  return c.json({ ok: true, id: groupId });
+}
+
+export async function handleAddDeviceGroupMember(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const groupId = c.req.param("groupId") ?? "";
+  const group = await getGroup(c.env.DB, appId, groupId);
+  if (!group) return c.json({ error: "device group not found" }, 404);
+  const body = await c.req.json().catch(() => ({})) as { device_id?: unknown; label?: unknown };
+  try {
+    const deviceId = normalizeDeviceId(body.device_id);
+    const label = normalizeLabel(body.label);
+    const now = Date.now();
+    await c.env.DB.prepare(
+      `INSERT INTO device_group_members (group_id, device_id, label, created_at)
+       VALUES (?1, ?2, ?3, ?4)
+       ON CONFLICT(group_id, device_id) DO UPDATE SET label = excluded.label`,
+    ).bind(groupId, deviceId, label, now).run();
+    await c.env.DB.prepare("UPDATE device_groups SET updated_at = ?1 WHERE id = ?2 AND app_id = ?3").bind(now, groupId, appId).run();
+    await audit(c.env.DB, appId, "device_group.member_upsert", currentActor(c), {
+      group_id: groupId,
+      device_id: deviceId,
+      label,
+    }, now);
+    return c.json({ group_id: groupId, device_id: deviceId, label }, 201);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+  }
+}
+
+export async function handleRemoveDeviceGroupMember(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const groupId = c.req.param("groupId") ?? "";
+  const group = await getGroup(c.env.DB, appId, groupId);
+  if (!group) return c.json({ error: "device group not found" }, 404);
+  let deviceId: string;
+  try {
+    deviceId = normalizeDeviceId(decodeURIComponent(c.req.param("deviceId") ?? ""));
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+  }
+  const now = Date.now();
+  await c.env.DB.prepare(
+    "DELETE FROM device_group_members WHERE group_id = ?1 AND device_id = ?2",
+  ).bind(groupId, deviceId).run();
+  await c.env.DB.prepare("UPDATE device_groups SET updated_at = ?1 WHERE id = ?2 AND app_id = ?3").bind(now, groupId, appId).run();
+  await audit(c.env.DB, appId, "device_group.member_remove", currentActor(c), { group_id: groupId, device_id: deviceId }, now);
+  return c.json({ ok: true, group_id: groupId, device_id: deviceId });
+}

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -6,10 +6,11 @@
  *   Headers: X-Quiver-Client-Platform, X-Quiver-Cohort, (cf.clientIp for ip_range)
  *
  * Server picks the most specific matching scope:
- *   1. ip_range    (priority 4) — CIDR match on cf.clientIp
- *   2. user_cohort (priority 3) — exact match on X-Quiver-Cohort header
- *   3. platform    (priority 2) — CSV match on X-Quiver-Client-Platform
- *   4. full        (priority 1) — catch-all
+ *   1. device_group (priority 5) — server-owned membership keyed by device id
+ *   2. ip_range     (priority 4) — CIDR match on cf.clientIp
+ *   3. user_cohort  (priority 3) — exact match on X-Quiver-Cohort header
+ *   4. platform     (priority 2) — CSV match on X-Quiver-Client-Platform
+ *   5. full         (priority 1) — catch-all
  *
  * Within a priority level, ties broken by created_at DESC, then release_id.
  *
@@ -25,7 +26,7 @@ import { isFeatureEnabled } from "../lib/feature_flags";
 
 interface ScopedResolution {
   release_id: string;
-  scope_type: "full" | "platform" | "user_cohort" | "ip_range";
+  scope_type: "full" | "platform" | "user_cohort" | "ip_range" | "device_group";
   scope_value: string;
   priority: number;
   release_created_at: number;
@@ -56,7 +57,7 @@ type PublicLatestResponse = {
   };
   assets: PublicAssetResponse[];
   scoped: {
-    scope_type: "full" | "platform" | "user_cohort" | "ip_range";
+    scope_type: "full" | "platform" | "user_cohort" | "ip_range" | "device_group";
     scope_value: string;
     release_id: string;
     rollout_cohort_count?: number | null;
@@ -69,6 +70,7 @@ const PUBLIC_DOWNLOAD_PREFIX = "/public/r2";
 
 const PRIORITY = {
   ip_range: 4,
+  device_group: 5,
   user_cohort: 3,
   platform: 2,
   full: 1,
@@ -172,6 +174,17 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
     .bind(...candidateIds)
     .all<{ release_id: string; scope_type: string; scope_value: string }>();
 
+  const deviceGroupIds = new Set<string>();
+  if (deviceId) {
+    const { results: memberships } = await c.env.DB.prepare(
+      `SELECT m.group_id
+       FROM device_group_members m
+       JOIN device_groups g ON g.id = m.group_id
+       WHERE g.app_id = ?1 AND m.device_id = ?2`,
+    ).bind(app.id, deviceId).all<{ group_id: string }>();
+    for (const membership of memberships) deviceGroupIds.add(membership.group_id);
+  }
+
   // Build match list (release, scope, priority).
   const matched: ScopedResolution[] = [];
   for (const release of candidates.results) {
@@ -183,6 +196,7 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
         cohort,
         clientPlatform,
         clientIp,
+        deviceGroupIds,
       );
       if (!ok) continue;
       const prio =
@@ -714,12 +728,15 @@ function matchesScope(
   cohort: string | null,
   clientPlatform: string | null,
   clientIp: string | null,
+  deviceGroupIds: ReadonlySet<string>,
 ): boolean {
   switch (scopeType) {
     case "full":
       return true;
     case "user_cohort":
       return !!cohort && scopeValue === cohort;
+    case "device_group":
+      return deviceGroupIds.has(scopeValue);
     case "platform": {
       if (!clientPlatform) return false;
       const tokens = scopeValue.split(",").map((s) => s.trim());

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -15,6 +15,8 @@ type ReleaseScopeInput = {
   scope_value: string;
 };
 
+const RELEASE_SCOPE_TYPES = new Set(["full", "platform", "user_cohort", "ip_range", "device_group"]);
+
 export interface ReleaseInput {
   build_id: string;
   channel_id?: string;
@@ -73,8 +75,42 @@ function jsonString(value: unknown, fallback: Record<string, unknown> | unknown[
 }
 
 function normalizeScopes(scopes: ReleaseScopeInput[] | undefined): ReleaseScopeInput[] {
-  const filtered = (scopes ?? []).filter((scope) => scope.scope_type && scope.scope_value);
+  const filtered = (scopes ?? [])
+    .map((scope) => ({
+      scope_type: String(scope.scope_type ?? "").trim(),
+      scope_value: String(scope.scope_value ?? "").trim(),
+    }))
+    .filter((scope) => scope.scope_type && scope.scope_value);
   return filtered.length > 0 ? filtered : [{ scope_type: "full", scope_value: "all" }];
+}
+
+async function validateScopes(
+  db: D1Database,
+  appId: string,
+  scopes: ReleaseScopeInput[] | undefined,
+): Promise<ReleaseScopeInput[]> {
+  const normalized = normalizeScopes(scopes);
+  const fullScopes = normalized.filter(
+    (scope) => scope.scope_type === "full" && scope.scope_value === "all",
+  );
+  if (fullScopes.length > 0 && normalized.length > 1) {
+    throw new Error("full release scope cannot be combined with other scopes");
+  }
+  for (const scope of normalized) {
+    if (!RELEASE_SCOPE_TYPES.has(scope.scope_type)) {
+      throw new Error(`unsupported release scope type: ${scope.scope_type}`);
+    }
+    if (scope.scope_type === "full" && scope.scope_value !== "all") {
+      throw new Error("full release scope value must be 'all'");
+    }
+    if (scope.scope_type === "device_group") {
+      const group = await db.prepare(
+        "SELECT id FROM device_groups WHERE id = ?1 AND app_id = ?2",
+      ).bind(scope.scope_value, appId).first<{ id: string }>();
+      if (!group) throw new Error(`device group not found for app: ${scope.scope_value}`);
+    }
+  }
+  return normalized;
 }
 
 function isFullRelease(scopes: ReleaseScopeInput[]): number {
@@ -84,6 +120,14 @@ function isFullRelease(scopes: ReleaseScopeInput[]): number {
     onlyScope.scope_value === "all"
     ? 1
     : 0;
+}
+
+function isFullCoverage(scopes: ReleaseScopeInput[], rolloutCohortCount: number | null | undefined): boolean {
+  // Treat legacy/malformed mixed rows containing full:all as full coverage so
+  // publish never restores or preserves fallbacks for a release that already
+  // matches every client. validateScopes rejects creating new mixed sets.
+  return scopes.some((scope) => scope.scope_type === "full" && scope.scope_value === "all") &&
+    (rolloutCohortCount === null || rolloutCohortCount === undefined || rolloutCohortCount >= 100);
 }
 
 async function insertAuditLog(
@@ -163,7 +207,7 @@ export async function createRelease(
   const productType = input.product_type ?? build.product_type;
   const releaseType = input.release_type ?? build.release_type;
   const status = releaseStatus(input.status);
-  const scopes = normalizeScopes(input.scopes);
+  const scopes = await validateScopes(db, appId, input.scopes);
   const now = Date.now();
   const changelog = inputChangelog(input);
 
@@ -217,7 +261,7 @@ export async function createRelease(
       ),
   ];
 
-  if (status === "active") {
+  if (status === "active" && isFullCoverage(scopes, input.rollout_cohort_count)) {
     statements.push(
       db
         .prepare(
@@ -311,7 +355,7 @@ async function updateReleaseFields(
 
   let scopes: ReleaseScopeInput[] | undefined;
   if (input.scopes !== undefined) {
-    scopes = normalizeScopes(input.scopes);
+    scopes = await validateScopes(db, appId, input.scopes);
     statements.push(
       db.prepare("DELETE FROM release_scopes WHERE release_id = ?1").bind(release.id),
       ...scopes.map((scope) =>
@@ -323,8 +367,47 @@ async function updateReleaseFields(
       ),
       db
         .prepare("UPDATE releases SET is_full = ?1, updated_at = ?2 WHERE id = ?3 AND app_id = ?4")
-        .bind(isFullRelease(scopes), now, release.id, appId),
+      .bind(isFullRelease(scopes), now, release.id, appId),
     );
+  }
+
+  if (release.status === "active" && (input.scopes !== undefined || input.rollout_cohort_count !== undefined)) {
+    const nextScopes = scopes ?? (await db.prepare(
+      "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
+    ).bind(release.id).all<ReleaseScopeInput>()).results;
+    const nextRollout = input.rollout_cohort_count !== undefined
+      ? input.rollout_cohort_count
+      : release.rollout_cohort_count;
+    if (isFullCoverage(nextScopes, nextRollout)) {
+      statements.push(
+        db.prepare(
+          `UPDATE releases
+           SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+           WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
+             AND release_type = ?6 AND status = 'active' AND id <> ?7`,
+        ).bind(
+          release.id,
+          now,
+          appId,
+          release.channel_id,
+          release.product_type,
+          release.release_type,
+          release.id,
+        ),
+      );
+    } else {
+      // A full release may already have superseded the fallback releases when
+      // it was activated. If operators narrow that active release later, put
+      // only its direct victims back into the active candidate set so clients
+      // outside the new scope/percentage still resolve a previous release.
+      statements.push(
+        db.prepare(
+          `UPDATE releases
+           SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
+           WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
+        ).bind(now, appId, release.id),
+      );
+    }
   }
 
   statements.push(
@@ -964,7 +1047,10 @@ export async function handlePublishRelease(c: AdminContext) {
     return c.json({ error: `cannot publish ${existing.status} release` }, 409);
   }
   const now = Date.now();
-  await c.env.DB.batch([
+  const { results: releaseScopes } = await c.env.DB.prepare(
+    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
+  ).bind(releaseId).all<ReleaseScopeInput>();
+  const statements = [
     c.env.DB
       .prepare(
         `UPDATE releases
@@ -972,22 +1058,6 @@ export async function handlePublishRelease(c: AdminContext) {
          WHERE id = ?2 AND app_id = ?3 AND status = 'draft'`,
       )
       .bind(now, releaseId, appId),
-    c.env.DB
-      .prepare(
-        `UPDATE releases
-         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
-         WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
-           AND release_type = ?6 AND status = 'active' AND id <> ?7`,
-      )
-      .bind(
-        releaseId,
-        now,
-        appId,
-        existing.channel_id,
-        existing.product_type,
-        existing.release_type,
-        releaseId,
-      ),
     c.env.DB
       .prepare(
         "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -1000,7 +1070,31 @@ export async function handlePublishRelease(c: AdminContext) {
         JSON.stringify({ release_id: releaseId, build_id: existing.build_id }),
         now,
       ),
-  ]);
+  ];
+  // Scoped and partial-rollout releases must coexist with the previous full
+  // active release so non-members can fall back. A full-coverage activation is
+  // the only event that supersedes every older active release in the lane.
+  if (isFullCoverage(releaseScopes, existing.rollout_cohort_count)) {
+    statements.splice(1, 0,
+      c.env.DB
+        .prepare(
+          `UPDATE releases
+           SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+           WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
+             AND release_type = ?6 AND status = 'active' AND id <> ?7`,
+        )
+        .bind(
+          releaseId,
+          now,
+          appId,
+          existing.channel_id,
+          existing.product_type,
+          existing.release_type,
+          releaseId,
+        ),
+    );
+  }
+  await c.env.DB.batch(statements);
 
   const orgId = c.get("org_id");
   if (orgId) {

--- a/worker/test/device_groups_migration.test.ts
+++ b/worker/test/device_groups_migration.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0049_device_groups.sql", import.meta.url),
+);
+
+describe("device-group migration invariants", () => {
+  it("enforces same-app scopes and blocks deletion while a live release references the group", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec(`
+      CREATE TABLE apps (id TEXT PRIMARY KEY);
+      CREATE TABLE releases (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+        status TEXT NOT NULL
+      );
+      CREATE TABLE release_scopes (
+        id TEXT PRIMARY KEY,
+        release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+        scope_type TEXT NOT NULL,
+        scope_value TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO apps (id) VALUES ('app-a'), ('app-b');
+      INSERT INTO releases (id, app_id, status)
+      VALUES ('release-a', 'app-a', 'draft'), ('release-b', 'app-b', 'active');
+    `);
+    db.exec(readFileSync(migrationPath, "utf8"));
+    db.exec(`
+      INSERT INTO device_groups (id, app_id, name, created_at, updated_at)
+      VALUES ('group-a', 'app-a', 'A devices', 1, 1),
+             ('group-b', 'app-b', 'B devices', 1, 1);
+    `);
+
+    expect(() => db.prepare(`
+      INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+      VALUES ('scope-valid', 'release-a', 'device_group', 'group-a', 1)
+    `).run()).not.toThrow();
+    expect(() => db.prepare(`
+      INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+      VALUES ('scope-cross-app', 'release-a', 'device_group', 'group-b', 1)
+    `).run()).toThrow("device_group scope must reference a group in the release app");
+    expect(() => db.prepare(`
+      UPDATE release_scopes SET scope_value = 'group-b' WHERE id = 'scope-valid'
+    `).run()).toThrow("device_group scope must reference a group in the release app");
+    expect(() => db.prepare("DELETE FROM device_groups WHERE id = 'group-a'").run())
+      .toThrow("device group is used by a draft or active release");
+
+    db.prepare("UPDATE releases SET status = 'superseded' WHERE id = 'release-a'").run();
+    expect(() => db.prepare("DELETE FROM device_groups WHERE id = 'group-a'").run()).not.toThrow();
+  });
+
+  it("does not block app cascade deletion", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec(`
+      CREATE TABLE apps (id TEXT PRIMARY KEY);
+      CREATE TABLE releases (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+        status TEXT NOT NULL
+      );
+      CREATE TABLE release_scopes (
+        id TEXT PRIMARY KEY,
+        release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+        scope_type TEXT NOT NULL,
+        scope_value TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO apps (id) VALUES ('app-delete');
+      INSERT INTO releases (id, app_id, status) VALUES ('release-delete', 'app-delete', 'active');
+    `);
+    db.exec(readFileSync(migrationPath, "utf8"));
+    db.exec(`
+      INSERT INTO device_groups (id, app_id, name, created_at, updated_at)
+      VALUES ('group-delete', 'app-delete', 'Delete devices', 1, 1);
+      INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+      VALUES ('scope-delete', 'release-delete', 'device_group', 'group-delete', 1);
+    `);
+
+    expect(() => db.prepare("DELETE FROM apps WHERE id = 'app-delete'").run()).not.toThrow();
+    expect(db.prepare("SELECT COUNT(*) AS count FROM device_groups").get()).toEqual({ count: 0 });
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -284,6 +284,23 @@ function makeMockDb() {
       created_at INTEGER NOT NULL,
       FOREIGN KEY (release_id) REFERENCES releases(id) ON DELETE CASCADE
     );
+    CREATE TABLE device_groups (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      description TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_device_groups_app_name
+      ON device_groups(app_id, name COLLATE NOCASE);
+    CREATE TABLE device_group_members (
+      group_id TEXT NOT NULL REFERENCES device_groups(id) ON DELETE CASCADE,
+      device_id TEXT NOT NULL,
+      label TEXT,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (group_id, device_id)
+    );
     CREATE TABLE release_metrics (
       release_id TEXT PRIMARY KEY,
       offered_count INTEGER NOT NULL DEFAULT 0,
@@ -2657,6 +2674,30 @@ describe("quiver releases — draft lifecycle", () => {
     } as any;
   }
 
+  function makeDeviceGroupContext(
+    params: { groupId?: string; deviceId?: string } = {},
+    body: unknown = {},
+  ) {
+    return {
+      env,
+      req: {
+        param: (name: string) => {
+          if (name === "appId") return "app-release";
+          if (name === "groupId") return params.groupId ?? "";
+          if (name === "deviceId") return params.deviceId ?? "";
+          return "";
+        },
+        json: async () => body,
+      },
+      get: (key: string) => (key === "admin_actor" ? "tester" : undefined),
+      json: (data: unknown, status = 200) =>
+        new Response(JSON.stringify(data), {
+          status,
+          headers: { "content-type": "application/json" },
+        }),
+    } as any;
+  }
+
   async function responseJson<T>(response: Response): Promise<T> {
     return (await response.json()) as T;
   }
@@ -2708,6 +2749,286 @@ describe("quiver releases — draft lifecycle", () => {
       { id: "rel-active", status: "superseded", superseded_by_release_id: "rel-draft" },
       { id: "rel-draft", status: "active", superseded_by_release_id: null },
     ]);
+  });
+
+  it("publishes a device-group draft without superseding the full fallback release", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-release-test", "app-release", "QA devices", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-active");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "group-release-test" }],
+    }, "tester", "rel-group-draft");
+
+    const response = await handlePublishRelease(makeReleaseContext("rel-group-draft"));
+    expect(response.status).toBe(200);
+    const { results } = await env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all();
+    expect(results).toEqual([
+      { id: "rel-active", status: "active", superseded_by_release_id: null },
+      { id: "rel-group-draft", status: "active", superseded_by_release_id: null },
+    ]);
+  });
+
+  it("treats a legacy mixed scope containing full:all as full coverage when publishing", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-legacy-mixed", "app-release", "Legacy mixed", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "group-legacy-mixed" }],
+    }, "tester", "rel-legacy-mixed");
+    await env.DB.prepare(
+      `INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+       VALUES (?, ?, 'full', 'all', ?)`,
+    ).bind("scope-legacy-full", "rel-legacy-mixed", now).run();
+
+    const response = await handlePublishRelease(makeReleaseContext("rel-legacy-mixed"));
+    expect(response.status).toBe(200);
+    const { results } = await env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all();
+    expect(results).toEqual([
+      { id: "rel-fallback", status: "superseded", superseded_by_release_id: "rel-legacy-mixed" },
+      { id: "rel-legacy-mixed", status: "active", superseded_by_release_id: null },
+    ]);
+  });
+
+  it("publishes a partial full-scope rollout without superseding the full fallback release", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-active");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      rollout_cohort_count: 25,
+    }, "tester", "rel-partial-draft");
+
+    const response = await handlePublishRelease(makeReleaseContext("rel-partial-draft"));
+    expect(response.status).toBe(200);
+    const { results } = await env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all();
+    expect(results).toEqual([
+      { id: "rel-active", status: "active", superseded_by_release_id: null },
+      { id: "rel-partial-draft", status: "active", superseded_by_release_id: null },
+    ]);
+  });
+
+  it("restores a directly superseded fallback when an active full release is narrowed", async () => {
+    const { createRelease, handleUpdateRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-narrow-active", "app-release", "Narrow active", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+    }, "tester", "rel-current");
+
+    const before = await env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-fallback'",
+    ).first<any>();
+    expect(before).toEqual({ status: "superseded", superseded_by_release_id: "rel-current" });
+
+    const response = await handleUpdateRelease(makeReleaseContext("rel-current", {
+      scopes: [{ scope_type: "device_group", scope_value: "group-narrow-active" }],
+    }));
+    expect(response.status).toBe(200);
+    const { results } = await env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all();
+    expect(results).toEqual([
+      { id: "rel-current", status: "active", superseded_by_release_id: null },
+      { id: "rel-fallback", status: "active", superseded_by_release_id: null },
+    ]);
+  });
+
+  it("supersedes coexisting fallbacks when an active scoped release becomes full coverage", async () => {
+    const { createRelease, handleUpdateRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-expand-active", "app-release", "Expand active", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+      scopes: [{ scope_type: "device_group", scope_value: "group-expand-active" }],
+    }, "tester", "rel-scoped");
+
+    const response = await handleUpdateRelease(makeReleaseContext("rel-scoped", {
+      scopes: [{ scope_type: "full", scope_value: "all" }],
+      rollout_cohort_count: 100,
+    }));
+    expect(response.status).toBe(200);
+    const { results } = await env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all();
+    expect(results).toEqual([
+      { id: "rel-fallback", status: "superseded", superseded_by_release_id: "rel-scoped" },
+      { id: "rel-scoped", status: "active", superseded_by_release_id: null },
+    ]);
+  });
+
+  it("rejects nonexistent and cross-app device groups as release scopes", async () => {
+    const { createRelease } = await import("../src/routes/releases");
+    await expect(createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "missing-group" }],
+    }, "tester", "rel-missing-group")).rejects.toThrow("device group not found for app");
+
+    const now = Date.now();
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).bind("app-other", "default", "other-app", "Other App", "android", now).run();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-other-app", "app-other", "Other devices", null, now, now).run();
+    await expect(createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "group-other-app" }],
+    }, "tester", "rel-cross-app-group")).rejects.toThrow("device group not found for app");
+  });
+
+  it("rejects mixing full:all with a device-group scope on create and active update", async () => {
+    const { createRelease, handleUpdateRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-no-mixed-full", "app-release", "No mixed full", null, now, now).run();
+    const mixedScopes = [
+      { scope_type: "full", scope_value: "all" },
+      { scope_type: "device_group", scope_value: "group-no-mixed-full" },
+    ];
+    await expect(createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: mixedScopes,
+    }, "tester", "rel-mixed-create")).rejects.toThrow("full release scope cannot be combined");
+
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-mixed-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+    }, "tester", "rel-mixed-current");
+    const response = await handleUpdateRelease(makeReleaseContext("rel-mixed-current", { scopes: mixedScopes }));
+    expect(response.status).toBe(400);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      error: "full release scope cannot be combined with other scopes",
+    });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-mixed-fallback'",
+    ).first()).resolves.toEqual({
+      status: "superseded",
+      superseded_by_release_id: "rel-mixed-current",
+    });
+  });
+
+  it("creates and manages device-group members, but blocks deletion while a live release uses the group", async () => {
+    const {
+      handleAddDeviceGroupMember,
+      handleCreateDeviceGroup,
+      handleDeleteDeviceGroup,
+      handleListDeviceGroups,
+      handleRemoveDeviceGroupMember,
+      handleUpdateDeviceGroup,
+    } = await import("../src/routes/device_groups");
+    const { createRelease } = await import("../src/routes/releases");
+
+    const createResponse = await handleCreateDeviceGroup(makeDeviceGroupContext({}, {
+      name: "  QA phones  ",
+      description: " exact rollout ",
+    }));
+    expect(createResponse.status).toBe(201);
+    const created = await responseJson<any>(createResponse);
+    expect(created).toMatchObject({ name: "QA phones", description: "exact rollout", member_count: 0 });
+
+    const updateResponse = await handleUpdateDeviceGroup(makeDeviceGroupContext({ groupId: created.id }, {
+      name: "QA tablets",
+      description: "physical acceptance devices",
+    }));
+    expect(updateResponse.status).toBe(200);
+    await expect(responseJson<any>(updateResponse)).resolves.toMatchObject({
+      id: created.id,
+      name: "QA tablets",
+      description: "physical acceptance devices",
+    });
+
+    const addResponse = await handleAddDeviceGroupMember(makeDeviceGroupContext({ groupId: created.id }, {
+      device_id: " install/device 1 ",
+      label: " Huawei ",
+    }));
+    expect(addResponse.status).toBe(201);
+    await expect(responseJson<any>(addResponse)).resolves.toMatchObject({
+      device_id: "install/device 1",
+      label: "Huawei",
+    });
+
+    const listResponse = await handleListDeviceGroups(makeDeviceGroupContext());
+    await expect(responseJson<any>(listResponse)).resolves.toMatchObject({
+      groups: [{
+        id: created.id,
+        name: "QA tablets",
+        description: "physical acceptance devices",
+        member_count: 1,
+        members: [{ device_id: "install/device 1", label: "Huawei" }],
+      }],
+    });
+
+    const removeResponse = await handleRemoveDeviceGroupMember(makeDeviceGroupContext({
+      groupId: created.id,
+      deviceId: encodeURIComponent("install/device 1"),
+    }));
+    expect(removeResponse.status).toBe(200);
+    const afterRemove = await responseJson<any>(await handleListDeviceGroups(makeDeviceGroupContext()));
+    expect(afterRemove.groups[0].member_count).toBe(0);
+
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: created.id }],
+    }, "tester", "rel-group-reference");
+    const blockedDelete = await handleDeleteDeviceGroup(makeDeviceGroupContext({ groupId: created.id }));
+    expect(blockedDelete.status).toBe(409);
+    await expect(responseJson<any>(blockedDelete)).resolves.toMatchObject({
+      error: "device group is used by a draft or active release",
+    });
   });
 
   it("updates editable release metadata and replaces scopes", async () => {
@@ -3965,6 +4286,57 @@ describe("quiver public API v2 — scope resolution", () => {
       { platform: "android-arm64-v8a", arch: null, filetype: "apk" },
     );
     expect(asset?.download_url).toBe("/arm64.apk");
+  });
+
+  it("serves a device-group release only to exact group members and falls back for other devices", async () => {
+    const env = makeEnv();
+    configureR2Presign(env);
+    const now = Date.now();
+    await seedRelease(env, "rel-device-fallback", "build-device-fallback", [["full", "all"]], {
+      createdAt: now - 1000,
+      versionCode: 10,
+      versionName: "1.0.0",
+    });
+    await seedAsset(env, "build-device-fallback", "asset-device-fallback", { arch: "arm64-v8a" });
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-artin", "app-scope", "Artin test devices", null, now, now).run();
+    await env.DB.prepare(
+      `INSERT INTO device_group_members (group_id, device_id, label, created_at)
+       VALUES (?, ?, ?, ?)`,
+    ).bind("group-artin", "device-artin", "Huawei", now).run();
+    await seedRelease(env, "rel-device-target", "build-device-target", [["device_group", "group-artin"]], {
+      createdAt: now,
+      versionCode: 11,
+      versionName: "1.1.0",
+    });
+    await seedAsset(env, "build-device-target", "asset-device-target", { arch: "arm64-v8a" });
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+
+    const memberResponse = await handlePublicV2Latest(makePublicContext(env, {
+      channel: "production",
+      product_type: "android-apk",
+      platform: "android",
+      arch: "arm64-v8a",
+    }, { "X-Hands-Device-Id": "device-artin" }));
+    expect(memberResponse.status).toBe(200);
+    await expect(responseJson<any>(memberResponse)).resolves.toMatchObject({
+      build: { version_code: 11 },
+      scoped: { scope_type: "device_group", scope_value: "group-artin" },
+    });
+
+    const otherResponse = await handlePublicV2Latest(makePublicContext(env, {
+      channel: "production",
+      product_type: "android-apk",
+      platform: "android",
+      arch: "arm64-v8a",
+    }, { "X-Hands-Device-Id": "device-someone-else" }));
+    expect(otherResponse.status).toBe(200);
+    await expect(responseJson<any>(otherResponse)).resolves.toMatchObject({
+      build: { version_code: 10 },
+      scoped: { scope_type: "full", scope_value: "all" },
+    });
   });
 
   it("updates/check returns no update without exposing assets when current version is latest", async () => {
@@ -6669,6 +7041,30 @@ describe("Hands iOS simulator QA artifacts", () => {
     const manifest = await response.json() as any;
     const actions = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action.endpoint]));
     expect(actions).toMatchObject({
+      "list-device-groups": {
+        method: "GET",
+        path: "/api/apps/{app_id}/device-groups",
+      },
+      "create-device-group": {
+        method: "POST",
+        path: "/api/apps/{app_id}/device-groups",
+      },
+      "update-device-group": {
+        method: "PATCH",
+        path: "/api/apps/{app_id}/device-groups/{group_id}",
+      },
+      "add-device-group-member": {
+        method: "POST",
+        path: "/api/apps/{app_id}/device-groups/{group_id}/members",
+      },
+      "remove-device-group-member": {
+        method: "DELETE",
+        path: "/api/apps/{app_id}/device-groups/{group_id}/members/{device_id}",
+      },
+      "delete-device-group": {
+        method: "DELETE",
+        path: "/api/apps/{app_id}/device-groups/{group_id}",
+      },
       "list-ios-simulator-artifacts": {
         method: "GET",
         path: "/api/apps/{app_id}/qa-artifacts/ios-simulator",
@@ -6698,5 +7094,8 @@ describe("Hands iOS simulator QA artifacts", () => {
         path: "/api/apps/{app_id}/testflight-uploads/{build_upload_id}",
       },
     });
+    const byName = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action]));
+    expect(byName["create-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
+    expect(byName["update-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
   });
 });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2852,7 +2852,7 @@ describe("quiver releases — draft lifecycle", () => {
 
     const before = await env.DB.prepare(
       "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-fallback'",
-    ).first<any>();
+    ).first();
     expect(before).toEqual({ status: "superseded", superseded_by_release_id: "rel-current" });
 
     const response = await handleUpdateRelease(makeReleaseContext("rel-current", {


### PR DESCRIPTION
## Summary

- add app-scoped device groups keyed by the stable Hands installation `device_id`
- resolve `device_group` release scopes server-side with higher priority than IP/cohort/platform scopes
- preserve the previous full active release as fallback for group non-members and partial percentage rollouts
- restore/supersede fallback topology correctly when an active release is narrowed or expanded
- add publisher API, Raft integration actions, CLI commands, Console group management/editing, and release scope selectors
- validate group ownership, protect draft/active references from deletion, and document the exact-rollout workflow

Migration is numbered `0049_device_groups.sql` after the concurrent Permission lane's `0048` slot.

## Database invariants

- `full:all` cannot be mixed with another scope; legacy mixed rows still publish as full coverage
- device-group scope INSERT/UPDATE triggers require the group and release to belong to the same app
- device-group DELETE trigger rejects draft/active release references while allowing historical cleanup and app cascade deletion

## Safety boundary

This PR does not activate or modify any production release. Publishing remains a separate explicit action. Device groups contain per-installation SDK IDs, not IMEI, hardware serial, or Raft account identity.

## Verification

- `pnpm --filter @botiverse/hands-worker build:shim`
- `pnpm --filter @botiverse/hands-worker test` — 187/187
- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm --filter @botiverse/hands-admin test` — 3/3
- `pnpm --filter @botiverse/hands-admin build`
- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli build`
- `pnpm --filter @botiverse/hands-cli test` — 21/21
- executable SQLite trigger tests: cross-app INSERT/UPDATE rejection, live-reference delete rejection, historical delete, app cascade
- `git diff --check`
