### PR TITLE
fix(db): make device-group triggers remote-D1 compatible

### DIFF
--- a/migrations/sql/0049_device_groups.sql
+++ b/migrations/sql/0049_device_groups.sql
@@ -24,41 +24,11 @@ CREATE INDEX IF NOT EXISTS idx_device_group_members_device
 -- release_scopes cannot use a normal foreign key because scope_value is
 -- polymorphic. Enforce the device-group branch in the database so concurrent
 -- create/update/delete requests cannot leave a dangling or cross-app scope.
-CREATE TRIGGER IF NOT EXISTS trg_release_scopes_device_group_insert
-BEFORE INSERT ON release_scopes
-WHEN NEW.scope_type = 'device_group'
-BEGIN
-  SELECT CASE WHEN NOT EXISTS (
-    SELECT 1
-    FROM releases r
-    JOIN device_groups g ON g.id = NEW.scope_value
-    WHERE r.id = NEW.release_id AND r.app_id = g.app_id
-  ) THEN RAISE(ABORT, 'device_group scope must reference a group in the release app') END;
-END;
+-- Cloudflare's remote D1 migration parser currently requires trigger bodies
+-- on one physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact
+-- even though multiline triggers work in SQLite and local Miniflare.
+CREATE TRIGGER IF NOT EXISTS trg_release_scopes_device_group_insert BEFORE INSERT ON release_scopes WHEN NEW.scope_type = 'device_group' BEGIN SELECT CASE WHEN NOT EXISTS (SELECT 1 FROM releases r JOIN device_groups g ON g.id = NEW.scope_value WHERE r.id = NEW.release_id AND r.app_id = g.app_id) THEN RAISE(ABORT, 'device_group scope must reference a group in the release app') END; END;
 
-CREATE TRIGGER IF NOT EXISTS trg_release_scopes_device_group_update
-BEFORE UPDATE OF release_id, scope_type, scope_value ON release_scopes
-WHEN NEW.scope_type = 'device_group'
-BEGIN
-  SELECT CASE WHEN NOT EXISTS (
-    SELECT 1
-    FROM releases r
-    JOIN device_groups g ON g.id = NEW.scope_value
-    WHERE r.id = NEW.release_id AND r.app_id = g.app_id
-  ) THEN RAISE(ABORT, 'device_group scope must reference a group in the release app') END;
-END;
+CREATE TRIGGER IF NOT EXISTS trg_release_scopes_device_group_update BEFORE UPDATE OF release_id, scope_type, scope_value ON release_scopes WHEN NEW.scope_type = 'device_group' BEGIN SELECT CASE WHEN NOT EXISTS (SELECT 1 FROM releases r JOIN device_groups g ON g.id = NEW.scope_value WHERE r.id = NEW.release_id AND r.app_id = g.app_id) THEN RAISE(ABORT, 'device_group scope must reference a group in the release app') END; END;
 
-CREATE TRIGGER IF NOT EXISTS trg_device_groups_live_release_delete
-BEFORE DELETE ON device_groups
-WHEN EXISTS (SELECT 1 FROM apps WHERE id = OLD.app_id)
-  AND EXISTS (
-    SELECT 1
-    FROM release_scopes s
-    JOIN releases r ON r.id = s.release_id
-    WHERE s.scope_type = 'device_group'
-      AND s.scope_value = OLD.id
-      AND r.status IN ('draft', 'active')
-  )
-BEGIN
-  SELECT RAISE(ABORT, 'device group is used by a draft or active release');
-END;
+CREATE TRIGGER IF NOT EXISTS trg_device_groups_live_release_delete BEFORE DELETE ON device_groups WHEN EXISTS (SELECT 1 FROM apps WHERE id = OLD.app_id) AND EXISTS (SELECT 1 FROM release_scopes s JOIN releases r ON r.id = s.release_id WHERE s.scope_type = 'device_group' AND s.scope_value = OLD.id AND r.status IN ('draft', 'active')) BEGIN SELECT RAISE(ABORT, 'device group is used by a draft or active release'); END;

--- a/worker/test/device_groups_migration.test.ts
+++ b/worker/test/device_groups_migration.test.ts
@@ -8,6 +8,18 @@ const migrationPath = fileURLToPath(
 );
 
 describe("device-group migration invariants", () => {
+  it("keeps trigger definitions on one physical line for remote D1 migrations", () => {
+    const triggerLines = readFileSync(migrationPath, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("CREATE TRIGGER"));
+
+    expect(triggerLines).toHaveLength(3);
+    for (const line of triggerLines) {
+      expect(line).toContain(" BEGIN ");
+      expect(line).toMatch(/ END;$/);
+    }
+  });
+
   it("enforces same-app scopes and blocks deletion while a live release references the group", () => {
     const db = new Database(":memory:");
     db.pragma("foreign_keys = ON");


### PR DESCRIPTION
## Summary
- keep all three migration 0049 trigger definitions on one physical line
- preserve same-app scope and live-reference delete invariants byte-for-byte
- add a regression that prevents multiline trigger definitions from returning

## Why
Production deploy run 29841009856 passed all checks but Cloudflare remote D1 rejected the multiline trigger migration with `incomplete input` before Worker deploy. This is the known remote parser issue tracked in cloudflare/workers-sdk#4998 / CFSQL-1402; local SQLite/Miniflare accepts the multiline form, so the existing executable invariant tests did not expose it.

## Verification
- generated Hands Worker types
- Worker business build PASS
- Worker 188/188 PASS, including 3 device-group migration tests
- git diff --check PASS
- signed-off commit

No production Worker was deployed by the failed run; migration 0049 remains unapplied and will retry normally after this fix merges.