### PR TITLE
docs(tauri): add updater guide and improve landing navigation

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -86,6 +86,13 @@ const pages = [
     source: "electron-sdk.md",
   },
   {
+    slug: "tauri-updater",
+    title: "Tauri Updater",
+    category: "SDKs & API",
+    description: "Publish signed Tauri v2 updater bundles and serve channel-specific dynamic update endpoints.",
+    source: "tauri-updater.md",
+  },
+  {
     slug: "public-api-reference",
     title: "Public API Reference",
     category: "SDKs & API",

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -947,9 +947,9 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
               </p>
               <div className="mt-6 flex flex-wrap items-center gap-2">
                 <span className="text-xs font-medium text-slate-500">
-                  Client platforms:
+                  Client stacks:
                 </span>
-                {["Android", "iOS", "HarmonyOS", "Electron"].map((p) => (
+                {["Android", "iOS", "HarmonyOS", "Electron", "Tauri"].map((p) => (
                   <span
                     key={p}
                     className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-medium text-slate-600"
@@ -1006,53 +1006,42 @@ function PublicLanding({ account }: { account?: AuthAccount }) {
         </section>
 
         <section className="border-t border-slate-200 bg-white">
-          <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-8 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold">Integrate an SDK, build from CI.</h2>
-              <p className="mt-1 text-sm text-slate-600">
-                SDKs for Android, iOS, HarmonyOS, and Electron add feedback and
-                crash reporting (plus in-app update checks and staged rollouts
-                on Android); the public npm CLI publishes releases and share
-                links from CI or Raft agents.
+          <div className="mx-auto max-w-6xl px-4 py-10">
+            <div className="max-w-2xl">
+              <h2 className="text-xl font-semibold">Choose an integration path.</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Start with the stack you ship, then use the CLI and Console
+                guides to automate draft-first delivery and operate releases.
               </p>
             </div>
-            <div className="flex flex-none flex-col gap-2 sm:flex-row">
-              <a
-                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
-                href="/docs/android-sdk/"
-              >
-                Android SDK
-              </a>
-              <a
-                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
-                href="/docs/ios-sdk/"
-              >
-                iOS SDK
-              </a>
-              <a
-                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
-                href="/docs/ohos-sdk/"
-              >
-                HarmonyOS SDK
-              </a>
-              <a
-                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
-                href="/docs/electron-sdk/"
-              >
-                Electron SDK
-              </a>
-              <a
-                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
-                href="/docs/cli-reference/"
-              >
-                CLI reference
-              </a>
-              <a
-                className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 hover:bg-slate-100"
-                href="/docs/admin-user-guide/"
-              >
-                Admin guide
-              </a>
+            <div className="mt-6 grid gap-4 md:grid-cols-3">
+              <LandingIntegrationCard
+                title="Native mobile SDKs"
+                body="Updates, feedback, crash capture, and device context inside mobile apps."
+                links={[
+                  { label: "Android", detail: "Updates, rollout, feedback, crashes", href: "/docs/android-sdk/" },
+                  { label: "iOS", detail: "Feedback and crash reporting", href: "/docs/ios-sdk/" },
+                  { label: "HarmonyOS", detail: "Feedback and crash reporting", href: "/docs/ohos-sdk/" },
+                ]}
+              />
+              <LandingIntegrationCard
+                title="Desktop integrations"
+                body="Host updater artifacts and add native desktop crash capture."
+                links={[
+                  { label: "Electron SDK", detail: "Crashpad crash reporting", href: "/docs/electron-sdk/" },
+                  { label: "Electron Updater", detail: "Generic-provider release files", href: "/docs/cli-reference/#publish-electron-generic-provider" },
+                  { label: "Tauri Updater", detail: "Signed Tauri v2 updater bundles", href: "/docs/tauri-updater/" },
+                ]}
+              />
+              <LandingIntegrationCard
+                title="Publishing & operations"
+                body="Build release automation and inspect every public contract."
+                links={[
+                  { label: "CLI Reference", detail: "Publish from CI or Raft agents", href: "/docs/cli-reference/" },
+                  { label: "Admin Guide", detail: "Operate apps and releases", href: "/docs/admin-user-guide/" },
+                  { label: "API Explorer", detail: "Try the HTTP API", href: "/api-docs" },
+                ]}
+              />
             </div>
           </div>
         </section>
@@ -1198,6 +1187,47 @@ function LandingFeature({ title, body }: { title: string; body: string }) {
     <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-xs">
       <h2 className="text-sm font-semibold">{title}</h2>
       <p className="mt-2 text-sm leading-6 text-slate-600">{body}</p>
+    </div>
+  );
+}
+
+function LandingIntegrationCard({
+  title,
+  body,
+  links,
+}: {
+  title: string;
+  body: string;
+  links: Array<{ label: string; detail: string; href: string }>;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-5">
+      <h3 className="text-sm font-semibold text-slate-950">{title}</h3>
+      <p className="mt-2 min-h-12 text-sm leading-6 text-slate-600">{body}</p>
+      <div className="mt-4 divide-y divide-slate-200 border-y border-slate-200">
+        {links.map((link) => (
+          <a
+            key={link.href}
+            className="group flex items-center justify-between gap-3 py-3 text-sm hover:text-sky-700"
+            href={link.href}
+          >
+            <span className="min-w-0">
+              <span className="block font-medium text-slate-900 group-hover:text-sky-700">
+                {link.label}
+              </span>
+              <span className="mt-0.5 block text-xs leading-5 text-slate-500">
+                {link.detail}
+              </span>
+            </span>
+            <span
+              aria-hidden="true"
+              className="flex-none text-base text-slate-400 transition-transform group-hover:translate-x-0.5 group-hover:text-sky-600"
+            >
+              →
+            </span>
+          </a>
+        ))}
+      </div>
     </div>
   );
 }

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -338,7 +338,9 @@ files but does not sign Electron applications.
 
 ## Publish Tauri updater artifacts
 
-Tauri v2 applications can use a Hands channel as a dynamic updater endpoint:
+For a complete setup, target matrix, release behavior, and signing boundary,
+start with the [Tauri Updater guide](tauri-updater.md). Tauri v2 applications
+can use a Hands channel as a dynamic updater endpoint:
 
 ```json
 {

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -379,10 +379,11 @@ CI; Hands stores only the signed bundle and the detached signature required by
 the updater response. Use separate `main`, `preview`, and `nightly` endpoints
 when applications follow different release channels.
 
-The Tauri lane currently serves full-channel releases only. Percentage rollout
-and scoped cohort releases require a stable client identifier that Tauri does
-not send by default, so non-full releases return no update instead of being
-expanded to every client.
+The Tauri lane currently serves full-scope releases only. Non-full scopes are
+ignored because Tauri does not send a stable client identifier for device-group
+or cohort resolution. Percentage rollout is not evaluated by the Tauri
+endpoint: keep it at 100% (or unset), and use separate channels such as
+`preview` and `main` for staged desktop delivery.
 
 ## Review and Publish (draft flow)
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -216,12 +216,14 @@ target and architecture, so an activation change cannot switch the bytes after
 an update check. Signature verification is performed by Tauri using the public key
 embedded in the application; Hands never receives the signing private key.
 
-Only full-scope active releases are eligible. Scoped or percentage rollout is
-not applied to Tauri requests because the default updater request has no stable
-installation identifier. Once an active release is superseded, its release-ID
-artifact URL remains downloadable so clients that already received the update
-response can finish. This immutable-cache contract assumes published build
-assets are never overwritten; publish a new build/release for changed bytes.
+Only full-scope active releases are eligible. Non-full scopes are ignored
+because the default updater request has no stable installation identifier.
+Percentage rollout is not evaluated for Tauri requests, so publishers must keep
+it at 100% (or unset) and use separate channels for staged delivery. Once an
+active release is superseded, its release-ID artifact URL remains downloadable
+so clients that already received the update response can finish. This
+immutable-cache contract assumes published build assets are never overwritten;
+publish a new build/release for changed bytes.
 
 macOS updates still require signed app artifacts. Hands only hosts the
 already-built and signed files; it does not sign Electron applications.

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -199,7 +199,9 @@ Example asset conventions:
 
 ### Tauri updater
 
-Tauri v2 applications can configure this dynamic updater endpoint:
+See the [Tauri Updater guide](tauri-updater.md) for application configuration,
+CLI publishing examples, supported bundles, and the signing boundary. Tauri v2
+applications can configure this dynamic updater endpoint:
 
 ```text
 GET /tauri/:appSlug/:channel/:target/:arch/:currentVersion

--- a/docs/public/tauri-updater.md
+++ b/docs/public/tauri-updater.md
@@ -1,0 +1,130 @@
+# Tauri Updater
+
+Hands can publish and serve signed updater bundles for Tauri v2 applications.
+The application checks a channel-specific dynamic endpoint; Hands returns the
+official Tauri updater JSON when a newer compatible release is active, or
+`204 No Content` when there is no update.
+
+Hands does not build or sign the desktop application. Keep the Tauri updater
+private key in CI. Upload only the generated bundle and its detached `.sig`
+file.
+
+## What is supported
+
+- Tauri v2 dynamic updater endpoints.
+- Separate Hands channels such as `main`, `preview`, and `nightly`.
+- One draft containing multiple operating-system and architecture targets.
+- Signed macOS, Linux, and Windows updater bundles.
+- Immutable release-specific download URLs, so an update response cannot
+  silently switch to different bytes later.
+- Draft-first publishing: CI uploads a draft; a human or authorized agent
+  reviews it before activation.
+
+## Configure the application
+
+Generate updater artifacts and configure the Hands endpoint in
+`tauri.conf.json`:
+
+```json
+{
+  "bundle": {
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "CONTENT FROM PUBLICKEY.PEM",
+      "endpoints": [
+        "https://hands.build/tauri/my-app/main/{{target}}/{{arch}}/{{current_version}}"
+      ]
+    }
+  }
+}
+```
+
+Replace `my-app` with the Hands app slug. Use a different channel segment for
+preview or nightly builds.
+
+The application calls:
+
+```http
+GET /tauri/:appSlug/:channel/:target/:arch/:currentVersion
+```
+
+Hands returns `204 No Content` when the active release is not newer or no
+matching signed target exists. A successful response contains `version`,
+`url`, `signature`, and optional `notes` and `pub_date` fields.
+
+## Publish a draft from CI
+
+Install and authenticate the Hands CLI, then upload each updater bundle with
+its matching signature and target:
+
+```bash
+hands builds publish-tauri my-app \
+  --version-name 1.2.3 \
+  --channel main \
+  --bundle target/release/bundle/macos/MyApp.app.tar.gz \
+  --signature target/release/bundle/macos/MyApp.app.tar.gz.sig \
+  --target darwin-aarch64
+```
+
+The command creates a draft by default. Repeat `--bundle`, `--signature`, and
+`--target` in the same order to aggregate multiple targets into one release:
+
+```bash
+hands builds publish-tauri my-app \
+  --version-name 1.2.3 \
+  --channel main \
+  --bundle dist/MyApp.app.tar.gz \
+  --signature dist/MyApp.app.tar.gz.sig \
+  --target darwin-aarch64 \
+  --bundle dist/MyApp_1.2.3_amd64.AppImage \
+  --signature dist/MyApp_1.2.3_amd64.AppImage.sig \
+  --target linux-x86_64 \
+  --bundle dist/MyApp_1.2.3_x64-setup.exe \
+  --signature dist/MyApp_1.2.3_x64-setup.exe.sig \
+  --target windows-x86_64
+```
+
+Use `--changelog` or `--changelog-file` for localized release notes. Use
+`--publish` only in an automation lane that already has explicit activation
+authorization.
+
+## Target and bundle formats
+
+| Target family | Architectures | Updater bundles |
+|---|---|---|
+| `darwin` | `aarch64`, `x86_64` | `.app.tar.gz` |
+| `linux` | `aarch64`, `x86_64`, `i686`, `armv7` | `.AppImage`, compatibility `.tar.gz` |
+| `windows` | `aarch64`, `x86_64`, `i686`, `armv7` | `.exe`, `.msi`, compatibility `.nsis.zip`, `.msi.zip` |
+
+Targets use Tauri names such as `darwin-aarch64`, `linux-x86_64`, and
+`windows-x86_64`. A `.dmg` is not a Tauri updater bundle and is not accepted by
+`publish-tauri`.
+
+## Release and download behavior
+
+- Only an active, full-scope `tauri-updater` release is offered.
+- Draft and cancelled releases are never returned by the update endpoint.
+- Scoped and percentage rollouts fail closed. Tauri's default updater request
+  has no stable installation identifier, so Hands does not expand a targeted
+  release to every desktop client.
+- The update response is revalidated quickly; a no-update response uses
+  `no-store`.
+- The artifact URL contains the concrete release ID, target, architecture, and
+  filename. A superseded release remains downloadable so a client that already
+  received the response can finish updating.
+- Cancelling the release acts as a kill switch: its update response disappears
+  and its artifact URL returns `404`.
+- Published build assets are immutable. Publish a new build and release when
+  bytes change instead of overwriting an active artifact.
+
+## Security boundary
+
+Tauri verifies the detached signature with the public key embedded in the
+application. Hands stores the bundle and signature, but never needs the updater
+private key. Keep private signing material in the CI secret store and do not
+put it in Hands metadata, changelogs, logs, or chat.
+
+See the [CLI Reference](cli-reference.md) for every command option and the
+[Public API Reference](public-api-reference.md) for the endpoint contract.

--- a/docs/public/tauri-updater.md
+++ b/docs/public/tauri-updater.md
@@ -106,9 +106,14 @@ Targets use Tauri names such as `darwin-aarch64`, `linux-x86_64`, and
 
 - Only an active, full-scope `tauri-updater` release is offered.
 - Draft and cancelled releases are never returned by the update endpoint.
-- Scoped and percentage rollouts fail closed. Tauri's default updater request
-  has no stable installation identifier, so Hands does not expand a targeted
-  release to every desktop client.
+- Non-full release scopes are ignored. Tauri's default updater request has no
+  stable installation identifier, so Hands cannot resolve device groups or
+  cohorts for this endpoint.
+- Percentage rollout is not evaluated for Tauri requests. Keep a Tauri release
+  at 100% (or leave percentage rollout unset); a lower percentage does not
+  create a safe staged rollout and may still offer the update to every matching
+  updater request. Use separate channels such as `preview` and `main` when you
+  need staged desktop delivery.
 - The update response is revalidated quickly; a no-update response uses
   `no-store`.
 - The artifact URL contains the concrete release ID, target, architecture, and


### PR DESCRIPTION
## Summary

- add a dedicated Tauri v2 updater guide with setup, target matrix, draft-first publishing, immutable downloads, and signing boundaries
- register the guide in the generated docs index/sidebar and cross-link it from CLI/API references
- replace the landing page's flat integration-button pile with grouped mobile, desktop, and operations paths, including Tauri discovery
- list Tauri among supported client stacks

## Validation

- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm --filter @botiverse/hands-admin test` (5/5)
- `pnpm --filter @botiverse/hands-admin build`
- generated `/docs/tauri-updater/`, `/docs/tauri-updater.md`, index card, and sidebar entry verified
- `git diff --check`

Raft: task #175
