### PR TITLE
feat: publish processed builds to TestFlight groups

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -287,7 +287,13 @@ export interface AuditLogEntry {
 export interface Operation {
   id: string;
   app_id: string;
-  kind: "parse" | "upload" | "publish" | "signed_url" | "testflight-upload";
+  kind:
+    | "parse"
+    | "upload"
+    | "publish"
+    | "signed_url"
+    | "testflight-upload"
+    | "testflight-publish";
   status: "pending" | "in_progress" | "success" | "failed" | "cancelled";
   parent_op_id: string | null;
   step_number: number | null;
@@ -876,6 +882,66 @@ export const getTestflightUploadStatus = (appId: string, buildUploadId: string) 
     build_number: string | null;
     uploaded_at: string | null;
   }>(`/api/apps/${appId}/testflight-uploads/${buildUploadId}`, { admin: true });
+
+export interface TestflightGroupState {
+  id: string;
+  name: string | null;
+  is_internal: boolean | null;
+  has_access_to_all_builds: boolean | null;
+  public_link_enabled: boolean | null;
+}
+
+export interface TestflightPublishState {
+  hands_build_id: string;
+  bundle_id: string;
+  asc_app_id: string;
+  asc_build_id: string | null;
+  version: string;
+  build_number: string;
+  processing_state?: string | null;
+  build_audience_type?: string | null;
+  expiration_date?: string | null;
+  expired?: boolean | null;
+  state: string;
+  distribution: "internal" | "external" | null;
+  assigned_groups?: TestflightGroupState[];
+  localizations?: Array<{
+    id: string;
+    locale: string | null;
+    whats_new: string | null;
+  }>;
+  beta_review?: {
+    id: string;
+    state: string | null;
+    submitted_at: string | null;
+  } | null;
+  beta_detail?: {
+    id: string;
+    auto_notify_enabled: boolean | null;
+    internal_build_state: string | null;
+    external_build_state: string | null;
+  } | null;
+  notification?: string;
+}
+
+export const getTestflightPublishStatus = (
+  appId: string,
+  buildId: string,
+  options: {
+    distribution?: "internal" | "external";
+    bundleId?: string;
+  } = {},
+) => {
+  const query = new URLSearchParams();
+  if (options.distribution) query.set("distribution", options.distribution);
+  if (options.bundleId) query.set("bundle_id", options.bundleId);
+  const queryString = query.toString();
+  const suffix = queryString ? `?${queryString}` : "";
+  return request<TestflightPublishState>(
+    `/api/apps/${appId}/builds/${buildId}/testflight-publish${suffix}`,
+    { admin: true },
+  );
+};
 
 // ---------- App Store review status (read-only) ----------
 

--- a/admin/src/pages/Builds.tsx
+++ b/admin/src/pages/Builds.tsx
@@ -380,7 +380,7 @@ function TestflightUploadPanel({ appId, build }: { appId: string; build: Build }
       )}
       {stateName === "COMPLETE" && (
         <p className="mt-1 text-xs text-green-700">
-          Processed — add it to a tester group in App Store Connect → TestFlight.
+          Upload processed. Ready for TestFlight group distribution.
         </p>
       )}
     </div>

