### PR TITLE
fix(docs): derive public routes from generated pages

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -14,6 +14,7 @@ import { Container, getRandom } from "@cloudflare/containers";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { cors } from "hono/cors";
+import { publicDocAssetPaths } from "./lib/public_docs";
 
 import { authMiddleware, currentActor } from "./middleware/auth";
 import {
@@ -473,21 +474,6 @@ app.get("/api-docs", (c) => c.html(`<!doctype html>
     </script>
   </body>
 </html>`));
-const publicDocs = new Set([
-  "/docs/",
-  "/docs/getting-started/",
-  "/docs/agent-guide/",
-  "/docs/admin-user-guide/",
-  "/docs/android-sdk/",
-  "/docs/ios-sdk/",
-  "/docs/ohos-sdk/",
-  "/docs/electron-sdk/",
-  "/docs/cli-reference/",
-  "/docs/agent-cli-feedback/",
-  "/docs/ios-testflight/",
-  "/docs/public-api-reference/",
-]);
-
 async function handlePublicDocs(c: Context<{ Bindings: Env }>) {
   const path = new URL(c.req.url).pathname;
   // Raw-markdown twins: /docs.md (machine index) and /docs/<slug>.md. The build
@@ -507,11 +493,23 @@ async function handlePublicDocs(c: Context<{ Bindings: Env }>) {
     headers.set("content-type", "text/markdown; charset=utf-8");
     return new Response(asset.body, { status: asset.status, headers });
   }
-  const normalizedPath = path.endsWith("/") ? path : `${path}/`;
-  if (!publicDocs.has(normalizedPath)) {
-    return c.text("Not found", 404);
+  const assetPaths = publicDocAssetPaths(path);
+  if (!assetPaths) return c.text("Not found", 404);
+
+  // Cloudflare Assets uses SPA fallback for the admin app, so an unknown docs
+  // URL would otherwise return the root index.html with status 200. Generated
+  // articles always have a Markdown twin; use that file as the automatic docs
+  // manifest before serving the article HTML.
+  if (assetPaths.markdownTwinPath) {
+    const twin = await c.env.ASSETS.fetch(
+      new Request(new URL(assetPaths.markdownTwinPath, c.req.url), c.req.raw),
+    );
+    const twinType = twin.headers.get("content-type") ?? "";
+    if (twin.status === 404 || twinType.includes("text/html")) {
+      return c.text("Not found", 404);
+    }
   }
-  return c.env.ASSETS.fetch(new Request(new URL(normalizedPath, c.req.url), c.req.raw));
+  return c.env.ASSETS.fetch(new Request(new URL(assetPaths.htmlPath, c.req.url), c.req.raw));
 }
 
 app.get("/docs", handlePublicDocs);

--- a/worker/src/lib/public_docs.ts
+++ b/worker/src/lib/public_docs.ts
@@ -1,0 +1,26 @@
+export type PublicDocAssetPaths = {
+  htmlPath: string;
+  markdownTwinPath: string | null;
+};
+
+/**
+ * Resolve public docs from the generated docs directory instead of a second
+ * hand-maintained slug allowlist. Every generated article has a Markdown twin;
+ * the docs index is the only HTML page without one.
+ */
+export function publicDocAssetPaths(pathname: string): PublicDocAssetPaths | null {
+  if (pathname === "/docs" || pathname === "/docs/") {
+    return { htmlPath: "/docs/", markdownTwinPath: null };
+  }
+  if (!pathname.startsWith("/docs/") || pathname.endsWith(".md")) return null;
+
+  const htmlPath = pathname.endsWith("/") ? pathname : `${pathname}/`;
+  const relativePath = htmlPath.slice("/docs/".length, -1);
+  if (!relativePath || relativePath.split("/").some((segment) => !segment || segment === "." || segment === "..")) {
+    return null;
+  }
+  return {
+    htmlPath,
+    markdownTwinPath: `/docs/${relativePath}.md`,
+  };
+}

--- a/worker/test/public_docs.test.ts
+++ b/worker/test/public_docs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { publicDocAssetPaths } from "../src/lib/public_docs";
+
+describe("public docs asset routing", () => {
+  it("serves the generated docs index without a Markdown twin", () => {
+    expect(publicDocAssetPaths("/docs")).toEqual({
+      htmlPath: "/docs/",
+      markdownTwinPath: null,
+    });
+  });
+
+  it("derives article HTML and Markdown twin paths from any generated slug", () => {
+    expect(publicDocAssetPaths("/docs/tauri-updater")).toEqual({
+      htmlPath: "/docs/tauri-updater/",
+      markdownTwinPath: "/docs/tauri-updater.md",
+    });
+    expect(publicDocAssetPaths("/docs/future-guide/")).toEqual({
+      htmlPath: "/docs/future-guide/",
+      markdownTwinPath: "/docs/future-guide.md",
+    });
+  });
+
+  it("rejects paths that are not generated article routes", () => {
+    expect(publicDocAssetPaths("/docs/tauri-updater.md")).toBeNull();
+    expect(publicDocAssetPaths("/docs//nested")).toBeNull();
+    expect(publicDocAssetPaths("/api/docs")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- remove the Worker's hand-maintained public docs slug allowlist
- derive every article route from its generated Markdown twin, which acts as the automatic docs manifest
- preserve real 404s even though Cloudflare Assets uses SPA fallback
- add routing tests for the docs index, current/future generated slugs, and invalid paths

## Production evidence

- deploy run `29865232732` uploaded `/docs/tauri-updater/index.html`
- `/docs/tauri-updater.md` returns 200
- `/docs/tauri-updater/` returns 404 because the old hardcoded `publicDocs` set omitted the new slug

## Validation

- Wrangler types
- Worker tests 208/208, including 3 public-doc routing tests
- Worker build + shim
- Admin production build (13 docs pages + 12 Markdown twins)
- `git diff --check`

Raft: task #178