### PR TITLE
feat(auth): add app token permissions

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -388,13 +388,30 @@ export interface AppDeployToken {
   app_id: string;
   name: string;
   token_prefix: string;
-  app_role: "publisher" | "viewer";
+  app_role: "publisher" | "viewer" | null;
+  scopes: AppPermission[] | null;
+  grant_valid: boolean;
+  effective_permissions: AppPermission[];
   created_by: string | null;
   created_by_actor: string;
   created_at: number;
   expires_at: number | null;
   last_used_at: number | null;
   revoked_at: number | null;
+}
+
+export type AppPermission =
+  | "app:read"
+  | "app:publish"
+  | "app:admin"
+  | "feedback:write";
+
+export interface AppPermissionModel {
+  permissions: Array<{ permission: AppPermission; label: string; description: string }>;
+  roles: Array<{
+    role: "admin" | "publisher" | "viewer";
+    permissions: AppPermission[];
+  }>;
 }
 
 export interface Invite {
@@ -990,11 +1007,15 @@ export const listAppDeployTokens = (appId: string) =>
     { admin: true },
   );
 
+export const getAppPermissionModel = () =>
+  request<AppPermissionModel>("/api/app-permissions", { admin: true });
+
 export const createAppDeployToken = (
   appId: string,
   input: {
     name: string;
-    app_role: AppDeployToken["app_role"];
+    app_role?: Exclude<AppDeployToken["app_role"], null>;
+    scopes?: AppPermission[];
     expires_at?: number | null;
   },
 ) =>

--- a/admin/src/lib/appPermissionDisplay.test.ts
+++ b/admin/src/lib/appPermissionDisplay.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { AppPermissionModel } from "./api";
+import { buildTokenGrantDisplay, resolveGrantPreview } from "./appPermissionDisplay";
+
+const model: AppPermissionModel = {
+  permissions: [
+    { permission: "app:read", label: "App read", description: "Read app data." },
+    { permission: "app:publish", label: "Publish releases", description: "Publish releases." },
+    { permission: "app:admin", label: "App administration", description: "Administer the app." },
+    { permission: "feedback:write", label: "Feedback write", description: "Submit feedback." },
+  ],
+  roles: [
+    { role: "viewer", permissions: ["app:read"] },
+    { role: "publisher", permissions: ["app:read", "app:publish", "feedback:write"] },
+    { role: "admin", permissions: ["app:read", "app:publish", "app:admin", "feedback:write"] },
+  ],
+};
+
+describe("app permission display", () => {
+  it("expands role bundles and marks only permissions outside the bundle as extra", () => {
+    expect(resolveGrantPreview(model, "viewer", ["app:read", "feedback:write"])).toEqual({
+      bundled: ["app:read"],
+      effective: ["app:read", "feedback:write"],
+      extras: ["feedback:write"],
+    });
+  });
+
+  it("renders role, additive, custom-only, and invalid grants without conflating them", () => {
+    expect(buildTokenGrantDisplay({
+      app_role: "viewer",
+      scopes: ["feedback:write"],
+      grant_valid: true,
+      effective_permissions: ["app:read", "feedback:write"],
+    }, model)).toMatchObject({
+      valid: true,
+      roleLabel: "Role · viewer",
+      permissions: [
+        { label: "App read", extra: false },
+        { label: "Feedback write", extra: true },
+      ],
+    });
+
+    expect(buildTokenGrantDisplay({
+      app_role: null,
+      scopes: ["feedback:write"],
+      grant_valid: true,
+      effective_permissions: ["feedback:write"],
+    }, model).roleLabel).toBe("Custom only");
+
+    expect(buildTokenGrantDisplay({
+      app_role: "viewer",
+      scopes: [],
+      grant_valid: false,
+      effective_permissions: [],
+    }, model)).toMatchObject({
+      valid: false,
+      permissions: [],
+    });
+  });
+});

--- a/admin/src/lib/appPermissionDisplay.ts
+++ b/admin/src/lib/appPermissionDisplay.ts
@@ -1,0 +1,53 @@
+import type {
+  AppDeployToken,
+  AppPermission,
+  AppPermissionModel,
+} from "./api";
+
+type DeployTokenRole = Exclude<AppDeployToken["app_role"], null>;
+
+function rolePermissions(
+  model: AppPermissionModel | undefined,
+  role: DeployTokenRole | null,
+): AppPermission[] {
+  if (!role) return [];
+  return [...(model?.roles.find((entry) => entry.role === role)?.permissions ?? [])];
+}
+
+export function resolveGrantPreview(
+  model: AppPermissionModel | undefined,
+  role: DeployTokenRole | null,
+  explicitPermissions: readonly AppPermission[],
+) {
+  const bundled = rolePermissions(model, role);
+  const effective = [...new Set([...bundled, ...explicitPermissions])];
+  const bundledSet = new Set(bundled);
+  return {
+    bundled,
+    effective,
+    extras: explicitPermissions.filter((permission) => !bundledSet.has(permission)),
+  };
+}
+
+export function buildTokenGrantDisplay(
+  token: Pick<
+    AppDeployToken,
+    "app_role" | "scopes" | "grant_valid" | "effective_permissions"
+  >,
+  model: AppPermissionModel | undefined,
+) {
+  const bundled = new Set(rolePermissions(model, token.app_role));
+  const explicit = new Set(token.scopes ?? []);
+  const labels = new Map(
+    (model?.permissions ?? []).map((entry) => [entry.permission, entry.label]),
+  );
+  return {
+    valid: token.grant_valid,
+    roleLabel: token.app_role ? `Role · ${token.app_role}` : "Custom only",
+    permissions: token.effective_permissions.map((permission) => ({
+      permission,
+      label: labels.get(permission) ?? permission,
+      extra: explicit.has(permission) && !bundled.has(permission),
+    })),
+  };
+}

