### PR TITLE
feat(agent): expose app provisioning actions

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -72,10 +72,27 @@ Show the installed version:
 hands version
 ```
 
+Create an app in the current Hands organization (requires org member or higher):
+
+```bash
+hands apps create \
+  --slug raft-web \
+  --name "Raft Web" \
+  --platform web \
+  --description "Raft browser feedback proxy"
+```
+
 List apps visible to the current token:
 
 ```bash
 hands apps list
+```
+
+Read the app's public SDK client key explicitly (requires app admin; this does
+not rotate the key or return any deploy token):
+
+```bash
+hands apps client-key raft-web
 ```
 
 List builds for an app:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,7 @@
 Hands CLI — manage apps, builds, releases from the terminal.
 
 Status: **alpha**. The npm package is public as `@botiverse/hands-cli`; v1 ships
-`login`, `logout`, `whoami`, `apps list/get`, `builds list/get`, and
+`login`, `logout`, `whoami`, `apps create/list/get/client-key`, `builds list/get`, and
 `builds publish-version`, `builds publish-android`, `builds publish-ios`,
 `builds testflight-groups`, `builds testflight-publish`,
 `builds testflight-status`, `builds publish-ohos`, `builds publish-electron`,
@@ -33,8 +33,12 @@ hands login
 # 2. Verify who you are.
 hands whoami
 
-# 3. List your apps.
+# 3. Create or list apps in your current Hands organization.
+hands apps create --slug myapp-web --name "My Web App" --platform web
 hands apps list
+
+# Read the public SDK client key explicitly (app admin only).
+hands apps client-key myapp-web
 
 # 4. List builds for an app (by slug or id).
 hands builds list myapp-android

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -7,7 +7,7 @@
  * + apiRequest routing (against a tiny local http.createServer stub).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -122,6 +122,110 @@ describe("apiRequest", () => {
     const { apiRequest, QuiverApiError } = await import("../src/lib/api.js");
     await expect(apiRequest("/api/missing")).rejects.toBeInstanceOf(QuiverApiError);
     delete process.env.QUIVER_API;
+  });
+});
+
+describe("app provisioning commands", () => {
+  it("creates a web app and explicitly reads its client key without verbose-log leakage", async () => {
+    const requests: Array<{ method: string; url: string; body?: unknown }> = [];
+    const clientKey = "qk_test_client_key_value";
+    const server = createServer(async (req, res) => {
+      let body: unknown;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps" && req.method === "POST") {
+        res.statusCode = 201;
+        return res.end(JSON.stringify({
+          id: "11111111-1111-4111-8111-111111111111",
+          org_id: "raft_target",
+          slug: "raft-web",
+          name: "Raft Web",
+          platform: "web",
+        }));
+      }
+      if (req.url === "/api/apps" && req.method === "GET") {
+        return res.end(JSON.stringify({
+          apps: [{
+            id: "11111111-1111-4111-8111-111111111111",
+            slug: "raft-web",
+            name: "Raft Web",
+            platform: "web",
+            archived: 0,
+            default_channel_slug: "main",
+            created_at: 1,
+          }],
+        }));
+      }
+      if (req.url === "/api/apps/11111111-1111-4111-8111-111111111111/client-key") {
+        return res.end(JSON.stringify({
+          app_id: "11111111-1111-4111-8111-111111111111",
+          client_key: clientKey,
+        }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    const originalVerbose = process.env.HANDS_VERBOSE;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+    process.env.HANDS_VERBOSE = "1";
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      const { registerAppCommands } = await import("../src/commands/apps.js");
+      const createProgram = new Command();
+      registerAppCommands(createProgram);
+      await createProgram.parseAsync([
+        "node", "hands", "apps", "create",
+        "--slug", "raft-web",
+        "--name", "Raft Web",
+        "--platform", "web",
+        "--description", "Raft browser feedback proxy",
+      ]);
+
+      const keyProgram = new Command();
+      registerAppCommands(keyProgram);
+      await keyProgram.parseAsync([
+        "node", "hands", "apps", "client-key", "raft-web",
+      ]);
+
+      expect(requests.find((request) => request.method === "POST")).toMatchObject({
+        url: "/api/apps",
+        body: {
+          slug: "raft-web",
+          name: "Raft Web",
+          platform: "web",
+          description: "Raft browser feedback proxy",
+        },
+      });
+      expect(requests.map((request) => request.url)).toContain(
+        "/api/apps/11111111-1111-4111-8111-111111111111/client-key",
+      );
+      expect(log.mock.calls.flat().join("\n")).toContain(clientKey);
+      expect(error.mock.calls.flat().join("\n")).not.toContain(clientKey);
+    } finally {
+      log.mockRestore();
+      error.mockRestore();
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      if (originalVerbose === undefined) delete process.env.HANDS_VERBOSE;
+      else process.env.HANDS_VERBOSE = originalVerbose;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -1,7 +1,8 @@
 /**
- * `quiver apps` — list / inspect apps in the caller's org.
+ * `hands apps` — create / list / inspect apps in the caller's org.
  *
- * Wires GET /api/apps + GET /api/apps/:appId.
+ * Wires POST/GET /api/apps, GET /api/apps/:appId, and the explicit
+ * app-admin-only client-key read endpoint.
  */
 
 import type { Command } from "commander";
@@ -17,8 +18,59 @@ interface AppRow {
   created_at: number;
 }
 
+interface CreatedApp {
+  id: string;
+  org_id: string;
+  slug: string;
+  name: string;
+  platform: string;
+}
+
+interface ClientKeyResponse {
+  app_id: string;
+  client_key: string | null;
+}
+
 export function registerAppCommands(program: Command): void {
   const apps = program.command("apps").description("Manage apps in your org.");
+
+  apps
+    .command("create")
+    .description("Create an app in the current Hands organization.")
+    .requiredOption("--slug <slug>", "Stable app slug.")
+    .requiredOption("--name <name>", "Display name.")
+    .requiredOption(
+      "--platform <platform>",
+      "App platform, for example web, android, ios, ohos, node, or electron.",
+    )
+    .option("--description <text>", "Optional app description.")
+    .option("--json", "Output JSON.", false)
+    .action(async (opts: {
+      slug: string;
+      name: string;
+      platform: string;
+      description?: string;
+      json?: boolean;
+    }) => {
+      const app = await apiRequest<CreatedApp>("/api/apps", {
+        method: "POST",
+        body: {
+          slug: opts.slug,
+          name: opts.name,
+          platform: opts.platform,
+          ...(opts.description !== undefined
+            ? { description: opts.description }
+            : {}),
+        },
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(app, null, 2));
+        return;
+      }
+      console.log(`Created app ${app.slug} (${app.platform}).`);
+      console.log(`  id: ${app.id}`);
+      console.log(`  org: ${app.org_id}`);
+    });
 
   apps
     .command("list")
@@ -35,7 +87,9 @@ export function registerAppCommands(program: Command): void {
         return;
       }
       if (res.apps.length === 0) {
-        console.log("No apps. Create one in the admin UI first.");
+        console.log(
+          "No apps. Create one with `hands apps create --slug <slug> --name <name> --platform <platform>`.",
+        );
         return;
       }
       console.log(
@@ -59,20 +113,7 @@ export function registerAppCommands(program: Command): void {
     .description("Show details for a single app.")
     .option("--json", "Output JSON.", false)
     .action(async (appIdOrSlug: string, opts: { json?: boolean }) => {
-      // The Worker endpoint accepts UUID; for slug we list + filter.
-      // Cheap heuristic: 36-char with dashes = UUID.
-      const isUuid =
-        appIdOrSlug.length === 36 && appIdOrUuidDash(appIdOrSlug);
-      let id = appIdOrSlug;
-      if (!isUuid) {
-        const res = await apiRequest<{ apps: AppRow[] }>("/api/apps");
-        const match = res.apps.find((a) => a.slug === appIdOrSlug);
-        if (!match) {
-          console.error(`No app with slug '${appIdOrSlug}'.`);
-          process.exit(1);
-        }
-        id = match.id;
-      }
+      const id = await resolveAppId(appIdOrSlug);
       const app = await apiRequest<AppRow>(`/api/apps/${id}`);
       if (opts.json) {
         console.log(JSON.stringify(app, null, 2));
@@ -86,6 +127,37 @@ export function registerAppCommands(program: Command): void {
         `  default_channel: ${app.default_channel_slug ?? "(none)"}`,
       );
     });
+
+  apps
+    .command("client-key <appIdOrSlug>")
+    .description("Read an app's public SDK client key. Requires app admin.")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<ClientKeyResponse>(
+        `/api/apps/${appId}/client-key`,
+      );
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      if (!result.client_key) {
+        console.log(`App ${appIdOrSlug} has no client key.`);
+        return;
+      }
+      // The key is intentionally printed only for this explicit read command.
+      // apiRequest's verbose diagnostics log only method/URL/status, never
+      // response bodies, so the value does not leak into debug logs.
+      console.log(result.client_key);
+    });
+}
+
+async function resolveAppId(input: string): Promise<string> {
+  if (input.length === 36 && appIdOrUuidDash(input)) return input;
+  const res = await apiRequest<{ apps: AppRow[] }>("/api/apps");
+  const match = res.apps.find((app) => app.slug === input);
+  if (!match) throw new Error(`No app with slug '${input}'.`);
+  return match.id;
 }
 
 function appIdOrUuidDash(s: string): boolean {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,7 +48,10 @@ program
     `
 Common recipes:
   hands whoami                                        Who am I / is my auth valid?