--- a/admin/src/pages/Testflight.tsx
+++ b/admin/src/pages/Testflight.tsx
@@ -1,17 +1,20 @@
 /**
- * TestFlight tab — one place to see every Hands→Apple upload request and its
- * live App Store Connect processing state. Upload attempts are recorded as
- * `testflight-upload` operations; each successful one carries a
+ * TestFlight tab — one place to see every Hands→Apple upload and distribution
+ * request. Upload attempts are recorded as `testflight-upload` operations;
+ * each successful one carries a
  * build_upload_id whose Apple state (PROCESSING → COMPLETE | FAILED) is
  * polled live, so the operation's "upload succeeded" is separated from
- * Apple's async accept/reject verdict.
+ * Apple's async accept/reject verdict. Group assignment/review attempts are
+ * recorded as `testflight-publish` operations.
  */
 import { useQuery } from "@tanstack/react-query";
 import {
   listOperations,
+  getTestflightPublishStatus,
   getTestflightUploadStatus,
   type Operation,
   type AscUploadState,
+  type TestflightPublishState,
 } from "../lib/api";
 
 interface UploadInput {
@@ -23,6 +26,14 @@ interface UploadOutput {
   build_upload_id?: string;
   asc_app_id?: string;
 }
+interface PublishInput {
+  hands_build_id?: string;
+  bundle_id?: string;
+  distribution?: "internal" | "external";
+  group_ids?: string[];
+  notify_testers?: boolean;
+}
+type PublishOutput = Partial<TestflightPublishState>;
 
 function ascTestflightUrl(ascAppId: string | undefined): string {
   return ascAppId
@@ -40,14 +51,17 @@ export function Testflight({ appId }: { appId: string }) {
   const uploads = (ops.data?.operations ?? []).filter(
     (o) => o.kind === "testflight-upload",
   );
+  const publishes = (ops.data?.operations ?? []).filter(
+    (o) => o.kind === "testflight-publish",
+  );
 
   return (
     <div>
       <div className="mb-4">
         <h2 className="text-lg font-semibold">TestFlight</h2>
         <p className="text-xs text-slate-500 mt-1">
-          Every Hands→Apple upload request and its live App Store Connect
-          processing state. Configure the key in{" "}
+          Hands→Apple uploads, processing, beta-group distribution, and review
+          state. Configure the key in{" "}
           <a className="underline" href={`/apps/${appId}/settings`}>
             Settings → TestFlight
           </a>
@@ -60,18 +74,33 @@ export function Testflight({ appId }: { appId: string }) {
       </div>
 
       {ops.isLoading && <p className="text-slate-500 text-sm">Loading…</p>}
-      {!ops.isLoading && uploads.length === 0 && (
+      {!ops.isLoading && uploads.length === 0 && publishes.length === 0 && (
         <p className="text-slate-500 text-sm">
-          No TestFlight uploads yet. Open the Builds tab, expand an iOS build,
-          and click “Upload to TestFlight”.
+          No TestFlight activity yet.
         </p>
       )}
 
-      <div className="space-y-2">
-        {uploads.map((op) => (
-          <UploadRow key={op.id} appId={appId} op={op} />
-        ))}
-      </div>
+      {uploads.length > 0 && (
+        <section className="mb-6">
+          <h3 className="text-sm font-semibold mb-2">Uploads</h3>
+          <div className="space-y-2">
+            {uploads.map((op) => (
+              <UploadRow key={op.id} appId={appId} op={op} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {publishes.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold mb-2">Distributions</h3>
+          <div className="space-y-2">
+            {publishes.map((op) => (
+              <PublishRow key={op.id} appId={appId} op={op} />
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 }
@@ -145,7 +174,7 @@ function UploadRow({ appId, op }: { appId: string; op: Operation }) {
       )}
       {appleState?.state === "COMPLETE" && (
         <p className="mt-1 text-xs text-green-700">
-          Processed — add it to a tester group in{" "}
+          Upload processed. Ready for group distribution. Inspect the build in{" "}
           <a
             className="underline"
             href={ascTestflightUrl(output.asc_app_id)}
@@ -155,6 +184,138 @@ function UploadRow({ appId, op }: { appId: string; op: Operation }) {
             App Store Connect → TestFlight
           </a>
           .
+        </p>
+      )}
+    </div>
+  );
+}
+
+function isTerminalPublishState(
+  state: string | undefined,
+  input: PublishInput,
+): boolean {
+  if (!state) return false;
+  if (
+    state === "rejected" ||
+    state === "expired" ||
+    state === "processing_failed" ||
+    state === "blocked_export_compliance" ||
+    state === "not_applicable"
+  ) {
+    return true;
+  }
+  if (state === "testing") return true;
+  return (
+    input.distribution === "external" &&
+    !input.notify_testers &&
+    (state === "approved" || state === "approved_not_notified")
+  );
+}
+
+function PublishRow({ appId, op }: { appId: string; op: Operation }) {
+  let input: PublishInput = {};
+  let output: PublishOutput = {};
+  try {
+    input = JSON.parse(op.input || "{}");
+  } catch {
+    /* ignore */
+  }
+  try {
+    output = JSON.parse(op.output || "{}");
+  } catch {
+    /* ignore */
+  }
+  const buildId = input.hands_build_id;
+  const liveStatus = useQuery({
+    queryKey: [
+      "testflight-publish-status",
+      appId,
+      buildId,
+      input.distribution,
+      input.bundle_id,
+    ],
+    queryFn: () =>
+      getTestflightPublishStatus(appId, buildId!, {
+        ...(input.distribution ? { distribution: input.distribution } : {}),
+        ...(input.bundle_id ? { bundleId: input.bundle_id } : {}),
+      }),
+    enabled: Boolean(buildId) && op.status === "success",
+    staleTime: 5000,
+    refetchInterval: (query) =>
+      isTerminalPublishState(query.state.data?.state, input) ? 300000 : 12000,
+  });
+  const current: PublishOutput = { ...output, ...(liveStatus.data ?? {}) };
+  const failed = op.status === "failed";
+  const state = failed ? "failed" : current.state ?? op.status;
+  const blocked =
+    state === "rejected" ||
+    state === "expired" ||
+    state === "processing_failed" ||
+    state === "blocked_export_compliance" ||
+    state === "not_applicable";
+  const badge =
+    failed || blocked
+      ? "badge-red"
+      : state === "testing"
+        ? "badge-green"
+        : "badge-blue";
+  const localizationLocales = (current.localizations ?? [])
+    .map((item) => item.locale)
+    .filter((locale): locale is string => Boolean(locale));
+
+  return (
+    <div className="card p-3!">
+      <div className="flex items-center gap-3 flex-wrap text-sm">
+        <span className="font-mono font-medium">
+          {current.version
+            ? `v${current.version}`
+            : input.hands_build_id?.slice(0, 8) ?? "—"}
+          {current.build_number ? ` (${current.build_number})` : ""}
+        </span>
+        {input.distribution && (
+          <span className="badge-gray text-xs">{input.distribution}</span>
+        )}
+        <span className={`${badge} text-xs`}>{state}</span>
+        {current.beta_review?.state && (
+          <span className="badge-gray text-xs">
+            review: {current.beta_review.state}
+          </span>
+        )}
+        {current.beta_detail?.auto_notify_enabled && (
+          <span className="badge-gray text-xs">auto notify on</span>
+        )}
+        <span className="text-xs text-slate-500 ml-auto">
+          {new Date(op.created_at).toISOString().slice(0, 16)}Z
+        </span>
+      </div>
+      {current.assigned_groups && current.assigned_groups.length > 0 && (
+        <p className="mt-1 text-xs text-slate-600">
+          Groups: {current.assigned_groups.map((group) => group.name ?? group.id).join(", ")}
+        </p>
+      )}
+      {localizationLocales.length > 0 && (
+        <p className="mt-1 text-xs text-slate-600">
+          What to Test: {localizationLocales.join(", ")}
+        </p>
+      )}
+      {current.expiration_date && (
+        <p className="mt-1 text-xs text-slate-500">
+          Expires: {new Date(current.expiration_date).toISOString().slice(0, 10)}
+        </p>
+      )}
+      {output.notification && (
+        <p className="mt-1 text-xs text-slate-600">
+          Notification action: {output.notification}
+        </p>
+      )}
+      {failed && op.error && (
+        <p className="mt-1 text-xs text-red-700 font-mono break-all">
+          {friendlyError(op.error)}
+        </p>
+      )}
+      {liveStatus.isError && !failed && (
+        <p className="mt-1 text-xs text-red-700">
+          Live state refresh failed: {friendlyError(liveStatus.error)}
         </p>
       )}
     </div>
@@ -180,11 +341,12 @@ function StateBadge({
   return <span className="badge-blue text-xs">Apple processing…</span>;
 }
 
-function friendlyError(raw: string): string {
+function friendlyError(raw: unknown): string {
+  const text = raw instanceof Error ? raw.message : String(raw);
   try {
-    const parsed = JSON.parse(raw) as { error?: string; detail?: string | null };
-    return [parsed.error, parsed.detail].filter(Boolean).join(" — ") || raw;
+    const parsed = JSON.parse(text) as { error?: string; detail?: string | null };
+    return [parsed.error, parsed.detail].filter(Boolean).join(" — ") || text;
   } catch {
-    return raw;
+    return text;
   }
 }

--- a/docs/ios-distribution-design.md
+++ b/docs/ios-distribution-design.md
@@ -1,12 +1,16 @@
 # iOS distribution and TestFlight spec
 
-Status: draft spec for review
+Status: implemented baseline; follow-up design remains below
 Owner: Codex-Android-DevOPS
-Updated: 2026-07-09
+Updated: 2026-07-21
 
 Official references:
 
 - Apple App Store Connect Help: [Upload builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/)
+- Apple App Store Connect API: [Prerelease Versions and Beta Testers](https://developer.apple.com/documentation/appstoreconnectapi/prerelease-versions-and-beta-testers)
+- Apple Help: [Add internal testers](https://developer.apple.com/help/app-store-connect/test-a-beta-version/add-internal-testers/)
+- Apple Help: [Invite external testers](https://developer.apple.com/help/app-store-connect/test-a-beta-version/invite-external-testers/)
+- Apple Help: [TestFlight overview](https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview/)
 
 Hands should treat iOS as a first-class product type. The platform should know
 when an app ships iOS artifacts, collect the right release assets, track
@@ -18,9 +22,11 @@ The recommended lane is:
 1. macOS CI builds and signs the app.
 2. CI uploads `.ipa`, `.dSYM.zip`, and build metadata to Hands as an immutable
    build record.
-3. CI uploads the same signed `.ipa` to App Store Connect / TestFlight.
-4. CI or a poller writes TestFlight processing/distribution status back to
-   Hands.
+3. Hands streams that same immutable `.ipa` to Apple's Build Upload API using
+   the app's encrypted server-side ASC credential.
+4. Hands resolves the processed build, assigns selected beta groups, writes
+   localized What to Test text, submits external Beta App Review when needed,
+   and synchronizes Apple state.
 5. Hands remains the release system of record; Apple remains the iOS
    distribution system.
 
@@ -31,9 +37,10 @@ The recommended lane is:
   model.
 - Manage TestFlight distribution configuration in Hands without exposing raw
   Apple secrets.
-- Support automated internal TestFlight uploads from CI.
-- Leave room for external TestFlight review, ad-hoc OTA, and enterprise OTA
-  without forcing those into the first implementation.
+- Support internal and external TestFlight distribution without exporting ASC
+  credentials to CI or agents.
+- Leave room for ad-hoc OTA and enterprise OTA without conflating either with
+  TestFlight or App Store production publishing.
 
 ## Non-goals
 
@@ -188,13 +195,14 @@ Inputs:
 
 Required CI secrets depend on signing mode. For the manual-secrets mode:
 
-- `ASC_KEY_ID`
-- `ASC_ISSUER_ID`
-- `ASC_PRIVATE_KEY_P8`
 - `IOS_DIST_CERT_P12`
 - `IOS_DIST_CERT_PASSWORD`
 - `IOS_PROVISIONING_PROFILE`
 - `HANDS_BEARER_TOKEN` or app deploy token
+
+The App Store Connect Key ID, Issuer ID, and `.p8` are configured once in
+Hands App Settings. Hands encrypts them server-side; CI and Raft agents never
+receive the key.
 
 Workflow:
 
@@ -210,13 +218,18 @@ Workflow:
    ```sh
    hands builds publish-ios --ipa build/App.ipa --dsym build/App.dSYM.zip --draft
    ```
-9. Upload `.ipa` to App Store Connect with Apple-supported upload tooling:
-   Xcode Organizer, `altool`, or Transporter. In CI, prefer Transporter with
-   App Store Connect API authentication, or fastlane `pilot` as a maintained
-   wrapper around the Apple upload path.
-10. Poll App Store Connect until processing is complete or times out.
-11. Add selected internal tester groups.
-12. Write TestFlight state back to Hands.
+9. An authorized app admin invokes Hands `testflight-upload`; the Worker
+   streams the exact stored IPA to Apple's official Build Upload API.
+10. Poll the returned Build Upload id to
+    `state.state=COMPLETE|FAILED`, then resolve the exact app/version/build
+    tuple until the ASC build is `VALID`.
+11. List stable beta group ids and invoke `testflight-publish` with an explicit
+    `internal|external` mode, selected group ids, localized What to Test text,
+    and an opt-in notification flag.
+12. For external groups, submit Beta App Review and track
+    `WAITING_FOR_REVIEW|IN_REVIEW|APPROVED|REJECTED`; notify automatically after
+    approval or send the official build notification for an already-approved
+    build.
 13. Leave final public release/publish decision under the same draft-first
     release governance as other platforms.
 
@@ -226,22 +239,20 @@ require beta review and should be represented as `waiting_for_review`,
 
 ## API surface
 
-Minimal API additions:
+Current TestFlight API:
 
 ```text
-GET    /api/apps/:appId/ios/distribution-profiles
-POST   /api/apps/:appId/ios/distribution-profiles
-PATCH  /api/apps/:appId/ios/distribution-profiles/:profileId
-DELETE /api/apps/:appId/ios/distribution-profiles/:profileId
-
-POST   /api/apps/:appId/builds/:buildId/testflight
-GET    /api/apps/:appId/builds/:buildId/testflight
-PATCH  /api/apps/:appId/builds/:buildId/testflight
+POST   /api/apps/:appId/builds/:buildId/testflight-upload
+GET    /api/apps/:appId/testflight-uploads/:buildUploadId
+GET    /api/apps/:appId/builds/:buildId/testflight-groups
+POST   /api/apps/:appId/builds/:buildId/testflight-publish
+GET    /api/apps/:appId/builds/:buildId/testflight-publish
 ```
 
-`POST /testflight` should not upload to Apple directly from the Worker. It
-should create a requested operation or accept CI-reported state. The actual
-upload runs in CI where Xcode and Apple credentials are available.
+The Worker is the upload/distribution boundary because it already owns the
+encrypted ASC API credential and immutable Hands IPA. CI owns signing, but it
+does not need upload credentials. Every mutation writes an operation/audit
+record with provider ids and states, never credential material.
 
 Suggested TestFlight state:
 
@@ -252,10 +263,14 @@ Suggested TestFlight state:
   "app_store_connect_build_id": "abcdef",
   "version": "1.2.3",
   "build_number": "456",
-  "processing_status": "processing|processed|failed|timeout",
-  "internal_distribution_status": "not_started|distributed|failed",
-  "external_review_status": "not_submitted|waiting_for_review|in_review|approved|rejected",
-  "groups": ["Internal QA"],
+  "processing_state": "PROCESSING|VALID|FAILED|INVALID",
+  "internal_build_state": "READY_FOR_BETA_TESTING|IN_BETA_TESTING|...",
+  "external_build_state": "READY_FOR_BETA_SUBMISSION|WAITING_FOR_BETA_REVIEW|IN_BETA_REVIEW|BETA_APPROVED|IN_BETA_TESTING|...",
+  "external_review_status": "WAITING_FOR_REVIEW|IN_REVIEW|APPROVED|REJECTED",
+  "groups": [{"id":"...","name":"Internal QA","is_internal":true}],
+  "localizations": [{"locale":"en-US","whats_new":"Verify login"}],
+  "auto_notify_enabled": false,
+  "expiration_date": "2026-10-19T00:00:00Z",
   "build_url": "https://appstoreconnect.apple.com/...",
   "updated_at": "2026-07-09T00:00:00Z"
 }
@@ -276,8 +291,9 @@ Suggested TestFlight state:
 
 ## Security requirements
 
-- Never store Apple private keys, `.p8`, `.p12`, profile content, or passwords
-  in D1.
+- Store the App Store Connect `.p8` only as authenticated encrypted ciphertext;
+  never return plaintext after the write request. Keep signing `.p12`, profile
+  content, and passwords outside Hands in the CI signing boundary.
 - Never log secret values or raw `ExportOptions.plist` with embedded sensitive
   paths/tokens.
 - Redact secret-shaped values in CI logs.
@@ -289,28 +305,24 @@ Suggested TestFlight state:
 
 ## Phasing
 
-### Phase 1: TestFlight bookkeeping and spec-visible UI
+### Implemented: Hands build, upload, and TestFlight distribution
 
-- Seed/support `ios-ipa`.
-- Add iOS distribution profile model with secret references.
-- Add admin UI for profile references.
-- Add TestFlight state fields on builds/releases.
-- Add CI adapter docs and a sample GitHub Actions workflow.
+- `ios-ipa` build plus private dSYM support asset.
+- Encrypted per-app ASC credential with verify/rotate/delete controls.
+- Official server-side Build Upload API and processing polling.
+- Stable internal/external beta group discovery.
+- Localized What to Test upsert, group assignment, external Beta App Review,
+  automatic/manual tester notification, and live state synchronization.
+- CLI and Raft integration actions that accept Hands build/group ids without
+  exposing Apple credentials.
 
-### Phase 2: CI upload adapter
-
-- Add `hands builds publish-ios-testflight` or equivalent CI command.
-- Upload IPA/dSYM to Hands.
-- Upload to TestFlight from macOS CI.
-- Write App Store Connect state back to Hands.
-
-### Phase 3: IPA parsing and dSYM symbolication integration
+### Follow-up: IPA parsing and dSYM symbolication integration
 
 - Implement `ipa-info` parser.
 - Connect dSYM uploads to the symbolication matrix.
 - Show iOS build metadata and crash symbolication readiness in admin UI.
 
-### Phase 4: Ad-hoc / enterprise OTA, if needed
+### Follow-up: Ad-hoc / enterprise OTA, if needed
 
 For machines and smoke devices, ad-hoc OTA may still be useful:
 
@@ -325,11 +337,6 @@ Developer Enterprise Program. Do not design the default flow around it.
 
 ## Open questions
 
-- Which GitHub Environment should hold iOS release secrets?
-- Do we require fastlane for the first adapter, or do we implement a pure
-  Xcode/Transporter path first?
 - Should Hands create GitHub workflow dispatches, or should mobile repos call
   Hands after their own build completes?
-- Should TestFlight external groups be platform-managed, or should Hands only
-  track their state?
 - How long should IPA archive retention be for TestFlight-only releases?

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -139,6 +139,68 @@ downloads. `window_minutes` is also accepted for recent-report windows, but
 SDK metrics pings are throttled, so this should not be labeled as true online
 presence.
 
+### TestFlight upload and distribution
+
+TestFlight is a separate state machine from the Hands draft and from App Store
+production publishing. The integration exposes five actions:
+
+- `upload-testflight-build` (app admin): stream the existing signed Hands IPA
+  to Apple's Build Upload API.
+- `get-testflight-upload-status` (viewer): poll the returned Apple upload id to
+  `state.state=COMPLETE|FAILED`, retaining Apple's errors/warnings/infos.
+- `list-testflight-groups` (viewer): get stable internal/external beta group
+  ids for the exact app.
+- `publish-testflight-build` (publisher): assign a processed build to selected
+  groups, upsert localized What to Test text, and submit external Beta App
+  Review when requested.
+- `get-testflight-publish-status` (viewer): refresh processing, expiry, group,
+  localization, review, and auto-notify state.
+
+The `.p8` stays encrypted in Hands. No action returns it, activates a Hands
+release, or creates/submits/releases an App Store production version.
+
+```bash
+# Upload only. Optional bundle_id is an assertion when metadata exists and a
+# fallback only when build metadata is absent; a mismatch fails closed.
+raft integration invoke --service <hands-service> \
+  --action upload-testflight-build \
+  --param app_id=<app-uuid> \
+  --param build_id=<hands-build-uuid> \
+  --param bundle_id=build.raft.app --json
+
+# Poll until response.state.state is COMPLETE or FAILED.
+raft integration invoke --service <hands-service> \
+  --action get-testflight-upload-status \
+  --param app_id=<app-uuid> \
+  --param build_upload_id=<asc-build-upload-id> --json
+
+# Once the exact ASC build is VALID, discover group ids.
+raft integration invoke --service <hands-service> \
+  --action list-testflight-groups \
+  --param app_id=<app-uuid> \
+  --param build_id=<hands-build-uuid> --json
+
+# Internal distribution. group_ids must all be internal.
+raft integration invoke --service <hands-service> \
+  --action publish-testflight-build \
+  --param app_id=<app-uuid> \
+  --param build_id=<hands-build-uuid> \
+  --data-json '{
+    "distribution":"internal",
+    "group_ids":["<asc-beta-group-id>"],
+    "what_to_test":{"en-US":"Verify login and Activity."},
+    "notify_testers":false
+  }' --json
+```
+
+External mode requires at least one existing or supplied What to Test
+localization. Set `notify_testers=true` to enable Apple's automatic
+notification after approval; for an already-approved build without automatic
+notification pending, Hands creates the official build beta notification.
+External Beta App Review can take hours,
+so agents should return the submission state and recheck with
+`get-testflight-publish-status` rather than holding a Raft turn open.
+
 ### Exact iOS simulator QA artifacts
 
 Use this lane for a zipped `.app` bundle that Stamp or another agent must

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -13,7 +13,7 @@ npm install -g @botiverse/hands-cli
 Or run it without a permanent install:
 
 ```bash
-npm exec --package @botiverse/hands-cli@0.3.2 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.12 -- hands --help
 ```
 
 In CI, pin a version so release scripts stay reproducible.
@@ -143,8 +143,10 @@ Public update checks only use the installable artifact. Mapping files, native sy
 ## Publish iOS / TestFlight
 
 CI should upload the **signed IPA** exported by macOS/Xcode, not an unsigned
-intermediate IPA. Hands stores and parses the IPA, but Apple signing material
-stays in the CI secret boundary.
+intermediate IPA. Hands stores the IPA and dSYM; Apple signing certificates,
+profiles, and passwords stay in the CI secret boundary. The separate App Store
+Connect API key used for server-side upload/distribution stays encrypted in
+Hands and is never copied to CI or an agent.
 
 Use `builds publish-ios` after `xcodebuild archive` and
 `xcodebuild -exportArchive`:
@@ -172,12 +174,75 @@ hands builds publish-ios raft-ios \
 dSYM. The `--dsym` file is a `.dSYM.zip` of the archive's `*.dSYM` bundles;
 without it, iOS crashes for that version show only raw frames.
 `--export-method`, `--appstore-build-number`, and `--testflight-status` are
-recorded as build metadata.
+recorded as build metadata. `publish-ios` creates the Hands build/release; it
+does not itself upload to Apple or activate TestFlight testing.
 
-The same signed IPA should then be uploaded to App Store Connect/TestFlight
-from the macOS CI job using Apple-supported tooling such as Transporter or
-fastlane `pilot`. Hands does not sign IPA files and should not receive Apple
-`.p8`, `.p12`, provisioning profiles, or passwords.
+An app admin then starts the **server-side upload** through the Hands console,
+API, or Raft integration action `upload-testflight-build`. Poll the returned
+Apple Build Upload id with `get-testflight-upload-status` until `COMPLETE` or
+`FAILED` (`response.state.state`; Apple errors/warnings/infos remain alongside
+it). This stage only uploads and processes the binary: it never assigns a beta
+group, notifies testers, activates the Hands release, or submits an App Store
+production release.
+
+After Apple exposes the exact build as `VALID`, list stable beta group ids:
+
+```bash
+hands builds testflight-groups raft-ios <hands-build-id>
+```
+
+Distribute to internal testers:
+
+```bash
+hands builds testflight-publish raft-ios <hands-build-id> \
+  --distribution internal \
+  --group-id 11111111-2222-3333-4444-555555555555 \
+  --what-to-test en-US="Verify login and Activity." \
+  --what-to-test zh-Hans="验证登录和活动页。" \
+  --wait
+```
+
+External distribution uses the same processed build, but submits TestFlight
+Beta App Review. `--notify-testers` enables Apple's automatic notification
+after approval; for an already-approved build without auto-notify pending,
+Hands sends the official build beta notification immediately.
+
+```bash
+hands builds testflight-publish raft-ios <hands-build-id> \
+  --distribution external \
+  --group-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
+  --what-to-test-file en-US=./testflight.en.txt \
+  --what-to-test-file zh-Hans=./testflight.zh.txt \
+  --notify-testers
+```
+
+External review can take longer than a normal CLI session. Omit `--wait` to
+submit and return immediately, then inspect the live state later:
+
+```bash
+hands builds testflight-status raft-ios <hands-build-id> \
+  --distribution external
+```
+
+When `--wait` is useful, tune its bounded poll contract with
+`--poll-interval-seconds` and `--timeout-seconds` (defaults: 15 and 3600).
+Terminal failure/rejection/expiry states fail the command. External mode
+requires an existing or supplied What to Test localization; selected group ids
+must all match the requested internal/external mode.
+
+Hands follows Apple's role boundary: uploading the IPA requires Hands app
+admin; TestFlight group distribution requires Hands app publisher. The stored
+App Store Connect key must have an Apple role permitted for the requested
+operation (external testing: Account Holder, Admin, or App Manager; internal
+testing also permits Developer or Marketing). Apple limits beta builds to 90
+days and permits at most one build of a version in Beta App Review at a time.
+
+Official Apple references:
+
+- [Prerelease Versions and Beta Testers](https://developer.apple.com/documentation/appstoreconnectapi/prerelease-versions-and-beta-testers)
+- [Add internal testers](https://developer.apple.com/help/app-store-connect/test-a-beta-version/add-internal-testers/)
+- [Invite external testers](https://developer.apple.com/help/app-store-connect/test-a-beta-version/invite-external-testers/)
+- [TestFlight overview](https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview/)
 
 For raw CI drafts, a single `--changelog-file ./changelog.txt` is still valid.
 For reviewed notes, prefer repeatable `lang=file` entries such as

--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -14,6 +14,9 @@ build + sign IPA  ──────────▶ build + assets in R2
                               (publish_hands=true)
                               testflight-upload  ───────────▶ Build Upload API
                               (streams IPA from R2)           PROCESSING → COMPLETE
+                              testflight-publish ───────────▶ VALID build
+                              groups + What to Test           internal testing, or
+                              beta review + notify            external Beta Review
 ```
 
 1. **Build + sign + publish** — dispatch the `iOS Release` workflow
@@ -29,14 +32,60 @@ build + sign IPA  ──────────▶ build + assets in R2
    Hands streams the IPA from R2 straight to Apple's Build Upload API
    (create → register file → part PUTs → commit) and returns the initial
    state. Console: the build row's TestFlight action.
-3. **Poll processing** —
+3. **Poll upload processing** —
 
    ```
    GET /api/apps/{app_id}/testflight-uploads/{build_upload_id}
    ```
 
-   States: `AWAITING_UPLOAD → PROCESSING → COMPLETE | FAILED`. On COMPLETE
-   the build appears in App Store Connect → TestFlight.
+   Read the nested `state.state` field:
+   `AWAITING_UPLOAD → PROCESSING → COMPLETE | FAILED`; the same object retains
+   Apple's errors, warnings, and infos. `COMPLETE` means Apple accepted the
+   upload transaction; wait until the corresponding build resource reports
+   `processingState=VALID` before distribution.
+4. **List beta groups** — use the processed Hands build to resolve the exact
+   App Store Connect app and list stable group ids:
+
+   ```
+   GET /api/apps/{app_id}/builds/{build_id}/testflight-groups
+   ```
+
+5. **Publish to TestFlight** — assign the exact processed build to groups and
+   write localized What to Test metadata:
+
+   ```
+   POST /api/apps/{app_id}/builds/{build_id}/testflight-publish
+   {
+     "distribution": "internal",
+     "group_ids": ["<asc-beta-group-id>"],
+     "what_to_test": {
+       "en-US": "Verify login and Activity.",
+       "zh-Hans": "验证登录和活动页。"
+     },
+     "notify_testers": false
+   }
+   ```
+
+   Internal mode adds only internal groups. External mode adds only external
+   groups, submits `betaAppReviewSubmissions`, and sets
+   `buildBetaDetails.autoNotifyEnabled`. When an external build is already
+   approved, `notify_testers=true` creates the official
+   `buildBetaNotifications` resource only when automatic notification was not
+   already enabled.
+6. **Refresh distribution state** —
+
+   ```
+   GET /api/apps/{app_id}/builds/{build_id}/testflight-publish?distribution=external
+   ```
+
+   The response keeps Apple's raw processing, expiry, internal/external build,
+   Beta App Review, auto-notify, assigned-group, and localization state. It
+   distinguishes `waiting_for_review`, `in_review`, `approved_not_notified`,
+   `testing`, `rejected`, `expired`, and processing failures.
+
+These endpoints and the matching CLI/integration actions are TestFlight-only.
+They never activate a Hands release and never create, submit, or release an
+App Store production version.
 
 ## One-time setup (app admin)
 
@@ -50,9 +99,60 @@ App Store review-state surface (`GET /api/apps/{app_id}/appstore-review`).
 Hands is the credential's only home — CI never needs a copy, so rotation
 stays single-source.
 
+Hands roles are intentionally split: uploading to Apple requires app admin,
+distribution requires app publisher, and status/group reads require app
+viewer. Apple's own role boundary still applies to the stored key: external
+testing requires Account Holder, Admin, or App Manager; internal testing also
+permits Developer or Marketing.
+
+Before first external testing, App Store Connect must have the required Beta
+App Description, feedback email, contact information, and export-compliance
+answers. Hands fails closed and returns Apple's actionable state/error if those
+prerequisites are missing. Apple allows only one build of a version in Beta App
+Review at a time and up to six submitted builds in a 24-hour period.
+
 ## Versioning rules
 
 - The **marketing version** (e.g. `1.0.0`) may repeat across uploads.
 - The **build number** (`versionCode`, e.g. `1000004`) must be unique and
   ascending for that marketing version — Apple rejects reused build numbers.
   Hands build history is the quick way to see the last used code.
+- TestFlight access expires 90 days after upload.
+- External distribution is fail-closed: Apple must explicitly return
+  `build_audience_type=APP_STORE_ELIGIBLE`. `INTERNAL_ONLY`, missing, or future
+  unknown audience values are rejected before any localization, group, review,
+  or notification mutation.
+
+## CLI and Raft actions
+
+CLI:
+
+```sh
+hands builds testflight-groups <app> <hands-build-id>
+hands builds testflight-publish <app> <hands-build-id> \
+  --distribution internal \
+  --group-id <asc-beta-group-id> \
+  --what-to-test en-US="Verify the release candidate." \
+  --wait
+hands builds testflight-status <app> <hands-build-id> --distribution internal
+```
+
+Raft integration actions:
+
+- `upload-testflight-build`
+- `get-testflight-upload-status`
+- `list-testflight-groups`
+- `publish-testflight-build`
+- `get-testflight-publish-status`
+
+Agents pass Hands app/build ids and stable beta group ids. The integration
+never returns the `.p8` credential.
+
+## Apple references
+
+- [App Store Connect API: Prerelease Versions and Beta Testers](https://developer.apple.com/documentation/appstoreconnectapi/prerelease-versions-and-beta-testers)
+- [Build Beta Notifications](https://developer.apple.com/documentation/appstoreconnectapi/build-beta-notifications)
+- [Add internal testers](https://developer.apple.com/help/app-store-connect/test-a-beta-version/add-internal-testers/)
+- [Invite external testers](https://developer.apple.com/help/app-store-connect/test-a-beta-version/invite-external-testers/)
+- [Provide test information](https://developer.apple.com/help/app-store-connect/test-a-beta-version/provide-test-information/)
+- [TestFlight overview](https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview/)

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -58,8 +58,10 @@ should remain `draft` until changelog review is complete.
 
 For iOS/TestFlight, the CI boundary is different: macOS CI signs the app, and
 Hands receives the signed output. Do not upload unsigned IPA intermediates to
-Hands as the release artifact, and do not move Apple signing credentials into
-Hands.
+Hands as the release artifact. Apple distribution certificates, provisioning
+profiles, and their passwords remain in CI; the App Store Connect API key is a
+separate credential encrypted server-side in Hands and never exported to CI or
+agents.
 
 ```sh
 # after xcodebuild archive + xcodebuild -exportArchive
@@ -75,15 +77,44 @@ hands builds publish-ios raft-ios \
   --ci-run-id "$GITHUB_RUN_ID" \
   --ci-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
   --draft
-
-# then upload that same signed IPA to App Store Connect/TestFlight
-# with Transporter or fastlane pilot in the same macOS CI job.
 ```
 
 Hands stores the signed `.ipa` as the installable artifact and `.dSYM.zip` as a
-support artifact for symbolication. TestFlight processing status can be written
-back through metadata/status follow-ups, but the release should still remain
-`draft` until changelog review is complete.
+support artifact for symbolication. An app admin then invokes the server-side
+`upload-testflight-build` Raft action (or the matching API/console action) with
+the Hands build id. Poll `get-testflight-upload-status` to Apple
+`state.state=COMPLETE|FAILED`, then wait until
+`hands builds testflight-status` reports the exact ASC build `VALID`.
+
+After the binary is valid, keep TestFlight distribution separate from Hands
+release activation:
+
+```sh
+# discover stable ASC group ids
+hands builds testflight-groups raft-ios <hands-build-id>
+
+# internal testing
+hands builds testflight-publish raft-ios <hands-build-id> \
+  --distribution internal \
+  --group-id <asc-internal-group-id> \
+  --what-to-test-file en-US=./testflight.en.txt \
+  --what-to-test-file zh-Hans=./testflight.zh.txt \
+  --wait
+
+# external testing: submits Beta App Review; notification is opt-in
+hands builds testflight-publish raft-ios <hands-build-id> \
+  --distribution external \
+  --group-id <asc-external-group-id> \
+  --what-to-test-file en-US=./testflight.en.txt \
+  --notify-testers
+```
+
+External review can take hours. Without `--wait`, the command returns after
+submission; use `hands builds testflight-status ... --distribution external`
+later. TestFlight assignment/review/notification never activates the Hands
+draft and never submits or releases an App Store production version. The human
+still reviews the bilingual Hands changelog and publishes the Hands release
+through the explicit flow below.
 
 For HarmonyOS/OHOS, CI signs the HAPs inside the App Pack, verifies each HAP,
 and exports both the signed `.app` and a standalone signed `.hap`. Publish both

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,9 @@ Hands CLI — manage apps, builds, releases from the terminal.
 Status: **alpha**. The npm package is public as `@botiverse/hands-cli`; v1 ships
 `login`, `logout`, `whoami`, `apps list/get`, `builds list/get`, and
 `builds publish-version`, `builds publish-android`, `builds publish-ios`,
-`builds publish-ohos`, `builds publish-electron`, and `builds publish-tauri`. Other commands listed in
+`builds testflight-groups`, `builds testflight-publish`,
+`builds testflight-status`, `builds publish-ohos`, `builds publish-electron`,
+and `builds publish-tauri`. Other commands listed in
 `docs/cli-reference.md` land incrementally as backend endpoints become available.
 
 ## Install
@@ -15,7 +17,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.11 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.12 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -375,7 +375,7 @@ describe("external build publish helpers", () => {
 
     try {
       const { registerBuildCommands } = await import("../src/commands/builds.js");
-      const program = new Command().version("0.5.10").option("--json", "JSON output", false);
+      const program = new Command().version("0.5.12").option("--json", "JSON output", false);
       registerBuildCommands(program);
       await program.parseAsync([
         "node", "hands", "builds", "publish-version", "computer",
@@ -424,6 +424,238 @@ describe("iOS build helper contract", () => {
     expect(() =>
       parseChangelogOptions({ changelog: ["plain update", "en=English update"] }),
     ).toThrow("mix of plain and lang= changelog entries");
+  });
+
+  it("parses repeatable localized What to Test text and files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hands-testflight-notes-"));
+    const zh = join(dir, "zh.txt");
+    writeFileSync(zh, "验证登录和活动页。\n");
+    try {
+      const { parseWhatToTestOptions } = await import("../src/commands/builds.js");
+      expect(
+        parseWhatToTestOptions({
+          whatToTest: ["en-US=Verify login and Activity."],
+          whatToTestFile: [`zh-Hans=${zh}`],
+        }),
+      ).toEqual({
+        "en-US": "Verify login and Activity.",
+        "zh-Hans": "验证登录和活动页。",
+      });
+      expect(() =>
+        parseWhatToTestOptions({ whatToTest: ["missing-locale-separator"] }),
+      ).toThrow("must use locale=text");
+      expect(() =>
+        parseWhatToTestOptions({
+          whatToTest: ["en-US=First", "en-US=Second"],
+        }),
+      ).toThrow("duplicate What to Test locale: en-US");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sends the TestFlight publish action with stable groups and metadata", async () => {
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-ios" }] }));
+      }
+      if (req.url === "/api/apps/app-1/builds/build-1/testflight-publish") {
+        return res.end(
+          JSON.stringify({
+            hands_build_id: "build-1",
+            bundle_id: "build.raft.app",
+            asc_app_id: "asc-app-1",
+            asc_build_id: "asc-build-1",
+            version: "1.0.0",
+            build_number: "1000005",
+            state: "waiting_for_review",
+            distribution: "external",
+            beta_review: { state: "WAITING_FOR_REVIEW" },
+            notification: "scheduled",
+          }),
+        );
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { registerBuildCommands } = await import("../src/commands/builds.js");
+      const program = new Command().version("0.5.12").option("--json", "JSON output", false);
+      registerBuildCommands(program);
+      await program.parseAsync([
+        "node",
+        "hands",
+        "builds",
+        "testflight-publish",
+        "raft-ios",
+        "build-1",
+        "--distribution",
+        "external",
+        "--group-id",
+        "group-1",
+        "--group-id",
+        "group-2",
+        "--what-to-test",
+        "en-US=Verify release candidate.",
+        "--notify-testers",
+      ]);
+
+      const publish = requests.find(
+        (request) =>
+          request.method === "POST" && request.url.endsWith("/testflight-publish"),
+      );
+      expect(publish?.body).toEqual({
+        distribution: "external",
+        group_ids: ["group-1", "group-2"],
+        what_to_test: { "en-US": "Verify release candidate." },
+        notify_testers: true,
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("waits for the exact ASC build before publishing and then polls review state", async () => {
+    const requests: string[] = [];
+    let statusReads = 0;
+    const server = createServer(async (req, res) => {
+      requests.push(`${req.method ?? "GET"} ${req.url ?? ""}`);
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(
+          JSON.stringify({ apps: [{ id: "app-1", slug: "raft-ios" }] }),
+        );
+      }
+      if (
+        req.method === "GET" &&
+        req.url?.startsWith(
+          "/api/apps/app-1/builds/build-1/testflight-publish",
+        )
+      ) {
+        statusReads += 1;
+        if (statusReads === 1) {
+          return res.end(
+            JSON.stringify({
+              hands_build_id: "build-1",
+              bundle_id: "build.raft.app",
+              asc_app_id: "asc-app-1",
+              asc_build_id: null,
+              version: "1.0.0",
+              build_number: "1000005",
+              state: "waiting_for_processing",
+              distribution: "external",
+            }),
+          );
+        }
+        const approved = statusReads >= 3;
+        return res.end(
+          JSON.stringify({
+            hands_build_id: "build-1",
+            bundle_id: "build.raft.app",
+            asc_app_id: "asc-app-1",
+            asc_build_id: "asc-build-1",
+            version: "1.0.0",
+            build_number: "1000005",
+            processing_state: "VALID",
+            state: approved ? "approved_not_notified" : "ready_for_beta_submission",
+            distribution: "external",
+            beta_review: approved ? { state: "APPROVED" } : null,
+          }),
+        );
+      }
+      if (
+        req.method === "POST" &&
+        req.url === "/api/apps/app-1/builds/build-1/testflight-publish"
+      ) {
+        for await (const _chunk of req) {
+          // Drain the request body before responding.
+        }
+        return res.end(
+          JSON.stringify({
+            hands_build_id: "build-1",
+            bundle_id: "build.raft.app",
+            asc_app_id: "asc-app-1",
+            asc_build_id: "asc-build-1",
+            version: "1.0.0",
+            build_number: "1000005",
+            state: "waiting_for_review",
+            distribution: "external",
+            beta_review: { state: "WAITING_FOR_REVIEW" },
+          }),
+        );
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { registerBuildCommands } = await import("../src/commands/builds.js");
+      const program = new Command()
+        .version("0.5.12")
+        .option("--json", "JSON output", false);
+      registerBuildCommands(program);
+      await program.parseAsync([
+        "node",
+        "hands",
+        "--json",
+        "builds",
+        "testflight-publish",
+        "raft-ios",
+        "build-1",
+        "--distribution",
+        "external",
+        "--group-id",
+        "external-1",
+        "--what-to-test",
+        "en-US=Verify release.",
+        "--wait",
+        "--poll-interval-seconds",
+        "0.001",
+        "--timeout-seconds",
+        "1",
+      ]);
+
+      expect(statusReads).toBe(3);
+      const postIndex = requests.findIndex((request) => request.startsWith("POST "));
+      const statusBeforePost = requests
+        .slice(0, postIndex)
+        .filter((request) => request.includes("testflight-publish"));
+      expect(statusBeforePost).toHaveLength(2);
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -44,7 +44,41 @@ interface ChannelRow {
   name: string;
 }
 
-function collect(value: string, previous: string[]): string[] {
+interface TestflightGroup {
+  id: string;
+  name: string | null;
+  is_internal: boolean | null;
+  has_access_to_all_builds: boolean | null;
+  public_link_enabled: boolean | null;
+}
+
+interface TestflightPublishStatus {
+  hands_build_id: string;
+  bundle_id: string;
+  asc_app_id: string;
+  asc_build_id: string | null;
+  version: string;
+  build_number: string;
+  state: string;
+  distribution: "internal" | "external" | null;
+  processing_state?: string | null;
+  expired?: boolean | null;
+  assigned_groups?: TestflightGroup[];
+  beta_review?: {
+    id: string;
+    state: string | null;
+    submitted_at: string | null;
+  } | null;
+  beta_detail?: {
+    auto_notify_enabled: boolean | null;
+    internal_build_state: string | null;
+    external_build_state: string | null;
+  } | null;
+  notification?: string;
+  operation_id?: string;
+}
+
+function collect(value: string, previous: string[] = []): string[] {
   return previous.concat(value);
 }
 
@@ -85,6 +119,218 @@ export function parseChangelogOptions(opts: {
     return JSON.stringify(byLang);
   }
   return plain ?? null;
+}
+
+export function parseWhatToTestOptions(opts: {
+  whatToTest?: string | string[];
+  whatToTestFile?: string | string[];
+}): Record<string, string> {
+  const result: Record<string, string> = {};
+  const values = (value?: string | string[]): string[] => {
+    if (value === undefined) return [];
+    return Array.isArray(value) ? value : [value];
+  };
+  const consume = (entry: string, fromFile: boolean) => {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(
+        `${fromFile ? "--what-to-test-file" : "--what-to-test"} must use locale=${fromFile ? "path" : "text"}`,
+      );
+    }
+    const locale = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1);
+    const text = (
+      fromFile ? readFileSync(value.trim(), "utf8") : value
+    ).trim();
+    if (!locale || !text) {
+      throw new Error("What to Test locale and text must be non-empty");
+    }
+    if (Object.prototype.hasOwnProperty.call(result, locale)) {
+      throw new Error(`duplicate What to Test locale: ${locale}`);
+    }
+    result[locale] = text;
+  };
+  for (const entry of values(opts.whatToTest)) consume(entry, false);
+  for (const entry of values(opts.whatToTestFile)) consume(entry, true);
+  return result;
+}
+
+function positiveSeconds(value: string, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${option} must be a positive number`);
+  }
+  return parsed;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function withTimeoutMessage<T>(
+  message: string,
+  request: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError")
+    ) {
+      throw new Error(message);
+    }
+    throw error;
+  }
+}
+
+async function getTestflightPublishStatus(
+  appId: string,
+  buildId: string,
+  options: {
+    distribution?: string;
+    bundleId?: string;
+    signal?: AbortSignal;
+  },
+): Promise<TestflightPublishStatus> {
+  return apiRequest<TestflightPublishStatus>(
+    `/api/apps/${appId}/builds/${buildId}/testflight-publish`,
+    {
+      query: {
+        distribution: options.distribution,
+        bundle_id: options.bundleId,
+      },
+      ...(options.signal ? { signal: options.signal } : {}),
+    },
+  );
+}
+
+function assertTestflightStatusHealthy(status: TestflightPublishStatus): void {
+  if (
+    status.state === "processing_failed" ||
+    status.state === "expired" ||
+    status.state === "rejected" ||
+    status.state === "blocked_export_compliance" ||
+    status.state === "not_applicable"
+  ) {
+    const appleState =
+      status.distribution === "external"
+        ? status.beta_review?.state ??
+          status.beta_detail?.external_build_state ??
+          status.processing_state
+        : status.beta_detail?.internal_build_state ?? status.processing_state;
+    throw new Error(
+      `TestFlight reached terminal state ${status.state}${appleState ? ` (Apple: ${appleState})` : ""}`,
+    );
+  }
+}
+
+async function waitForAscBuild(
+  appId: string,
+  buildId: string,
+  options: {
+    distribution: "internal" | "external";
+    bundleId?: string;
+    intervalSeconds: number;
+    timeoutSeconds: number;
+    quiet: boolean;
+  },
+): Promise<TestflightPublishStatus> {
+  const deadline = Date.now() + options.timeoutSeconds * 1000;
+  const timeoutMessage =
+    `timed out after ${options.timeoutSeconds}s waiting for ` +
+    "App Store Connect processing";
+  while (true) {
+    const remainingMilliseconds = deadline - Date.now();
+    if (remainingMilliseconds <= 0) {
+      throw new Error(timeoutMessage);
+    }
+    const status = await withTimeoutMessage(timeoutMessage, () =>
+      getTestflightPublishStatus(appId, buildId, {
+        ...options,
+        signal: AbortSignal.timeout(
+          Math.max(1, Math.ceil(remainingMilliseconds)),
+        ),
+      }),
+    );
+    assertTestflightStatusHealthy(status);
+    if (status.asc_build_id && status.processing_state === "VALID") return status;
+    if (Date.now() >= deadline) {
+      throw new Error(timeoutMessage);
+    }
+    if (!options.quiet) {
+      console.error(
+        `TestFlight ${status.version} (${status.build_number}): ` +
+          `${status.state}; polling again in ${options.intervalSeconds}s`,
+      );
+    }
+    await sleep(
+      Math.min(
+        options.intervalSeconds * 1000,
+        Math.max(0, deadline - Date.now()),
+      ),
+    );
+  }
+}
+
+async function waitForTestflightDistribution(
+  appId: string,
+  buildId: string,
+  options: {
+    distribution: "internal" | "external";
+    notifyTesters: boolean;
+    bundleId?: string;
+    intervalSeconds: number;
+    timeoutSeconds: number;
+    quiet: boolean;
+  },
+): Promise<TestflightPublishStatus> {
+  const deadline = Date.now() + options.timeoutSeconds * 1000;
+  const timeoutMessage =
+    `timed out after ${options.timeoutSeconds}s waiting for ` +
+    `TestFlight ${options.distribution} distribution`;
+  while (true) {
+    const remainingMilliseconds = deadline - Date.now();
+    if (remainingMilliseconds <= 0) {
+      throw new Error(timeoutMessage);
+    }
+    const status = await withTimeoutMessage(timeoutMessage, () =>
+      getTestflightPublishStatus(appId, buildId, {
+        ...options,
+        signal: AbortSignal.timeout(
+          Math.max(1, Math.ceil(remainingMilliseconds)),
+        ),
+      }),
+    );
+    assertTestflightStatusHealthy(status);
+    const complete =
+      options.distribution === "internal"
+        ? status.state === "testing"
+        : options.notifyTesters
+          ? status.state === "testing"
+          : status.state === "approved_not_notified" ||
+            status.state === "approved" ||
+            status.state === "testing";
+    if (complete) return status;
+    if (Date.now() >= deadline) {
+      throw new Error(timeoutMessage);
+    }
+    if (!options.quiet) {
+      const review = status.beta_review?.state
+        ? ` review=${status.beta_review.state}`
+        : "";
+      console.error(
+        `TestFlight ${status.version} (${status.build_number}): ` +
+          `${status.state}${review}; polling again in ${options.intervalSeconds}s`,
+      );
+    }
+    await sleep(
+      Math.min(
+        options.intervalSeconds * 1000,
+        Math.max(0, deadline - Date.now()),
+      ),
+    );
+  }
 }
 
 export function registerBuildCommands(program: Command): void {
@@ -707,7 +953,261 @@ export function registerBuildCommands(program: Command): void {
             "warning: no --dsym uploaded; iOS crashes for this version_code won't symbolicate.",
           );
         }
-        console.log("  note:    upload the same signed IPA to TestFlight from macOS CI.");
+        console.log(
+          "  note:    upload this Hands build with the server-side upload-testflight-build action.",
+        );
+      },
+    );
+
+  builds
+    .command("testflight-groups <appIdOrSlug> <buildId>")
+    .description(
+      "List App Store Connect internal/external beta groups for an existing Hands iOS build.",
+    )
+    .option(
+      "--bundle-id <id>",
+      "Bundle-id assertion; must match immutable build metadata, or acts as fallback when metadata is absent.",
+    )
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        buildId: string,
+        opts: { bundleId?: string; json?: boolean },
+      ) => {
+        const appId = await resolveAppId(appIdOrSlug);
+        const result = await apiRequest<{
+          hands_build_id: string;
+          bundle_id: string;
+          asc_app_id: string;
+          groups: TestflightGroup[];
+        }>(`/api/apps/${appId}/builds/${buildId}/testflight-groups`, {
+          query: { bundle_id: opts.bundleId },
+        });
+        if (shouldOutputJson(program, opts.json)) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        if (result.groups.length === 0) {
+          console.log("No TestFlight beta groups found.");
+          return;
+        }
+        for (const group of result.groups) {
+          const kind = group.is_internal ? "internal" : "external";
+          const automatic = group.has_access_to_all_builds ? " auto-all-builds" : "";
+          console.log(`${group.id}  ${kind.padEnd(8)}  ${group.name ?? "(unnamed)"}${automatic}`);
+        }
+      },
+    );
+
+  builds
+    .command("testflight-status <appIdOrSlug> <buildId>")
+    .description(
+      "Refresh live TestFlight processing, group assignment, beta review, auto-notify, and expiry state.",
+    )
+    .option("--distribution <mode>", "Project state for internal or external distribution.")
+    .option(
+      "--bundle-id <id>",
+      "Bundle-id assertion; must match immutable build metadata, or acts as fallback when metadata is absent.",
+    )
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        buildId: string,
+        opts: { distribution?: string; bundleId?: string; json?: boolean },
+      ) => {
+        if (
+          opts.distribution !== undefined &&
+          opts.distribution !== "internal" &&
+          opts.distribution !== "external"
+        ) {
+          throw new Error("--distribution must be internal or external");
+        }
+        const appId = await resolveAppId(appIdOrSlug);
+        const status = await getTestflightPublishStatus(appId, buildId, opts);
+        if (shouldOutputJson(program, opts.json)) {
+          console.log(JSON.stringify(status, null, 2));
+          return;
+        }
+        console.log(
+          `TestFlight ${status.version} (${status.build_number}): ${status.state}`,
+        );
+        console.log(`  ASC app:   ${status.asc_app_id}`);
+        console.log(`  ASC build: ${status.asc_build_id ?? "not available yet"}`);
+        if (status.processing_state) {
+          console.log(`  processing: ${status.processing_state}`);
+        }
+        if (status.beta_review?.state) {
+          console.log(`  beta review: ${status.beta_review.state}`);
+        }
+        if (status.assigned_groups && status.assigned_groups.length > 0) {
+          console.log(
+            `  groups: ${status.assigned_groups.map((group) => `${group.name ?? group.id} (${group.id})`).join(", ")}`,
+          );
+        }
+      },
+    );
+
+  builds
+    .command("testflight-publish <appIdOrSlug> <buildId>")
+    .description(
+      "Distribute an already-processed App Store Connect build to TestFlight beta groups. This never publishes to the App Store or activates a Hands release.",
+    )
+    .requiredOption("--distribution <mode>", "internal or external.")
+    .requiredOption(
+      "--group-id <id>",
+      "Stable beta group id from testflight-groups. Repeat for multiple groups.",
+      collect,
+    )
+    .option(
+      "--what-to-test <locale=text>",
+      "Localized What to Test text. Repeat for multiple locales.",
+      collect,
+      [],
+    )
+    .option(
+      "--what-to-test-file <locale=path>",
+      "Read localized What to Test text from a file. Repeat for multiple locales.",
+      collect,
+      [],
+    )
+    .option(
+      "--notify-testers",
+      "External only: enable auto-notify before review, or notify an already-approved build when no auto-notify is pending.",
+      false,
+    )
+    .option(
+      "--bundle-id <id>",
+      "Bundle-id assertion; must match immutable build metadata, or acts as fallback when metadata is absent.",
+    )
+    .option(
+      "--wait",
+      "Wait for Apple processing and the requested TestFlight terminal state.",
+      false,
+    )
+    .option("--poll-interval-seconds <n>", "Polling interval while --wait is active.", "15")
+    .option("--timeout-seconds <n>", "Maximum --wait duration.", "3600")
+    .option("--json", "Output JSON.", false)
+    .action(
+      async (
+        appIdOrSlug: string,
+        buildId: string,
+        opts: {
+          distribution: string;
+          groupId: string[];
+          whatToTest?: string[];
+          whatToTestFile?: string[];
+          notifyTesters?: boolean;
+          bundleId?: string;
+          wait?: boolean;
+          pollIntervalSeconds: string;
+          timeoutSeconds: string;
+          json?: boolean;
+        },
+      ) => {
+        if (opts.distribution !== "internal" && opts.distribution !== "external") {
+          throw new Error("--distribution must be internal or external");
+        }
+        if (opts.distribution === "internal" && opts.notifyTesters) {
+          throw new Error("--notify-testers applies only to external distribution");
+        }
+        const appId = await resolveAppId(appIdOrSlug);
+        const intervalSeconds = positiveSeconds(
+          opts.pollIntervalSeconds,
+          "--poll-interval-seconds",
+        );
+        const timeoutSeconds = positiveSeconds(
+          opts.timeoutSeconds,
+          "--timeout-seconds",
+        );
+        const quiet = shouldOutputJson(program, opts.json);
+        const distribution = opts.distribution;
+        const waitStartedAt = Date.now();
+        if (opts.wait) {
+          await waitForAscBuild(appId, buildId, {
+            distribution,
+            ...(opts.bundleId ? { bundleId: opts.bundleId } : {}),
+            intervalSeconds,
+            timeoutSeconds,
+            quiet,
+          });
+        }
+
+        const remainingBeforePublishMilliseconds =
+          timeoutSeconds * 1000 - (Date.now() - waitStartedAt);
+        if (opts.wait && remainingBeforePublishMilliseconds <= 0) {
+          throw new Error(
+            `timed out after ${timeoutSeconds}s before TestFlight publish began`,
+          );
+        }
+        const publishRequest = () =>
+          apiRequest<TestflightPublishStatus>(
+            `/api/apps/${appId}/builds/${buildId}/testflight-publish`,
+            {
+              method: "POST",
+              body: {
+                distribution,
+                group_ids: opts.groupId,
+                what_to_test: parseWhatToTestOptions(opts),
+                notify_testers: Boolean(opts.notifyTesters),
+                ...(opts.bundleId ? { bundle_id: opts.bundleId } : {}),
+              },
+              ...(opts.wait
+                ? {
+                    signal: AbortSignal.timeout(
+                      Math.max(
+                        1,
+                        Math.ceil(remainingBeforePublishMilliseconds),
+                      ),
+                    ),
+                  }
+                : {}),
+            },
+          );
+        const result = opts.wait
+          ? await withTimeoutMessage(
+              `timed out after ${timeoutSeconds}s while submitting the TestFlight publish request`,
+              publishRequest,
+            )
+          : await publishRequest();
+        const elapsedSeconds = (Date.now() - waitStartedAt) / 1000;
+        const remainingTimeoutSeconds = Math.max(
+          0,
+          timeoutSeconds - elapsedSeconds,
+        );
+        if (opts.wait && remainingTimeoutSeconds === 0) {
+          throw new Error(
+            `timed out after ${timeoutSeconds}s before TestFlight distribution polling began`,
+          );
+        }
+        const finalStatus = opts.wait
+          ? await waitForTestflightDistribution(appId, buildId, {
+              distribution,
+              notifyTesters: Boolean(opts.notifyTesters),
+              ...(opts.bundleId ? { bundleId: opts.bundleId } : {}),
+              intervalSeconds,
+              timeoutSeconds: remainingTimeoutSeconds,
+              quiet,
+            })
+          : result;
+
+        if (quiet) {
+          console.log(JSON.stringify(finalStatus, null, 2));
+          return;
+        }
+        console.log(
+          `TestFlight ${distribution} publish: ${finalStatus.state}`,
+        );
+        console.log(`  Hands build: ${finalStatus.hands_build_id}`);
+        console.log(`  ASC build:   ${finalStatus.asc_build_id}`);
+        console.log(`  groups:      ${opts.groupId.join(", ")}`);
+        if (finalStatus.beta_review?.state) {
+          console.log(`  beta review: ${finalStatus.beta_review.state}`);
+        }
+        if (finalStatus.notification) {
+          console.log(`  notification: ${finalStatus.notification}`);
+        }
       },
     );
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.11")
+  .version("0.5.12")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",
@@ -53,6 +53,7 @@ Common recipes:
   hands feedback show <app> <ticketId>                One ticket: device context + attachments
   hands feedback download-attachment <app> <t> <a>    Pull a crash log / screenshot
   hands releases list <app>                           Release history
+  hands builds testflight-status <app> <build>        Apple processing / beta review state
   hands logs collect                                  Bundle local CLI logs for a bug report
 
 Every command supports --json for scripts/agents. Full docs:

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -40,6 +40,7 @@ export interface ApiRequestOptions {
   body?: unknown;
   query?: Record<string, string | number | boolean | null | undefined>;
   raw?: boolean; // when true, return Response instead of parsed JSON
+  signal?: AbortSignal;
 }
 
 export async function apiRequest<T = unknown>(
@@ -67,6 +68,7 @@ export async function apiRequest<T = unknown>(
     method: opts.method ?? "GET",
     headers,
     ...(body !== undefined ? { body } : {}),
+    ...(opts.signal ? { signal: opts.signal } : {}),
   });
   if (readEnv("VERBOSE") === "1") {
     console.error(`> ${opts.method ?? "GET"} ${url}`);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -105,6 +105,9 @@ import {
   handleVerifyAscCredentials,
 } from "./routes/asc_credentials";
 import {
+  handleListTestflightGroups,
+  handleTestflightPublish,
+  handleTestflightPublishStatus,
   handleTestflightUpload,
   handleTestflightUploadStatus,
 } from "./routes/testflight";
@@ -893,6 +896,9 @@ admin.get("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleGet
 admin.post("/api/apps/:appId/asc-credentials/verify", requireAppRole("admin"), handleVerifyAscCredentials);
 admin.post("/api/apps/:appId/builds/:buildId/testflight-upload", requireAppRole("admin"), handleTestflightUpload);
 admin.get("/api/apps/:appId/testflight-uploads/:buildUploadId", requireAppRole("viewer"), handleTestflightUploadStatus);
+admin.get("/api/apps/:appId/builds/:buildId/testflight-groups", requireAppRole("viewer"), handleListTestflightGroups);
+admin.post("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("publisher"), handleTestflightPublish);
+admin.get("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("viewer"), handleTestflightPublishStatus);
 admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);

--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -146,13 +146,20 @@ export type BuildUploadState =
   | "FAILED"
   | "COMPLETE";
 
+export interface BuildUploadStateInfo {
+  state: BuildUploadState | null;
+  errors?: Array<{ code?: string; description?: string }>;
+  warnings?: Array<{ code?: string; description?: string }>;
+  infos?: Array<{ code?: string; description?: string }>;
+}
+
 export interface BuildUploadResource {
   id: string;
   attributes: {
     cfBundleShortVersionString: string | null;
     cfBundleVersion: string | null;
     platform: string | null;
-    state: BuildUploadState | null;
+    state: BuildUploadStateInfo | null;
     createdDate: string | null;
     uploadedDate: string | null;
   };
@@ -272,6 +279,352 @@ export async function getBuildUpload(
     creds,
     "GET",
     `/v1/buildUploads/${buildUploadId}`,
+  );
+  return res.data;
+}
+
+// ---------- TestFlight distribution resources ----------
+
+export type AscBuildProcessingState =
+  | "PROCESSING"
+  | "FAILED"
+  | "INVALID"
+  | "VALID";
+
+export interface AscBuildResource {
+  id: string;
+  attributes: {
+    version: string | null;
+    uploadedDate: string | null;
+    expirationDate: string | null;
+    expired: boolean | null;
+    processingState: AscBuildProcessingState | string | null;
+    buildAudienceType?:
+      | "INTERNAL_ONLY"
+      | "APP_STORE_ELIGIBLE"
+      | string
+      | null;
+  };
+  relationships?: {
+    betaGroups?: {
+      data?: Array<{ type: "betaGroups"; id: string }>;
+    };
+  };
+}
+
+export interface BetaGroupResource {
+  id: string;
+  attributes: {
+    name: string | null;
+    createdDate: string | null;
+    isInternalGroup: boolean | null;
+    hasAccessToAllBuilds: boolean | null;
+    publicLinkEnabled: boolean | null;
+    publicLink: string | null;
+  };
+}
+
+export interface BetaBuildLocalizationResource {
+  id: string;
+  attributes: {
+    locale: string | null;
+    whatsNew: string | null;
+  };
+}
+
+export interface BetaAppReviewSubmissionResource {
+  id: string;
+  attributes: {
+    betaReviewState: string | null;
+    submittedDate: string | null;
+  };
+}
+
+export interface BuildBetaDetailResource {
+  id: string;
+  attributes: {
+    autoNotifyEnabled: boolean | null;
+    internalBuildState: string | null;
+    externalBuildState: string | null;
+  };
+}
+
+/** Resolve the processed ASC build matching one exact Hands version tuple. */
+export async function resolveAscBuild(
+  creds: AscApiCredentials,
+  args: {
+    ascAppId: string;
+    version: string;
+    buildNumber: string;
+    platform?: "IOS" | "MAC_OS" | "TV_OS" | "VISION_OS";
+  },
+): Promise<AscBuildResource | null> {
+  const query = [
+    `filter[app]=${encodeURIComponent(args.ascAppId)}`,
+    `filter[version]=${encodeURIComponent(args.buildNumber)}`,
+    `filter[preReleaseVersion.version]=${encodeURIComponent(args.version)}`,
+    `filter[preReleaseVersion.platform]=${encodeURIComponent(args.platform ?? "IOS")}`,
+    "limit=2",
+  ].join("&");
+  const res = await ascRequest<{ data: AscBuildResource[] }>(
+    creds,
+    "GET",
+    `/v1/builds?${query}`,
+  );
+  if ((res.data ?? []).length > 1) {
+    throw new Error(
+      `multiple App Store Connect builds matched ${args.version} (${args.buildNumber})`,
+    );
+  }
+  return res.data?.[0] ?? null;
+}
+
+export async function listBetaGroups(
+  creds: AscApiCredentials,
+  ascAppId: string,
+): Promise<BetaGroupResource[]> {
+  const res = await ascRequest<{ data: BetaGroupResource[] }>(
+    creds,
+    "GET",
+    `/v1/apps/${encodeURIComponent(ascAppId)}/betaGroups?limit=200`,
+  );
+  return res.data ?? [];
+}
+
+export async function getAssignedBetaGroupIds(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<string[]> {
+  const res = await ascRequest<{
+    data: AscBuildResource;
+    included?: Array<{ type?: string; id?: string }>;
+  }>(
+    creds,
+    "GET",
+    `/v1/builds/${encodeURIComponent(ascBuildId)}?include=betaGroups&limit[betaGroups]=50`,
+  );
+  const relationshipIds =
+    res.data.relationships?.betaGroups?.data?.map((item) => item.id) ?? [];
+  const includedIds = (res.included ?? [])
+    .filter((item) => item.type === "betaGroups" && typeof item.id === "string")
+    .map((item) => item.id!);
+  return Array.from(new Set([...relationshipIds, ...includedIds]));
+}
+
+export async function addBuildToBetaGroups(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+  groupIds: string[],
+): Promise<void> {
+  if (groupIds.length === 0) return;
+  await ascRequest(
+    creds,
+    "POST",
+    `/v1/builds/${encodeURIComponent(ascBuildId)}/relationships/betaGroups`,
+    {
+      data: groupIds.map((id) => ({ type: "betaGroups", id })),
+    },
+  );
+}
+
+export async function getBetaBuildLocalizations(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<BetaBuildLocalizationResource[]> {
+  const res = await ascRequest<{ data: BetaBuildLocalizationResource[] }>(
+    creds,
+    "GET",
+    `/v1/builds/${encodeURIComponent(ascBuildId)}/betaBuildLocalizations?limit=200`,
+  );
+  return res.data ?? [];
+}
+
+export async function createBetaBuildLocalization(
+  creds: AscApiCredentials,
+  args: { ascBuildId: string; locale: string; whatsNew: string },
+): Promise<BetaBuildLocalizationResource> {
+  const res = await ascRequest<{ data: BetaBuildLocalizationResource }>(
+    creds,
+    "POST",
+    "/v1/betaBuildLocalizations",
+    {
+      data: {
+        type: "betaBuildLocalizations",
+        attributes: {
+          locale: args.locale,
+          whatsNew: args.whatsNew,
+        },
+        relationships: {
+          build: { data: { type: "builds", id: args.ascBuildId } },
+        },
+      },
+    },
+  );
+  return res.data;
+}
+
+export async function updateBetaBuildLocalization(
+  creds: AscApiCredentials,
+  args: { localizationId: string; whatsNew: string },
+): Promise<BetaBuildLocalizationResource> {
+  const res = await ascRequest<{ data: BetaBuildLocalizationResource }>(
+    creds,
+    "PATCH",
+    `/v1/betaBuildLocalizations/${encodeURIComponent(args.localizationId)}`,
+    {
+      data: {
+        type: "betaBuildLocalizations",
+        id: args.localizationId,
+        attributes: { whatsNew: args.whatsNew },
+      },
+    },
+  );
+  return res.data;
+}
+
+/** Create or update every supplied locale without touching other locales. */
+export async function upsertBetaBuildLocalizations(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+  localizations: Record<string, string>,
+): Promise<BetaBuildLocalizationResource[]> {
+  const requested = Object.entries(localizations);
+  if (requested.length === 0) return [];
+  const existing = await getBetaBuildLocalizations(creds, ascBuildId);
+  const byLocale = new Map(
+    existing
+      .filter((item) => item.attributes.locale)
+      .map((item) => [item.attributes.locale!, item]),
+  );
+  const results: BetaBuildLocalizationResource[] = [];
+  for (const [locale, whatsNew] of requested) {
+    const current = byLocale.get(locale);
+    if (!current) {
+      try {
+        results.push(
+          await createBetaBuildLocalization(creds, {
+            ascBuildId,
+            locale,
+            whatsNew,
+          }),
+        );
+      } catch (error) {
+        if (!(error instanceof AscApiError) || error.status !== 409) {
+          throw error;
+        }
+        const raced = (await getBetaBuildLocalizations(creds, ascBuildId)).find(
+          (item) => item.attributes.locale === locale,
+        );
+        if (!raced) throw error;
+        results.push(
+          raced.attributes.whatsNew === whatsNew
+            ? raced
+            : await updateBetaBuildLocalization(creds, {
+                localizationId: raced.id,
+                whatsNew,
+              }),
+        );
+      }
+    } else if (current.attributes.whatsNew !== whatsNew) {
+      results.push(
+        await updateBetaBuildLocalization(creds, {
+          localizationId: current.id,
+          whatsNew,
+        }),
+      );
+    } else {
+      results.push(current);
+    }
+  }
+  return results;
+}
+
+export async function getBetaAppReviewSubmission(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<BetaAppReviewSubmissionResource | null> {
+  try {
+    const res = await ascRequest<{
+      data: BetaAppReviewSubmissionResource | null;
+    }>(
+      creds,
+      "GET",
+      `/v1/builds/${encodeURIComponent(ascBuildId)}/betaAppReviewSubmission`,
+    );
+    return res.data ?? null;
+  } catch (error) {
+    if (error instanceof AscApiError && error.status === 404) return null;
+    throw error;
+  }
+}
+
+export async function createBetaAppReviewSubmission(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<BetaAppReviewSubmissionResource> {
+  const res = await ascRequest<{ data: BetaAppReviewSubmissionResource }>(
+    creds,
+    "POST",
+    "/v1/betaAppReviewSubmissions",
+    {
+      data: {
+        type: "betaAppReviewSubmissions",
+        relationships: {
+          build: { data: { type: "builds", id: ascBuildId } },
+        },
+      },
+    },
+  );
+  return res.data;
+}
+
+export async function getBuildBetaDetail(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<BuildBetaDetailResource> {
+  const res = await ascRequest<{ data: BuildBetaDetailResource }>(
+    creds,
+    "GET",
+    `/v1/builds/${encodeURIComponent(ascBuildId)}/buildBetaDetail`,
+  );
+  return res.data;
+}
+
+export async function updateBuildBetaAutoNotify(
+  creds: AscApiCredentials,
+  args: { buildBetaDetailId: string; enabled: boolean },
+): Promise<BuildBetaDetailResource> {
+  const res = await ascRequest<{ data: BuildBetaDetailResource }>(
+    creds,
+    "PATCH",
+    `/v1/buildBetaDetails/${encodeURIComponent(args.buildBetaDetailId)}`,
+    {
+      data: {
+        type: "buildBetaDetails",
+        id: args.buildBetaDetailId,
+        attributes: { autoNotifyEnabled: args.enabled },
+      },
+    },
+  );
+  return res.data;
+}
+
+export async function sendBuildBetaNotification(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<{ id: string }> {
+  const res = await ascRequest<{ data: { id: string } }>(
+    creds,
+    "POST",
+    "/v1/buildBetaNotifications",
+    {
+      data: {
+        type: "buildBetaNotifications",
+        relationships: {
+          build: { data: { type: "builds", id: ascBuildId } },
+        },
+      },
+    },
   );
   return res.data;
 }

--- a/worker/src/lib/asc_credentials.ts
+++ b/worker/src/lib/asc_credentials.ts
@@ -1,11 +1,11 @@
 /**
  * Per-app App Store Connect (ASC) API credentials, stored in Hands so the
- * "Upload to TestFlight" action runs server-side (Container + iTMSTransporter)
- * instead of the app's CI holding the ASC key.
+ * TestFlight upload/distribution actions run against Apple's official App
+ * Store Connect API instead of the app's CI holding the ASC key.
  *
  * The .p8 private key is stored ENCRYPTED with AES-GCM (unlike deploy tokens,
- * which are hashed — this must be reversible because iTMSTransporter needs the
- * real key). The AES key is derived from the ASC_CRED_ENC_KEY worker secret;
+ * which are hashed — this must be reversible because Hands signs short-lived
+ * ASC JWTs). The AES key is derived from the ASC_CRED_ENC_KEY worker secret;
  * key_id / issuer_id are non-secret identifiers stored in plaintext.
  */
 

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -75,6 +75,11 @@ export const openApiDocument = docs.getOpenAPI31Document({
       description: "Create, inspect, and download build artifacts.",
     },
     {
+      name: "TestFlight",
+      description:
+        "Server-side App Store Connect upload, beta group distribution, review, and status synchronization.",
+    },
+    {
       name: "QA artifacts",
       description: "Exact-byte, non-release artifacts used by agents and device test lanes.",
     },

--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -17,6 +17,9 @@ import {
 const AppBuildParams = AppIdParam.merge(BuildIdParam);
 const AppBuildAssetParams = AppBuildParams.merge(AssetIdParam);
 const AppQaArtifactParams = AppIdParam.merge(AssetIdParam);
+const AppBuildUploadParams = AppIdParam.merge(
+  z.object({ buildUploadId: z.string().openapi({ param: { name: "buildUploadId", in: "path" } }) }),
+);
 
 const BuildInput = z
   .object({
@@ -96,6 +99,23 @@ const IosSimulatorQaArtifactInput = z
     metadata_json: z.record(z.string(), z.unknown()).optional(),
   })
   .openapi("IosSimulatorQaArtifactInput");
+
+const TestflightBundleAssertion = z.object({
+  bundle_id: z.string().min(3).optional().openapi({
+    description:
+      "Optional assertion that must match immutable build metadata; used as fallback only when metadata is absent.",
+  }),
+});
+
+const TestflightPublishInput = TestflightBundleAssertion.extend({
+  distribution: z.enum(["internal", "external"]),
+  group_ids: z.array(z.string().min(1)).min(1),
+  what_to_test: z.record(z.string(), z.string().min(1)).optional(),
+  notify_testers: z.boolean().default(false).optional().openapi({
+    description:
+      "External only. Enables automatic notification before review; for an already-approved build without auto-notify pending, sends the manual build notification.",
+  }),
+}).openapi("TestflightPublishInput");
 
 export function registerBuildRoutes(registry: OpenApiRegistry) {
   register(registry, {
@@ -200,6 +220,104 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
       200: success("Deleted build.", GenericObject),
       403: error("Current principal cannot delete this build."),
       404: error("Build was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/builds/{buildId}/testflight-upload",
+    tags: ["TestFlight"],
+    summary: "Upload an existing signed IPA to App Store Connect",
+    description:
+      "Streams the immutable Hands IPA through Apple's Build Upload API. Upload only: no beta groups, tester notification, Hands activation, or App Store production publish.",
+    security: auth,
+    request: {
+      params: AppBuildParams,
+      body: { content: json(TestflightBundleAssertion), required: false },
+    },
+    responses: {
+      200: success("Apple Build Upload was created and committed.", GenericObject),
+      400: error("ASC credentials, IPA metadata, or bundle assertion is invalid."),
+      403: error("App admin role is required."),
+      404: error("Hands build or IPA was not found."),
+      502: error("Apple rejected the upload request."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/testflight-uploads/{buildUploadId}",
+    tags: ["TestFlight"],
+    summary: "Get Apple Build Upload processing state",
+    security: auth,
+    request: { params: AppBuildUploadParams },
+    responses: {
+      200: success("Live Apple Build Upload state.", GenericObject),
+      400: error("ASC credentials are not configured."),
+      403: error("App viewer role is required."),
+      502: error("Apple status lookup failed."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/builds/{buildId}/testflight-groups",
+    tags: ["TestFlight"],
+    summary: "List TestFlight beta groups for a build's app",
+    security: auth,
+    request: {
+      params: AppBuildParams,
+      query: TestflightBundleAssertion,
+    },
+    responses: {
+      200: success("Internal and external beta groups with stable ids.", GenericObject),
+      400: error("ASC credentials or bundle assertion is invalid."),
+      403: error("App viewer role is required."),
+      404: error("Hands build or App Store Connect app was not found."),
+      502: error("Apple group lookup failed."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/builds/{buildId}/testflight-publish",
+    tags: ["TestFlight"],
+    summary: "Distribute a processed build to TestFlight groups",
+    description:
+      "Assigns stable beta group ids, upserts localized What to Test text, submits external Beta App Review, and optionally notifies external testers. Never publishes an App Store production version or activates a Hands release.",
+    security: auth,
+    request: {
+      params: AppBuildParams,
+      body: { content: json(TestflightPublishInput), required: true },
+    },
+    responses: {
+      200: success("TestFlight distribution request and live Apple state.", GenericObject),
+      400: error("Distribution, group, localization, or bundle input is invalid."),
+      403: error("App publisher role is required."),
+      404: error("Hands build, ASC app, or beta group was not found."),
+      409: error("The Apple build or beta-review state is not ready."),
+      502: error("Apple rejected the distribution request."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/builds/{buildId}/testflight-publish",
+    tags: ["TestFlight"],
+    summary: "Get live TestFlight distribution state",
+    security: auth,
+    request: {
+      params: AppBuildParams,
+      query: TestflightBundleAssertion.extend({
+        distribution: z.enum(["internal", "external"]).optional(),
+      }),
+    },
+    responses: {
+      200: success("Processing, expiry, groups, localizations, and beta-review state.", GenericObject),
+      400: error("ASC credentials, distribution, or bundle assertion is invalid."),
+      403: error("App viewer role is required."),
+      404: error("Hands build or App Store Connect app was not found."),
+      502: error("Apple status lookup failed."),
     },
   });
 

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -720,7 +720,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
       "4. Release management (app publisher): create-release from an existing build (DRAFT by default) → update-release with bilingual release_notes → after explicit human authorization, publish-release. See docs.release_guide.",
       "5. iOS simulator QA fixtures: create-ios-simulator-artifact → PUT the .app.zip to upload.url with the returned headers → complete-ios-simulator-artifact → get/presign the durable exact-byte artifact. QA artifacts can never become releases or update offers.",
-      "6. TestFlight upload (app admin): upload-testflight-build streams an existing signed Hands IPA to Apple; poll get-testflight-upload-status to COMPLETE or FAILED. Upload never assigns beta groups, notifies testers, publishes a Hands release, or submits an App Store production release.",
+      "6. TestFlight: an app admin runs upload-testflight-build and polls get-testflight-upload-status to COMPLETE; an app viewer lists stable beta-group ids, then an app publisher runs publish-testflight-build and polls distribution status. These actions never activate a Hands release or submit an App Store production release.",
     ],
     auth: {
       raft_agents:
@@ -751,6 +751,8 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
         "POST /api/apps/{app_id}/qa-artifacts/ios-simulator/{asset_id}/complete — publisher; one-shot stream verification of size/SHA-256 followed by immutable storage sealing",
       upload_testflight_build:
         "POST /api/apps/{app_id}/builds/{build_id}/testflight-upload — admin; streams the stored signed IPA to Apple's Build Upload API without distributing it",
+      publish_testflight_build:
+        "POST /api/apps/{app_id}/builds/{build_id}/testflight-publish — publisher; assigns processed builds to beta groups and optionally submits external Beta App Review",
     },
     docs: {
       agent_guide: `${origin}/docs/agent-cli-feedback`,
@@ -780,9 +782,9 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       method: "GET",
     },
     // HTTP API actions an agent can self-serve via `raft integration invoke`.
-    // Paths are relative to execution.base_url (`${origin}/api`). Focused on the
-    // feedback-read/log-retrieval flow; Hands serves raw attachments and does
-    // not interpret their contents.
+    // Paths are relative to execution.base_url. Actions cover release,
+    // TestFlight/AppGallery, exact QA artifacts, and feedback triage without
+    // returning provider credentials or interpreting raw attachments.
     actions: [
       {
         name: "help",
@@ -1061,13 +1063,13 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
           build_id: { type: "string", in: "path", required: true, description: "Hands build UUID containing the signed installable IPA." },
-          bundle_id: { type: "string", in: "body", required: false, description: "Optional reverse-DNS identifier used only when build metadata does not contain it." },
+          bundle_id: { type: "string", in: "body", required: false, description: "Optional bundle-id assertion that must match immutable build metadata; it is also the fallback when metadata is absent." },
         },
       },
       {
         name: "get-testflight-upload-status",
         description:
-          "Poll one Apple Build Upload id returned by upload-testflight-build until state is COMPLETE or FAILED. Read-only; requires app viewer.",
+          "Poll one Apple Build Upload id returned by upload-testflight-build until state.state is COMPLETE or FAILED; Apple's errors, warnings, and infos remain in the state object. Read-only; requires app viewer.",
         endpoint: {
           method: "GET",
           path: "/api/apps/{app_id}/testflight-uploads/{build_upload_id}",
@@ -1075,6 +1077,53 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
           build_upload_id: { type: "string", in: "path", required: true, description: "App Store Connect Build Upload id returned by upload-testflight-build." },
+        },
+      },
+      {
+        name: "list-testflight-groups",
+        description:
+          "List internal and external App Store Connect beta groups for the exact iOS app represented by a Hands build. Returns stable group ids for publish-testflight-build. Read-only; requires app viewer.",
+        endpoint: {
+          method: "GET",
+          path: "/api/apps/{app_id}/builds/{build_id}/testflight-groups",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Hands build UUID used to resolve the bundle id." },
+          bundle_id: { type: "string", in: "query", required: false, description: "Optional bundle-id assertion; it must match immutable build metadata, and is only a fallback when metadata is absent." },
+        },
+      },
+      {
+        name: "publish-testflight-build",
+        description:
+          "Distribute one already-processed App Store Connect build to selected TestFlight groups. Upserts localized What to Test text; external mode submits Beta App Review and can auto-notify testers after approval. Never publishes to the App Store or activates a Hands release. Requires app publisher.",
+        endpoint: {
+          method: "POST",
+          path: "/api/apps/{app_id}/builds/{build_id}/testflight-publish",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Hands build UUID whose exact version/build number is already processed by Apple." },
+          distribution: { type: "string", in: "body", required: true, description: "internal or external; every selected group must match." },
+          group_ids: { type: "array", in: "body", required: true, description: "Non-empty stable beta group ids from list-testflight-groups." },
+          what_to_test: { type: "object", in: "body", required: false, description: "Locale-to-text map, for example {\"en-US\":\"Verify login\"}. External distribution requires at least one existing or supplied localization." },
+          notify_testers: { type: "boolean", in: "body", required: false, description: "External only. Enables automatic notification before review; for an already-approved build without auto-notify pending, sends the manual build notification." },
+          bundle_id: { type: "string", in: "body", required: false, description: "Optional bundle-id assertion; it must match immutable build metadata, and is only a fallback when metadata is absent." },
+        },
+      },
+      {
+        name: "get-testflight-publish-status",
+        description:
+          "Refresh live App Store Connect processing, expiration, assigned groups, localizations, internal/external build state, and Beta App Review state for a Hands build. Read-only; requires app viewer.",
+        endpoint: {
+          method: "GET",
+          path: "/api/apps/{app_id}/builds/{build_id}/testflight-publish",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Hands build UUID." },
+          distribution: { type: "string", in: "query", required: false, description: "Optional internal or external state projection." },
+          bundle_id: { type: "string", in: "query", required: false, description: "Optional bundle-id assertion; it must match immutable build metadata, and is only a fallback when metadata is absent." },
         },
       },
       {

--- a/worker/src/routes/operations.ts
+++ b/worker/src/routes/operations.ts
@@ -19,7 +19,14 @@ export interface OperationLog {
   id: string;
   /** Nullable — parse operations are app-less (run before the user picks an app). */
   app_id: string | null;
-  kind: "parse" | "upload" | "publish" | "signed_url" | "testflight-upload" | "delta-generate";
+  kind:
+    | "parse"
+    | "upload"
+    | "publish"
+    | "signed_url"
+    | "testflight-upload"
+    | "testflight-publish"
+    | "delta-generate";
   status: "pending" | "in_progress" | "success" | "failed" | "cancelled";
   parent_op_id: string | null;
   step_number: number | null;

--- a/worker/src/routes/testflight.ts
+++ b/worker/src/routes/testflight.ts
@@ -12,6 +12,18 @@
  * GET /api/apps/:appId/testflight-uploads/:buildUploadId
  *   Polls Apple for the processing state (AWAITING_UPLOAD → PROCESSING →
  *   COMPLETE | FAILED).
+ *
+ * GET /api/apps/:appId/builds/:buildId/testflight-groups
+ *   Lists the App Store Connect beta groups available to the exact iOS app.
+ *
+ * POST /api/apps/:appId/builds/:buildId/testflight-publish
+ *   Assigns one already-processed ASC build to internal or external groups,
+ *   upserts localized What to Test text, submits external Beta App Review,
+ *   and optionally enables/sends tester notifications.
+ *
+ * GET /api/apps/:appId/builds/:buildId/testflight-publish
+ *   Refreshes the live processing, group, beta-review, notification, and
+ *   expiration state without mutating App Store production release state.
  */
 import type { Context } from "hono";
 import type { AdminEnv } from "../middleware/auth";
@@ -19,17 +31,930 @@ import { currentActor } from "../middleware/auth";
 import { getAscCredentials } from "../lib/asc_credentials";
 import {
   AscApiError,
+  addBuildToBetaGroups,
   commitBuildUploadFile,
+  createBetaAppReviewSubmission,
   createBuildUpload,
   createBuildUploadFile,
+  getAssignedBetaGroupIds,
+  getBetaAppReviewSubmission,
+  getBetaBuildLocalizations,
+  getBuildBetaDetail,
   getBuildUpload,
+  listBetaGroups,
   resolveAscAppId,
+  resolveAscBuild,
+  sendBuildBetaNotification,
+  updateBuildBetaAutoNotify,
+  upsertBetaBuildLocalizations,
+  type AscBuildResource,
   type AscApiCredentials,
+  type BetaAppReviewSubmissionResource,
+  type BetaGroupResource,
+  type BuildUploadStateInfo,
+  type BuildBetaDetailResource,
 } from "../lib/asc_api";
 import { createOperation, updateOperation } from "./operations";
 import { insertAuditLog } from "../lib/permissions";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+type TestflightDistribution = "internal" | "external";
+
+interface HandsTestflightBuild {
+  id: string;
+  product_type: string;
+  version_name: string;
+  version_code: number;
+  build_metadata_json: string;
+}
+
+interface TestflightPublishInput {
+  distribution: TestflightDistribution;
+  group_ids: string[];
+  what_to_test: Record<string, string>;
+  notify_testers: boolean;
+  bundle_id?: string;
+}
+
+export class TestflightPublishError extends Error {
+  status: 400 | 404 | 409;
+  code: string;
+  details: Record<string, unknown>;
+
+  constructor(
+    status: 400 | 404 | 409,
+    code: string,
+    message: string,
+    details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+async function loadHandsTestflightBuild(
+  c: AdminContext,
+  appId: string,
+  buildIdParam: string,
+): Promise<HandsTestflightBuild> {
+  const rows = await c.env.DB.prepare(
+    `SELECT b.id, b.product_type, b.version_name, b.version_code,
+            b.build_metadata_json
+     FROM builds b
+     WHERE b.app_id = ?1 AND b.id LIKE ?2 || '%' LIMIT 2`,
+  )
+    .bind(appId, buildIdParam)
+    .all<HandsTestflightBuild>();
+  if (!rows.results || rows.results.length !== 1) {
+    throw new TestflightPublishError(
+      404,
+      "HANDS_BUILD_NOT_FOUND",
+      "build not found (or ambiguous short id)",
+    );
+  }
+  const build = rows.results[0]!;
+  if (build.product_type !== "ios-ipa") {
+    throw new TestflightPublishError(
+      400,
+      "HANDS_BUILD_NOT_IOS",
+      "TestFlight distribution requires an ios-ipa Hands build",
+      { product_type: build.product_type },
+    );
+  }
+  return build;
+}
+
+function bundleIdFromMetadata(raw: string): string {
+  try {
+    const metadata = JSON.parse(raw || "{}") as {
+      bundle_id?: unknown;
+      ios?: { bundle_id?: unknown };
+    };
+    const candidate = metadata.bundle_id ?? metadata.ios?.bundle_id;
+    return typeof candidate === "string" ? candidate.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+async function resolveBuildBundleId(
+  c: AdminContext,
+  build: HandsTestflightBuild,
+  requested?: string,
+): Promise<string> {
+  const requestedBundleId = requested?.trim() ?? "";
+  let metadataBundleId = bundleIdFromMetadata(build.build_metadata_json);
+  if (!metadataBundleId) {
+    const metaAsset = await c.env.DB.prepare(
+      `SELECT r2_key FROM build_assets
+       WHERE build_id = ?1 AND artifact_kind = 'metadata-file' LIMIT 1`,
+    )
+      .bind(build.id)
+      .first<{ r2_key: string }>();
+    if (metaAsset) {
+      const obj = await c.env.APK_BUCKET.get(metaAsset.r2_key);
+      if (obj) {
+        try {
+          const metadata = (await obj.json()) as {
+            bundle_id?: unknown;
+            ios?: { bundle_id?: unknown };
+          };
+          const candidate = metadata.bundle_id ?? metadata.ios?.bundle_id;
+          metadataBundleId =
+            typeof candidate === "string" ? candidate.trim() : "";
+        } catch {
+          // The actionable error below covers malformed metadata.
+        }
+      }
+    }
+  }
+  const expectedBundleId = metadataBundleId;
+  if (
+    expectedBundleId &&
+    requestedBundleId &&
+    expectedBundleId !== requestedBundleId
+  ) {
+    throw new TestflightPublishError(
+      400,
+      "BUNDLE_ID_MISMATCH",
+      "bundle_id does not match the immutable build metadata",
+      { metadata_bundle_id: expectedBundleId },
+    );
+  }
+  const bundleId = expectedBundleId || requestedBundleId;
+  if (!bundleId) {
+    throw new TestflightPublishError(
+      400,
+      "BUNDLE_ID_REQUIRED",
+      'bundle_id not found in immutable build metadata; pass {"bundle_id":"..."}',
+    );
+  }
+  return bundleId;
+}
+
+async function loadAscCredentials(
+  c: AdminContext,
+  appId: string,
+): Promise<AscApiCredentials> {
+  const encKey = c.env.ASC_CRED_ENC_KEY;
+  if (!encKey) {
+    throw new Error("server is missing ASC_CRED_ENC_KEY");
+  }
+  const creds = await getAscCredentials(c.env.DB, encKey, appId);
+  if (!creds) {
+    throw new TestflightPublishError(
+      400,
+      "ASC_CREDENTIALS_REQUIRED",
+      "no ASC credentials configured - add them in Settings > TestFlight first",
+    );
+  }
+  return creds;
+}
+
+export function parsePublishInput(raw: unknown): TestflightPublishInput {
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const distribution = body.distribution;
+  if (distribution !== "internal" && distribution !== "external") {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_DISTRIBUTION",
+      "distribution must be internal or external",
+    );
+  }
+  if (!Array.isArray(body.group_ids)) {
+    throw new TestflightPublishError(
+      400,
+      "GROUP_IDS_REQUIRED",
+      "group_ids must be a non-empty array of App Store Connect beta group ids",
+    );
+  }
+  const groupIds = Array.from(
+    new Set(
+      body.group_ids
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+  if (groupIds.length === 0 || groupIds.length !== body.group_ids.length) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_GROUP_IDS",
+      "group_ids must contain only non-empty unique strings",
+    );
+  }
+
+  const whatToTest: Record<string, string> = {};
+  if (body.what_to_test !== undefined) {
+    if (
+      !body.what_to_test ||
+      typeof body.what_to_test !== "object" ||
+      Array.isArray(body.what_to_test)
+    ) {
+      throw new TestflightPublishError(
+        400,
+        "INVALID_WHAT_TO_TEST",
+        "what_to_test must be an object mapping locale to text",
+      );
+    }
+    for (const [locale, value] of Object.entries(
+      body.what_to_test as Record<string, unknown>,
+    )) {
+      const normalizedLocale = locale.trim();
+      const text = typeof value === "string" ? value.trim() : "";
+      if (!normalizedLocale || !text) {
+        throw new TestflightPublishError(
+          400,
+          "INVALID_WHAT_TO_TEST",
+          "what_to_test locales and text must be non-empty strings",
+        );
+      }
+      whatToTest[normalizedLocale] = text;
+    }
+  }
+
+  if (
+    body.notify_testers !== undefined &&
+    typeof body.notify_testers !== "boolean"
+  ) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_NOTIFY_TESTERS",
+      "notify_testers must be a boolean",
+    );
+  }
+  if (body.bundle_id !== undefined && typeof body.bundle_id !== "string") {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_BUNDLE_ID",
+      "bundle_id must be a non-empty string",
+    );
+  }
+  const bundleId =
+    typeof body.bundle_id === "string" ? body.bundle_id.trim() : undefined;
+  if (body.bundle_id !== undefined && !bundleId) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_BUNDLE_ID",
+      "bundle_id must be a non-empty string",
+    );
+  }
+  return {
+    distribution,
+    group_ids: groupIds,
+    what_to_test: whatToTest,
+    notify_testers: body.notify_testers ?? false,
+    ...(bundleId ? { bundle_id: bundleId } : {}),
+  };
+}
+
+function publicGroup(group: BetaGroupResource) {
+  return {
+    id: group.id,
+    name: group.attributes.name,
+    is_internal: group.attributes.isInternalGroup,
+    has_access_to_all_builds: group.attributes.hasAccessToAllBuilds,
+    public_link_enabled: group.attributes.publicLinkEnabled,
+  };
+}
+
+interface TestflightSnapshot {
+  assignedGroupIds: string[];
+  localizations: Array<{ id: string; locale: string | null; whats_new: string | null }>;
+  betaReview: BetaAppReviewSubmissionResource | null;
+  betaDetail: BuildBetaDetailResource;
+}
+
+async function readTestflightSnapshot(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<TestflightSnapshot> {
+  const [assignedGroupIds, localizations, betaReview, betaDetail] =
+    await Promise.all([
+      getAssignedBetaGroupIds(creds, ascBuildId),
+      getBetaBuildLocalizations(creds, ascBuildId),
+      getBetaAppReviewSubmission(creds, ascBuildId),
+      getBuildBetaDetail(creds, ascBuildId),
+    ]);
+  return {
+    assignedGroupIds,
+    localizations: localizations.map((item) => ({
+      id: item.id,
+      locale: item.attributes.locale,
+      whats_new: item.attributes.whatsNew,
+    })),
+    betaReview,
+    betaDetail,
+  };
+}
+
+function publishState(
+  build: AscBuildResource,
+  snapshot: TestflightSnapshot | null,
+  distribution?: TestflightDistribution,
+): string {
+  if (build.attributes.expired) return "expired";
+  const processing = build.attributes.processingState;
+  if (processing === "PROCESSING") return "processing";
+  if (processing === "FAILED" || processing === "INVALID") {
+    return "processing_failed";
+  }
+  if (!snapshot) return "ready";
+  if (distribution === "internal") {
+    const state = snapshot.betaDetail.attributes.internalBuildState;
+    if (state === "IN_BETA_TESTING") return "testing";
+    if (state === "READY_FOR_BETA_TESTING") return "ready";
+    if (state === "EXPIRED") return "expired";
+    if (state === "PROCESSING_EXCEPTION") return "processing_failed";
+    if (
+      state === "MISSING_EXPORT_COMPLIANCE" ||
+      state === "IN_EXPORT_COMPLIANCE_REVIEW"
+    ) {
+      return "blocked_export_compliance";
+    }
+    return (state ?? "ready").toLowerCase();
+  }
+  if (distribution === "external") {
+    const review = snapshot.betaReview?.attributes.betaReviewState;
+    const state = snapshot.betaDetail.attributes.externalBuildState;
+    if (review === "REJECTED" || state === "BETA_REJECTED") {
+      return "rejected";
+    }
+    if (state === "EXPIRED") return "expired";
+    if (state === "PROCESSING_EXCEPTION") return "processing_failed";
+    if (
+      state === "MISSING_EXPORT_COMPLIANCE" ||
+      state === "IN_EXPORT_COMPLIANCE_REVIEW"
+    ) {
+      return "blocked_export_compliance";
+    }
+    if (state === "NOT_APPLICABLE") return "not_applicable";
+    if (review === "WAITING_FOR_REVIEW") return "waiting_for_review";
+    if (review === "IN_REVIEW") return "in_review";
+    if (state === "IN_BETA_TESTING") return "testing";
+    if (state === "BETA_APPROVED" || review === "APPROVED") {
+      return snapshot.betaDetail.attributes.autoNotifyEnabled
+        ? "approved"
+        : "approved_not_notified";
+    }
+    return (state ?? "ready_for_beta_submission").toLowerCase();
+  }
+  return "ready";
+}
+
+function assertBuildCanDistribute(
+  build: AscBuildResource,
+  distribution: TestflightDistribution,
+) {
+  if (build.attributes.expired) {
+    throw new TestflightPublishError(409, "ASC_BUILD_EXPIRED", "the TestFlight build is expired");
+  }
+  if (build.attributes.processingState !== "VALID") {
+    throw new TestflightPublishError(
+      409,
+      "ASC_BUILD_NOT_READY",
+      `App Store Connect build is ${build.attributes.processingState ?? "not ready"}`,
+      { processing_state: build.attributes.processingState },
+    );
+  }
+  if (distribution === "external") {
+    const audience = build.attributes.buildAudienceType;
+    if (audience !== "APP_STORE_ELIGIBLE") {
+      throw new TestflightPublishError(
+        409,
+        audience === "INTERNAL_ONLY"
+          ? "ASC_BUILD_INTERNAL_ONLY"
+          : "ASC_BUILD_AUDIENCE_NOT_ELIGIBLE",
+        audience === "INTERNAL_ONLY"
+          ? "this build was uploaded as TestFlight Internal Only and cannot be distributed externally"
+          : "App Store Connect did not explicitly mark this build as eligible for external TestFlight distribution",
+        { build_audience_type: audience ?? null },
+      );
+    }
+  }
+}
+
+function assertBetaStateCanDistribute(
+  distribution: TestflightDistribution,
+  betaDetail: BuildBetaDetailResource,
+) {
+  const state =
+    distribution === "internal"
+      ? betaDetail.attributes.internalBuildState
+      : betaDetail.attributes.externalBuildState;
+  if (distribution === "external" && state === "BETA_REJECTED") {
+    throw new TestflightPublishError(
+      409,
+      "BETA_REVIEW_REJECTED",
+      "this build's TestFlight Beta App Review was rejected",
+      { beta_state: state },
+    );
+  }
+  if (
+    state === "MISSING_EXPORT_COMPLIANCE" ||
+    state === "IN_EXPORT_COMPLIANCE_REVIEW" ||
+    state === "PROCESSING" ||
+    state === "PROCESSING_EXCEPTION" ||
+    state === "EXPIRED" ||
+    state === "NOT_APPLICABLE"
+  ) {
+    throw new TestflightPublishError(
+      409,
+      "ASC_BETA_STATE_NOT_READY",
+      `TestFlight ${distribution} build state is ${state}`,
+      { beta_state: state },
+    );
+  }
+}
+
+function selectedGroupsOrThrow(
+  groups: BetaGroupResource[],
+  input: TestflightPublishInput,
+): BetaGroupResource[] {
+  const byId = new Map(groups.map((group) => [group.id, group]));
+  const missing = input.group_ids.filter((id) => !byId.has(id));
+  if (missing.length > 0) {
+    throw new TestflightPublishError(
+      404,
+      "ASC_BETA_GROUP_NOT_FOUND",
+      `beta group ids not found for this app: ${missing.join(", ")}`,
+      { missing_group_ids: missing },
+    );
+  }
+  const selected = input.group_ids.map((id) => byId.get(id)!);
+  const wrongKind = selected.filter(
+    (group) =>
+      group.attributes.isInternalGroup !== (input.distribution === "internal"),
+  );
+  if (wrongKind.length > 0) {
+    throw new TestflightPublishError(
+      400,
+      "ASC_BETA_GROUP_TYPE_MISMATCH",
+      `selected groups do not match distribution=${input.distribution}`,
+      {
+        mismatched_groups: wrongKind.map((group) => ({
+          id: group.id,
+          name: group.attributes.name,
+          is_internal: group.attributes.isInternalGroup,
+        })),
+      },
+    );
+  }
+  return selected;
+}
+
+function statusPayload(args: {
+  handsBuild: HandsTestflightBuild;
+  bundleId: string;
+  ascAppId: string;
+  ascBuild: AscBuildResource;
+  groups: BetaGroupResource[];
+  snapshot: TestflightSnapshot | null;
+  distribution?: TestflightDistribution;
+}) {
+  const assigned = new Set(args.snapshot?.assignedGroupIds ?? []);
+  const assignedGroups = args.groups.filter(
+    (group) => assigned.has(group.id) || group.attributes.hasAccessToAllBuilds,
+  );
+  return {
+    hands_build_id: args.handsBuild.id,
+    bundle_id: args.bundleId,
+    asc_app_id: args.ascAppId,
+    asc_build_id: args.ascBuild.id,
+    version: args.handsBuild.version_name,
+    build_number: String(args.handsBuild.version_code),
+    processing_state: args.ascBuild.attributes.processingState,
+    build_audience_type: args.ascBuild.attributes.buildAudienceType,
+    uploaded_at: args.ascBuild.attributes.uploadedDate,
+    expiration_date: args.ascBuild.attributes.expirationDate,
+    expired: args.ascBuild.attributes.expired,
+    state: publishState(args.ascBuild, args.snapshot, args.distribution),
+    distribution: args.distribution ?? null,
+    assigned_groups: assignedGroups.map(publicGroup),
+    localizations: args.snapshot?.localizations ?? [],
+    beta_review: args.snapshot?.betaReview
+      ? {
+          id: args.snapshot.betaReview.id,
+          state: args.snapshot.betaReview.attributes.betaReviewState,
+          submitted_at: args.snapshot.betaReview.attributes.submittedDate,
+        }
+      : null,
+    beta_detail: args.snapshot
+      ? {
+          id: args.snapshot.betaDetail.id,
+          auto_notify_enabled:
+            args.snapshot.betaDetail.attributes.autoNotifyEnabled,
+          internal_build_state:
+            args.snapshot.betaDetail.attributes.internalBuildState,
+          external_build_state:
+            args.snapshot.betaDetail.attributes.externalBuildState,
+        }
+      : null,
+  };
+}
+
+export async function publishProcessedAscBuild(
+  creds: AscApiCredentials,
+  args: {
+    handsBuild: HandsTestflightBuild;
+    bundleId: string;
+    ascAppId: string;
+    ascBuild: AscBuildResource;
+    input: TestflightPublishInput;
+  },
+) {
+  if (args.input.distribution === "internal" && args.input.notify_testers) {
+    throw new TestflightPublishError(
+      400,
+      "NOTIFY_EXTERNAL_ONLY",
+      "notify_testers applies only to external TestFlight distribution",
+    );
+  }
+
+  assertBuildCanDistribute(args.ascBuild, args.input.distribution);
+  const groups = await listBetaGroups(creds, args.ascAppId);
+  const selected = selectedGroupsOrThrow(groups, args.input);
+  let snapshot = await readTestflightSnapshot(creds, args.ascBuild.id);
+  assertBetaStateCanDistribute(
+    args.input.distribution,
+    snapshot.betaDetail,
+  );
+
+  if (
+    args.input.distribution === "external" &&
+    snapshot.betaReview?.attributes.betaReviewState === "REJECTED"
+  ) {
+    throw new TestflightPublishError(
+      409,
+      "BETA_REVIEW_REJECTED",
+      "this build's TestFlight Beta App Review was rejected",
+    );
+  }
+
+  if (
+    args.input.distribution === "external" &&
+    Object.keys(args.input.what_to_test).length === 0 &&
+    !snapshot.localizations.some((item) => item.whats_new?.trim())
+  ) {
+    throw new TestflightPublishError(
+      400,
+      "WHAT_TO_TEST_REQUIRED",
+      "external TestFlight distribution requires at least one What to Test localization",
+    );
+  }
+
+  await upsertBetaBuildLocalizations(
+    creds,
+    args.ascBuild.id,
+    args.input.what_to_test,
+  );
+
+  const assigned = new Set(snapshot.assignedGroupIds);
+  const missingGroupIds = selected
+    .filter(
+      (group) =>
+        !assigned.has(group.id) && !group.attributes.hasAccessToAllBuilds,
+    )
+    .map((group) => group.id);
+  await addBuildToBetaGroups(creds, args.ascBuild.id, missingGroupIds);
+
+  let notification: "not_requested" | "scheduled" | "sent" | "already_sent" =
+    "not_requested";
+  if (args.input.distribution === "external") {
+    let detail = snapshot.betaDetail;
+    let review = snapshot.betaReview;
+    const wasApproved =
+      review?.attributes.betaReviewState === "APPROVED" ||
+      detail.attributes.externalBuildState === "BETA_APPROVED" ||
+      detail.attributes.externalBuildState === "IN_BETA_TESTING";
+    if (
+      !wasApproved &&
+      detail.attributes.autoNotifyEnabled !== args.input.notify_testers
+    ) {
+      detail = await updateBuildBetaAutoNotify(creds, {
+        buildBetaDetailId: detail.id,
+        enabled: args.input.notify_testers,
+      });
+    }
+
+    if (!review && !wasApproved) {
+      try {
+        review = await createBetaAppReviewSubmission(creds, args.ascBuild.id);
+      } catch (error) {
+        if (!(error instanceof AscApiError) || error.status !== 409) {
+          throw error;
+        }
+        review = await getBetaAppReviewSubmission(creds, args.ascBuild.id);
+        if (!review) throw error;
+      }
+    }
+
+    if (args.input.notify_testers) {
+      const approved =
+        wasApproved || review?.attributes.betaReviewState === "APPROVED";
+      if (approved) {
+        if (detail.attributes.externalBuildState === "IN_BETA_TESTING") {
+          notification = "already_sent";
+        } else if (detail.attributes.autoNotifyEnabled) {
+          notification = "scheduled";
+        } else {
+          try {
+            await sendBuildBetaNotification(creds, args.ascBuild.id);
+            notification = "sent";
+          } catch (error) {
+            if (!(error instanceof AscApiError) || error.status !== 409) {
+              throw error;
+            }
+            const refreshed = await getBuildBetaDetail(creds, args.ascBuild.id);
+            if (refreshed.attributes.externalBuildState !== "IN_BETA_TESTING") {
+              throw error;
+            }
+            notification = "already_sent";
+          }
+        }
+      } else {
+        notification = "scheduled";
+      }
+    }
+  }
+
+  snapshot = await readTestflightSnapshot(creds, args.ascBuild.id);
+  const payload = statusPayload({
+    handsBuild: args.handsBuild,
+    bundleId: args.bundleId,
+    ascAppId: args.ascAppId,
+    ascBuild: args.ascBuild,
+    groups,
+    snapshot,
+    distribution: args.input.distribution,
+  });
+  return {
+    ok: true,
+    ...payload,
+    requested_group_ids: args.input.group_ids,
+    notification,
+  };
+}
+
+function testflightErrorResponse(c: AdminContext, error: unknown) {
+  if (error instanceof TestflightPublishError) {
+    return c.json(
+      { error: error.message, code: error.code, ...error.details },
+      error.status,
+    );
+  }
+  if (error instanceof AscApiError) {
+    return c.json(
+      {
+        error: error.message,
+        code: error.status === 409 ? "ASC_CONFLICT" : "ASC_API_ERROR",
+        detail: error.detail,
+        upstream_status: error.status,
+      },
+      error.status === 409 ? 409 : 502,
+    );
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return c.json({ error: message }, 500);
+}
+
+export async function handleListTestflightGroups(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  try {
+    const build = await loadHandsTestflightBuild(
+      c,
+      appId,
+      c.req.param("buildId") ?? "",
+    );
+    const bundleId = await resolveBuildBundleId(
+      c,
+      build,
+      c.req.query("bundle_id"),
+    );
+    const creds = await loadAscCredentials(c, appId);
+    const ascAppId = await resolveAscAppId(creds, bundleId);
+    if (!ascAppId) {
+      throw new TestflightPublishError(
+        404,
+        "ASC_APP_NOT_FOUND",
+        `no App Store Connect app record for bundle id ${bundleId}`,
+      );
+    }
+    const groups = await listBetaGroups(creds, ascAppId);
+    return c.json({
+      hands_build_id: build.id,
+      bundle_id: bundleId,
+      asc_app_id: ascAppId,
+      groups: groups.map(publicGroup),
+    });
+  } catch (error) {
+    return testflightErrorResponse(c, error);
+  }
+}
+
+export async function handleTestflightPublishStatus(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  try {
+    const build = await loadHandsTestflightBuild(
+      c,
+      appId,
+      c.req.param("buildId") ?? "",
+    );
+    const bundleId = await resolveBuildBundleId(
+      c,
+      build,
+      c.req.query("bundle_id"),
+    );
+    const distributionParam = c.req.query("distribution");
+    if (
+      distributionParam !== undefined &&
+      distributionParam !== "internal" &&
+      distributionParam !== "external"
+    ) {
+      throw new TestflightPublishError(
+        400,
+        "INVALID_DISTRIBUTION",
+        "distribution must be internal or external",
+      );
+    }
+    const distribution =
+      distributionParam === "internal" || distributionParam === "external"
+        ? distributionParam
+        : undefined;
+    const creds = await loadAscCredentials(c, appId);
+    const ascAppId = await resolveAscAppId(creds, bundleId);
+    if (!ascAppId) {
+      throw new TestflightPublishError(
+        404,
+        "ASC_APP_NOT_FOUND",
+        `no App Store Connect app record for bundle id ${bundleId}`,
+      );
+    }
+    const ascBuild = await resolveAscBuild(creds, {
+      ascAppId,
+      version: build.version_name,
+      buildNumber: String(build.version_code),
+    });
+    if (!ascBuild) {
+      return c.json({
+        hands_build_id: build.id,
+        bundle_id: bundleId,
+        asc_app_id: ascAppId,
+        asc_build_id: null,
+        version: build.version_name,
+        build_number: String(build.version_code),
+        state: "waiting_for_processing",
+        distribution: distribution ?? null,
+      });
+    }
+    if (
+      ascBuild.attributes.processingState !== "VALID" ||
+      ascBuild.attributes.expired
+    ) {
+      return c.json(
+        statusPayload({
+          handsBuild: build,
+          bundleId,
+          ascAppId,
+          ascBuild,
+          groups: [],
+          snapshot: null,
+          ...(distribution ? { distribution } : {}),
+        }),
+      );
+    }
+    const [groups, snapshot] = await Promise.all([
+      listBetaGroups(creds, ascAppId),
+      readTestflightSnapshot(creds, ascBuild.id),
+    ]);
+    return c.json(
+      statusPayload({
+        handsBuild: build,
+        bundleId,
+        ascAppId,
+        ascBuild,
+        groups,
+        snapshot,
+        ...(distribution ? { distribution } : {}),
+      }),
+    );
+  } catch (error) {
+    return testflightErrorResponse(c, error);
+  }
+}
+
+export async function handleTestflightPublish(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  let op: Awaited<ReturnType<typeof createOperation>> | null = null;
+  try {
+    const input = parsePublishInput(await c.req.json().catch(() => ({})));
+    const build = await loadHandsTestflightBuild(
+      c,
+      appId,
+      c.req.param("buildId") ?? "",
+    );
+    const bundleId = await resolveBuildBundleId(c, build, input.bundle_id);
+    op = await createOperation(c.env.DB, {
+      app_id: appId,
+      kind: "testflight-publish",
+      actor: currentActor(c),
+      input: JSON.stringify({
+        hands_build_id: build.id,
+        bundle_id: bundleId,
+        distribution: input.distribution,
+        group_ids: input.group_ids,
+        what_to_test: input.what_to_test,
+        notify_testers: input.notify_testers,
+      }),
+    });
+    await updateOperation(c.env.DB, op.id, {
+      status: "in_progress",
+      progress: 5,
+    });
+
+    const creds = await loadAscCredentials(c, appId);
+    const ascAppId = await resolveAscAppId(creds, bundleId);
+    if (!ascAppId) {
+      throw new TestflightPublishError(
+        404,
+        "ASC_APP_NOT_FOUND",
+        `no App Store Connect app record for bundle id ${bundleId}`,
+      );
+    }
+    const ascBuild = await resolveAscBuild(creds, {
+      ascAppId,
+      version: build.version_name,
+      buildNumber: String(build.version_code),
+    });
+    if (!ascBuild) {
+      throw new TestflightPublishError(
+        409,
+        "ASC_BUILD_NOT_AVAILABLE",
+        "the exact App Store Connect build is not available yet; upload it and wait for processing",
+        {
+          version: build.version_name,
+          build_number: String(build.version_code),
+          state: "waiting_for_processing",
+        },
+      );
+    }
+
+    await updateOperation(c.env.DB, op.id, {
+      status: "in_progress",
+      progress: 10,
+    });
+
+    const result = await publishProcessedAscBuild(creds, {
+      handsBuild: build,
+      bundleId,
+      ascAppId,
+      ascBuild,
+      input,
+    });
+    await updateOperation(c.env.DB, op.id, {
+      status: "success",
+      progress: 100,
+      output: JSON.stringify(result),
+      completed_at: Date.now(),
+    });
+    await insertAuditLog(c.env.DB, c, {
+      app_id: appId,
+      action: "testflight.publish",
+      payload: {
+        build_id: build.id,
+        asc_build_id: ascBuild.id,
+        distribution: input.distribution,
+        group_ids: input.group_ids,
+        notify_testers: input.notify_testers,
+      },
+    });
+    return c.json({ operation_id: op.id, ...result });
+  } catch (error) {
+    if (op) {
+      const detail =
+        error instanceof TestflightPublishError
+          ? { error: error.message, code: error.code, ...error.details }
+          : error instanceof AscApiError
+            ? {
+                error: error.message,
+                code:
+                  error.status === 409 ? "ASC_CONFLICT" : "ASC_API_ERROR",
+                detail: error.detail,
+                upstream_status: error.status,
+              }
+            : { error: error instanceof Error ? error.message : String(error) };
+      await updateOperation(c.env.DB, op.id, {
+        status: "failed",
+        error: JSON.stringify(detail),
+        completed_at: Date.now(),
+      });
+    }
+    return testflightErrorResponse(c, error);
+  }
+}
 
 export async function handleTestflightUpload(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
@@ -183,7 +1108,7 @@ async function runUpload(
   asc_app_id: string;
   build_upload_id: string;
   parts_uploaded: number;
-  state: string | null;
+  state: BuildUploadStateInfo | null;
 }> {
   const ascAppId = await resolveAscAppId(creds, args.bundleId);
   if (!ascAppId) {

--- a/worker/test/asc_api.test.ts
+++ b/worker/test/asc_api.test.ts
@@ -12,6 +12,7 @@ import {
   createBuildUpload,
   createBuildUploadFile,
   commitBuildUploadFile,
+  resolveAscBuild,
   resolveAscAppId,
   AscApiError,
   type AscApiCredentials,
@@ -139,7 +140,17 @@ describe("build upload resource shapes", () => {
       });
       return new Response(
         JSON.stringify({
-          data: { id: "bu-1", attributes: { state: "AWAITING_UPLOAD" } },
+          data: {
+            id: "bu-1",
+            attributes: {
+              state: {
+                state: "AWAITING_UPLOAD",
+                errors: [],
+                warnings: [],
+                infos: [],
+              },
+            },
+          },
         }),
         { status: 201 },
       );
@@ -152,6 +163,7 @@ describe("build upload resource shapes", () => {
       buildNumber: "1020000",
     });
     expect(bu.id).toBe("bu-1");
+    expect(bu.attributes.state?.state).toBe("AWAITING_UPLOAD");
     expect(String(fetchMock.mock.calls[0]![0])).toContain("/v1/buildUploads");
   });
 
@@ -214,5 +226,43 @@ describe("build upload resource shapes", () => {
 
     await commitBuildUploadFile(creds, { fileId: "file-1", sha256: "abc123" });
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe("TestFlight build resolution", () => {
+  it("matches the exact app, marketing version, build number, and platform", async () => {
+    const { creds } = await generateTestCreds();
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const parsed = new URL(String(url));
+      expect(parsed.pathname).toBe("/v1/builds");
+      expect(parsed.searchParams.get("filter[app]")).toBe("app-1");
+      expect(parsed.searchParams.get("filter[version]")).toBe("1000005");
+      expect(parsed.searchParams.get("filter[preReleaseVersion.version]")).toBe(
+        "1.0.0",
+      );
+      expect(parsed.searchParams.get("filter[preReleaseVersion.platform]")).toBe(
+        "IOS",
+      );
+      return Response.json({
+        data: [
+          {
+            id: "build-1",
+            attributes: {
+              version: "1000005",
+              processingState: "VALID",
+              expired: false,
+            },
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const build = await resolveAscBuild(creds, {
+      ascAppId: "app-1",
+      version: "1.0.0",
+      buildNumber: "1000005",
+    });
+    expect(build?.id).toBe("build-1");
   });
 });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -87,6 +87,10 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/builds",
       "/api/apps/{appId}/builds/publish-version",
       "/api/apps/{appId}/builds/{buildId}/external-targets",
+      "/api/apps/{appId}/builds/{buildId}/testflight-upload",
+      "/api/apps/{appId}/testflight-uploads/{buildUploadId}",
+      "/api/apps/{appId}/builds/{buildId}/testflight-groups",
+      "/api/apps/{appId}/builds/{buildId}/testflight-publish",
       "/api/apps/{appId}/qa-artifacts/ios-simulator",
       "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}",
       "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/complete",
@@ -7092,6 +7096,18 @@ describe("Hands iOS simulator QA artifacts", () => {
       "get-testflight-upload-status": {
         method: "GET",
         path: "/api/apps/{app_id}/testflight-uploads/{build_upload_id}",
+      },
+      "list-testflight-groups": {
+        method: "GET",
+        path: "/api/apps/{app_id}/builds/{build_id}/testflight-groups",
+      },
+      "publish-testflight-build": {
+        method: "POST",
+        path: "/api/apps/{app_id}/builds/{build_id}/testflight-publish",
+      },
+      "get-testflight-publish-status": {
+        method: "GET",
+        path: "/api/apps/{app_id}/builds/{build_id}/testflight-publish",
       },
     });
     const byName = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action]));

--- a/worker/test/testflight_publish.test.ts
+++ b/worker/test/testflight_publish.test.ts
@@ -1,0 +1,652 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { AscApiCredentials } from "../src/lib/asc_api";
+import {
+  handleTestflightPublish,
+  parsePublishInput,
+  publishProcessedAscBuild,
+  TestflightPublishError,
+} from "../src/routes/testflight";
+
+async function generateTestCreds(): Promise<AscApiCredentials> {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(
+    (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer,
+  );
+  let binary = "";
+  for (const byte of pkcs8) binary += String.fromCharCode(byte);
+  return {
+    key_id: "TESTKEY123",
+    issuer_id: "issuer-uuid-1234",
+    p8: `-----BEGIN PRIVATE KEY-----\n${btoa(binary)}\n-----END PRIVATE KEY-----`,
+  };
+}
+
+interface FakeAscOptions {
+  processingState?: string;
+  audience?: string;
+  internalState?: string;
+  externalState?: string;
+  reviewState?: string | null;
+}
+
+function fakeAsc(options: FakeAscOptions = {}) {
+  const assigned = new Set<string>();
+  const localizations = new Map<string, { id: string; whatsNew: string }>();
+  let autoNotify = false;
+  let internalState = options.internalState ?? "IN_BETA_TESTING";
+  let externalState = options.externalState ?? "READY_FOR_BETA_SUBMISSION";
+  let reviewState = options.reviewState ?? null;
+  let notificationCount = 0;
+
+  const groups = [
+    {
+      id: "internal-1",
+      attributes: {
+        name: "Internal QA",
+        isInternalGroup: true,
+        hasAccessToAllBuilds: false,
+      },
+    },
+    {
+      id: "internal-2",
+      attributes: {
+        name: "Dogfood",
+        isInternalGroup: true,
+        hasAccessToAllBuilds: false,
+      },
+    },
+    {
+      id: "external-1",
+      attributes: {
+        name: "External Beta",
+        isInternalGroup: false,
+        hasAccessToAllBuilds: false,
+      },
+    },
+  ];
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const json = () => JSON.parse(String(init?.body ?? "{}"));
+
+    if (method === "GET" && url.pathname === "/v1/apps/app-1/betaGroups") {
+      return Response.json({ data: groups });
+    }
+    if (method === "GET" && url.pathname === "/v1/builds/build-1") {
+      return Response.json({
+        data: {
+          id: "build-1",
+          attributes: {},
+          relationships: {
+            betaGroups: {
+              data: [...assigned].map((id) => ({ type: "betaGroups", id })),
+            },
+          },
+        },
+      });
+    }
+    if (
+      method === "GET" &&
+      url.pathname === "/v1/builds/build-1/betaBuildLocalizations"
+    ) {
+      return Response.json({
+        data: [...localizations.entries()].map(([locale, value]) => ({
+          id: value.id,
+          attributes: { locale, whatsNew: value.whatsNew },
+        })),
+      });
+    }
+    if (
+      method === "GET" &&
+      url.pathname === "/v1/builds/build-1/betaAppReviewSubmission"
+    ) {
+      return Response.json({
+        data: reviewState
+          ? {
+              id: "review-1",
+              attributes: {
+                betaReviewState: reviewState,
+                submittedDate: "2026-07-21T00:00:00Z",
+              },
+            }
+          : null,
+      });
+    }
+    if (
+      method === "GET" &&
+      url.pathname === "/v1/builds/build-1/buildBetaDetail"
+    ) {
+      return Response.json({
+        data: {
+          id: "detail-1",
+          attributes: {
+            autoNotifyEnabled: autoNotify,
+            internalBuildState: internalState,
+            externalBuildState: externalState,
+          },
+        },
+      });
+    }
+    if (
+      method === "POST" &&
+      url.pathname === "/v1/builds/build-1/relationships/betaGroups"
+    ) {
+      for (const item of json().data) assigned.add(item.id);
+      return new Response(null, { status: 204 });
+    }
+    if (method === "POST" && url.pathname === "/v1/betaBuildLocalizations") {
+      const body = json().data;
+      const id = `loc-${localizations.size + 1}`;
+      localizations.set(body.attributes.locale, {
+        id,
+        whatsNew: body.attributes.whatsNew,
+      });
+      return Response.json(
+        { data: { id, attributes: body.attributes } },
+        { status: 201 },
+      );
+    }
+    if (method === "PATCH" && url.pathname.startsWith("/v1/betaBuildLocalizations/")) {
+      const body = json().data;
+      const entry = [...localizations.entries()].find(
+        ([, value]) => value.id === body.id,
+      );
+      if (entry) entry[1].whatsNew = body.attributes.whatsNew;
+      return Response.json({
+        data: {
+          id: body.id,
+          attributes: { locale: entry?.[0] ?? null, whatsNew: body.attributes.whatsNew },
+        },
+      });
+    }
+    if (method === "PATCH" && url.pathname === "/v1/buildBetaDetails/detail-1") {
+      autoNotify = json().data.attributes.autoNotifyEnabled;
+      return Response.json({
+        data: {
+          id: "detail-1",
+          attributes: {
+            autoNotifyEnabled: autoNotify,
+            internalBuildState: internalState,
+            externalBuildState: externalState,
+          },
+        },
+      });
+    }
+    if (method === "POST" && url.pathname === "/v1/betaAppReviewSubmissions") {
+      reviewState = "WAITING_FOR_REVIEW";
+      externalState = "WAITING_FOR_BETA_REVIEW";
+      return Response.json(
+        {
+          data: {
+            id: "review-1",
+            attributes: {
+              betaReviewState: reviewState,
+              submittedDate: "2026-07-21T00:00:00Z",
+            },
+          },
+        },
+        { status: 201 },
+      );
+    }
+    if (method === "POST" && url.pathname === "/v1/buildBetaNotifications") {
+      notificationCount += 1;
+      externalState = "IN_BETA_TESTING";
+      return Response.json({ data: { id: "notification-1" } }, { status: 201 });
+    }
+
+    return Response.json(
+      { errors: [{ title: "UNEXPECTED_REQUEST", detail: `${method} ${url.pathname}` }] },
+      { status: 500 },
+    );
+  });
+
+  return {
+    assigned,
+    localizations,
+    fetchMock,
+    setReviewState(value: string, buildState = externalState) {
+      reviewState = value;
+      externalState = buildState;
+    },
+    notificationCount: () => notificationCount,
+  };
+}
+
+function baseArgs() {
+  return {
+    handsBuild: {
+      id: "hands-build-1",
+      product_type: "ios-ipa",
+      version_name: "1.0.0",
+      version_code: 1000005,
+      build_metadata_json: "{}",
+    },
+    bundleId: "build.raft.app",
+    ascAppId: "app-1",
+    ascBuild: {
+      id: "build-1",
+      attributes: {
+        version: "1000005",
+        uploadedDate: "2026-07-21T00:00:00Z",
+        expirationDate: "2026-10-19T00:00:00Z",
+        expired: false,
+        processingState: "VALID",
+        buildAudienceType: "APP_STORE_ELIGIBLE",
+      },
+    },
+  } as const;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("publishProcessedAscBuild", () => {
+  it("rejects a bundle assertion mismatch before operation or Apple access", async () => {
+    let operationWrites = 0;
+    const db = {
+      prepare(sql: string) {
+        if (sql.includes("INSERT INTO operation_logs")) operationWrites += 1;
+        return {
+          bind() {
+            return this;
+          },
+          async all() {
+            if (sql.includes("FROM builds b")) {
+              return {
+                results: [
+                  {
+                    id: "build-1",
+                    product_type: "ios-ipa",
+                    version_name: "1.0.0",
+                    version_code: 1000005,
+                    build_metadata_json: JSON.stringify({
+                      bundle_id: "build.raft.app",
+                    }),
+                  },
+                ],
+              };
+            }
+            return { results: [] };
+          },
+          async first() {
+            return null;
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+      },
+    };
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const app = new Hono();
+    app.post(
+      "/api/apps/:appId/builds/:buildId/testflight-publish",
+      handleTestflightPublish as any,
+    );
+
+    const response = await app.request(
+      "/api/apps/app-1/builds/build-1/testflight-publish",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          distribution: "internal",
+          group_ids: ["internal-1"],
+          bundle_id: "other.example.app",
+        }),
+      },
+      { DB: db, APK_BUCKET: { get: vi.fn() } } as any,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "BUNDLE_ID_MISMATCH",
+      metadata_bundle_id: "build.raft.app",
+    });
+    expect(operationWrites).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("validates boolean notification and bundle assertions", () => {
+    expect(() =>
+      parsePublishInput({
+        distribution: "external",
+        group_ids: ["external-1"],
+        notify_testers: "true",
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "INVALID_NOTIFY_TESTERS" }),
+    );
+    expect(() =>
+      parsePublishInput({
+        distribution: "internal",
+        group_ids: ["internal-1"],
+        bundle_id: "   ",
+      }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_BUNDLE_ID" }));
+  });
+
+  it("assigns multiple internal groups and is idempotent on retry", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    vi.stubGlobal("fetch", fake.fetchMock);
+
+    const input = {
+      distribution: "internal" as const,
+      group_ids: ["internal-1", "internal-2"],
+      what_to_test: { "en-US": "Verify login and Activity." },
+      notify_testers: false,
+    };
+    const first = await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input,
+    });
+    const second = await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input,
+    });
+
+    expect(first.state).toBe("testing");
+    expect(second.state).toBe("testing");
+    expect([...fake.assigned].sort()).toEqual(["internal-1", "internal-2"]);
+    expect(fake.localizations.get("en-US")?.whatsNew).toBe(
+      "Verify login and Activity.",
+    );
+    const relationshipPosts = fake.fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).includes("/relationships/betaGroups") &&
+        init?.method === "POST",
+    );
+    expect(relationshipPosts).toHaveLength(1);
+    const localizationPosts = fake.fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).endsWith("/v1/betaBuildLocalizations") &&
+        init?.method === "POST",
+    );
+    expect(localizationPosts).toHaveLength(1);
+  });
+
+  it("lets scheduled auto-notify complete without a duplicate manual notification", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    vi.stubGlobal("fetch", fake.fetchMock);
+    const input = {
+      distribution: "external" as const,
+      group_ids: ["external-1"],
+      what_to_test: {
+        "en-US": "Verify the release candidate.",
+        "zh-Hans": "验证发布候选版本。",
+      },
+      notify_testers: true,
+    };
+
+    const submitted = await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input,
+    });
+    expect(submitted.state).toBe("waiting_for_review");
+    expect(submitted.notification).toBe("scheduled");
+    expect(fake.notificationCount()).toBe(0);
+
+    fake.setReviewState("APPROVED", "IN_BETA_TESTING");
+    const approved = await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input,
+    });
+    expect(approved.notification).toBe("already_sent");
+    expect(approved.state).toBe("testing");
+    expect(fake.notificationCount()).toBe(0);
+
+    const notificationPosts = fake.fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).endsWith("/v1/buildBetaNotifications") &&
+        init?.method === "POST",
+    );
+    expect(notificationPosts).toHaveLength(0);
+    const autoNotifyPatches = fake.fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).endsWith("/v1/buildBetaDetails/detail-1") &&
+        init?.method === "PATCH",
+    );
+    expect(autoNotifyPatches).toHaveLength(1);
+  });
+
+  it("sends one manual notification when review was approved without auto-notify", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    vi.stubGlobal("fetch", fake.fetchMock);
+    const initialInput = {
+      distribution: "external" as const,
+      group_ids: ["external-1"],
+      what_to_test: { "en-US": "Verify the release candidate." },
+      notify_testers: false,
+    };
+    await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input: initialInput,
+    });
+    fake.setReviewState("APPROVED", "BETA_APPROVED");
+
+    const notifyInput = { ...initialInput, notify_testers: true };
+    const approved = await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input: notifyInput,
+    });
+    expect(approved.notification).toBe("sent");
+    expect(approved.state).toBe("testing");
+    expect(fake.notificationCount()).toBe(1);
+
+    const retried = await publishProcessedAscBuild(creds, {
+      ...baseArgs(),
+      input: notifyInput,
+    });
+    expect(retried.notification).toBe("already_sent");
+    expect(fake.notificationCount()).toBe(1);
+    const autoNotifyPatches = fake.fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).endsWith("/v1/buildBetaDetails/detail-1") &&
+        init?.method === "PATCH",
+    );
+    expect(autoNotifyPatches).toHaveLength(0);
+  });
+
+  it("fails closed while the ASC build is still processing", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    vi.stubGlobal("fetch", fake.fetchMock);
+    const args = baseArgs();
+
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...args,
+        ascBuild: {
+          ...args.ascBuild,
+          attributes: { ...args.ascBuild.attributes, processingState: "PROCESSING" },
+        },
+        input: {
+          distribution: "internal",
+          group_ids: ["internal-1"],
+          what_to_test: {},
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "ASC_BUILD_NOT_READY",
+    } satisfies Partial<TestflightPublishError>);
+    expect(fake.assigned.size).toBe(0);
+    expect(fake.localizations.size).toBe(0);
+  });
+
+  it("rejects missing or wrong-kind beta groups before mutation", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    vi.stubGlobal("fetch", fake.fetchMock);
+
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...baseArgs(),
+        input: {
+          distribution: "internal",
+          group_ids: ["missing-group"],
+          what_to_test: {},
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "ASC_BETA_GROUP_NOT_FOUND" });
+
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...baseArgs(),
+        input: {
+          distribution: "external",
+          group_ids: ["internal-1"],
+          what_to_test: { "en-US": "Verify release." },
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "ASC_BETA_GROUP_TYPE_MISMATCH" });
+    expect(fake.assigned.size).toBe(0);
+  });
+
+  it("requires external What to Test metadata and rejects internal-only builds", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    vi.stubGlobal("fetch", fake.fetchMock);
+
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...baseArgs(),
+        input: {
+          distribution: "external",
+          group_ids: ["external-1"],
+          what_to_test: {},
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "WHAT_TO_TEST_REQUIRED" });
+
+    const args = baseArgs();
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...args,
+        ascBuild: {
+          ...args.ascBuild,
+          attributes: {
+            ...args.ascBuild.attributes,
+            buildAudienceType: "INTERNAL_ONLY",
+          },
+        },
+        input: {
+          distribution: "external",
+          group_ids: ["external-1"],
+          what_to_test: { "en-US": "Verify release." },
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "ASC_BUILD_INTERNAL_ONLY",
+      details: { build_audience_type: "INTERNAL_ONLY" },
+    });
+  });
+
+  it.each([
+    ["null", null],
+    ["missing", undefined],
+    ["unknown", "FUTURE_AUDIENCE"],
+  ])(
+    "rejects an external %s build audience before any Apple access",
+    async (_label, audience) => {
+      const creds = await generateTestCreds();
+      const fake = fakeAsc();
+      vi.stubGlobal("fetch", fake.fetchMock);
+      const args = baseArgs();
+      const {
+        buildAudienceType: baseAudience,
+        ...attributesWithoutAudience
+      } = args.ascBuild.attributes;
+      void baseAudience;
+      const attributes = {
+        ...attributesWithoutAudience,
+        ...(audience === undefined ? {} : { buildAudienceType: audience }),
+      };
+
+      expect(Object.hasOwn(attributes, "buildAudienceType")).toBe(
+        audience !== undefined,
+      );
+      expect(attributes.buildAudienceType).toBe(audience);
+
+      await expect(
+        publishProcessedAscBuild(creds, {
+          ...args,
+          ascBuild: {
+            ...args.ascBuild,
+            attributes,
+          },
+          input: {
+            distribution: "external",
+            group_ids: ["external-1"],
+            what_to_test: { "en-US": "Verify release." },
+            notify_testers: true,
+          },
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: "ASC_BUILD_AUDIENCE_NOT_ELIGIBLE",
+        details: { build_audience_type: audience ?? null },
+      } satisfies Partial<TestflightPublishError>);
+
+      expect(fake.fetchMock).not.toHaveBeenCalled();
+      expect(fake.assigned.size).toBe(0);
+      expect(fake.localizations.size).toBe(0);
+      expect(fake.notificationCount()).toBe(0);
+    },
+  );
+
+  it("treats rejected and export-compliance beta states as terminal blockers", async () => {
+    const creds = await generateTestCreds();
+    const rejected = fakeAsc({ externalState: "BETA_REJECTED" });
+    vi.stubGlobal("fetch", rejected.fetchMock);
+
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...baseArgs(),
+        input: {
+          distribution: "external",
+          group_ids: ["external-1"],
+          what_to_test: { "en-US": "Verify release." },
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BETA_REVIEW_REJECTED" });
+    expect(rejected.assigned.size).toBe(0);
+
+    const compliance = fakeAsc({
+      internalState: "MISSING_EXPORT_COMPLIANCE",
+    });
+    vi.stubGlobal("fetch", compliance.fetchMock);
+    await expect(
+      publishProcessedAscBuild(creds, {
+        ...baseArgs(),
+        input: {
+          distribution: "internal",
+          group_ids: ["internal-1"],
+          what_to_test: {},
+          notify_testers: false,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "ASC_BETA_STATE_NOT_READY",
+      details: { beta_state: "MISSING_EXPORT_COMPLIANCE" },
+    });
+    expect(compliance.assigned.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve the exact App Store Connect build from a Hands iOS build and expose stable internal/external beta-group IDs
- distribute processed builds to selected groups, upsert localized What to Test text, submit external Beta App Review, and opt into automatic/manual tester notification without duplicating retries
- synchronize processing, expiry, audience, assigned groups, localizations, beta review, internal/external build state, and auto-notify state through API, Admin, CLI, and Raft integration actions
- add `hands builds testflight-groups`, `testflight-publish`, and `testflight-status`; bump the CLI to `0.5.12`
- update the public guides, release runbook, OpenAPI document, agent help, and Raft manifest

## Boundaries

- reuses an existing signed Hands IPA / exact processed ASC build
- immutable build metadata is authoritative for `bundle_id`; an explicit value is an assertion or legacy fallback, and mismatches fail before credentials, operations, or Apple access
- rejects non-iOS builds, wrong-kind/missing groups, processing failures, expiry, export-compliance blocks, and rejected beta review
- external distribution is fail-closed: only an explicit Apple `buildAudienceType=APP_STORE_ELIGIBLE` may proceed; `INTERNAL_ONLY`, null/missing, and unknown values fail before any Apple access or mutation
- no App Store production-version endpoint is called
- no Hands release is activated
- ASC `.p8` material remains encrypted server-side and is never returned to CI, CLI, agents, operations, or audit output

## Apple contract

Implemented against Apple's official App Store Connect API contract for builds, beta groups, beta build localizations, build beta details, beta app review submissions, and build beta notifications. The upload state type is also corrected to Apple's nested `state/errors/warnings/infos` object.

References:

- https://developer.apple.com/documentation/appstoreconnectapi/prerelease-versions-and-beta-testers
- https://developer.apple.com/documentation/appstoreconnectapi/build-beta-notifications
- https://developer.apple.com/help/app-store-connect/test-a-beta-version/add-internal-testers/
- https://developer.apple.com/help/app-store-connect/test-a-beta-version/invite-external-testers/
- https://developer.apple.com/help/app-store-connect/test-a-beta-version/provide-test-information/
- https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview/

## Verification

Rebased onto deployed current `main@5e57d1128cc3943527090572b49cf66cc37c6c5c` after PR #324 and its #327/#328 remote-D1 parser follow-ups. Production deploy run `29843109050` succeeded. Final candidate gates:

- `cd worker && pnpm exec wrangler types --config wrangler.hands.jsonc`
- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-worker build:shim`
- `pnpm --filter @botiverse/hands-worker test` (201/201)
- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli build`
- `pnpm --filter @botiverse/hands-cli test` (24/24)
- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm --filter @botiverse/hands-admin test` (3/3)
- `pnpm --filter @botiverse/hands-admin build`
- recursive non-Worker workspace build, including Container and Electron
- `git diff --check`

The audience regression includes null, truly omitted, and future-unknown fixtures; each proves 409 with zero Apple requests, localization writes, group assignment, review submission, or notification. The missing fixture omits the optional property rather than assigning explicit `undefined`, so the Worker business build also passes with `exactOptionalPropertyTypes` enabled.

`pnpm --filter @botiverse/hands-worker lint` cannot enter rule execution because the repository uses ESLint 9 without an `eslint.config.*`; this is the existing repository-wide lint configuration gap.

## Related

- upload/status prerequisite: #323, deployed and validated against the existing `1.0.0 (1000005)` Hands build through terminal ASC upload `COMPLETE`
- exact device-group baseline and production migration fixes: #324, #327, #328
- Raft task: `#proj-hands` task #170