--- a/admin/src/pages/AppAccess.tsx
+++ b/admin/src/pages/AppAccess.tsx
@@ -18,6 +18,7 @@ import {
   addAppServerGrant,
   createOrgInvite,
   createAppDeployToken,
+  getAppPermissionModel,
   getAuthMe,
   listApps,
   listAppMembers,
@@ -30,9 +31,14 @@ import {
   updateAppMember,
   type AppMember,
   type AppDeployToken,
+  type AppPermission,
   type App,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
+import {
+  buildTokenGrantDisplay,
+  resolveGrantPreview,
+} from "../lib/appPermissionDisplay";
 import {
   Button,
   Input,
@@ -54,6 +60,7 @@ import {
   DialogClose,
   EmptyState,
   EmptyStateTitle,
+  Checkbox,
   Skeleton,
 } from "raft-ui";
 
@@ -667,6 +674,10 @@ function AppDeployTokenList({
     queryKey: ["app-deploy-tokens", appId],
     queryFn: () => listAppDeployTokens(appId),
   });
+  const permissionModel = useQuery({
+    queryKey: ["app-permissions"],
+    queryFn: getAppPermissionModel,
+  });
   const revoke = useMutation({
     mutationFn: (tokenId: string) => revokeAppDeployToken(appId, tokenId),
     onSuccess: () => {
@@ -715,18 +726,21 @@ function AppDeployTokenList({
             <tr className="text-slate-500 text-left border-b border-slate-100">
               <th className="font-normal py-1 pr-2">Name</th>
               <th className="font-normal py-1 pr-2">Prefix</th>
-              <th className="font-normal py-1 pr-2">Role</th>
+              <th className="font-normal py-1 pr-2">Grant</th>
               <th className="font-normal py-1 pr-2">Expires</th>
               <th className="font-normal py-1 pr-2">Last used</th>
               <th className="font-normal py-1">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {rows.map((token) => (
-              <tr
-                key={token.id}
-                className="border-b border-slate-50 hover:bg-slate-50"
-              >
+            {rows.map((token) => {
+              const display = buildTokenGrantDisplay(token, permissionModel.data);
+              const shownPermissions = display.permissions.slice(0, 4);
+              return (
+                <tr
+                  key={token.id}
+                  className="border-b border-slate-50 hover:bg-slate-50"
+                >
                 <td className="py-2 pr-2">
                   <div className="font-medium">{token.name}</div>
                   <div className="text-xs text-slate-500">
@@ -739,7 +753,36 @@ function AppDeployTokenList({
                   </span>
                 </td>
                 <td className="py-2 pr-2">
-                  <span className="text-xs font-medium">{token.app_role}</span>
+                  <div className="max-w-sm space-y-1">
+                    <div className="flex flex-wrap gap-1 text-xs">
+                      <span className="rounded bg-slate-900 px-1.5 py-0.5 font-medium text-white">
+                        {display.roleLabel}
+                      </span>
+                      {!display.valid && (
+                        <span className="rounded bg-red-100 px-1.5 py-0.5 font-medium text-red-700">
+                          Invalid grant
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-1 text-xs">
+                      {shownPermissions.map(({ permission, label, extra }) => (
+                        <span
+                          key={permission}
+                          title={permission}
+                          className={extra
+                            ? "rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-amber-800"
+                            : "rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-slate-600"}
+                        >
+                          {label}{extra ? " · Extra" : ""}
+                        </span>
+                      ))}
+                      {display.permissions.length > shownPermissions.length && (
+                        <span className="rounded border border-slate-200 px-1.5 py-0.5 text-slate-500">
+                          +{display.permissions.length - shownPermissions.length}
+                        </span>
+                      )}
+                    </div>
+                  </div>
                 </td>
                 <td className="py-2 pr-2 text-xs text-slate-500">
                   {token.expires_at
@@ -766,8 +809,9 @@ function AppDeployTokenList({
                     Revoke
                   </Button>
                 </td>
-              </tr>
-            ))}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}
@@ -790,10 +834,17 @@ function AddAppDeployTokenDialog({
 }) {
   const qc = useQueryClient();
   const toast = useToast();
+  const permissionModel = useQuery({
+    queryKey: ["app-permissions"],
+    queryFn: getAppPermissionModel,
+  });
   const [name, setName] = useState("");
-  const [role, setRole] = useState<AppDeployToken["app_role"]>("publisher");
+  const [role, setRole] = useState<"publisher" | "viewer" | "none">("publisher");
+  const [scopes, setScopes] = useState<AppPermission[]>([]);
   const [expiry, setExpiry] = useState<"30d" | "90d" | "365d" | "never">("365d");
   const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const selectedRole = role === "none" ? null : role;
+  const grantPreview = resolveGrantPreview(permissionModel.data, selectedRole, scopes);
 
   const expiresAt = () => {
     if (expiry === "never") return null;
@@ -805,7 +856,8 @@ function AddAppDeployTokenDialog({
     mutationFn: () =>
       createAppDeployToken(appId, {
         name: name.trim(),
-        app_role: role,
+        ...(role === "none" ? {} : { app_role: role }),
+        ...(scopes.length > 0 ? { scopes } : {}),
         expires_at: expiresAt(),
       }),
     onSuccess: (data) => {
@@ -903,13 +955,22 @@ function AddAppDeployTokenDialog({
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="label">Role</label>
+                    <label className="label">Role bundle</label>
                     <Select
-                      items={{ publisher: "publisher", viewer: "viewer" }}
+                      items={{ publisher: "publisher", viewer: "viewer", none: "No role" }}
                       value={role}
-                      onValueChange={(v) =>
-                        setRole(v as AppDeployToken["app_role"])
-                      }
+                      onValueChange={(v) => {
+                        const nextRole = v as typeof role;
+                        const nextPreview = resolveGrantPreview(
+                          permissionModel.data,
+                          nextRole === "none" ? null : nextRole,
+                          [],
+                        );
+                        setRole(nextRole);
+                        setScopes((current) => current.filter(
+                          (permission) => !nextPreview.bundled.includes(permission),
+                        ));
+                      }}
                     >
                       <SelectTrigger>
                         <SelectValue />
@@ -918,6 +979,7 @@ function AddAppDeployTokenDialog({
                       <SelectContent>
                         <SelectItem value="publisher">publisher</SelectItem>
                         <SelectItem value="viewer">viewer</SelectItem>
+                        <SelectItem value="none">No role (custom only)</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -943,9 +1005,61 @@ function AddAppDeployTokenDialog({
                     </Select>
                   </div>
                 </div>
+                <div className="space-y-2 rounded-md border border-slate-200 p-3">
+                  <div className="text-xs font-medium text-slate-700">Additional permissions</div>
+                  {permissionModel.isPending && (
+                    <p className="text-xs text-slate-500">Loading permission registry…</p>
+                  )}
+                  {permissionModel.isError && (
+                    <p className="text-xs text-red-600">
+                      Permission registry could not be loaded. Try again before creating a token.
+                    </p>
+                  )}
+                  {(permissionModel.data?.permissions ?? []).map((permission) => (
+                    <label key={permission.permission} className="flex items-center gap-2 text-sm text-slate-700">
+                      <Checkbox
+                        checked={grantPreview.bundled.includes(permission.permission)
+                          || scopes.includes(permission.permission)}
+                        disabled={grantPreview.bundled.includes(permission.permission)}
+                        onCheckedChange={(checked) => {
+                          setScopes((current) => checked
+                            ? [...new Set([...current, permission.permission])]
+                            : current.filter((value) => value !== permission.permission));
+                        }}
+                      />
+                      <span>{permission.description}</span>
+                      <code className="text-xs text-slate-400">{permission.permission}</code>
+                      {grantPreview.bundled.includes(permission.permission) && (
+                        <span className="text-xs text-slate-400">Included by role</span>
+                      )}
+                    </label>
+                  ))}
+                </div>
+                <div className="space-y-2 rounded-md bg-slate-50 p-3">
+                  <div className="text-xs font-medium text-slate-700">Effective permissions</div>
+                  <div className="flex flex-wrap gap-1 text-xs">
+                    {grantPreview.effective.map((permission) => {
+                      const definition = permissionModel.data?.permissions.find(
+                        (entry) => entry.permission === permission,
+                      );
+                      const extra = grantPreview.extras.includes(permission);
+                      return (
+                        <span
+                          key={permission}
+                          title={permission}
+                          className={extra
+                            ? "rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-amber-800"
+                            : "rounded border border-slate-200 bg-white px-1.5 py-0.5 text-slate-600"}
+                        >
+                          {definition?.label ?? permission}{extra ? " · Extra" : ""}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
                 <p className="text-xs text-slate-500">
-                  Publisher tokens can upload builds, create releases, and create
-                  share pages for this app only.
+                  The role expands to its permission bundle. Additional permissions
+                  are unioned into the token's effective permissions.
                 </p>
               </form>
             </DialogBody>
@@ -957,7 +1071,13 @@ function AddAppDeployTokenDialog({
                 type="submit"
                 form="add-app-deploy-token-form"
                 variant="primary"
-                disabled={!name.trim() || create.isPending}
+                disabled={
+                  !name.trim()
+                  || (role === "none" && scopes.length === 0)
+                  || permissionModel.isPending
+                  || permissionModel.isError
+                  || create.isPending
+                }
               >
                 {create.isPending ? "Creating…" : "Create"}
               </Button>

--- a/docs/rbac-permissions.md
+++ b/docs/rbac-permissions.md
@@ -1,9 +1,36 @@
 # Hands RBAC — roles & permissions reference
 
-Hands uses **role-based access control** (RBAC) with two role scopes: an
-**organization** role and a per-**app** role. Every admin API endpoint declares
-the minimum role required; the public (client) update/download/feedback-submit
-API is separate and needs no admin role.
+Hands authorizes app actions with atomic **permissions**. Human memberships use
+named roles as permission bundles; app tokens may use a role bundle, explicit
+permissions, or both. Route guards expand and union all grants into one
+effective-permission set before authorizing the request.
+
+Organization membership remains role-based. The public client
+update/download/feedback-submit API is separate unless a route explicitly
+requires an app-token permission.
+
+## App permissions
+
+The initial registry is:
+
+| Permission | Meaning |
+| --- | --- |
+| `app:read` | Read app data, builds, releases, feedback, and analytics. |
+| `app:publish` | Create and publish builds, releases, and distribution assets. |
+| `app:admin` | Manage app settings, members, credentials, and destructive operations. |
+| `feedback:write` | Submit feedback tickets for the app. |
+
+App roles are centrally defined bundles:
+
+| Role | Effective app permissions |
+| --- | --- |
+| `viewer` | `app:read` |
+| `publisher` | `app:read`, `app:publish`, `feedback:write` |
+| `admin` | `app:read`, `app:publish`, `app:admin`, `feedback:write` |
+
+`GET /api/app-permissions` returns the live registry and role mappings used by
+the Console. Adding a permission happens in the registry, not in a UI-specific
+role/permission union.
 
 ## Roles
 
@@ -34,9 +61,25 @@ for write endpoints — except endpoints that opt into a lower org bar:
 - **Feedback triage** (`requireFeedbackTriageRole`) uses org bar **member** (or
   app `publisher`). So any org member can triage; a bare read-only viewer cannot.
 
-**Deploy tokens** carry only an app role (`viewer` or `publisher`) and no org
-role, so a token uses the app-role bar directly — e.g. a `publisher` token can
-triage feedback, a `viewer` token can only read it.
+**App tokens** are app-scoped and have no org role. A token can keep a role
+bundle (`viewer` or `publisher`), explicit permissions, or both. At least one
+grant is required. The resolver expands the symbolic role bundle and unions it
+with the explicit permissions, deduplicating the effective set. The role is not
+copied into a permission snapshot, so future bundle changes remain authoritative.
+
+Scoped tokens are also fenced to `/api/apps/{theirAppId}` before route-level
+authorization. They cannot use org/global endpoints or another app's URL.
+
+Legacy `requireAppRole(...)` routes still require an actual role grant. A
+custom permission such as `app:publish` does not impersonate the `publisher`
+role or satisfy every route historically guarded by that role. Custom grants
+are accepted only by routes migrated to an exact `requireAppPermission(...)`
+check. This keeps capability-specific permissions narrow while existing role
+routes are migrated deliberately.
+
+If stored explicit-permission JSON is empty, malformed, or contains an unknown
+permission, the entire token grant fails closed: the role is not expanded,
+effective permissions are empty, and authentication returns 403.
 
 ## Endpoint → minimum role
 
@@ -81,8 +124,10 @@ fail:
 
 ## Changing an operation's required role
 
-Route guards live in `worker/src/index.ts` (`requireAppRole("<role>")`,
-`requireOrgRole(...)`, or a purpose-built guard like
-`requireFeedbackTriageRole()`); the role helpers and `ensureAppRole` live in
-`worker/src/lib/permissions.ts`. When you change a bar, update this table, the
-handler doc comment, and any agent/admin guide that names the role.
+Route guards live in `worker/src/index.ts`. New capability-specific routes use
+`requireAppPermission("<permission>")`; existing `requireAppRole("<role>")`
+routes resolve the role bundle's required permission through the same
+effective-permission evaluator. Registry and role mappings live in
+`worker/src/lib/app_permissions.ts`; principal resolution and guards live in
+`worker/src/lib/permissions.ts`. When changing a permission boundary, update
+this table, the handler comment, and any agent/admin guide that names it.

--- a/migrations/sql/0048_app_token_permissions.sql
+++ b/migrations/sql/0048_app_token_permissions.sql
@@ -1,0 +1,32 @@
+CREATE TABLE app_deploy_tokens_v2 (
+  id TEXT PRIMARY KEY,
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  token_prefix TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  app_role TEXT CHECK (app_role IN ('publisher', 'viewer')),
+  scopes_json TEXT,
+  created_by TEXT REFERENCES raft_accounts(id) ON DELETE SET NULL,
+  created_by_actor TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER,
+  last_used_at INTEGER,
+  revoked_at INTEGER,
+  CHECK (app_role IS NOT NULL OR scopes_json IS NOT NULL)
+);
+
+INSERT INTO app_deploy_tokens_v2
+  (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+   created_by, created_by_actor, created_at, expires_at, last_used_at, revoked_at)
+SELECT id, app_id, name, token_prefix, token_hash, app_role, NULL,
+       created_by, created_by_actor, created_at, expires_at, last_used_at, revoked_at
+FROM app_deploy_tokens;
+
+DROP TABLE app_deploy_tokens;
+ALTER TABLE app_deploy_tokens_v2 RENAME TO app_deploy_tokens;
+
+CREATE INDEX idx_app_deploy_tokens_app
+  ON app_deploy_tokens(app_id, revoked_at, expires_at);
+
+CREATE INDEX idx_app_deploy_tokens_hash
+  ON app_deploy_tokens(token_hash);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -95,6 +95,7 @@ import {
 } from "./routes/history";
 import {
   handleCreateAppDeployToken,
+  handleGetAppPermissionModel,
   handleListAppDeployTokens,
   handleRevokeAppDeployToken,
 } from "./routes/deploy_tokens";
@@ -888,6 +889,7 @@ admin.post("/api/apps/:appId/server-grants", requireAppRole("admin"), handleAddA
 admin.patch("/api/apps/:appId/server-grants/:serverId", requireAppRole("admin"), handleUpdateAppServerGrant);
 admin.delete("/api/apps/:appId/server-grants/:serverId", requireAppRole("admin"), handleRemoveAppServerGrant);
 admin.get("/api/apps/:appId/deploy-tokens", requireAppRole("admin"), handleListAppDeployTokens);
+admin.get("/api/app-permissions", handleGetAppPermissionModel);
 admin.post("/api/apps/:appId/deploy-tokens", requireAppRole("admin"), handleCreateAppDeployToken);
 admin.delete("/api/apps/:appId/deploy-tokens/:tokenId", requireAppRole("admin"), handleRevokeAppDeployToken);
 

--- a/worker/src/lib/app_permissions.ts
+++ b/worker/src/lib/app_permissions.ts
@@ -1,0 +1,70 @@
+export type AppRole = "admin" | "publisher" | "viewer";
+
+export const APP_PERMISSIONS = [
+  "app:read",
+  "app:publish",
+  "app:admin",
+  "feedback:write",
+] as const;
+
+export type AppPermission = (typeof APP_PERMISSIONS)[number];
+
+export const APP_PERMISSION_LABELS: Record<AppPermission, string> = {
+  "app:read": "App read",
+  "app:publish": "Publish releases",
+  "app:admin": "App administration",
+  "feedback:write": "Feedback write",
+};
+
+export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
+  "app:read": "Read app data, builds, releases, feedback, and analytics.",
+  "app:publish": "Create and publish builds, releases, and distribution assets.",
+  "app:admin": "Manage app settings, members, credentials, and destructive operations.",
+  "feedback:write": "Submit feedback tickets for this app.",
+};
+
+export const APP_ROLE_PERMISSIONS: Record<AppRole, readonly AppPermission[]> = {
+  viewer: ["app:read"],
+  publisher: ["app:read", "app:publish", "feedback:write"],
+  admin: ["app:read", "app:publish", "app:admin", "feedback:write"],
+};
+
+export const APP_ROLE_REQUIRED_PERMISSION: Record<AppRole, AppPermission> = {
+  viewer: "app:read",
+  publisher: "app:publish",
+  admin: "app:admin",
+};
+
+export const APP_PERMISSION_MINIMUM_ROLE: Record<AppPermission, AppRole> = {
+  "app:read": "viewer",
+  "app:publish": "publisher",
+  "app:admin": "admin",
+  "feedback:write": "publisher",
+};
+
+const APP_ROLE_PRIORITY: Record<AppRole, number> = {
+  viewer: 1,
+  publisher: 2,
+  admin: 3,
+};
+
+export function isAppRole(value: unknown): value is AppRole {
+  return value === "admin" || value === "publisher" || value === "viewer";
+}
+
+export function isAppPermission(value: unknown): value is AppPermission {
+  return typeof value === "string" && (APP_PERMISSIONS as readonly string[]).includes(value);
+}
+
+export function permissionsForAppRole(role: AppRole): ReadonlySet<AppPermission> {
+  return new Set(APP_ROLE_PERMISSIONS[role]);
+}
+
+export function isAppAtLeast(role: AppRole | null | undefined, minimum: AppRole): boolean {
+  if (!role) return false;
+  return permissionsForAppRole(role).has(APP_ROLE_REQUIRED_PERMISSION[minimum]);
+}
+
+export function strongestAppRole(roles: readonly AppRole[]): AppRole | null {
+  return [...roles].sort((left, right) => APP_ROLE_PRIORITY[right] - APP_ROLE_PRIORITY[left])[0] ?? null;
+}

--- a/worker/src/lib/deploy_tokens.ts
+++ b/worker/src/lib/deploy_tokens.ts
@@ -1,16 +1,21 @@
-import type { AppRole } from "./permissions";
+import {
+  APP_ROLE_PERMISSIONS,
+  isAppPermission,
+  type AppPermission,
+  type AppRole,
+} from "./app_permissions";
 
 const TOKEN_PREFIX = "qvdt";
 
 export type DeployTokenRole = Extract<AppRole, "publisher" | "viewer">;
-
 export type AppDeployToken = {
   id: string;
   app_id: string;
   app_slug: string;
   name: string;
   token_prefix: string;
-  app_role: DeployTokenRole;
+  app_role: DeployTokenRole | null;
+  scopes: AppPermission[] | null;
   created_by: string | null;
   created_by_actor: string;
   created_at: number;
@@ -21,6 +26,32 @@ export type AppDeployToken = {
 
 export function isDeployTokenRole(value: unknown): value is DeployTokenRole {
   return value === "publisher" || value === "viewer";
+}
+
+export function resolveAppGrantPermissions(
+  appRole: DeployTokenRole | null,
+  scopes: readonly AppPermission[] | null,
+): ReadonlySet<AppPermission> {
+  const permissions = new Set<AppPermission>();
+  if (appRole) {
+    for (const permission of APP_ROLE_PERMISSIONS[appRole]) permissions.add(permission);
+  }
+  if (scopes) {
+    for (const permission of scopes) permissions.add(permission);
+  }
+  return permissions;
+}
+
+export function resolveDeployTokenPermissions(token: AppDeployToken): ReadonlySet<AppPermission> {
+  // A non-null empty array is the fail-closed sentinel for corrupt, empty, or
+  // unknown stored scopes. An invalid explicit grant invalidates the entire
+  // token grant; a role must not remain usable beside corrupt scope data.
+  if (token.scopes !== null && token.scopes.length === 0) return new Set();
+  return resolveAppGrantPermissions(token.app_role, token.scopes);
+}
+
+export function hasDeployTokenPermission(token: AppDeployToken, permission: AppPermission): boolean {
+  return resolveDeployTokenPermissions(token).has(permission);
 }
 
 function base64Url(bytes: Uint8Array): string {
@@ -65,7 +96,7 @@ export async function loadDeployToken(
   const now = Date.now();
   const row = await env.DB.prepare(
     `SELECT dt.id, dt.app_id, a.slug AS app_slug, dt.name, dt.token_prefix,
-            dt.app_role, dt.created_by, dt.created_by_actor, dt.created_at,
+            dt.app_role, dt.scopes_json, dt.created_by, dt.created_by_actor, dt.created_at,
             dt.expires_at, dt.last_used_at, dt.revoked_at
      FROM app_deploy_tokens dt
      JOIN apps a ON a.id = dt.app_id
@@ -75,7 +106,7 @@ export async function loadDeployToken(
      LIMIT 1`,
   )
     .bind(tokenHash, now)
-    .first<AppDeployToken>();
+    .first<Omit<AppDeployToken, "scopes"> & { scopes_json: string | null }>();
 
   if (!row) return null;
 
@@ -84,5 +115,15 @@ export async function loadDeployToken(
   )
     .bind(now, row.id)
     .run();
-  return { ...row, last_used_at: now };
+  let scopes: AppPermission[] | null = null;
+  if (row.scopes_json !== null) {
+    try {
+      const parsed = JSON.parse(row.scopes_json);
+      scopes = Array.isArray(parsed) && parsed.every(isAppPermission) ? parsed : [];
+    } catch {
+      scopes = [];
+    }
+  }
+  const { scopes_json: _scopesJson, ...tokenRow } = row;
+  return { ...tokenRow, scopes, last_used_at: now };
 }

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -1,10 +1,24 @@
 import type { Context, MiddlewareHandler } from "hono";
 import { currentActorInfo, type AdminAccount, type AdminEnv } from "../middleware/auth";
-import type { AppDeployToken } from "./deploy_tokens";
+import {
+  hasDeployTokenPermission,
+  resolveDeployTokenPermissions,
+  type AppDeployToken,
+} from "./deploy_tokens";
+import {
+  APP_PERMISSION_MINIMUM_ROLE,
+  isAppAtLeast,
+  isAppRole,
+  strongestAppRole,
+  type AppRole,
+  type AppPermission,
+} from "./app_permissions";
 import { dashboardOrigin } from "./origin";
 
+export { isAppAtLeast, isAppRole } from "./app_permissions";
+export type { AppRole, AppPermission } from "./app_permissions";
+
 export type OrgRole = "owner" | "admin" | "member" | "viewer";
-export type AppRole = "admin" | "publisher" | "viewer";
 export type EffectiveRole = OrgRole | AppRole;
 
 type RoleContext = AdminEnv & { Bindings: Env };
@@ -17,28 +31,13 @@ const orgRank: Record<OrgRole, number> = {
   owner: 4,
 };
 
-const appRank: Record<AppRole, number> = {
-  viewer: 1,
-  publisher: 2,
-  admin: 3,
-};
-
 export function isOrgRole(value: unknown): value is OrgRole {
   return value === "owner" || value === "admin" || value === "member" || value === "viewer";
-}
-
-export function isAppRole(value: unknown): value is AppRole {
-  return value === "admin" || value === "publisher" || value === "viewer";
 }
 
 export function isOrgAtLeast(role: OrgRole | null | undefined, minimum: OrgRole) {
   if (!role) return false;
   return orgRank[role] >= orgRank[minimum];
-}
-
-export function isAppAtLeast(role: AppRole | null | undefined, minimum: AppRole) {
-  if (!role) return false;
-  return appRank[role] >= appRank[minimum];
 }
 
 function devTokenBypass(c: AdminContext) {
@@ -137,7 +136,7 @@ export async function getEffectiveRole(
       : Promise.resolve(null),
   ]);
   const roles = [appRole, serverAppRole].filter(Boolean) as AppRole[];
-  const effectiveAppRole = roles.sort((a, b) => appRank[b] - appRank[a])[0] ?? null;
+  const effectiveAppRole = strongestAppRole(roles);
   return { org_role: orgRole, app_role: effectiveAppRole, server_app_role: serverAppRole, org_id: orgId };
 }
 
@@ -150,7 +149,11 @@ function forbiddenRole(
   scope: "org" | "app",
   requiredRole: string,
   currentRole: string | null,
-  ids: { org_id?: string | null; app_id?: string | null },
+  ids: {
+    org_id?: string | null;
+    app_id?: string | null;
+    current_permissions?: AppPermission[];
+  },
 ) {
   let resource = "";
   try {
@@ -186,8 +189,29 @@ function forbiddenRole(
       resource,
       org_id: ids.org_id ?? null,
       app_id: ids.app_id ?? null,
+      ...(ids.current_permissions
+        ? { current_permissions: ids.current_permissions }
+        : {}),
       manage_url: manageUrl,
       ...(scope === "org" ? { org_role: currentRole } : { app_role: currentRole }),
+    },
+    403,
+  );
+}
+
+function forbiddenAppPermission(
+  c: AdminContext,
+  appId: string,
+  permission: AppPermission,
+  deployToken: AppDeployToken,
+) {
+  return c.json(
+    {
+      error: "insufficient_app_permission",
+      code: "INSUFFICIENT_APP_PERMISSION",
+      required_permission: permission,
+      current_permissions: [...resolveDeployTokenPermissions(deployToken)],
+      app_id: appId,
     },
     403,
   );
@@ -218,7 +242,11 @@ export async function ensureAppRole(
   if (devTokenBypass(c)) return { ok: true as const, app_role: "admin" as AppRole, org_role: "owner" as OrgRole };
   const deployToken = currentDeployToken(c);
   if (deployToken) {
-    if (deployToken.app_id !== appId || !isAppAtLeast(deployToken.app_role, minimum)) {
+    if (
+      deployToken.app_id !== appId
+      || resolveDeployTokenPermissions(deployToken).size === 0
+      || !isAppAtLeast(deployToken.app_role, minimum)
+    ) {
       return {
         ok: false as const,
         response: forbiddenRole(
@@ -226,7 +254,10 @@ export async function ensureAppRole(
           "app",
           minimum,
           deployToken.app_id === appId ? deployToken.app_role : null,
-          { app_id: appId },
+          {
+            app_id: appId,
+            current_permissions: [...resolveDeployTokenPermissions(deployToken)],
+          },
         ),
       };
     }
@@ -280,6 +311,26 @@ export async function ensureAppRole(
   return { ok: true as const, ...role };
 }
 
+export async function ensureAppPermission(
+  c: AdminContext,
+  appId: string,
+  permission: AppPermission,
+  opts?: { orgMinimum?: OrgRole },
+) {
+  if (devTokenBypass(c)) return { ok: true as const, app_permission: permission };
+  const deployToken = currentDeployToken(c);
+  if (deployToken) {
+    if (deployToken.app_id !== appId || !hasDeployTokenPermission(deployToken, permission)) {
+      return {
+        ok: false as const,
+        response: forbiddenAppPermission(c, appId, permission, deployToken),
+      };
+    }
+    return { ok: true as const, app_permission: permission };
+  }
+  return ensureAppRole(c, appId, APP_PERMISSION_MINIMUM_ROLE[permission], opts);
+}
+
 export function requireOrgRole(paramName: string, minimum: OrgRole): MiddlewareHandler<RoleContext> {
   return async (c, next) => {
     const orgId = c.req.param(paramName);
@@ -299,7 +350,7 @@ export function requireCurrentOrgRole(minimum: OrgRole): MiddlewareHandler<RoleC
         return;
       }
       const deployToken = c.get("admin_deploy_token");
-      if (deployToken && minimum === "viewer") {
+      if (deployToken && deployToken.scopes === null && minimum === "viewer") {
         await next();
         return;
       }
@@ -316,6 +367,16 @@ export function requireAppRole(minimum: AppRole): MiddlewareHandler<RoleContext>
     const appId = c.req.param("appId");
     if (!appId) return c.json({ error: "missing appId" }, 400);
     const allowed = await ensureAppRole(c, appId, minimum);
+    if (!allowed.ok) return allowed.response;
+    await next();
+  };
+}
+
+export function requireAppPermission(permission: AppPermission): MiddlewareHandler<RoleContext> {
+  return async (c, next) => {
+    const appId = c.req.param("appId");
+    if (!appId) return c.json({ error: "missing appId" }, 400);
+    const allowed = await ensureAppPermission(c, appId, permission);
     if (!allowed.ok) return allowed.response;
     await next();
   };

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -14,7 +14,12 @@
 
 import type { Context, MiddlewareHandler } from "hono";
 import { getCookie } from "hono/cookie";
-import { loadDeployToken, sha256Hex, type AppDeployToken } from "../lib/deploy_tokens";
+import {
+  loadDeployToken,
+  resolveDeployTokenPermissions,
+  sha256Hex,
+  type AppDeployToken,
+} from "../lib/deploy_tokens";
 
 // Session cookie carrying the Hands auth token. Set on the stateless agent-login
 // callback (routes/auth) so the raft CLI's Agent Login — which stores/replays a
@@ -186,6 +191,31 @@ export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
     if (bearerToken) {
       const deployToken = await loadDeployToken(c.env, bearerToken);
       if (deployToken) {
+        const effectivePermissions = resolveDeployTokenPermissions(deployToken);
+        if (effectivePermissions.size === 0) {
+          return c.json(
+            {
+              error: "invalid_deploy_token_grant",
+              code: "INVALID_DEPLOY_TOKEN_GRANT",
+              current_permissions: [],
+              app_id: deployToken.app_id,
+            },
+            403,
+          );
+        }
+        if (deployToken.scopes !== null) {
+          const pathname = new URL(c.req.url).pathname;
+          const appRoot = `/api/apps/${deployToken.app_id}`;
+          if (pathname !== appRoot && !pathname.startsWith(`${appRoot}/`)) {
+            return c.json(
+              {
+                error: "scoped_token_app_boundary",
+                app_id: deployToken.app_id,
+              },
+              403,
+            );
+          }
+        }
         c.set("admin_deploy_token", deployToken);
         c.set("admin_actor", `deploy-token:${deployToken.name}@${deployToken.app_slug}`);
         await next();

--- a/worker/src/openapi/common.ts
+++ b/worker/src/openapi/common.ts
@@ -162,6 +162,7 @@ export const OkResponse = z.object({ ok: z.literal(true) }).catchall(z.unknown()
 export const AppRole = z.enum(["viewer", "publisher", "admin"]);
 export const OrgRole = z.enum(["owner", "admin", "member", "viewer"]);
 export const DeployTokenRole = z.enum(["viewer", "publisher"]);
+export const AppPermission = z.enum(["app:read", "app:publish", "app:admin", "feedback:write"]);
 
 export const auth = [{ bearerAuth: [] }];
 

--- a/worker/src/openapi/releases.ts
+++ b/worker/src/openapi/releases.ts
@@ -1,6 +1,7 @@
 import { z } from "@hono/zod-openapi";
 import {
   AppIdParam,
+  AppPermission,
   AppRole,
   DeployTokenRole,
   GenericObject,
@@ -126,7 +127,10 @@ const AppDeployToken = z
     app_id: z.string(),
     name: z.string(),
     token_prefix: z.string(),
-    app_role: DeployTokenRole,
+    app_role: DeployTokenRole.nullable(),
+    scopes: z.array(AppPermission).nullable(),
+    grant_valid: z.boolean(),
+    effective_permissions: z.array(AppPermission),
     created_by: z.string().nullable().optional(),
     created_by_actor: z.string(),
     created_at: z.number().int(),
@@ -139,7 +143,8 @@ const AppDeployToken = z
 const CreateAppDeployTokenRequest = z
   .object({
     name: z.string().min(1).max(80),
-    app_role: DeployTokenRole,
+    app_role: DeployTokenRole.optional(),
+    scopes: z.array(AppPermission).min(1).optional(),
     expires_at: z.number().int().nullable().optional().openapi({
       description:
         "Optional absolute expiry as unix timestamp in milliseconds. Must be at least 60 seconds in the future.",
@@ -157,7 +162,30 @@ const CreateAppDeployTokenResponse = z
   })
   .openapi("CreateAppDeployTokenResponse");
 
+const AppPermissionModel = z.object({
+  permissions: z.array(z.object({
+    permission: AppPermission,
+    label: z.string(),
+    description: z.string(),
+  })),
+  roles: z.array(z.object({
+    role: AppRole,
+    permissions: z.array(AppPermission),
+  })),
+}).openapi("AppPermissionModel");
+
 export function registerReleaseRoutes(registry: OpenApiRegistry) {
+  register(registry, {
+    method: "get",
+    path: "/api/app-permissions",
+    tags: ["App access"],
+    summary: "Read the app permission registry and role bundles",
+    security: auth,
+    responses: {
+      200: success("App permission model.", AppPermissionModel),
+      401: error("Missing or invalid authentication."),
+    },
+  });
   register(registry, {
     method: "get",
     path: "/api/apps/{appId}/releases",
@@ -368,7 +396,7 @@ function registerAccessRoutes(registry: OpenApiRegistry) {
     tags: ["App access"],
     summary: "Create an app deploy token",
     description:
-      "Creates an app-scoped deploy token. The raw token is returned once in this response; store it directly in a secret manager.",
+      "Creates an app-scoped deploy token. Provide app_role, scopes, or both; at least one grant is required and effective permissions are their union. The raw token is returned once in this response; store it directly in a secret manager.",
     security: auth,
     request: {
       params: AppIdParam,

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -973,6 +973,10 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         endpoint: { method: "POST", path: "/api/apps/{app_id}/deploy-tokens" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          name: { type: "string", in: "body", required: true, description: "Human-readable token name." },
+          app_role: { type: "string", in: "body", required: false, description: "Optional role bundle: publisher or viewer." },
+          scopes: { type: "array", in: "body", required: false, description: "Optional additional atomic permissions, unioned with the role bundle. At least one grant is required." },
+          expires_in_days: { type: "number", in: "body", required: false, description: "Optional expiry in days, up to 3650." },
         },
       },
       {

--- a/worker/src/routes/deploy_tokens.ts
+++ b/worker/src/routes/deploy_tokens.ts
@@ -5,17 +5,41 @@ import {
   generateDeployToken,
   hashDeployToken,
   isDeployTokenRole,
+  resolveAppGrantPermissions,
   type DeployTokenRole,
 } from "../lib/deploy_tokens";
+import {
+  APP_PERMISSIONS,
+  APP_PERMISSION_DESCRIPTIONS,
+  APP_PERMISSION_LABELS,
+  APP_ROLE_PERMISSIONS,
+  isAppPermission,
+  type AppPermission,
+} from "../lib/app_permissions";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+export function handleGetAppPermissionModel(c: AdminContext) {
+  return c.json({
+    permissions: APP_PERMISSIONS.map((permission) => ({
+      permission,
+      label: APP_PERMISSION_LABELS[permission],
+      description: APP_PERMISSION_DESCRIPTIONS[permission],
+    })),
+    roles: Object.entries(APP_ROLE_PERMISSIONS).map(([role, permissions]) => ({
+      role,
+      permissions,
+    })),
+  });
+}
 
 type DeployTokenRow = {
   id: string;
   app_id: string;
   name: string;
   token_prefix: string;
-  app_role: DeployTokenRole;
+  app_role: DeployTokenRole | null;
+  scopes_json: string | null;
   created_by: string | null;
   created_by_actor: string;
   created_at: number;
@@ -35,12 +59,29 @@ function parseExpiresAt(value: unknown): number | null {
 }
 
 function toResponse(row: DeployTokenRow) {
-  return {
+  let scopes: AppPermission[] | null = null;
+  let grantValid = true;
+  if (row.scopes_json !== null) {
+    try {
+      const parsed = JSON.parse(row.scopes_json);
+      if (Array.isArray(parsed) && parsed.length > 0 && parsed.every(isAppPermission)) {
+        scopes = parsed;
+      } else {
+        scopes = [];
+        grantValid = false;
+      }
+    } catch {
+      scopes = [];
+      grantValid = false;
+    }
+  }
+  const token = {
     id: row.id,
     app_id: row.app_id,
     name: row.name,
     token_prefix: row.token_prefix,
     app_role: row.app_role,
+    scopes,
     created_by: row.created_by,
     created_by_actor: row.created_by_actor,
     created_at: row.created_at,
@@ -48,13 +89,20 @@ function toResponse(row: DeployTokenRow) {
     last_used_at: row.last_used_at,
     revoked_at: row.revoked_at,
   };
+  return {
+    ...token,
+    grant_valid: grantValid && (token.app_role !== null || token.scopes !== null),
+    effective_permissions: grantValid
+      ? [...resolveAppGrantPermissions(token.app_role, token.scopes)]
+      : [],
+  };
 }
 
 export async function handleListAppDeployTokens(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const includeRevoked = c.req.query("include_revoked") === "1";
   const { results } = await c.env.DB.prepare(
-    `SELECT id, app_id, name, token_prefix, app_role, created_by,
+    `SELECT id, app_id, name, token_prefix, app_role, scopes_json, created_by,
             created_by_actor, created_at, expires_at, last_used_at, revoked_at
      FROM app_deploy_tokens
      WHERE app_id = ?1
@@ -71,6 +119,7 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
   const body = (await c.req.json().catch(() => ({}))) as {
     name?: unknown;
     app_role?: unknown;
+    scopes?: unknown;
     expires_at?: unknown;
     expires_in_days?: unknown;
   } & Record<string, unknown>;
@@ -80,11 +129,11 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
   // expiry field used to yield a NON-EXPIRING token).
   // app_id appears in the body when invoked through the agent-manifest layer
   // (path params are mirrored into the body); accept and ignore it.
-  const allowedKeys = new Set(["name", "app_role", "expires_at", "expires_in_days", "app_id"]);
+  const allowedKeys = new Set(["name", "app_role", "scopes", "expires_at", "expires_in_days", "app_id"]);
   const unknownKeys = Object.keys(body).filter((k) => !allowedKeys.has(k));
   if (unknownKeys.length > 0) {
     return c.json(
-      { error: `unknown field(s): ${unknownKeys.join(", ")} — accepted: name, app_role, expires_at (unix ms), expires_in_days` },
+      { error: `unknown field(s): ${unknownKeys.join(", ")} — accepted: name, app_role, scopes, expires_at (unix ms), expires_in_days` },
       400,
     );
   }
@@ -92,8 +141,19 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
   const name = typeof body.name === "string" ? body.name.trim() : "";
   if (!name) return c.json({ error: "name is required" }, 400);
   if (name.length > 80) return c.json({ error: "name must be 80 characters or fewer" }, 400);
-  if (!isDeployTokenRole(body.app_role)) {
+  const appRole = body.app_role == null ? null : body.app_role;
+  if (appRole !== null && !isDeployTokenRole(appRole)) {
     return c.json({ error: "app_role must be publisher or viewer" }, 400);
+  }
+  let scopes: AppPermission[] | null = null;
+  if (body.scopes != null) {
+    if (!Array.isArray(body.scopes) || body.scopes.length === 0 || !body.scopes.every(isAppPermission)) {
+      return c.json({ error: "scopes must be a non-empty array of supported permissions" }, 400);
+    }
+    scopes = [...new Set(body.scopes)] as AppPermission[];
+  }
+  if (appRole === null && scopes === null) {
+    return c.json({ error: "provide app_role, scopes, or both" }, 400);
   }
 
   if (body.expires_at != null && body.expires_in_days != null) {
@@ -123,9 +183,9 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
 
   await c.env.DB.prepare(
     `INSERT INTO app_deploy_tokens
-     (id, app_id, name, token_prefix, token_hash, app_role, created_by,
+     (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by,
       created_by_actor, created_at, expires_at, last_used_at, revoked_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL)`,
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL, NULL)`,
   )
     .bind(
       id,
@@ -133,7 +193,8 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
       name,
       token_prefix,
       tokenHash,
-      body.app_role,
+      appRole,
+      scopes ? JSON.stringify(scopes) : null,
       account?.id ?? null,
       actor,
       now,
@@ -148,7 +209,9 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
       id,
       name,
       token_prefix,
-      app_role: body.app_role,
+      app_role: appRole,
+      scopes,
+      effective_permissions: [...resolveAppGrantPermissions(appRole, scopes)],
       expires_at: expiresAt,
     },
     created_at: now,
@@ -162,7 +225,10 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
         app_id: appId,
         name,
         token_prefix,
-        app_role: body.app_role,
+        app_role: appRole,
+        scopes,
+        grant_valid: true,
+        effective_permissions: [...resolveAppGrantPermissions(appRole, scopes)],
         created_by: account?.id ?? null,
         created_by_actor: actor,
         created_at: now,

--- a/worker/test/app_permissions_migration.test.ts
+++ b/worker/test/app_permissions_migration.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0048_app_token_permissions.sql", import.meta.url),
+);
+
+describe("app-token permission migration", () => {
+  it("preserves legacy role tokens and allows additive role and explicit grants", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec(`
+      CREATE TABLE apps (id TEXT PRIMARY KEY);
+      CREATE TABLE raft_accounts (id TEXT PRIMARY KEY);
+      CREATE TABLE app_deploy_tokens (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        token_prefix TEXT NOT NULL,
+        token_hash TEXT NOT NULL UNIQUE,
+        app_role TEXT NOT NULL CHECK (app_role IN ('publisher', 'viewer')),
+        created_by TEXT REFERENCES raft_accounts(id) ON DELETE SET NULL,
+        created_by_actor TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER,
+        last_used_at INTEGER,
+        revoked_at INTEGER
+      );
+      CREATE INDEX idx_app_deploy_tokens_app
+        ON app_deploy_tokens(app_id, revoked_at, expires_at);
+      CREATE INDEX idx_app_deploy_tokens_hash
+        ON app_deploy_tokens(token_hash);
+      INSERT INTO apps (id) VALUES ('app-1');
+      INSERT INTO app_deploy_tokens
+        (id, app_id, name, token_prefix, token_hash, app_role, created_by_actor, created_at)
+      VALUES ('legacy', 'app-1', 'legacy CI', 'qvdt_legacy', 'hash-legacy', 'publisher', 'test', 1);
+    `);
+
+    db.exec(readFileSync(migrationPath, "utf8"));
+
+    expect(db.prepare(
+      "SELECT app_role, scopes_json FROM app_deploy_tokens WHERE id = 'legacy'",
+    ).get()).toEqual({ app_role: "publisher", scopes_json: null });
+
+    expect(() => db.prepare(`
+      INSERT INTO app_deploy_tokens
+        (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by_actor, created_at)
+      VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)
+    `).run(
+      "scoped",
+      "app-1",
+      "feedback writer",
+      "qvdt_scoped",
+      "hash-scoped",
+      JSON.stringify(["feedback:write"]),
+      "test",
+      2,
+    )).not.toThrow();
+
+    const additive = db.prepare(`
+      INSERT INTO app_deploy_tokens
+        (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by_actor, created_at)
+      VALUES (?, 'app-1', ?, ?, ?, ?, ?, 'test', 3)
+    `);
+    expect(() => additive.run(
+      "both",
+      "both",
+      "qvdt_both",
+      "hash-both",
+      "viewer",
+      "[\"feedback:write\"]",
+    )).not.toThrow();
+    expect(() => additive.run(
+      "neither",
+      "neither",
+      "qvdt_neither",
+      "hash-neither",
+      null,
+      null,
+    ))
+      .toThrow();
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -20,7 +20,12 @@ import Database from "better-sqlite3";
 import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
-import { requireAppRole, requireCurrentOrgRole, requireFeedbackTriageRole } from "../src/lib/permissions";
+import {
+  requireAppPermission,
+  requireAppRole,
+  requireCurrentOrgRole,
+  requireFeedbackTriageRole,
+} from "../src/lib/permissions";
 import {
   handleUpdateFeedback,
   handleAddFeedbackComment,
@@ -97,6 +102,7 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/download",
       "/api/apps/{appId}/releases/{releaseId}/publish",
       "/api/apps/{appId}/feedback/{ticketId}/comments",
+      "/api/app-permissions",
       "/api/apps/{appId}/client-key",
       "/api/apps/{appId}/analytics/versions",
       "/api/orgs/{orgId}/invites",
@@ -518,13 +524,15 @@ function makeMockDb() {
       name TEXT NOT NULL,
       token_prefix TEXT NOT NULL,
       token_hash TEXT NOT NULL UNIQUE,
-      app_role TEXT NOT NULL CHECK (app_role IN ('publisher', 'viewer')),
+      app_role TEXT CHECK (app_role IN ('publisher', 'viewer')),
+      scopes_json TEXT,
       created_by TEXT REFERENCES raft_accounts(id) ON DELETE SET NULL,
       created_by_actor TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       expires_at INTEGER,
       last_used_at INTEGER,
-      revoked_at INTEGER
+      revoked_at INTEGER,
+      CHECK (app_role IS NOT NULL OR scopes_json IS NOT NULL)
     );
     CREATE TABLE invites (
       id TEXT PRIMARY KEY,
@@ -2167,7 +2175,10 @@ describe("quiver Hono app — auth + dispatch", () => {
     await env.DB.prepare(
       "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
     ).bind("dt-app", "default", "dt-app", "DT App", "android", now).run();
-    const { handleCreateAppDeployToken } = await import("../src/routes/deploy_tokens");
+    const {
+      handleCreateAppDeployToken,
+      handleListAppDeployTokens,
+    } = await import("../src/routes/deploy_tokens");
     const ctx = (body: unknown) =>
       ({
         env,
@@ -2192,6 +2203,12 @@ describe("quiver Hono app — auth + dispatch", () => {
     const ok = await handleCreateAppDeployToken(ctx({ name: "t2", app_role: "publisher", expires_in_days: 7 }));
     expect(ok.status).toBe(201);
     const created = (await ok.json()) as any;
+    expect(created.deploy_token).toMatchObject({
+      app_role: "publisher",
+      scopes: null,
+      grant_valid: true,
+      effective_permissions: ["app:read", "app:publish", "feedback:write"],
+    });
     expect(created.deploy_token.expires_at).toBeGreaterThan(now + 6.9 * 86_400_000);
     expect(created.deploy_token.expires_at).toBeLessThan(now + 7.1 * 86_400_000);
 
@@ -2204,6 +2221,117 @@ describe("quiver Hono app — auth + dispatch", () => {
     // Invalid days → 400.
     const bad = await handleCreateAppDeployToken(ctx({ name: "t4", app_role: "publisher", expires_in_days: -1 }));
     expect(bad.status).toBe(400);
+
+    const neither = await handleCreateAppDeployToken(ctx({ name: "neither" }));
+    expect(neither.status).toBe(400);
+    const bothGrants = await handleCreateAppDeployToken(
+      ctx({ name: "both", app_role: "viewer", scopes: ["feedback:write"] }),
+    );
+    expect(bothGrants.status).toBe(201);
+    expect((await bothGrants.json()) as any).toMatchObject({
+      deploy_token: {
+        app_role: "viewer",
+        scopes: ["feedback:write"],
+        grant_valid: true,
+        effective_permissions: ["app:read", "feedback:write"],
+      },
+    });
+    const auditRows = await env.DB.prepare(
+      "SELECT payload FROM audit_logs WHERE action = 'deploy_token.create'",
+    ).all();
+    const bothAudit = auditRows.results
+      .map((row: any) => JSON.parse(row.payload))
+      .find((payload: any) => payload.name === "both");
+    expect(bothAudit).toMatchObject({
+      app_role: "viewer",
+      scopes: ["feedback:write"],
+      effective_permissions: ["app:read", "feedback:write"],
+    });
+    const unknownScope = await handleCreateAppDeployToken(
+      ctx({ name: "unknown", scopes: ["releases:delete"] }),
+    );
+    expect(unknownScope.status).toBe(400);
+    const scoped = await handleCreateAppDeployToken(
+      ctx({ name: "feedback-only", scopes: ["feedback:write"], expires_in_days: 7 }),
+    );
+    expect(scoped.status).toBe(201);
+    expect((await scoped.json()) as any).toMatchObject({
+      deploy_token: {
+        app_role: null,
+        scopes: ["feedback:write"],
+        grant_valid: true,
+        effective_permissions: ["feedback:write"],
+      },
+    });
+
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+        created_by_actor, created_at)
+       VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+    ).bind(
+      "invalid-grant",
+      "dt-app",
+      "invalid stored grant",
+      "qvdt_invalid",
+      "hash-invalid",
+      JSON.stringify(["unknown:permission"]),
+      "tester",
+      now,
+    ).run();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+        created_by_actor, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, '', ?, ?)`,
+    ).bind(
+      "empty-string-grant",
+      "dt-app",
+      "empty string stored grant",
+      "qvdt_empty_string",
+      "hash-empty-string",
+      "viewer",
+      "tester",
+      now,
+    ).run();
+    const listed = await handleListAppDeployTokens(ctx({}));
+    const listedBody = await listed.json() as any;
+    expect(listedBody.deploy_tokens.find((token: any) => token.name === "both"))
+      .toMatchObject({
+        app_role: "viewer",
+        scopes: ["feedback:write"],
+        grant_valid: true,
+        effective_permissions: ["app:read", "feedback:write"],
+      });
+    expect(listedBody.deploy_tokens.find((token: any) => token.id === "invalid-grant"))
+      .toMatchObject({
+        grant_valid: false,
+        effective_permissions: [],
+      });
+    expect(listedBody.deploy_tokens.find((token: any) => token.id === "empty-string-grant"))
+      .toMatchObject({
+        grant_valid: false,
+        effective_permissions: [],
+      });
+  });
+
+  it("exposes one permission registry with role bundles", async () => {
+    const { handleGetAppPermissionModel } = await import("../src/routes/deploy_tokens");
+    const response = handleGetAppPermissionModel({
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any);
+    const body = await response.json() as any;
+    expect(body.permissions.map((entry: any) => entry.permission)).toEqual([
+      "app:read",
+      "app:publish",
+      "app:admin",
+      "feedback:write",
+    ]);
+    expect(body.permissions.find((entry: any) => entry.permission === "app:read").label)
+      .toBe("App read");
+    expect(body.roles.find((entry: any) => entry.role === "viewer").permissions).toEqual(["app:read"]);
+    expect(body.roles.find((entry: any) => entry.role === "publisher").permissions).toContain("feedback:write");
+    expect(body.roles.find((entry: any) => entry.role === "admin").permissions).toContain("app:admin");
   });
 
   it("loads app-scoped deploy tokens and updates last_used_at", async () => {
@@ -2236,6 +2364,7 @@ describe("quiver Hono app — auth + dispatch", () => {
       app_id: "deploy-app",
       app_slug: "deploy-app",
       app_role: "publisher",
+      scopes: null,
     });
     const row = (await env.DB.prepare(
       "SELECT last_used_at FROM app_deploy_tokens WHERE id = ?",
@@ -2243,9 +2372,196 @@ describe("quiver Hono app — auth + dispatch", () => {
     expect(row?.last_used_at).toBeTypeOf("number");
   });
 
+  it("keeps scoped tokens inside their app route boundary", async () => {
+    const env = makeMockEnv();
+    const now = Date.now();
+    const token = "qvdt_scopeprefix_scopesecret";
+    const tokenHash = createHash("sha256").update(token).digest("hex");
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).bind("scope-app", "default", "scope-app", "Scope App", "web", now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json, created_by_actor, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
+    ).bind(
+      "scope-token",
+      "scope-app",
+      "feedback writer",
+      "qvdt_scopeprefix",
+      tokenHash,
+      JSON.stringify(["feedback:write"]),
+      "raft:owner@server",
+      now,
+      now + 60_000,
+    ).run();
+
+    const { authMiddleware } = await import("../src/middleware/auth");
+    const invoke = async (url: string) => {
+      const variables = new Map<string, unknown>();
+      let nextCalled = false;
+      const response = await authMiddleware({
+        env,
+        req: {
+          url,
+          header: (name: string) => name.toLowerCase() === "authorization" ? `Bearer ${token}` : undefined,
+        },
+        get: (name: string) => variables.get(name),
+        set: (name: string, value: unknown) => { variables.set(name, value); },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any, async () => { nextCalled = true; });
+      return { response, nextCalled };
+    };
+
+    const global = await invoke("https://quiver-worker.test/api/orgs");
+    expect(global.response?.status).toBe(403);
+    expect(global.nextCalled).toBe(false);
+    const ownApp = await invoke("https://quiver-worker.test/api/apps/scope-app/releases");
+    expect(ownApp.response).toBeUndefined();
+    expect(ownApp.nextCalled).toBe(true);
+    const otherApp = await invoke("https://quiver-worker.test/api/apps/other/releases");
+    expect(otherApp.response?.status).toBe(403);
+  });
+
+  it("separates legacy role guards from exact custom-permission guards", async () => {
+    const env = makeMockEnv();
+    const now = Date.now();
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).bind("guard-app", "default", "guard-app", "Guard App", "web", now).run();
+
+    const fixtures = [
+      {
+        id: "custom-publish",
+        token: "qvdt_custom_publish",
+        role: null,
+        scopes: JSON.stringify(["app:publish"]),
+      },
+      {
+        id: "viewer-feedback",
+        token: "qvdt_viewer_feedback",
+        role: "viewer",
+        scopes: JSON.stringify(["feedback:write"]),
+      },
+      {
+        id: "corrupt-viewer",
+        token: "qvdt_corrupt_viewer",
+        role: "viewer",
+        scopes: JSON.stringify(["unknown:permission"]),
+      },
+      {
+        id: "empty-viewer",
+        token: "qvdt_empty_viewer",
+        role: "viewer",
+        scopes: "",
+      },
+    ];
+    for (const fixture of fixtures) {
+      await env.DB.prepare(
+        `INSERT INTO app_deploy_tokens
+         (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+          created_by_actor, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        fixture.id,
+        "guard-app",
+        fixture.id,
+        fixture.token,
+        createHash("sha256").update(fixture.token).digest("hex"),
+        fixture.role,
+        fixture.scopes,
+        "tester",
+        now,
+        now + 60_000,
+      ).run();
+    }
+
+    const app = new Hono<{ Bindings: Env }>();
+    app.use("*", authMiddleware as any);
+    app.patch(
+      "/api/apps/:appId/feedback/:ticketId",
+      requireFeedbackTriageRole() as any,
+      (c) => c.json({ ok: true }),
+    );
+    app.get(
+      "/api/apps/:appId/view",
+      requireAppRole("viewer") as any,
+      (c) => c.json({ ok: true }),
+    );
+    app.post(
+      "/api/apps/:appId/exact-publish",
+      requireAppPermission("app:publish") as any,
+      (c) => c.json({ ok: true }),
+    );
+    app.post(
+      "/api/apps/:appId/exact-feedback",
+      requireAppPermission("feedback:write") as any,
+      (c) => c.json({ ok: true }),
+    );
+
+    const request = (path: string, token: string, method: string) => app.request(
+      `https://quiver-worker.test${path}`,
+      { method, headers: { authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect((await request(
+      "/api/apps/guard-app/feedback/ticket-1",
+      "qvdt_custom_publish",
+      "PATCH",
+    )).status).toBe(403);
+    expect((await request(
+      "/api/apps/guard-app/view",
+      "qvdt_custom_publish",
+      "GET",
+    )).status).toBe(403);
+    expect((await request(
+      "/api/apps/guard-app/exact-publish",
+      "qvdt_custom_publish",
+      "POST",
+    )).status).toBe(200);
+
+    expect((await request(
+      "/api/apps/guard-app/view",
+      "qvdt_viewer_feedback",
+      "GET",
+    )).status).toBe(200);
+    expect((await request(
+      "/api/apps/guard-app/feedback/ticket-1",
+      "qvdt_viewer_feedback",
+      "PATCH",
+    )).status).toBe(403);
+    expect((await request(
+      "/api/apps/guard-app/exact-feedback",
+      "qvdt_viewer_feedback",
+      "POST",
+    )).status).toBe(200);
+
+    const corrupt = await request(
+      "/api/apps/guard-app/view",
+      "qvdt_corrupt_viewer",
+      "GET",
+    );
+    expect(corrupt.status).toBe(403);
+    await expect(corrupt.json()).resolves.toMatchObject({
+      code: "INVALID_DEPLOY_TOKEN_GRANT",
+      current_permissions: [],
+    });
+    const empty = await request(
+      "/api/apps/guard-app/view",
+      "qvdt_empty_viewer",
+      "GET",
+    );
+    expect(empty.status).toBe(403);
+    await expect(empty.json()).resolves.toMatchObject({
+      code: "INVALID_DEPLOY_TOKEN_GRANT",
+      current_permissions: [],
+    });
+  });
+
   it("allows deploy tokens only for their app and role", async () => {
     const env = makeMockEnv();
-    const { ensureAppRole } = await import("../src/lib/permissions");
+    const { ensureAppPermission, ensureAppRole } = await import("../src/lib/permissions");
     const ctx = {
       env,
       get: (key: string) =>
@@ -2257,6 +2573,7 @@ describe("quiver Hono app — auth + dispatch", () => {
               name: "ci",
               token_prefix: "qvdt_test",
               app_role: "publisher",
+              scopes: null,
               created_by: null,
               created_by_actor: "raft:owner@server",
               created_at: 1,
@@ -2279,6 +2596,119 @@ describe("quiver Hono app — auth + dispatch", () => {
     const tooHigh = await ensureAppRole(ctx as any, "app-1", "admin");
     expect(tooHigh.ok).toBe(false);
     if (!tooHigh.ok) expect(tooHigh.response.status).toBe(403);
+
+    const scopedCtx = {
+      ...ctx,
+      get: (key: string) =>
+        key === "admin_deploy_token"
+          ? {
+              ...(ctx.get("admin_deploy_token") as object),
+              app_role: null,
+              scopes: ["app:read"],
+            }
+          : undefined,
+    };
+    const scopedReadRole = await ensureAppRole(scopedCtx as any, "app-1", "viewer");
+    expect(scopedReadRole.ok).toBe(false);
+    await expect(ensureAppPermission(scopedCtx as any, "app-1", "app:read"))
+      .resolves.toMatchObject({ ok: true, app_permission: "app:read" });
+    const scopedPublish = await ensureAppRole(scopedCtx as any, "app-1", "publisher");
+    expect(scopedPublish.ok).toBe(false);
+
+    const customPublishCtx = {
+      ...ctx,
+      get: (key: string) =>
+        key === "admin_deploy_token"
+          ? {
+              ...(ctx.get("admin_deploy_token") as object),
+              app_role: null,
+              scopes: ["app:publish"],
+            }
+          : undefined,
+    };
+    const customPublishRole = await ensureAppRole(
+      customPublishCtx as any,
+      "app-1",
+      "publisher",
+    );
+    expect(customPublishRole.ok).toBe(false);
+    await expect(ensureAppPermission(customPublishCtx as any, "app-1", "app:publish"))
+      .resolves.toMatchObject({ ok: true, app_permission: "app:publish" });
+    const customPublishRead = await ensureAppPermission(
+      customPublishCtx as any,
+      "app-1",
+      "app:read",
+    );
+    expect(customPublishRead.ok).toBe(false);
+
+    const feedbackCtx = {
+      ...ctx,
+      get: (key: string) =>
+        key === "admin_deploy_token"
+          ? {
+              ...(ctx.get("admin_deploy_token") as object),
+              app_role: null,
+              scopes: ["feedback:write"],
+            }
+          : undefined,
+    };
+    await expect(ensureAppPermission(feedbackCtx as any, "app-1", "feedback:write"))
+      .resolves.toMatchObject({ ok: true, app_permission: "feedback:write" });
+    const feedbackRead = await ensureAppPermission(feedbackCtx as any, "app-1", "app:read");
+    expect(feedbackRead.ok).toBe(false);
+
+    const additiveViewerCtx = {
+      ...ctx,
+      get: (key: string) =>
+        key === "admin_deploy_token"
+          ? {
+              ...(ctx.get("admin_deploy_token") as object),
+              app_role: "viewer",
+              scopes: ["feedback:write"],
+            }
+          : undefined,
+    };
+    await expect(ensureAppRole(additiveViewerCtx as any, "app-1", "viewer"))
+      .resolves.toMatchObject({ ok: true, app_role: "viewer" });
+    const additivePublish = await ensureAppRole(additiveViewerCtx as any, "app-1", "publisher");
+    expect(additivePublish.ok).toBe(false);
+    if (!additivePublish.ok) {
+      await expect(additivePublish.response.json()).resolves.toMatchObject({
+        current_permissions: ["app:read", "feedback:write"],
+      });
+    }
+    await expect(ensureAppPermission(additiveViewerCtx as any, "app-1", "feedback:write"))
+      .resolves.toMatchObject({ ok: true, app_permission: "feedback:write" });
+
+    const corruptRoleCtx = {
+      ...ctx,
+      get: (key: string) =>
+        key === "admin_deploy_token"
+          ? {
+              ...(ctx.get("admin_deploy_token") as object),
+              app_role: "viewer",
+              scopes: [],
+            }
+          : undefined,
+    };
+    const corruptRole = await ensureAppRole(corruptRoleCtx as any, "app-1", "viewer");
+    expect(corruptRole.ok).toBe(false);
+    if (!corruptRole.ok) {
+      await expect(corruptRole.response.json()).resolves.toMatchObject({
+        current_permissions: [],
+      });
+    }
+    const corruptPermission = await ensureAppPermission(
+      corruptRoleCtx as any,
+      "app-1",
+      "app:read",
+    );
+    expect(corruptPermission.ok).toBe(false);
+    if (!corruptPermission.ok) {
+      await expect(corruptPermission.response.json()).resolves.toMatchObject({
+        current_permissions: [],
+      });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- define a single app-permission registry and map viewer/publisher/admin roles to permission bundles
- let deploy tokens carry a role bundle, explicit permissions, or both, with one additive fail-closed resolver
- keep legacy role guards bound to actual roles while exact permission guards accept narrow custom grants
- expose resolved effective permissions through the API, audit log, and Console, including source/permission tags and live creation preview
- fence tokens with explicit grants to their app routes and migrate existing role tokens without snapshotting their bundles

## Authorization model

Permissions are the endpoint authorization primitives. A principal's effective permissions are the deduplicated union of its expanded role bundle and valid explicit permission grants. At least one grant is required.

Initial permissions:

- `app:read`
- `app:publish`
- `app:admin`
- `feedback:write`

Existing `requireAppRole(...)` routes still require an actual role grant. Custom permissions are accepted only by exact `requireAppPermission(...)` routes, so a custom `app:publish` grant cannot impersonate the full publisher role.

Existing role-only tokens remain symbolic, so future role-bundle changes remain authoritative rather than being copied into stale permission snapshots. Malformed, empty, or unknown stored explicit grants invalidate the entire token grant and resolve to no permissions.

## Verification

- Worker tests: 180 passed
- Worker TypeScript build: passed
- Admin tests: 4 passed
- Admin TypeScript typecheck: passed
- Admin production build: passed
- SQLite migration test: passed
- `git diff --check`: passed

Worker lint cannot start because the repository uses ESLint 9 without an `eslint.config.js`; this is unchanged by the PR.