+  hands apps create --slug <s> --name <n> --platform web
+                                                       Create an app in my current org
   hands apps list                                     Apps I can access
+  hands apps client-key <app>                         Read public SDK client key (admin)
   hands feedback list <app> --kind crash              Newest crash tickets
   hands feedback show <app> <ticketId>                One ticket: device context + attachments
   hands feedback download-attachment <app> <t> <a>    Pull a crash log / screenshot

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -122,47 +122,98 @@ export async function handleCreateApp(c: AdminContext) {
   const id = crypto.randomUUID();
   const now = Date.now();
   const orgId = await currentOrgId(c);
+  const duplicate = await c.env.DB.prepare(
+    "SELECT id FROM apps WHERE slug = ?1 LIMIT 1",
+  )
+    .bind(body.slug)
+    .first<{ id: string }>();
+  if (duplicate) {
+    return c.json(
+      {
+        error: "app slug already exists",
+        code: "APP_SLUG_CONFLICT",
+        slug: body.slug,
+      },
+      409,
+    );
+  }
 
   // Seed default product_types and distribution channels for the new app.
   // (Phase 2.3 app-creation wizard path; small enough to inline here.)
-  await c.env.DB.batch([
-    c.env.DB.prepare(
-      "INSERT INTO apps (id, org_id, slug, name, platform, description, created_at, client_key) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-    ).bind(id, orgId, body.slug, body.name, body.platform, body.description ?? null, now, generateClientKey()),
-    // product_types
-    c.env.DB.prepare(
-      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'android-apk', 'Android APK', 'Android application package', '[]', '[{"platform":"android","filetype":"apk"}]', 'apk-aapt', '{"requires_native_codes":true}', ?, ?)`,
-    ).bind(crypto.randomUUID(), id, now, now),
-    c.env.DB.prepare(
-      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'electron-installer', 'Electron desktop app', 'Cross-platform desktop app', '["darwin-arm64","darwin-x64","linux-x64","linux-arm64","win32-x64","win32-arm64"]', '[{"platform":"darwin-arm64","filetype":"dmg"}]', 'electron-asar', '{}', ?, ?)`,
-    ).bind(crypto.randomUUID(), id, now, now),
-    c.env.DB.prepare(
-      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'rn-bundle', 'React Native OTA bundle', 'JS bundle hot-update', '[]', '[{"platform":"rn","filetype":"bundle"}]', 'rn-bundle', '{}', ?, ?)`,
-    ).bind(crypto.randomUUID(), id, now, now),
-    c.env.DB.prepare(
-      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'ios-ipa', 'iOS app', 'iOS IPA distributed through TestFlight, ad-hoc, or enterprise lanes', '["ios"]', '[{"platform":"ios","filetype":"ipa"},{"platform":"ios","filetype":"dsym.zip","artifact_kind":"dsym"}]', 'ipa-info', '{"distribution_profile_required":true}', ?, ?)`,
-    ).bind(crypto.randomUUID(), id, now, now),
-    c.env.DB.prepare(
-      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'ohos-app', 'OHOS app', 'Signed App Pack and HAP artifacts for AppGallery and sideloading', '["ohos"]', '[{"platform":"ohos","filetype":"app"},{"platform":"ohos","filetype":"hap"}]', 'ohos-package', '{}', ?, ?)`,
-    ).bind(crypto.randomUUID(), id, now, now),
-    c.env.DB.prepare(
-      `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'cli-binary', 'Node / CLI binary', 'Externally hosted Node SEA or CLI binaries', '["darwin-arm64","darwin-x64","linux-arm64","linux-x64","win32-arm64","win32-x64"]', '[]', 'external', '{"external_source":true}', ?, ?)`,
-    ).bind(crypto.randomUUID(), id, now, now),
-    // channels (with default bundle_id overrides for parallel install)
-    c.env.DB.prepare(
-      `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'main', 'Main', NULL, NULL, NULL, '["android-apk","electron-installer","rn-bundle","ios-ipa","ohos-app","cli-binary"]', '{}', ?)`,
-    ).bind(crypto.randomUUID(), id, now),
-    c.env.DB.prepare(
-      `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'preview', 'Preview', ?, NULL, NULL, '["android-apk","rn-bundle","ios-ipa"]', '{}', ?)`,
-    ).bind(crypto.randomUUID(), id, body.slug + '.preview', now),
-    c.env.DB.prepare(
-      `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'nightly', 'Nightly', ?, NULL, NULL, '["android-apk"]', '{}', ?)`,
-    ).bind(crypto.randomUUID(), id, body.slug + '.nightly', now),
-    // audit log
-    c.env.DB.prepare(
-      "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-    ).bind(crypto.randomUUID(), id, "app.create", currentActor(c), JSON.stringify(body), now),
-  ]);
+  try {
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        "INSERT INTO apps (id, org_id, slug, name, platform, description, created_at, client_key) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+      ).bind(
+        id,
+        orgId,
+        body.slug,
+        body.name,
+        body.platform,
+        body.description ?? null,
+        now,
+        generateClientKey(),
+      ),
+      // product_types
+      c.env.DB.prepare(
+        `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'android-apk', 'Android APK', 'Android application package', '[]', '[{"platform":"android","filetype":"apk"}]', 'apk-aapt', '{"requires_native_codes":true}', ?, ?)`,
+      ).bind(crypto.randomUUID(), id, now, now),
+      c.env.DB.prepare(
+        `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'electron-installer', 'Electron desktop app', 'Cross-platform desktop app', '["darwin-arm64","darwin-x64","linux-x64","linux-arm64","win32-x64","win32-arm64"]', '[{"platform":"darwin-arm64","filetype":"dmg"}]', 'electron-asar', '{}', ?, ?)`,
+      ).bind(crypto.randomUUID(), id, now, now),
+      c.env.DB.prepare(
+        `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'rn-bundle', 'React Native OTA bundle', 'JS bundle hot-update', '[]', '[{"platform":"rn","filetype":"bundle"}]', 'rn-bundle', '{}', ?, ?)`,
+      ).bind(crypto.randomUUID(), id, now, now),
+      c.env.DB.prepare(
+        `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'ios-ipa', 'iOS app', 'iOS IPA distributed through TestFlight, ad-hoc, or enterprise lanes', '["ios"]', '[{"platform":"ios","filetype":"ipa"},{"platform":"ios","filetype":"dsym.zip","artifact_kind":"dsym"}]', 'ipa-info', '{"distribution_profile_required":true}', ?, ?)`,
+      ).bind(crypto.randomUUID(), id, now, now),
+      c.env.DB.prepare(
+        `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'ohos-app', 'OHOS app', 'Signed App Pack and HAP artifacts for AppGallery and sideloading', '["ohos"]', '[{"platform":"ohos","filetype":"app"},{"platform":"ohos","filetype":"hap"}]', 'ohos-package', '{}', ?, ?)`,
+      ).bind(crypto.randomUUID(), id, now, now),
+      c.env.DB.prepare(
+        `INSERT INTO product_types (id, app_id, name, display_name, description, supported_platforms_json, default_assets_json, parser_kind, schema_json, created_at, updated_at) VALUES (?, ?, 'cli-binary', 'Node / CLI binary', 'Externally hosted Node SEA or CLI binaries', '["darwin-arm64","darwin-x64","linux-arm64","linux-x64","win32-arm64","win32-x64"]', '[]', 'external', '{"external_source":true}', ?, ?)`,
+      ).bind(crypto.randomUUID(), id, now, now),
+      // channels (with default bundle_id overrides for parallel install)
+      c.env.DB.prepare(
+        `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'main', 'Main', NULL, NULL, NULL, '["android-apk","electron-installer","rn-bundle","ios-ipa","ohos-app","cli-binary"]', '{}', ?)`,
+      ).bind(crypto.randomUUID(), id, now),
+      c.env.DB.prepare(
+        `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'preview', 'Preview', ?, NULL, NULL, '["android-apk","rn-bundle","ios-ipa"]', '{}', ?)`,
+      ).bind(crypto.randomUUID(), id, body.slug + ".preview", now),
+      c.env.DB.prepare(
+        `INSERT INTO channels (id, app_id, slug, name, bundle_id, password, git_url, enabled_product_types_json, metadata_json, created_at) VALUES (?, ?, 'nightly', 'Nightly', ?, NULL, NULL, '["android-apk"]', '{}', ?)`,
+      ).bind(crypto.randomUUID(), id, body.slug + ".nightly", now),
+      // audit log
+      c.env.DB.prepare(
+        "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+      ).bind(
+        crypto.randomUUID(),
+        id,
+        "app.create",
+        currentActor(c),
+        JSON.stringify(body),
+        now,
+      ),
+    ]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Preserve the documented 409 contract under a concurrent create race.
+    // Other batch failures still reach the global error handler unchanged.
+    if (
+      message.includes("apps.slug") &&
+      (message.includes("UNIQUE") || message.includes("SQLITE_CONSTRAINT"))
+    ) {
+      return c.json(
+        {
+          error: "app slug already exists",
+          code: "APP_SLUG_CONFLICT",
+          slug: body.slug,
+        },
+        409,
+      );
+    }
+    throw error;
+  }
 
   return c.json({ id, org_id: orgId, slug: body.slug, name: body.name, platform: body.platform }, 201);
 }

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -810,6 +810,53 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         endpoint: { method: "GET", path: "/api/apps" },
       },
       {
+        name: "create-app",
+        description:
+          "Create an app in the caller's current Hands organization. Requires org member or higher. This creates no release and activates nothing.",
+        endpoint: { method: "POST", path: "/api/apps" },
+        parameters: {
+          slug: {
+            type: "string",
+            in: "body",
+            required: true,
+            description: "Stable unique app slug.",
+          },
+          name: {
+            type: "string",
+            in: "body",
+            required: true,
+            description: "Display name.",
+          },
+          platform: {
+            type: "string",
+            in: "body",
+            required: true,
+            description:
+              "App platform, for example web, android, ios, ohos, node, or electron.",
+          },
+          description: {
+            type: "string",
+            in: "body",
+            required: false,
+            description: "Optional app description.",
+          },
+        },
+      },
+      {
+        name: "get-client-key",
+        description:
+          "Read an app's public SDK client key. Requires app admin. This never returns deploy tokens or other secrets and does not rotate the key.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/client-key" },
+        parameters: {
+          app_id: {
+            type: "string",
+            in: "path",
+            required: true,
+            description: "App UUID.",
+          },
+        },
+      },
+      {
         name: "list-channels",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/channels" },
         description: "List an app's release channels (id, slug, name). Requires app viewer.",

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -938,7 +938,7 @@ describe("quiver route handlers — SQL smoke", () => {
           authorization: `Bearer ${memberToken}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify({ slug: "member-app", name: "Member App", platform: "android" }),
+        body: JSON.stringify({ slug: "member-app", name: "Member App", platform: "web" }),
       },
       env as any,
     );
@@ -947,7 +947,26 @@ describe("quiver route handlers — SQL smoke", () => {
       org_id: "raft_create",
       slug: "member-app",
       name: "Member App",
-      platform: "android",
+      platform: "web",
+    });
+
+    const duplicateResponse = await testApp.request(
+      "https://quiver-worker.test/api/apps",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${memberToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "member-app", name: "Duplicate", platform: "web" }),
+      },
+      env as any,
+    );
+    expect(duplicateResponse.status).toBe(409);
+    await expect(duplicateResponse.json()).resolves.toMatchObject({
+      error: "app slug already exists",
+      code: "APP_SLUG_CONFLICT",
+      slug: "member-app",
     });
 
     const seededChannels = await env.DB
@@ -1486,7 +1505,7 @@ describe("quiver route handlers — SQL smoke", () => {
         body: JSON.stringify({
           slug: "secondary-created",
           name: "Secondary Created",
-          platform: "android",
+          platform: "web",
         }),
       },
       env as any,
@@ -1495,6 +1514,7 @@ describe("quiver route handlers — SQL smoke", () => {
     await expect(createResponse.json()).resolves.toMatchObject({
       org_id: "org-secondary",
       slug: "secondary-created",
+      platform: "web",
     });
 
     const invalidResponse = await requestApps("org-not-a-member");
@@ -7828,6 +7848,14 @@ describe("Hands iOS simulator QA artifacts", () => {
     const manifest = await response.json() as any;
     const actions = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action.endpoint]));
     expect(actions).toMatchObject({
+      "create-app": {
+        method: "POST",
+        path: "/api/apps",
+      },
+      "get-client-key": {
+        method: "GET",
+        path: "/api/apps/{app_id}/client-key",
+      },
       "list-device-groups": {
         method: "GET",
         path: "/api/apps/{app_id}/device-groups",
@@ -7894,6 +7922,17 @@ describe("Hands iOS simulator QA artifacts", () => {
       },
     });
     const byName = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action]));
+    expect(byName["create-app"].parameters).toMatchObject({
+      slug: { type: "string", in: "body", required: true },
+      name: { type: "string", in: "body", required: true },
+      platform: { type: "string", in: "body", required: true },
+      description: { type: "string", in: "body", required: false },
+    });
+    expect(byName["get-client-key"].parameters.app_id).toMatchObject({
+      type: "string",
+      in: "path",
+      required: true,
+    });
     expect(byName["create-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
     expect(byName["update-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
   });


### PR DESCRIPTION
## Summary
- add `hands apps create` and `hands apps client-key` CLI commands
- expose `create-app` and `get-client-key` through the Raft Agent Login manifest using the existing API/RBAC routes
- return the documented 409 conflict for duplicate app slugs, including the normal preflight path and concurrent unique-constraint race
- document the provisioning commands and keep client-key values out of verbose request logs

## Verification
- `pnpm -r test` (Worker 215/215, CLI 25/25, Node 13/13, Admin 5/5, Electron 3/3)
- `pnpm -r build`
- `pnpm --filter @botiverse/hands-worker build:shim`
- `node packages/cli/dist/index.js apps --help`
- `git diff --check`

## Notes
- no schema, migration, or new backend route
- app creation still requires org member+; client-key read still requires app admin
- creates no release and performs no production provisioning by itself
- repository-wide ESLint remains blocked by the existing ESLint 9 missing `eslint.config.*` configuration
