### PR TITLE
feat(android-sdk): capture QNC2 native crash context

### DIFF
--- a/clients/android/.gitignore
+++ b/clients/android/.gitignore
@@ -1,4 +1,5 @@
 .gradle/
+/.cxx/
 # Anchored so this only ignores the Gradle output dir, NOT the `build/hands`
 # Java package directory under src/main/kotlin.
 /build/
@@ -6,4 +7,5 @@
 # directory under src. Re-include it so the repo-root `build/` ignore rule
 # does not silently drop SDK source files (e.g. update/internal/*).
 !src/main/kotlin/build/
+!src/test/kotlin/build/
 local.properties

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -28,6 +28,16 @@ val packageReleaseNativeSymbols by tasks.registering(Exec::class) {
     )
 }
 
+val testNativeRecordIdentity by tasks.registering(Exec::class) {
+    inputs.files(
+        file("src/main/cpp/hands_record_file.c"),
+        file("src/main/cpp/hands_record_file.h"),
+        file("src/test/cpp/hands_record_file_test.c"),
+        file("src/test/scripts/test_qnc2_record_identity.sh"),
+    )
+    commandLine("bash", file("src/test/scripts/test_qnc2_record_identity.sh"))
+}
+
 android {
     namespace = "build.hands.update"
     compileSdk = 34
@@ -68,6 +78,11 @@ dependencies {
     // Delta (incremental) APK apply. Maintained fork of Google's Play-Store
     // file-by-file engine; the CLI/CI side generates patches with the SAME jar.
     implementation("com.eidu:archive-patcher:3.0.0")
+    testImplementation("junit:junit:4.13.2")
+}
+
+tasks.matching { it.name == "testReleaseUnitTest" }.configureEach {
+    dependsOn(testNativeRecordIdentity)
 }
 
 afterEvaluate {

--- a/clients/android/src/main/cpp/CMakeLists.txt
+++ b/clients/android/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(handscrash C)
 
-add_library(handscrash SHARED hands_native_crash.c)
+add_library(handscrash SHARED hands_native_crash.c hands_record_file.c)
 target_compile_options(handscrash PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
 # JNIEXPORT carries default visibility, so the entry point stays exported.

--- a/clients/android/src/main/cpp/hands_native_crash.c
+++ b/clients/android/src/main/cpp/hands_native_crash.c
@@ -1,53 +1,71 @@
 /*
- * Async-signal-safe native crash capture (symbolication matrix, task #80).
+ * Async-signal-safe native crash capture (QNC2, task #120).
  *
- * Discipline (same as the iOS handler): the signal handler uses ONLY
- * async-signal-safe calls — open/write/close, time(), and local char
- * formatting. No malloc, no JSON, no dladdr, no locks. The record is raw
- * frame PCs from _Unwind_Backtrace plus a copy of /proc/self/maps; the
- * Kotlin side turns PCs into (soname, offset, BuildId) on the NEXT launch,
- * where address-space math is done from the maps snapshot.
+ * QNC1 unwound from this signal handler and discarded ucontext, so the first
+ * frame described the recorder rather than the crashing thread. QNC2 treats
+ * the kernel-provided ucontext as the source of truth: it records the crash
+ * thread's registers, PC/LR/SP, pid/tid/name, siginfo, a precomputed loaded
+ * image BuildId snapshot, and /proc/self/maps. The Kotlin next-launch path
+ * joins context PCs to those images and the server refuses to symbolicate a
+ * frame unless its ELF BuildId exactly matches the uploaded symbols archive.
+ *
+ * The handler itself uses only bounded stack/static storage and
+ * async-signal-safe system calls. Loaded-image enumeration and ELF note
+ * parsing happen once during nativeInstall, before handlers are installed.
  */
+#include <elf.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <jni.h>
+#include <link.h>
 #include <signal.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
 #include <time.h>
+#include <ucontext.h>
 #include <unistd.h>
-#include <unwind.h>
 
-#define QUIVER_MAX_FRAMES 64
-#define QUIVER_DIR_MAX 512
+#include "hands_record_file.h"
 
-static char g_crash_dir[QUIVER_DIR_MAX];
+#define HANDS_DIR_MAX 512
+#define HANDS_MAX_MODULES 192
+#define HANDS_MODULE_PATH_MAX 384
+#define HANDS_BUILD_ID_MAX 32
+
+struct hands_module {
+  uintptr_t start;
+  uintptr_t end;
+  unsigned char build_id[HANDS_BUILD_ID_MAX];
+  size_t build_id_size;
+  char path[HANDS_MODULE_PATH_MAX];
+};
+
+static char g_crash_dir[HANDS_DIR_MAX];
 static volatile sig_atomic_t g_handling = 0;
 static int g_fatal_signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE, SIGTRAP};
 static struct sigaction g_previous[sizeof(g_fatal_signals) / sizeof(int)];
 static char g_altstack[SIGSTKSZ * 2];
+static struct hands_module g_modules[HANDS_MAX_MODULES];
+static size_t g_module_count = 0;
 
-struct quiver_unwind_state {
-  uintptr_t frames[QUIVER_MAX_FRAMES];
-  int count;
-};
-
-static _Unwind_Reason_Code quiver_unwind_cb(struct _Unwind_Context *ctx, void *arg) {
-  struct quiver_unwind_state *state = (struct quiver_unwind_state *)arg;
-  if (state->count >= QUIVER_MAX_FRAMES) return _URC_END_OF_STACK;
-  uintptr_t pc = _Unwind_GetIP(ctx);
-  if (pc != 0) state->frames[state->count++] = pc;
-  return _URC_NO_REASON;
+static size_t hands_strlen(const char *text) {
+  size_t n = 0;
+  if (text == NULL) return 0;
+  while (text[n] != '\0') n++;
+  return n;
 }
 
-static size_t quiver_append(char *buf, size_t cap, size_t off, const char *text) {
-  size_t n = strlen(text);
+static size_t hands_append(char *buf, size_t cap, size_t off, const char *text) {
+  size_t n = hands_strlen(text);
   if (off + n >= cap) return off;
-  memcpy(buf + off, text, n);
+  for (size_t i = 0; i < n; i++) buf[off + i] = text[i];
   buf[off + n] = '\0';
   return off + n;
 }
 
-static size_t quiver_append_hex(char *buf, size_t cap, size_t off, uint64_t value) {
+static size_t hands_append_hex(char *buf, size_t cap, size_t off, uint64_t value) {
   char tmp[19];
   int i = 18;
   tmp[i--] = '\0';
@@ -57,10 +75,10 @@ static size_t quiver_append_hex(char *buf, size_t cap, size_t off, uint64_t valu
     tmp[i--] = digits[value & 0xf];
     value >>= 4;
   }
-  return quiver_append(buf, cap, off, &tmp[i + 1]);
+  return hands_append(buf, cap, off, &tmp[i + 1]);
 }
 
-static size_t quiver_append_dec(char *buf, size_t cap, size_t off, uint64_t value) {
+static size_t hands_append_dec(char *buf, size_t cap, size_t off, uint64_t value) {
   char tmp[21];
   int i = 20;
   tmp[i--] = '\0';
@@ -69,30 +87,305 @@ static size_t quiver_append_dec(char *buf, size_t cap, size_t off, uint64_t valu
     tmp[i--] = (char)('0' + (value % 10));
     value /= 10;
   }
-  return quiver_append(buf, cap, off, &tmp[i + 1]);
+  return hands_append(buf, cap, off, &tmp[i + 1]);
 }
 
-static void quiver_copy_maps(int out_fd) {
+static size_t hands_append_signed_dec(char *buf, size_t cap, size_t off, int64_t value) {
+  if (value < 0) {
+    off = hands_append(buf, cap, off, "-");
+    /* Avoid signed overflow for INT64_MIN. */
+    return hands_append_dec(buf, cap, off, (uint64_t)(-(value + 1)) + 1U);
+  }
+  return hands_append_dec(buf, cap, off, (uint64_t)value);
+}
+
+static void hands_write_all(int fd, const void *data, size_t size) {
+  const char *bytes = (const char *)data;
+  size_t written = 0;
+  while (written < size) {
+    ssize_t n = write(fd, bytes + written, size - written);
+    if (n > 0) {
+      written += (size_t)n;
+    } else if (n < 0 && errno == EINTR) {
+      continue;
+    } else {
+      break;
+    }
+  }
+}
+
+static void hands_write_text(int fd, const char *text) {
+  hands_write_all(fd, text, hands_strlen(text));
+}
+
+static void hands_write_key_hex(int fd, const char *key, uint64_t value) {
+  char line[96];
+  size_t off = 0;
+  off = hands_append(line, sizeof(line), off, key);
+  off = hands_append(line, sizeof(line), off, " 0x");
+  off = hands_append_hex(line, sizeof(line), off, value);
+  off = hands_append(line, sizeof(line), off, "\n");
+  hands_write_all(fd, line, off);
+}
+
+static void hands_write_key_dec(int fd, const char *key, uint64_t value) {
+  char line[96];
+  size_t off = 0;
+  off = hands_append(line, sizeof(line), off, key);
+  off = hands_append(line, sizeof(line), off, " ");
+  off = hands_append_dec(line, sizeof(line), off, value);
+  off = hands_append(line, sizeof(line), off, "\n");
+  hands_write_all(fd, line, off);
+}
+
+static void hands_write_key_signed_dec(int fd, const char *key, int64_t value) {
+  char line[96];
+  size_t off = 0;
+  off = hands_append(line, sizeof(line), off, key);
+  off = hands_append(line, sizeof(line), off, " ");
+  off = hands_append_signed_dec(line, sizeof(line), off, value);
+  off = hands_append(line, sizeof(line), off, "\n");
+  hands_write_all(fd, line, off);
+}
+
+static uintptr_t hands_align4(uintptr_t value) {
+  return (value + 3U) & ~(uintptr_t)3U;
+}
+
+static void hands_copy_bounded(char *dst, size_t cap, const char *src) {
+  if (cap == 0) return;
+  size_t i = 0;
+  if (src != NULL) {
+    while (i + 1 < cap && src[i] != '\0') {
+      dst[i] = src[i];
+      i++;
+    }
+  }
+  dst[i] = '\0';
+}
+
+/* Called only at install time, never from a signal handler. */
+static int hands_collect_module(struct dl_phdr_info *info, size_t size, void *data) {
+  (void)size;
+  (void)data;
+  if (g_module_count >= HANDS_MAX_MODULES || info == NULL || info->dlpi_phdr == NULL) return 0;
+
+  uintptr_t start = UINTPTR_MAX;
+  uintptr_t end = 0;
+  const unsigned char *build_id = NULL;
+  size_t build_id_size = 0;
+
+  for (ElfW(Half) i = 0; i < info->dlpi_phnum; i++) {
+    const ElfW(Phdr) *phdr = &info->dlpi_phdr[i];
+    if (phdr->p_type == PT_LOAD && phdr->p_memsz > 0) {
+      uintptr_t segment_start = (uintptr_t)info->dlpi_addr + (uintptr_t)phdr->p_vaddr;
+      uintptr_t segment_end = segment_start + (uintptr_t)phdr->p_memsz;
+      if (segment_start < start) start = segment_start;
+      if (segment_end > end) end = segment_end;
+    }
+    if (phdr->p_type != PT_NOTE || phdr->p_memsz < sizeof(ElfW(Nhdr))) continue;
+
+    const unsigned char *cursor =
+        (const unsigned char *)((uintptr_t)info->dlpi_addr + (uintptr_t)phdr->p_vaddr);
+    const unsigned char *limit = cursor + (size_t)phdr->p_memsz;
+    while ((size_t)(limit - cursor) >= sizeof(ElfW(Nhdr))) {
+      const ElfW(Nhdr) *note = (const ElfW(Nhdr) *)cursor;
+      cursor += sizeof(ElfW(Nhdr));
+      uintptr_t name_size = hands_align4((uintptr_t)note->n_namesz);
+      uintptr_t desc_size = hands_align4((uintptr_t)note->n_descsz);
+      if (name_size > (uintptr_t)(limit - cursor)) break;
+      const unsigned char *name = cursor;
+      cursor += name_size;
+      if (desc_size > (uintptr_t)(limit - cursor)) break;
+      const unsigned char *desc = cursor;
+      cursor += desc_size;
+      if (note->n_type == NT_GNU_BUILD_ID && note->n_namesz >= 3 &&
+          name[0] == 'G' && name[1] == 'N' && name[2] == 'U' && note->n_descsz > 0) {
+        build_id = desc;
+        build_id_size = note->n_descsz;
+        break;
+      }
+    }
+  }
+
+  if (start == UINTPTR_MAX || end <= start) return 0;
+  struct hands_module *module = &g_modules[g_module_count++];
+  module->start = start;
+  module->end = end;
+  module->build_id_size = build_id_size > HANDS_BUILD_ID_MAX ? HANDS_BUILD_ID_MAX : build_id_size;
+  for (size_t i = 0; i < module->build_id_size; i++) module->build_id[i] = build_id[i];
+  hands_copy_bounded(module->path, sizeof(module->path),
+                     info->dlpi_name != NULL && info->dlpi_name[0] != '\0'
+                         ? info->dlpi_name
+                         : "/proc/self/exe");
+  return 0;
+}
+
+static void hands_refresh_modules(void) {
+  g_module_count = 0;
+  memset(g_modules, 0, sizeof(g_modules));
+  dl_iterate_phdr(hands_collect_module, NULL);
+}
+
+static void hands_write_thread_name(int fd, pid_t tid) {
+  char path[96];
+  size_t off = 0;
+  off = hands_append(path, sizeof(path), off, "/proc/self/task/");
+  off = hands_append_dec(path, sizeof(path), off, (uint64_t)tid);
+  off = hands_append(path, sizeof(path), off, "/comm");
+  int name_fd = open(path, O_RDONLY);
+  if (name_fd < 0) return;
+  unsigned char name[64];
+  ssize_t n = read(name_fd, name, sizeof(name));
+  close(name_fd);
+  if (n <= 0) return;
+  while (n > 0 && (name[n - 1] == '\n' || name[n - 1] == '\r' || name[n - 1] == '\0')) n--;
+
+  static const char digits[] = "0123456789abcdef";
+  char line[160];
+  off = 0;
+  off = hands_append(line, sizeof(line), off, "thread_name_hex ");
+  for (ssize_t i = 0; i < n && off + 2 < sizeof(line); i++) {
+    line[off++] = digits[(name[i] >> 4) & 0xf];
+    line[off++] = digits[name[i] & 0xf];
+  }
+  line[off++] = '\n';
+  hands_write_all(fd, line, off);
+}
+
+static void hands_write_frame(int fd, uintptr_t pc, const char *source) {
+  if (pc == 0) return;
+  char line[96];
+  size_t off = 0;
+  off = hands_append(line, sizeof(line), off, "0x");
+  off = hands_append_hex(line, sizeof(line), off, (uint64_t)pc);
+  off = hands_append(line, sizeof(line), off, " ");
+  off = hands_append(line, sizeof(line), off, source);
+  off = hands_append(line, sizeof(line), off, "\n");
+  hands_write_all(fd, line, off);
+}
+
+static void hands_write_context(int fd, void *ucontext) {
+  uintptr_t pc = 0;
+  uintptr_t lr = 0;
+  hands_write_text(fd, "registers\n");
+  if (ucontext == NULL) {
+    hands_write_text(fd, "frames\n");
+    return;
+  }
+  const ucontext_t *context = (const ucontext_t *)ucontext;
+  hands_write_key_hex(fd, "uc_flags", (uint64_t)context->uc_flags);
+
+#if defined(__aarch64__)
+  hands_write_text(fd, "arch arm64-v8a\n");
+  for (int i = 0; i < 31; i++) {
+    char name[8];
+    size_t off = 0;
+    off = hands_append(name, sizeof(name), off, "x");
+    off = hands_append_dec(name, sizeof(name), off, (uint64_t)i);
+    name[off] = '\0';
+    hands_write_key_hex(fd, name, (uint64_t)context->uc_mcontext.regs[i]);
+  }
+  hands_write_key_hex(fd, "sp", (uint64_t)context->uc_mcontext.sp);
+  hands_write_key_hex(fd, "pc", (uint64_t)context->uc_mcontext.pc);
+  hands_write_key_hex(fd, "pstate", (uint64_t)context->uc_mcontext.pstate);
+  hands_write_key_hex(fd, "fault_address", (uint64_t)context->uc_mcontext.fault_address);
+  pc = (uintptr_t)context->uc_mcontext.pc;
+  lr = (uintptr_t)context->uc_mcontext.regs[30];
+#elif defined(__arm__)
+  hands_write_text(fd, "arch armeabi-v7a\n");
+  hands_write_key_hex(fd, "r0", (uint64_t)context->uc_mcontext.arm_r0);
+  hands_write_key_hex(fd, "r1", (uint64_t)context->uc_mcontext.arm_r1);
+  hands_write_key_hex(fd, "r2", (uint64_t)context->uc_mcontext.arm_r2);
+  hands_write_key_hex(fd, "r3", (uint64_t)context->uc_mcontext.arm_r3);
+  hands_write_key_hex(fd, "r4", (uint64_t)context->uc_mcontext.arm_r4);
+  hands_write_key_hex(fd, "r5", (uint64_t)context->uc_mcontext.arm_r5);
+  hands_write_key_hex(fd, "r6", (uint64_t)context->uc_mcontext.arm_r6);
+  hands_write_key_hex(fd, "r7", (uint64_t)context->uc_mcontext.arm_r7);
+  hands_write_key_hex(fd, "r8", (uint64_t)context->uc_mcontext.arm_r8);
+  hands_write_key_hex(fd, "r9", (uint64_t)context->uc_mcontext.arm_r9);
+  hands_write_key_hex(fd, "r10", (uint64_t)context->uc_mcontext.arm_r10);
+  hands_write_key_hex(fd, "fp", (uint64_t)context->uc_mcontext.arm_fp);
+  hands_write_key_hex(fd, "ip", (uint64_t)context->uc_mcontext.arm_ip);
+  hands_write_key_hex(fd, "sp", (uint64_t)context->uc_mcontext.arm_sp);
+  hands_write_key_hex(fd, "lr", (uint64_t)context->uc_mcontext.arm_lr);
+  hands_write_key_hex(fd, "pc", (uint64_t)context->uc_mcontext.arm_pc);
+  hands_write_key_hex(fd, "cpsr", (uint64_t)context->uc_mcontext.arm_cpsr);
+  hands_write_key_hex(fd, "fault_address", (uint64_t)context->uc_mcontext.fault_address);
+  pc = (uintptr_t)context->uc_mcontext.arm_pc & ~(uintptr_t)1U;
+  lr = (uintptr_t)context->uc_mcontext.arm_lr & ~(uintptr_t)1U;
+#elif defined(__x86_64__)
+  hands_write_text(fd, "arch x86_64\n");
+  hands_write_key_hex(fd, "r8", (uint64_t)context->uc_mcontext.gregs[REG_R8]);
+  hands_write_key_hex(fd, "r9", (uint64_t)context->uc_mcontext.gregs[REG_R9]);
+  hands_write_key_hex(fd, "r10", (uint64_t)context->uc_mcontext.gregs[REG_R10]);
+  hands_write_key_hex(fd, "r11", (uint64_t)context->uc_mcontext.gregs[REG_R11]);
+  hands_write_key_hex(fd, "r12", (uint64_t)context->uc_mcontext.gregs[REG_R12]);
+  hands_write_key_hex(fd, "r13", (uint64_t)context->uc_mcontext.gregs[REG_R13]);
+  hands_write_key_hex(fd, "r14", (uint64_t)context->uc_mcontext.gregs[REG_R14]);
+  hands_write_key_hex(fd, "r15", (uint64_t)context->uc_mcontext.gregs[REG_R15]);
+  hands_write_key_hex(fd, "rdi", (uint64_t)context->uc_mcontext.gregs[REG_RDI]);
+  hands_write_key_hex(fd, "rsi", (uint64_t)context->uc_mcontext.gregs[REG_RSI]);
+  hands_write_key_hex(fd, "rbp", (uint64_t)context->uc_mcontext.gregs[REG_RBP]);
+  hands_write_key_hex(fd, "rbx", (uint64_t)context->uc_mcontext.gregs[REG_RBX]);
+  hands_write_key_hex(fd, "rdx", (uint64_t)context->uc_mcontext.gregs[REG_RDX]);
+  hands_write_key_hex(fd, "rax", (uint64_t)context->uc_mcontext.gregs[REG_RAX]);
+  hands_write_key_hex(fd, "rcx", (uint64_t)context->uc_mcontext.gregs[REG_RCX]);
+  hands_write_key_hex(fd, "rsp", (uint64_t)context->uc_mcontext.gregs[REG_RSP]);
+  hands_write_key_hex(fd, "rip", (uint64_t)context->uc_mcontext.gregs[REG_RIP]);
+  hands_write_key_hex(fd, "eflags", (uint64_t)context->uc_mcontext.gregs[REG_EFL]);
+  hands_write_key_hex(fd, "trapno", (uint64_t)context->uc_mcontext.gregs[REG_TRAPNO]);
+  hands_write_key_hex(fd, "error", (uint64_t)context->uc_mcontext.gregs[REG_ERR]);
+  hands_write_key_hex(fd, "cr2", (uint64_t)context->uc_mcontext.gregs[REG_CR2]);
+  pc = (uintptr_t)context->uc_mcontext.gregs[REG_RIP];
+#else
+  hands_write_text(fd, "arch unknown\n");
+#endif
+
+  hands_write_text(fd, "frames\n");
+  hands_write_frame(fd, pc, "context_pc");
+  if (lr != 0 && lr != pc) hands_write_frame(fd, lr, "context_lr");
+}
+
+static void hands_write_modules(int fd) {
+  hands_write_text(fd, "modules\n");
+  static const char digits[] = "0123456789abcdef";
+  for (size_t i = 0; i < g_module_count; i++) {
+    const struct hands_module *module = &g_modules[i];
+    char line[HANDS_MODULE_PATH_MAX + 192];
+    size_t off = 0;
+    off = hands_append(line, sizeof(line), off, "0x");
+    off = hands_append_hex(line, sizeof(line), off, (uint64_t)module->start);
+    off = hands_append(line, sizeof(line), off, "-0x");
+    off = hands_append_hex(line, sizeof(line), off, (uint64_t)module->end);
+    off = hands_append(line, sizeof(line), off, " ");
+    if (module->build_id_size == 0) {
+      off = hands_append(line, sizeof(line), off, "-");
+    } else {
+      for (size_t j = 0; j < module->build_id_size && off + 2 < sizeof(line); j++) {
+        line[off++] = digits[(module->build_id[j] >> 4) & 0xf];
+        line[off++] = digits[module->build_id[j] & 0xf];
+      }
+    }
+    off = hands_append(line, sizeof(line), off, " ");
+    off = hands_append(line, sizeof(line), off, module->path);
+    off = hands_append(line, sizeof(line), off, "\n");
+    hands_write_all(fd, line, off);
+  }
+}
+
+static void hands_copy_maps(int out_fd) {
   int maps_fd = open("/proc/self/maps", O_RDONLY);
   if (maps_fd < 0) return;
   char chunk[4096];
   ssize_t n;
   while ((n = read(maps_fd, chunk, sizeof(chunk))) > 0) {
-    ssize_t written = 0;
-    while (written < n) {
-      ssize_t w = write(out_fd, chunk + written, (size_t)(n - written));
-      if (w <= 0) break;
-      written += w;
-    }
+    hands_write_all(out_fd, chunk, (size_t)n);
   }
   close(maps_fd);
 }
 
-static void quiver_signal_handler(int signo, siginfo_t *info, void *ucontext) {
-  (void)ucontext;
-  /* Re-entrancy guard (sentry-native inproc pattern): a crash inside the
-   * handler — e.g. unwinding a corrupted stack — must not recurse; fall
-   * straight through to the default disposition. */
+static void hands_signal_handler(int signo, siginfo_t *info, void *ucontext) {
   if (g_handling) {
     signal(signo, SIG_DFL);
     raise(signo);
@@ -100,48 +393,32 @@ static void quiver_signal_handler(int signo, siginfo_t *info, void *ucontext) {
   }
   g_handling = 1;
   if (g_crash_dir[0] != '\0') {
-    long long ts = (long long)time(NULL) * 1000LL;
+    struct timespec now;
+    uint64_t ts = clock_gettime(CLOCK_REALTIME, &now) == 0
+        ? (uint64_t)now.tv_sec * 1000U + (uint64_t)now.tv_nsec / 1000000U
+        : (uint64_t)time(NULL) * 1000U;
+    pid_t tid = (pid_t)syscall(__NR_gettid);
 
-    char path[QUIVER_DIR_MAX + 64];
-    size_t off = 0;
-    off = quiver_append(path, sizeof(path), off, g_crash_dir);
-    off = quiver_append(path, sizeof(path), off, "/native-");
-    off = quiver_append_dec(path, sizeof(path), off, (uint64_t)ts);
-    off = quiver_append(path, sizeof(path), off, ".qnc");
-
-    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    char path[HANDS_DIR_MAX + 64];
+    int fd = hands_open_crash_record(g_crash_dir, ts, getpid(), tid, path, sizeof(path));
     if (fd >= 0) {
-      char header[256];
-      off = 0;
-      off = quiver_append(header, sizeof(header), off, "QNC1\nsignal ");
-      off = quiver_append_dec(header, sizeof(header), off, (uint64_t)signo);
-      off = quiver_append(header, sizeof(header), off, "\nfault_addr 0x");
-      off = quiver_append_hex(header, sizeof(header), off,
-                              (uint64_t)(uintptr_t)(info != NULL ? info->si_addr : 0));
-      off = quiver_append(header, sizeof(header), off, "\ncrash_at ");
-      off = quiver_append_dec(header, sizeof(header), off, (uint64_t)ts);
-      off = quiver_append(header, sizeof(header), off, "\nframes\n");
-      write(fd, header, off);
-
-      struct quiver_unwind_state state;
-      state.count = 0;
-      _Unwind_Backtrace(quiver_unwind_cb, &state);
-      char line[32];
-      for (int i = 0; i < state.count; i++) {
-        off = 0;
-        off = quiver_append(line, sizeof(line), off, "0x");
-        off = quiver_append_hex(line, sizeof(line), off, (uint64_t)state.frames[i]);
-        off = quiver_append(line, sizeof(line), off, "\n");
-        write(fd, line, off);
-      }
-
-      write(fd, "maps\n", 5);
-      quiver_copy_maps(fd);
+      hands_write_text(fd, "QNC2\n");
+      hands_write_key_dec(fd, "signal", (uint64_t)signo);
+      hands_write_key_signed_dec(fd, "signal_code", info != NULL ? (int64_t)info->si_code : 0);
+      hands_write_key_hex(fd, "fault_addr", (uint64_t)(uintptr_t)(info != NULL ? info->si_addr : 0));
+      hands_write_key_dec(fd, "crash_at", ts);
+      hands_write_key_dec(fd, "pid", (uint64_t)getpid());
+      hands_write_key_dec(fd, "tid", (uint64_t)tid);
+      hands_write_thread_name(fd, tid);
+      hands_write_context(fd, ucontext);
+      hands_write_modules(fd);
+      hands_write_text(fd, "maps\n");
+      hands_copy_maps(fd);
       close(fd);
     }
   }
 
-  /* Restore and re-raise so the system (and any chained handler) proceeds. */
+  /* Restore and re-raise so debuggerd and any previously installed handler run. */
   for (size_t i = 0; i < sizeof(g_fatal_signals) / sizeof(int); i++) {
     if (g_fatal_signals[i] == signo) {
       sigaction(signo, &g_previous[i], NULL);
@@ -162,6 +439,8 @@ Java_build_hands_update_HandsNativeCrash_nativeInstall(JNIEnv *env, jclass clazz
   g_crash_dir[sizeof(g_crash_dir) - 1] = '\0';
   (*env)->ReleaseStringUTFChars(env, crash_dir, dir);
 
+  hands_refresh_modules();
+
   stack_t ss;
   ss.ss_sp = g_altstack;
   ss.ss_size = sizeof(g_altstack);
@@ -170,7 +449,7 @@ Java_build_hands_update_HandsNativeCrash_nativeInstall(JNIEnv *env, jclass clazz
 
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
-  sa.sa_sigaction = quiver_signal_handler;
+  sa.sa_sigaction = hands_signal_handler;
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
   for (size_t i = 0; i < sizeof(g_fatal_signals) / sizeof(int); i++) {

--- a/clients/android/src/main/cpp/hands_record_file.c
+++ b/clients/android/src/main/cpp/hands_record_file.c
@@ -1,0 +1,66 @@
+#include "hands_record_file.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#define HANDS_RECORD_COLLISION_ATTEMPTS 64U
+
+static int hands_path_append(char *path, size_t capacity, size_t *offset, const char *text) {
+  size_t i = 0;
+  while (text[i] != '\0') {
+    if (*offset + 1 >= capacity) return 0;
+    path[(*offset)++] = text[i++];
+  }
+  path[*offset] = '\0';
+  return 1;
+}
+
+static int hands_path_append_dec(char *path, size_t capacity, size_t *offset, uint64_t value) {
+  char digits[21];
+  int index = 20;
+  digits[index--] = '\0';
+  if (value == 0) digits[index--] = '0';
+  while (value != 0 && index >= 0) {
+    digits[index--] = (char)('0' + value % 10U);
+    value /= 10U;
+  }
+  return hands_path_append(path, capacity, offset, &digits[index + 1]);
+}
+
+static int hands_format_crash_record_path(const char *directory, uint64_t timestamp_ms,
+                                          pid_t pid, pid_t tid, unsigned int collision,
+                                          char *path, size_t capacity) {
+  if (directory == NULL || path == NULL || capacity == 0) return 0;
+  size_t offset = 0;
+  path[0] = '\0';
+  if (!hands_path_append(path, capacity, &offset, directory) ||
+      !hands_path_append(path, capacity, &offset, "/native-") ||
+      !hands_path_append_dec(path, capacity, &offset, timestamp_ms) ||
+      !hands_path_append(path, capacity, &offset, "-") ||
+      !hands_path_append_dec(path, capacity, &offset, (uint64_t)pid) ||
+      !hands_path_append(path, capacity, &offset, "-") ||
+      !hands_path_append_dec(path, capacity, &offset, (uint64_t)tid)) {
+    return 0;
+  }
+  if (collision > 0 &&
+      (!hands_path_append(path, capacity, &offset, "-") ||
+       !hands_path_append_dec(path, capacity, &offset, (uint64_t)collision))) {
+    return 0;
+  }
+  return hands_path_append(path, capacity, &offset, ".qnc");
+}
+
+int hands_open_crash_record(const char *directory, uint64_t timestamp_ms, pid_t pid, pid_t tid,
+                            char *path, size_t path_capacity) {
+  for (unsigned int collision = 0; collision < HANDS_RECORD_COLLISION_ATTEMPTS; collision++) {
+    if (!hands_format_crash_record_path(directory, timestamp_ms, pid, tid, collision,
+                                        path, path_capacity)) {
+      return -1;
+    }
+    int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+    if (fd >= 0) return fd;
+    if (errno != EEXIST) return -1;
+  }
+  return -1;
+}

--- a/clients/android/src/main/cpp/hands_record_file.h
+++ b/clients/android/src/main/cpp/hands_record_file.h
@@ -1,0 +1,16 @@
+#ifndef HANDS_RECORD_FILE_H
+#define HANDS_RECORD_FILE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/*
+ * Opens a unique QNC record with O_EXCL. The identity is timestamp+pid+tid;
+ * bounded numeric suffixes preserve evidence if those coordinates collide.
+ * Returns the file descriptor, or -1 without truncating an existing record.
+ */
+int hands_open_crash_record(const char *directory, uint64_t timestamp_ms, pid_t pid, pid_t tid,
+                            char *path, size_t path_capacity);
+
+#endif

--- a/clients/android/src/main/kotlin/build/hands/update/HandsNativeCrash.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsNativeCrash.kt
@@ -1,20 +1,35 @@
 package build.hands.update
 
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
 import android.content.Context
+import android.os.Build
+import org.json.JSONArray
+import org.json.JSONObject
 import java.io.File
+import kotlin.math.abs
 
 /**
- * NDK crash capture (symbolication matrix, task #80). The native handler
- * writes a minimal async-signal-safe record (.qnc: signal, fault address,
- * raw frame PCs, /proc/self/maps snapshot) at crash time; this class turns
- * records into `crash_native_frames` metadata on the NEXT launch and
- * submits them as kind=crash tickets. The server symbolicates against the
- * build's native-symbols asset.
+ * NDK crash capture and next-launch upload.
+ *
+ * QNC2 records the kernel-provided crash-thread ucontext (PC/LR/SP + registers),
+ * thread identity, siginfo, loaded-image ELF BuildIds, and /proc/self/maps. This
+ * parser turns context PCs into `(soname, offset, build_id)` frames; the server
+ * refuses to symbolicate any frame whose BuildId cannot be verified exactly.
+ *
+ * QNC1 remains readable so already-stored crashes are not discarded, but those
+ * legacy frames have no BuildId and therefore fail closed at symbolication.
  */
 object HandsNativeCrash {
 
     private const val MAX_STORED = 5
     private const val MAX_FRAMES = 64
+    private const val MAX_IMAGES_IN_METADATA = 64
+    // ApplicationExitInfo.timestamp is millisecond precision; QNC2 uses
+    // CLOCK_REALTIME millisecond timestamps. Five seconds covers scheduling
+    // delay without admitting unrelated exits from the same crash loop.
+    private const val EXIT_MATCH_WINDOW_MS = 5_000L
+    private const val MAX_EXIT_TRACE_BYTES = 2 * 1024 * 1024L
 
     @JvmStatic
     private external fun nativeInstall(crashDir: String)
@@ -48,7 +63,49 @@ object HandsNativeCrash {
             .sortedBy { it.name }
         if (records.isEmpty()) return
         // Retention: newest survive, same policy as HandsCrash.
-        records.dropLast(MAX_STORED).forEach { it.delete() }
+        records.dropLast(MAX_STORED).forEach {
+            it.delete()
+            deleteExitSidecars(it)
+        }
+
+        val pending = records.takeLast(MAX_STORED).mapNotNull { record ->
+            val parsed = runCatching { parseRecord(record.readText()) }.getOrNull()
+            if (parsed == null) {
+                record.delete()
+                deleteExitSidecars(record)
+                null
+            } else {
+                PendingRecord(record, parsed)
+            }
+        }
+        if (pending.isEmpty()) return
+
+        // Reuse only a sidecar whose recorded QNC coordinates still match.
+        // Valid bindings also reserve the system exit identity so another QNC
+        // cannot claim the same retained tombstone on this or a later retry.
+        val storedByRecord = pending.mapNotNull { item ->
+            readStoredExitEvidence(item.record, item.parsed)?.let { item.record.name to it }
+        }.toMap().toMutableMap()
+        val claimedExitKeys = storedByRecord.values.mapTo(mutableSetOf()) { it.exitKey }
+        val liveExits = loadNativeExitEvidence(context)
+        val liveByKey = liveExits.associateBy { it.match.exitKey }
+        val assignments = assignExitCandidates(
+            records = pending
+                .filterNot { storedByRecord.containsKey(it.record.name) }
+                .map { ExitMatchRecord(it.record.name, it.parsed.pid, it.parsed.crashAt) },
+            candidates = liveExits.map { it.match },
+            claimedExitKeys = claimedExitKeys,
+        )
+        for ((recordName, match) in assignments) {
+            val item = pending.firstOrNull { it.record.name == recordName } ?: continue
+            val live = liveByKey[match.exitKey] ?: continue
+            val stored = StoredExitEvidence.from(item.parsed, live.info)
+            if (writeStoredExitEvidence(item.record, stored)) {
+                storedByRecord[recordName] = stored
+                claimedExitKeys += stored.exitKey
+                persistExitTrace(live.info, exitTraceFile(item.record))
+            }
+        }
 
         val feedback = HandsFeedback(
             context = context,
@@ -59,41 +116,146 @@ object HandsNativeCrash {
             channel = channel,
             clientKey = clientKey,
         )
-        for (record in records.takeLast(MAX_STORED)) {
-            val parsed = runCatching { parseRecord(record.readText()) }.getOrNull()
-            if (parsed == null) {
-                record.delete()
-                continue
+        for ((record, parsed) in pending) {
+            val exitEvidence = storedByRecord[record.name]
+            val trace = exitEvidence?.let {
+                exitTraceFile(record).takeIf { file -> file.isFile && file.length() > 0L }
             }
-            val framesJson = parsed.frames.joinToString(",", "[", "]") { f ->
-                """{"index":${f.index},"offset":"0x${f.offset.toString(16)}","soname":"${f.soname}"}"""
+            val attachments = buildList {
+                add(record)
+                if (trace != null) add(trace)
             }
             val top = parsed.frames.firstOrNull()
             val result = runCatching {
                 feedback.submit(
-                    message = "Native crash: ${parsed.signalName}" +
-                        (top?.let { "\nat ${it.soname}+0x${it.offset.toString(16)}" } ?: ""),
+                    message = buildString {
+                        append("Native crash: ").append(parsed.signalName)
+                        parsed.threadName?.let { append(" on thread ").append(it) }
+                        top?.let { append("\nat ").append(it.soname).append("+0x").append(it.offset.toString(16)) }
+                    },
                     kind = "crash",
-                    attachments = listOf(record),
-                    extras = mapOf(
-                        "crash_exception_class" to parsed.signalName,
-                        "crash_top_frame" to (top?.let { "${it.soname}+0x${it.offset.toString(16)}" } ?: ""),
-                        "crash_reason" to "native_signal",
-                        "crash_at" to parsed.crashAt.toString(),
-                        "crash_native_frames" to framesJson,
-                    ),
+                    attachments = attachments,
+                    extras = buildMap {
+                        put("crash_exception_class", parsed.signalName)
+                        put("crash_top_frame", top?.let { "${it.soname}+0x${it.offset.toString(16)}" } ?: "")
+                        put("crash_reason", "native_signal")
+                        put("crash_at", parsed.crashAt.toString())
+                        put("crash_native_format", parsed.format)
+                        put("crash_native_frames", framesJson(parsed.frames))
+                        put("crash_native_images", imagesJson(parsed.modules))
+                        put("crash_registers", JSONObject(parsed.registers).toString())
+                        parsed.arch?.let { put("crash_arch", it) }
+                        parsed.signalCode?.let { put("crash_signal_code", it) }
+                        parsed.faultAddress?.let { put("crash_fault_addr", "0x${it.toString(16)}") }
+                        parsed.pid?.let { put("crash_process_id", it) }
+                        parsed.tid?.let { put("crash_thread_id", it) }
+                        parsed.threadName?.let { put("crash_thread_name", it) }
+                        parsed.registers["pc"]?.let { put("crash_context_pc", it) }
+                        (parsed.registers["lr"] ?: parsed.registers["x30"])
+                            ?.let { put("crash_context_lr", it) }
+                        (parsed.registers["sp"] ?: parsed.registers["rsp"])
+                            ?.let { put("crash_context_sp", it) }
+                        put("crash_tombstone_attached", trace != null)
+                        exitEvidence?.let {
+                            put("crash_exit_reason", exitReasonName(it.reason))
+                            put("crash_exit_status", it.status)
+                            put("crash_exit_importance", it.importance)
+                            put("crash_exit_pss", it.pss)
+                            put("crash_exit_rss", it.rss)
+                            put("crash_exit_timestamp", it.timestamp)
+                            it.description?.takeIf(String::isNotBlank)
+                                ?.let { description -> put("crash_exit_description", description) }
+                        }
+                    },
                 )
             }
-            if (result.isSuccess) record.delete()
+            if (result.isSuccess) {
+                record.delete()
+                deleteExitSidecars(record)
+            }
         }
     }
 
-    internal data class NativeFrame(val index: Int, val offset: Long, val soname: String)
+    internal data class NativeFrame(
+        val index: Int,
+        val offset: Long,
+        val soname: String,
+        val buildId: String? = null,
+        val source: String? = null,
+    )
+
+    internal data class NativeModule(
+        val start: Long,
+        val end: Long,
+        val buildId: String?,
+        val path: String,
+    )
+
     internal data class ParsedRecord(
+        val format: String,
         val signalName: String,
+        val signalCode: Int?,
+        val faultAddress: Long?,
         val crashAt: Long,
+        val pid: Long?,
+        val tid: Long?,
+        val threadName: String?,
+        val arch: String?,
+        val registers: Map<String, String>,
+        val modules: List<NativeModule>,
         val frames: List<NativeFrame>,
     )
+
+    private data class PendingRecord(val record: File, val parsed: ParsedRecord)
+
+    internal data class ExitMatchRecord(
+        val id: String,
+        val pid: Long?,
+        val crashAt: Long,
+    )
+
+    internal data class ExitMatchCandidate(
+        val pid: Long,
+        val timestamp: Long,
+        val reason: Int,
+    ) {
+        val exitKey: String get() = "$pid:$timestamp:$reason"
+    }
+
+    internal data class StoredExitEvidence(
+        val recordPid: Long,
+        val recordCrashAt: Long,
+        val exitPid: Long,
+        val timestamp: Long,
+        val reason: Int,
+        val status: Int,
+        val importance: Int,
+        val pss: Long,
+        val rss: Long,
+        val description: String?,
+    ) {
+        val exitKey: String get() = "$exitPid:$timestamp:$reason"
+
+        fun matches(record: ParsedRecord): Boolean =
+            record.format == "QNC2" && record.pid == recordPid && record.crashAt == recordCrashAt &&
+                exitPid == recordPid && reason == ApplicationExitInfo.REASON_CRASH_NATIVE
+
+        companion object {
+            fun from(record: ParsedRecord, info: ApplicationExitInfo): StoredExitEvidence =
+                StoredExitEvidence(
+                    recordPid = requireNotNull(record.pid),
+                    recordCrashAt = record.crashAt,
+                    exitPid = info.pid.toLong(),
+                    timestamp = info.timestamp,
+                    reason = info.reason,
+                    status = info.status,
+                    importance = info.importance,
+                    pss = info.pss,
+                    rss = info.rss,
+                    description = info.description?.take(8_192)?.takeIf(String::isNotBlank),
+                )
+        }
+    }
 
     private val SIGNAL_NAMES = mapOf(
         4 to "SIGILL", 5 to "SIGTRAP", 6 to "SIGABRT",
@@ -108,53 +270,97 @@ object HandsNativeCrash {
     )
 
     /**
-     * .qnc format (written by the signal handler):
-     *   QNC1 / "signal N" / "fault_addr 0x…" / "crash_at MS" / "frames" /
-     *   one 0x<pc> per line / "maps" / raw /proc/self/maps lines.
-     * PC → (soname, offset) uses the maps snapshot from the same process, so
-     * ASLR is already accounted for: offset = pc - start + file_offset.
+     * QNC1: signal/fault/crash_at + handler unwind PCs + maps.
+     * QNC2: adds siginfo, pid/tid/name, arch, crash ucontext registers, context
+     * PC/LR frames, and a loaded-module BuildId snapshot before maps.
      */
     internal fun parseRecord(text: String): ParsedRecord? {
         val lines = text.lines()
-        if (lines.firstOrNull()?.trim() != "QNC1") return null
+        val format = lines.firstOrNull()?.trim().orEmpty()
+        if (format != "QNC1" && format != "QNC2") return null
         var signal = 0
+        var signalCode: Int? = null
+        var faultAddress: Long? = null
         var crashAt = 0L
-        val pcs = mutableListOf<Long>()
+        var pid: Long? = null
+        var tid: Long? = null
+        var threadName: String? = null
+        var arch: String? = null
+        val contextFrames = mutableListOf<Pair<Long, String?>>()
         val maps = mutableListOf<MapEntry>()
+        val modules = mutableListOf<NativeModule>()
+        val registers = linkedMapOf<String, String>()
         var section = "header"
         for (line in lines.drop(1)) {
             val trimmed = line.trim()
             when {
+                trimmed == "registers" -> section = "registers"
                 trimmed == "frames" -> section = "frames"
+                trimmed == "modules" -> section = "modules"
                 trimmed == "maps" -> section = "maps"
                 section == "header" && trimmed.startsWith("signal ") ->
                     signal = trimmed.removePrefix("signal ").trim().toIntOrNull() ?: 0
+                section == "header" && trimmed.startsWith("signal_code ") ->
+                    signalCode = trimmed.removePrefix("signal_code ").trim().toIntOrNull()
+                section == "header" && trimmed.startsWith("fault_addr ") ->
+                    faultAddress = parseHexLong(trimmed.removePrefix("fault_addr "))
                 section == "header" && trimmed.startsWith("crash_at ") ->
                     crashAt = trimmed.removePrefix("crash_at ").trim().toLongOrNull() ?: 0L
-                section == "frames" && trimmed.startsWith("0x") ->
-                    trimmed.removePrefix("0x").toLongOrNull(16)?.let { pcs.add(it) }
-                section == "maps" && trimmed.isNotEmpty() -> parseMapLine(trimmed)?.let { maps.add(it) }
+                section == "header" && trimmed.startsWith("pid ") ->
+                    pid = trimmed.removePrefix("pid ").trim().toLongOrNull()
+                section == "header" && trimmed.startsWith("tid ") ->
+                    tid = trimmed.removePrefix("tid ").trim().toLongOrNull()
+                section == "header" && trimmed.startsWith("thread_name_hex ") ->
+                    threadName = decodeHexUtf8(trimmed.removePrefix("thread_name_hex ").trim())
+                section == "registers" && trimmed.startsWith("arch ") ->
+                    arch = trimmed.removePrefix("arch ").trim().takeIf(String::isNotBlank)
+                section == "registers" -> parseRegister(trimmed)?.let { (name, value) ->
+                    registers[name] = value
+                }
+                section == "frames" && trimmed.startsWith("0x") -> {
+                    val parts = trimmed.split(Regex("\\s+"), limit = 2)
+                    parseHexLong(parts[0])?.let { pc ->
+                        contextFrames += pc to parts.getOrNull(1)?.takeIf(String::isNotBlank)
+                    }
+                }
+                section == "modules" && trimmed.isNotEmpty() ->
+                    parseModuleLine(trimmed)?.let(modules::add)
+                section == "maps" && trimmed.isNotEmpty() ->
+                    parseMapLine(trimmed)?.let(maps::add)
             }
         }
-        if (signal == 0 || pcs.isEmpty()) return null
-        val frames = pcs.take(MAX_FRAMES).mapIndexedNotNull { index, pc ->
-            val map = maps.firstOrNull { pc >= it.start && pc < it.end && it.path.endsWith(".so") }
+        if (signal == 0 || contextFrames.isEmpty()) return null
+        val frames = contextFrames.distinctBy { it.first }.take(MAX_FRAMES).mapIndexedNotNull { index, pair ->
+            val (pc, source) = pair
+            val map = maps.firstOrNull { pc >= it.start && pc < it.end && it.path.contains(".so") }
                 ?: return@mapIndexedNotNull null
+            val module = modules.firstOrNull { pc >= it.start && pc < it.end }
             NativeFrame(
                 index = index,
                 offset = pc - map.start + map.fileOffset,
                 soname = map.path.substringAfterLast('/'),
+                buildId = module?.buildId,
+                source = source,
             )
         }
         if (frames.isEmpty()) return null
         return ParsedRecord(
+            format = format,
             signalName = SIGNAL_NAMES[signal] ?: "SIG$signal",
+            signalCode = signalCode,
+            faultAddress = faultAddress,
             crashAt = crashAt,
+            pid = pid,
+            tid = tid,
+            threadName = threadName,
+            arch = arch,
+            registers = registers,
+            modules = modules,
             frames = frames,
         )
     }
 
-    /** "7f0000-7f1000 r-xp 00042000 fd:00 123  /path/libfoo.so" */
+    /** "7f0000-7f1000 r-xp 00042000 fd:00 123 /path/libfoo.so" */
     private fun parseMapLine(line: String): MapEntry? {
         val parts = line.split(Regex("\\s+"))
         if (parts.size < 6) return null
@@ -166,5 +372,246 @@ object HandsNativeCrash {
             fileOffset = parts[2].toLongOrNull(16) ?: return null,
             path = parts.subList(5, parts.size).joinToString(" "),
         )
+    }
+
+    /** "0x700000-0x710000 deadbeef /path/libfoo.so" */
+    private fun parseModuleLine(line: String): NativeModule? {
+        val parts = line.split(Regex("\\s+"), limit = 3)
+        if (parts.size != 3) return null
+        val range = parts[0].split('-')
+        if (range.size != 2) return null
+        val buildId = parts[1].lowercase().takeIf { it.matches(Regex("[0-9a-f]{8,64}")) }
+        return NativeModule(
+            start = parseHexLong(range[0]) ?: return null,
+            end = parseHexLong(range[1]) ?: return null,
+            buildId = buildId,
+            path = parts[2],
+        )
+    }
+
+    private fun parseRegister(line: String): Pair<String, String>? {
+        val parts = line.split(Regex("\\s+"), limit = 2)
+        if (parts.size != 2 || !parts[0].matches(Regex("[A-Za-z][A-Za-z0-9_]{0,15}"))) return null
+        val value = parts[1].lowercase()
+        if (!value.matches(Regex("0x[0-9a-f]{1,16}"))) return null
+        return parts[0] to value
+    }
+
+    private fun parseHexLong(value: String): Long? =
+        value.trim().removePrefix("0x").toLongOrNull(16)
+
+    private fun encodeUtf8Hex(value: String): String = buildString {
+        val digits = "0123456789abcdef"
+        value.toByteArray(Charsets.UTF_8).forEach { byte ->
+            val unsigned = byte.toInt() and 0xff
+            append(digits[unsigned ushr 4])
+            append(digits[unsigned and 0x0f])
+        }
+    }
+
+    private fun decodeUtf8Hex(value: String, maxBytes: Int): String? {
+        if (
+            value.length !in 2..(maxBytes * 2) || value.length % 2 != 0 ||
+            !value.matches(Regex("[0-9a-fA-F]+"))
+        ) {
+            return null
+        }
+        val bytes = ByteArray(value.length / 2) { index ->
+            value.substring(index * 2, index * 2 + 2).toInt(16).toByte()
+        }
+        return bytes.toString(Charsets.UTF_8)
+    }
+
+    private fun decodeHexUtf8(value: String): String? =
+        decodeUtf8Hex(value, 64)?.replace(Regex("[\\r\\n\\u0000]"), " ")?.trim()
+            ?.takeIf(String::isNotBlank)
+
+    private fun framesJson(frames: List<NativeFrame>): String = JSONArray().apply {
+        frames.forEach { frame ->
+            put(JSONObject().apply {
+                put("index", frame.index)
+                put("offset", "0x${frame.offset.toString(16)}")
+                put("soname", frame.soname)
+                frame.buildId?.let { put("build_id", it) }
+                frame.source?.let { put("source", it) }
+            })
+        }
+    }.toString()
+
+    private fun imagesJson(modules: List<NativeModule>): String = JSONArray().apply {
+        modules.asSequence()
+            .filter { it.buildId != null && it.path.contains(".so") }
+            .distinctBy { it.buildId to it.path.substringAfterLast('/') }
+            .take(MAX_IMAGES_IN_METADATA)
+            .forEach { module ->
+                put(JSONObject().apply {
+                    put("soname", module.path.substringAfterLast('/'))
+                    put("build_id", module.buildId)
+                    put("start", "0x${module.start.toString(16)}")
+                    put("end", "0x${module.end.toString(16)}")
+                })
+            }
+    }.toString()
+
+    private data class LiveExitEvidence(
+        val info: ApplicationExitInfo,
+        val match: ExitMatchCandidate,
+    )
+
+    /**
+     * Deterministically assigns retained native exits one-to-one to QNC2
+     * records. Cross-process exits, ANRs/JVM exits, stale timestamps, and exits
+     * already claimed by a persisted retry sidecar are ineligible.
+     */
+    internal fun assignExitCandidates(
+        records: List<ExitMatchRecord>,
+        candidates: List<ExitMatchCandidate>,
+        claimedExitKeys: Set<String> = emptySet(),
+        windowMs: Long = EXIT_MATCH_WINDOW_MS,
+    ): Map<String, ExitMatchCandidate> {
+        val available = candidates
+            .filter { it.reason == ApplicationExitInfo.REASON_CRASH_NATIVE }
+            .filterNot { it.exitKey in claimedExitKeys }
+            .distinctBy { it.exitKey }
+            .toMutableList()
+        val assigned = linkedMapOf<String, ExitMatchCandidate>()
+        for (record in records.sortedWith(compareBy<ExitMatchRecord> { it.crashAt }.thenBy { it.id })) {
+            val pid = record.pid ?: continue
+            if (record.crashAt <= 0L) continue
+            val candidate = available
+                .asSequence()
+                .filter { it.pid == pid && abs(it.timestamp - record.crashAt) <= windowMs }
+                .sortedWith(
+                    compareBy<ExitMatchCandidate> { abs(it.timestamp - record.crashAt) }
+                        .thenBy { it.timestamp }
+                        .thenBy { it.exitKey },
+                )
+                .firstOrNull() ?: continue
+            assigned[record.id] = candidate
+            available.remove(candidate)
+        }
+        return assigned
+    }
+
+    private fun loadNativeExitEvidence(context: Context): List<LiveExitEvidence> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return emptyList()
+        return runCatching {
+            val manager = context.getSystemService(ActivityManager::class.java) ?: return emptyList()
+            manager.getHistoricalProcessExitReasons(context.packageName, 0, 32)
+                .asSequence()
+                .filter { it.reason == ApplicationExitInfo.REASON_CRASH_NATIVE }
+                .map {
+                    LiveExitEvidence(
+                        info = it,
+                        match = ExitMatchCandidate(
+                            pid = it.pid.toLong(),
+                            timestamp = it.timestamp,
+                            reason = it.reason,
+                        ),
+                    )
+                }
+                .toList()
+        }.getOrDefault(emptyList())
+    }
+
+    private fun exitReasonName(reason: Int): String = when (reason) {
+        ApplicationExitInfo.REASON_CRASH_NATIVE -> "crash_native"
+        ApplicationExitInfo.REASON_CRASH -> "crash"
+        ApplicationExitInfo.REASON_ANR -> "anr"
+        else -> "reason_$reason"
+    }
+
+    private fun exitTraceFile(record: File): File =
+        File(record.parentFile, "${record.nameWithoutExtension}.exit-trace.txt")
+
+    private fun exitMetaFile(record: File): File =
+        File(record.parentFile, "${record.nameWithoutExtension}.exit-meta")
+
+    private fun deleteExitSidecars(record: File) {
+        exitTraceFile(record).delete()
+        exitMetaFile(record).delete()
+    }
+
+    private fun readStoredExitEvidence(record: File, parsed: ParsedRecord): StoredExitEvidence? {
+        val meta = exitMetaFile(record)
+        if (!meta.isFile) {
+            // A trace without its binding coordinates is not causal evidence.
+            exitTraceFile(record).delete()
+            return null
+        }
+        val stored = runCatching { decodeStoredExitEvidence(meta.readText()) }.getOrNull()
+        if (stored == null || !stored.matches(parsed)) {
+            deleteExitSidecars(record)
+            return null
+        }
+        return stored
+    }
+
+    private fun writeStoredExitEvidence(record: File, evidence: StoredExitEvidence): Boolean =
+        runCatching {
+            exitMetaFile(record).writeText(encodeStoredExitEvidence(evidence))
+            true
+        }.getOrElse {
+            deleteExitSidecars(record)
+            false
+        }
+
+    internal fun encodeStoredExitEvidence(evidence: StoredExitEvidence): String = buildString {
+        appendLine("QNE1")
+        appendLine("record_pid ${evidence.recordPid}")
+        appendLine("record_crash_at ${evidence.recordCrashAt}")
+        appendLine("exit_pid ${evidence.exitPid}")
+        appendLine("exit_timestamp ${evidence.timestamp}")
+        appendLine("exit_reason ${evidence.reason}")
+        appendLine("exit_status ${evidence.status}")
+        appendLine("exit_importance ${evidence.importance}")
+        appendLine("exit_pss ${evidence.pss}")
+        appendLine("exit_rss ${evidence.rss}")
+        evidence.description?.let { appendLine("description_hex ${encodeUtf8Hex(it)}") }
+    }
+
+    internal fun decodeStoredExitEvidence(text: String): StoredExitEvidence? {
+        val lines = text.lineSequence().toList()
+        if (lines.firstOrNull()?.trim() != "QNE1") return null
+        val fields = lines.drop(1).mapNotNull { line ->
+            val separator = line.indexOf(' ')
+            if (separator <= 0) null else line.substring(0, separator) to line.substring(separator + 1).trim()
+        }.toMap()
+        return StoredExitEvidence(
+            recordPid = fields["record_pid"]?.toLongOrNull() ?: return null,
+            recordCrashAt = fields["record_crash_at"]?.toLongOrNull() ?: return null,
+            exitPid = fields["exit_pid"]?.toLongOrNull() ?: return null,
+            timestamp = fields["exit_timestamp"]?.toLongOrNull() ?: return null,
+            reason = fields["exit_reason"]?.toIntOrNull() ?: return null,
+            status = fields["exit_status"]?.toIntOrNull() ?: return null,
+            importance = fields["exit_importance"]?.toIntOrNull() ?: return null,
+            pss = fields["exit_pss"]?.toLongOrNull() ?: return null,
+            rss = fields["exit_rss"]?.toLongOrNull() ?: return null,
+            description = fields["description_hex"]?.let { decodeUtf8Hex(it, 8_192) ?: return null },
+        )
+    }
+
+    private fun persistExitTrace(info: ApplicationExitInfo, destination: File): File? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return null
+        return runCatching {
+            val stream = info.traceInputStream ?: return null
+            destination.outputStream().buffered().use { output ->
+                stream.use { input ->
+                    val buffer = ByteArray(8192)
+                    var total = 0L
+                    while (total < MAX_EXIT_TRACE_BYTES) {
+                        val limit = minOf(buffer.size.toLong(), MAX_EXIT_TRACE_BYTES - total).toInt()
+                        val read = input.read(buffer, 0, limit)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        total += read
+                    }
+                }
+            }
+            destination.takeIf { it.isFile && it.length() > 0L }
+        }.getOrElse {
+            destination.delete()
+            null
+        }
     }
 }

--- a/clients/android/src/test/cpp/hands_record_file_test.c
+++ b/clients/android/src/test/cpp/hands_record_file_test.c
@@ -1,0 +1,31 @@
+#include "hands_record_file.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  if (argc != 2) return 2;
+  char first[1024];
+  char second[1024];
+  int first_fd = hands_open_crash_record(argv[1], 1721810000123ULL, 4123, 4177,
+                                         first, sizeof(first));
+  int second_fd = hands_open_crash_record(argv[1], 1721810000123ULL, 4123, 4177,
+                                          second, sizeof(second));
+  if (first_fd < 0 || second_fd < 0) return 3;
+  close(first_fd);
+  close(second_fd);
+  struct stat first_stat;
+  struct stat second_stat;
+  if (strcmp(first, second) == 0 || stat(first, &first_stat) != 0 ||
+      stat(second, &second_stat) != 0) {
+    return 4;
+  }
+  if (strstr(first, "native-1721810000123-4123-4177.qnc") == NULL ||
+      strstr(second, "native-1721810000123-4123-4177-1.qnc") == NULL) {
+    return 5;
+  }
+  puts("QNC2 record identity collision test PASS");
+  return 0;
+}

--- a/clients/android/src/test/kotlin/build/hands/update/HandsNativeCrashTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsNativeCrashTest.kt
@@ -1,0 +1,218 @@
+package build.hands.update
+
+import android.app.ApplicationExitInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HandsNativeCrashTest {
+
+    @Test
+    fun parsesQnc2CrashContextThreadRegistersAndBuildIds() {
+        val record = """
+            QNC2
+            signal 6
+            signal_code -6
+            fault_addr 0x7a001234
+            crash_at 1721810000123
+            pid 4123
+            tid 4177
+            thread_name_hex 526166742d776f726b6572
+            registers
+            arch arm64-v8a
+            x0 0x1
+            x30 0x70002040
+            sp 0x7ff0abcd
+            pc 0x70001234
+            pstate 0x60000000
+            frames
+            0x70001234 context_pc
+            0x70002040 context_lr
+            modules
+            0x70000000-0x70010000 1de2e1c0bc046f0654f9fdc8173912735aeea751 /data/app/lib/arm64/libraft.so
+            0x71000000-0x71010000 - /apex/com.android.runtime/lib64/bionic/libc.so
+            maps
+            70000000-70010000 r-xp 00000000 00:00 0 /data/app/lib/arm64/libraft.so
+            71000000-71010000 r-xp 00004000 00:00 0 /apex/com.android.runtime/lib64/bionic/libc.so
+        """.trimIndent()
+
+        val parsed = HandsNativeCrash.parseRecord(record)!!
+
+        assertEquals("QNC2", parsed.format)
+        assertEquals("SIGABRT", parsed.signalName)
+        assertEquals(-6, parsed.signalCode)
+        assertEquals(0x7a001234L, parsed.faultAddress)
+        assertEquals(1721810000123L, parsed.crashAt)
+        assertEquals(4123L, parsed.pid)
+        assertEquals(4177L, parsed.tid)
+        assertEquals("Raft-worker", parsed.threadName)
+        assertEquals("arm64-v8a", parsed.arch)
+        assertEquals("0x70001234", parsed.registers["pc"])
+        assertEquals("0x7ff0abcd", parsed.registers["sp"])
+        assertEquals(2, parsed.frames.size)
+        assertEquals(
+            HandsNativeCrash.NativeFrame(
+                index = 0,
+                offset = 0x1234,
+                soname = "libraft.so",
+                buildId = "1de2e1c0bc046f0654f9fdc8173912735aeea751",
+                source = "context_pc",
+            ),
+            parsed.frames[0],
+        )
+        assertEquals("context_lr", parsed.frames[1].source)
+    }
+
+    @Test
+    fun keepsQnc1ReadableButDoesNotInventBuildIdOrThreadContext() {
+        val record = """
+            QNC1
+            signal 11
+            fault_addr 0x42
+            crash_at 1721810000999
+            frames
+            0x7f004200
+            maps
+            7f000000-7f010000 r-xp 00002000 00:00 0 /data/app/lib/arm64/libhandscrash.so
+        """.trimIndent()
+
+        val parsed = HandsNativeCrash.parseRecord(record)!!
+
+        assertEquals("QNC1", parsed.format)
+        assertEquals("SIGSEGV", parsed.signalName)
+        assertNull(parsed.tid)
+        assertNull(parsed.threadName)
+        assertTrue(parsed.registers.isEmpty())
+        assertEquals(0x6200L, parsed.frames.single().offset)
+        assertNull(parsed.frames.single().buildId)
+    }
+
+    @Test
+    fun rejectsMalformedOrContextFreeRecords() {
+        assertNull(HandsNativeCrash.parseRecord("QNC3\nsignal 6\n"))
+        assertNull(HandsNativeCrash.parseRecord("QNC2\nsignal 6\nframes\nmodules\nmaps\n"))
+        assertNull(
+            HandsNativeCrash.parseRecord(
+                "QNC2\nsignal 6\nframes\n0x123 context_pc\nmodules\nmaps\n",
+            ),
+        )
+    }
+
+    @Test
+    fun ignoresInvalidModuleBuildIdsAndDeduplicatesContextFrames() {
+        val record = """
+            QNC2
+            signal 7
+            crash_at 10
+            registers
+            arch x86_64
+            rip 0x400010
+            rsp 0x500000
+            frames
+            0x400010 context_pc
+            0x400010 duplicate
+            modules
+            0x400000-0x410000 not-a-build-id /data/app/lib/x86_64/libfoo.so
+            maps
+            400000-410000 r-xp 00000000 00:00 0 /data/app/lib/x86_64/libfoo.so
+        """.trimIndent()
+
+        val parsed = HandsNativeCrash.parseRecord(record)!!
+
+        assertEquals(1, parsed.frames.size)
+        assertNull(parsed.frames.single().buildId)
+        assertEquals("context_pc", parsed.frames.single().source)
+    }
+
+    @Test
+    fun exitEvidenceRequiresSamePidNativeReasonAndNarrowTimestamp() {
+        val assignments = HandsNativeCrash.assignExitCandidates(
+            records = listOf(HandsNativeCrash.ExitMatchRecord("record", pid = 42, crashAt = 10_000)),
+            candidates = listOf(
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 99,
+                    timestamp = 10_000,
+                    reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ),
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 42,
+                    timestamp = 10_001,
+                    reason = ApplicationExitInfo.REASON_ANR,
+                ),
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 42,
+                    timestamp = 20_000,
+                    reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ),
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 42,
+                    timestamp = 10_002,
+                    reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ),
+            ),
+        )
+
+        assertEquals(1, assignments.size)
+        assertEquals(10_002L, assignments.getValue("record").timestamp)
+    }
+
+    @Test
+    fun twoPendingRecordsCannotConsumeTheSameSystemExit() {
+        val assignments = HandsNativeCrash.assignExitCandidates(
+            records = listOf(
+                HandsNativeCrash.ExitMatchRecord("first", pid = 42, crashAt = 10_000),
+                HandsNativeCrash.ExitMatchRecord("second", pid = 42, crashAt = 10_003),
+            ),
+            candidates = listOf(
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 42,
+                    timestamp = 10_001,
+                    reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ),
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 42,
+                    timestamp = 10_004,
+                    reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ),
+            ),
+        )
+
+        assertEquals(10_001L, assignments.getValue("first").timestamp)
+        assertEquals(10_004L, assignments.getValue("second").timestamp)
+        assertEquals(2, assignments.values.map { it.exitKey }.toSet().size)
+    }
+
+    @Test
+    fun retryBindingRoundTripsAndReservesItsExitIdentity() {
+        val stored = HandsNativeCrash.StoredExitEvidence(
+            recordPid = 42,
+            recordCrashAt = 10_000,
+            exitPid = 42,
+            timestamp = 10_001,
+            reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+            status = 6,
+            importance = 100,
+            pss = 1234,
+            rss = 5678,
+            description = "Abort message\n第二行",
+        )
+        val decoded = HandsNativeCrash.decodeStoredExitEvidence(
+            HandsNativeCrash.encodeStoredExitEvidence(stored),
+        )
+        assertEquals(stored, decoded)
+
+        val assignments = HandsNativeCrash.assignExitCandidates(
+            records = listOf(HandsNativeCrash.ExitMatchRecord("new-record", pid = 42, crashAt = 10_000)),
+            candidates = listOf(
+                HandsNativeCrash.ExitMatchCandidate(
+                    pid = 42,
+                    timestamp = 10_001,
+                    reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+                ),
+            ),
+            claimedExitKeys = setOf(stored.exitKey),
+        )
+        assertTrue(assignments.isEmpty())
+    }
+}

--- a/clients/android/src/test/scripts/test_qnc2_record_identity.sh
+++ b/clients/android/src/test/scripts/test_qnc2_record_identity.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"$root/main/cpp" \
+  "$root/main/cpp/hands_record_file.c" \
+  "$root/test/cpp/hands_record_file_test.c" \
+  -o "$tmp/hands_record_file_test"
+"$tmp/hands_record_file_test" "$tmp"

--- a/container/package.json
+++ b/container/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",
     "build": "tsc --noEmit",
-    "test": "echo 'no tests yet'"
+    "test": "tsx --test src/native-symbols.test.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/container/src/native-symbols.test.ts
+++ b/container/src/native-symbols.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectNativeSymbolCandidate } from "./native-symbols.js";
+
+test("selects the exact BuildId when an archive contains the same soname for several ABIs", () => {
+  assert.deepEqual(
+    selectNativeSymbolCandidate(
+      [
+        { path: "symbols/armeabi-v7a/libhandscrash.so", buildId: "127cdaa1e71909f5" },
+        { path: "symbols/arm64-v8a/libhandscrash.so", buildId: "54e47f291d6289f0" },
+        { path: "symbols/x86_64/libhandscrash.so", buildId: "a4c82974933de559" },
+      ],
+      "54E47F291D6289F0",
+      "libhandscrash.so",
+    ),
+    { ok: true, path: "symbols/arm64-v8a/libhandscrash.so" },
+  );
+});
+
+test("fails closed when the crash BuildId is absent", () => {
+  assert.deepEqual(
+    selectNativeSymbolCandidate(
+      [{ path: "symbols/arm64-v8a/libhandscrash.so", buildId: "54e47f291d6289f0" }],
+      undefined,
+      "libhandscrash.so",
+    ),
+    { ok: false, error: "missing crash BuildId (fail-closed)" },
+  );
+});
+
+test("fails closed on mismatched and unreadable archive BuildIds", () => {
+  assert.deepEqual(
+    selectNativeSymbolCandidate(
+      [{ path: "symbols/arm64-v8a/libhandscrash.so", buildId: "54e47f291d6289f0" }],
+      "aaaaaaaaaaaaaaaa",
+      "libhandscrash.so",
+    ),
+    {
+      ok: false,
+      error: "BuildId mismatch: crash aaaaaaaaaaaaaaaa, archive 54e47f291d6289f0",
+    },
+  );
+  assert.deepEqual(
+    selectNativeSymbolCandidate(
+      [{ path: "symbols/arm64-v8a/libhandscrash.so", buildId: "" }],
+      "aaaaaaaaaaaaaaaa",
+      "libhandscrash.so",
+    ),
+    { ok: false, error: "BuildId unverifiable for libhandscrash.so (fail-closed)" },
+  );
+});

--- a/container/src/native-symbols.ts
+++ b/container/src/native-symbols.ts
@@ -1,0 +1,35 @@
+export interface NativeSymbolCandidate {
+  path: string;
+  buildId: string;
+}
+
+export type NativeSymbolSelection =
+  | { ok: true; path: string }
+  | { ok: false; error: string };
+
+/**
+ * Select one same-soname symbols file by exact ELF BuildId.
+ *
+ * Archives commonly contain one `libfoo.so` per ABI. Traversal order is not
+ * identity, so missing/unreadable/mismatched BuildIds always fail closed.
+ */
+export function selectNativeSymbolCandidate(
+  candidates: NativeSymbolCandidate[],
+  crashBuildIdInput: unknown,
+  soname: string,
+): NativeSymbolSelection {
+  const crashBuildId = String(crashBuildIdInput ?? "").trim().toLowerCase();
+  if (!/^[0-9a-f]{8,64}$/.test(crashBuildId)) {
+    return { ok: false, error: "missing crash BuildId (fail-closed)" };
+  }
+  const exact = candidates.find((candidate) => candidate.buildId === crashBuildId);
+  if (exact) return { ok: true, path: exact.path };
+
+  const readableIds = [...new Set(candidates.map((candidate) => candidate.buildId).filter(Boolean))];
+  return {
+    ok: false,
+    error: readableIds.length > 0
+      ? `BuildId mismatch: crash ${crashBuildId}, archive ${readableIds.join(",")}`
+      : `BuildId unverifiable for ${soname} (fail-closed)`,
+  };
+}

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -31,6 +31,7 @@ import {
   parseWithDispatcher,
   type ParserKind,
 } from "./parsers/index.js";
+import { selectNativeSymbolCandidate } from "./native-symbols.js";
 
 const app = new Hono();
 
@@ -179,9 +180,11 @@ app.post("/retrace", async (c) => {
 /**
  * POST /symbolicate-native — body = raw native-symbols zip (unstripped .so
  * files), X-Quiver-Frames header = JSON array of
- * { index, offset, soname, build_id? } (offset hex like "0x1a2b" or bare
- * hex). Extracts the zip, matches each frame's soname (verifying the ELF
- * BuildId when provided), and resolves offsets with llvm-symbolizer.
+ * { index, offset, soname, build_id } (offset hex like "0x1a2b" or bare
+ * hex). Extracts the zip, selects a same-basename candidate only when its ELF
+ * BuildId exactly matches the crash frame, and resolves offsets with
+ * llvm-symbolizer. Missing/unreadable/mismatched BuildIds fail closed; the
+ * endpoint never falls back to basename-only symbolication.
  * Returns { frames: [{ index, resolved | error }] }.
  */
 app.post("/symbolicate-native", async (c) => {
@@ -210,13 +213,19 @@ app.post("/symbolicate-native", async (c) => {
       maxBuffer: 8 * 1024 * 1024,
     });
 
-    // Index extracted .so files by basename (archives often nest abi dirs).
-    const soByName = new Map<string, string>();
+    // Index every extracted .so by basename. A native-symbols archive normally
+    // contains the same soname for multiple ABIs, so keeping only the first
+    // candidate would make resolution depend on unzip traversal order.
+    const soByName = new Map<string, string[]>();
     const walk = async (d: string): Promise<void> => {
       for (const entry of await readdir(d, { withFileTypes: true })) {
         const full = join(d, entry.name);
         if (entry.isDirectory()) await walk(full);
-        else if (entry.name.endsWith(".so") && !soByName.has(entry.name)) soByName.set(entry.name, full);
+        else if (entry.name.endsWith(".so")) {
+          const candidates = soByName.get(entry.name) ?? [];
+          candidates.push(full);
+          soByName.set(entry.name, candidates);
+        }
       }
     };
     await walk(outDir);
@@ -241,21 +250,20 @@ app.post("/symbolicate-native", async (c) => {
     const results: Array<{ index: number; resolved?: string; error?: string }> = [];
     for (const frame of frames) {
       const soname = String(frame.soname ?? "").split("/").pop() ?? "";
-      const soPath = soname ? soByName.get(soname) : undefined;
-      if (!soPath) {
+      const candidates = soname ? soByName.get(soname) : undefined;
+      if (!candidates || candidates.length === 0) {
         results.push({ index: frame.index, error: `no ${soname || "(missing soname)"} in symbols archive` });
         continue;
       }
-      if (frame.build_id) {
-        const actual = await elfBuildId(soPath);
-        if (actual && actual !== String(frame.build_id).toLowerCase()) {
-          results.push({
-            index: frame.index,
-            error: `BuildId mismatch: crash ${frame.build_id}, archive ${actual}`,
-          });
-          continue;
-        }
+      const candidateIds = await Promise.all(
+        candidates.map(async (candidate) => ({ path: candidate, buildId: await elfBuildId(candidate) })),
+      );
+      const selected = selectNativeSymbolCandidate(candidateIds, frame.build_id, soname);
+      if (!selected.ok) {
+        results.push({ index: frame.index, error: selected.error });
+        continue;
       }
+      const soPath = selected.path;
       const offset = String(frame.offset ?? "").startsWith("0x")
         ? String(frame.offset)
         : `0x${frame.offset}`;

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -130,7 +130,16 @@ class App : Application() {
 To get readable (deobfuscated) stacks in the console, publish the release
 with its R8/ProGuard `mapping.txt` (and, for NDK crashes, the unstripped
 `.so` archive) — Hands symbolicates crash reports for that `versionCode`
-automatically.
+automatically. QNC2 native reports preserve the crashing thread's PC/LR/SP,
+registers, thread identity, and loaded-image ELF BuildIds. Symbolication is
+strictly fail-closed: the crash frame's BuildId must exactly match an ELF in
+the uploaded archive; Hands never guesses by version or filename. On Android
+11+ the SDK also attaches the matching `ApplicationExitInfo` trace and exit
+description when the OS retained them, providing the sanctioned
+tombstone/abort-message equivalent without reading `/data/tombstones`. The
+match requires the recorded process id, native-crash reason, and a narrow
+timestamp window; retained evidence is assigned one-to-one and persisted for
+deterministic retry rather than guessed from the nearest package exit.
 
 ## Release health
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -249,7 +249,7 @@ find and rotate the key in the app's Settings tab or via
 | `submission_id` | No | Client-generated UUID for idempotent retries. Keep it fixed for one draft. An exact replay returns the original ticket; reusing it with different content returns `409`. |
 | `kind` | No | `feedback` (default), `bug`, or `crash`. |
 | `contact` | No | Reply-to handle (email, Raft name, …). |
-| `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. Crash tickets add `crash_exception_class` / `crash_top_frame` (grouping signature) and, for native crashes, `crash_native_frames` — an array of `{ index, offset, soname, build_id }` that the server symbolicates against the build's `native-symbols` asset. |
+| `metadata` | No | JSON string: `version_name`, `version_code`, `channel`, `device_id`, `device_model`, `os_version`, `arch`, `locale`, plus custom keys. Crash tickets add `crash_exception_class` / `crash_top_frame` (grouping signature). QNC2 Android native reports add `crash_native_frames` (`{ index, offset, soname, build_id, source }`), `crash_registers`, crash thread fields, and `crash_native_images`; server symbolication requires an exact per-frame BuildId match against the build's `native-symbols` asset. API 30+ reports may also include `crash_exit_*` metadata and a retained system trace attachment. |
 | `attachments` | No | Inline files (multipart), up to 10 MB each, ≤9 total. |
 | `presigned` | No | JSON array of `{ r2_key, filename, content_type, size }` for files already uploaded via the presign flow (below). |
 

--- a/docs/sdk-parity/roadmap.md
+++ b/docs/sdk-parity/roadmap.md
@@ -49,20 +49,27 @@ its own rolling JSONL log to fill this hole — demand is proven.
 
 ## P1 — crash-capture depth + symbolication completion + hygiene
 
-1. **Android ANR detection** — main-thread watchdog (5s heartbeat) +
+1. **Android native crash context (source complete; runtime gate open)** —
+   QNC2 captures crash-thread PC/LR/SP + registers/ucontext, pid/tid/name,
+   siginfo, loaded-image ELF BuildIds, and API 30+ `ApplicationExitInfo`
+   tombstone-equivalent evidence. Server/container require exact per-frame
+   BuildId and fail closed. Closure still requires a successor SDK/runtime
+   reproduction or same-device causal-fix soak; merge or absence alone is not
+   sufficient.
+2. **Android ANR detection** — main-thread watchdog (5s heartbeat) +
    `ApplicationExitInfo` (REASON_ANR) harvest on next launch.
-2. **iOS depth** — Mach exception handler, watchdog/hang detection,
+3. **iOS depth** — Mach exception handler, watchdog/hang detection,
    all-threads dump (documented v1 gaps in `HandsCrashReporter`).
-3. **OHOS native crashes** — wire `hiAppEvent`/`faultLogger` so native
+4. **OHOS native crashes** — wire `hiAppEvent`/`faultLogger` so native
    faults are captured, not just ArkTS errors.
-4. **Electron JS layer** — main-process `uncaughtException`/
+5. **Electron JS layer** — main-process `uncaughtException`/
    `unhandledRejection` + renderer error capture (renderer.init is currently
    a no-op); renderer sourcemap support; feedback submit API.
-5. **iOS dSYM server resolver** — client already ships
+6. **iOS dSYM server resolver** — client already ships
    `crash_binary_images` (UUID/slide/ranges); implement the server-side
    dSYM lookup + frame resolution (dSYMs already uploaded via
    `hands builds publish-ios --dsym`).
-6. **SDK hygiene** — single source of truth for versions (Android reports
+7. **SDK hygiene** — single source of truth for versions (Android reports
    0.1.0-SNAPSHOT/0.4.0/0.9.0 depending on where you look; OHOS package
    0.2.0 reports 0.1.0; iOS podspec 0.1.4 vs constant 0.1.5); finish the
    Quiver→Hands rename (mobile iOS app still consumes the old `Quiver` pod

--- a/docs/symbolication-matrix.md
+++ b/docs/symbolication-matrix.md
@@ -12,7 +12,7 @@ lane exists.
 | Lane | Client uploads | Build asset | Server pipeline | Status |
 |---|---|---|---|---|
 | Android Java/R8 | stack text (kind=crash ticket, `crash_*` signature fields) | `proguard-mapping` (mapping.txt) | container `retrace` → internal ticket comment | ✅ |
-| Android native (NDK) | `metadata.crash_native_frames`: `[{ index, offset, soname, build_id }]` (plus the human-readable dump as attachment) | `native-symbols` (zip of unstripped `.so`) | ✅ container `/symbolicate-native`: unzip → BuildId verify (`readelf -n`) → `llvm-symbolizer` per frame → internal ticket comment (missing asset ⇒ actionable comment). `symbolic` upgrade slot reserved. | server ✅ · SDK capture 🔨 |
+| Android native (NDK) | QNC2 crash-thread context + `metadata.crash_native_frames`: `[{ index, offset, soname, build_id, source }]`, registers/thread/image table, raw QNC record, and API 30+ `ApplicationExitInfo` trace when available | `native-symbols` (zip of unstripped `.so`) | ✅ container `/symbolicate-native`: index all ABI candidates → require exact per-frame BuildId (`readelf -n`) → `llvm-symbolizer`; missing/unreadable/mismatched BuildId fails closed with no basename fallback | source ✅ · successor runtime validation 🔨 |
 | iOS | crash record with a **binary images section** (image UUID + load address + slide) and frame addresses — `backtrace_symbols` text alone is NOT symbolicatable | `dsym` (zip of dSYM bundles) | container: `symbolic` by image UUID + address-slide; no mac/atos dependency | 📐 (SDK prerequisite: images section) |
 | Electron / Crashpad | minidump POSTed by Electron's built-in `crashReporter` to `POST /public/v2/apps/:slug/minidump` (`upload_file_minidump` + Sentry-electron-style annotations) | `breakpad-symbols` (zip of `dump_syms` `.sym`) | ✅ container `/symbolicate-minidump`: rebuild Breakpad tree from each `.sym` MODULE header → `minidump-stackwalk --json` → internal ticket comment (no symbols ⇒ module+offset + upload tip) | server ✅ · SDK ✅ (`@botiverse/hands-electron`, main+renderer) |
 
@@ -50,19 +50,30 @@ lane exists.
    the ELF BuildId (Android) / Mach-O UUID (iOS) from the crash record
    against the artifact before symbolicating; version_code only narrows the
    candidate set.
-4. **Android native capture: minimal async-signal-safe handler, not
-   Breakpad.** Breakpad/Crashpad in-process brings a large NDK dependency
-   into a Kotlin SDK for marginal gain. v1 (same store-then-send shape and
-   the same handler discipline as the iOS SDK): the fatal-signal handler
-   writes only a minimal, preallocated append-only record (signal number,
-   fault address, raw frame pointers/offsets via a signal-safe unwinder) —
-   no allocation, no JSON, no HTTP, no path assembly; all
-   `pc <offset> <soname> (BuildId)` formatting and the upload happen on the
-   NEXT launch. System tombstones/debuggerd output are NOT a data source:
-   app processes cannot read /data/tombstones on release devices
-   (`ApplicationExitInfo` traces are the only sanctioned peek, API 30+ and
-   NDK-crash coverage is spotty). Crashpad reconsidered only if we need
-   out-of-process minidump quality.
+   For Android native frames this is strictly fail-closed: a missing crash
+   BuildId, an unreadable archive BuildId, or a mismatch produces an
+   unsymbolicated evidence block. Basename-only and version-only fallbacks are
+   forbidden, including when an archive contains the same soname for multiple
+   ABIs.
+4. **Android native capture: QNC2 crash context, not handler unwind.**
+   Breakpad/Crashpad in-process brings a large NDK dependency into a Kotlin
+   SDK. The QNC2 fatal-signal handler therefore stays bounded and
+   async-signal-safe, but treats the kernel-provided `ucontext` as the source
+   of truth: signal/siginfo, crash-thread pid/tid/name, PC/LR/SP and relevant
+   registers, context PC/LR frames, precomputed loaded-image ELF BuildIds, and
+   `/proc/self/maps`. It does not call `_Unwind_Backtrace` from the handler —
+   that was the QNC1 bug which produced recorder frames. Mapping, JSON, HTTP,
+   and upload still happen on the NEXT launch. API 30+
+   `ApplicationExitInfo` supplies the sanctioned tombstone/abort-description
+   evidence when the OEM retained it. Matching is fail-closed on the QNC2
+   recorded pid, `REASON_CRASH_NATIVE`, and a five-second timestamp window;
+   one system exit can bind to only one pending QNC, and that identity is
+   persisted for deterministic retry. Coverage is best-effort, never invented.
+   QNC filenames use millisecond timestamp + pid + tid and `O_EXCL` with a
+   bounded collision suffix, so a same-time crash loop cannot truncate an
+   earlier record.
+   Crashpad remains the upgrade path if we later require full out-of-process
+   stack unwinding/minidumps.
 5. **iOS SDK prerequisite before any server work:** extend the crash record
    with the loaded-images table (`dyld` image list: UUID, address, path) so
    offsets are computable. Until then, dSYM upload is accepted but unused.

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -947,8 +947,11 @@ export interface NativeFrame {
 /**
  * SDK contract (symbolication matrix): metadata.crash_native_frames is a
  * JSON array (or already-parsed array) of
- * { index, offset, soname, build_id? }. Bounded and shape-checked here so a
- * hostile client can't feed junk to the container.
+ * { index, offset, soname, build_id? }. Legacy clients may omit build_id, so
+ * parsing preserves those frames for diagnostics, but native symbolication is
+ * fail-closed per frame and never resolves one without an exact ELF BuildId.
+ * Input is bounded and shape-checked here so a hostile client can't feed junk
+ * to the container.
  */
 export function parseNativeFrames(raw: unknown): NativeFrame[] {
   let value = raw;
@@ -996,6 +999,19 @@ export async function symbolicateNativeCrashTicket(
   try {
     if (versionCode === null || frames.length === 0) return;
 
+    if (!frames.some((frame) => Boolean(frame.build_id))) {
+      await appendSymbolication(
+        env,
+        ticketId,
+        "native",
+        "unsymbolicated",
+        "Native frames did not include an ELF BuildId. Hands refuses basename/version-only " +
+          "symbolication because it can select the wrong binary. Update to a QNC2-capable " +
+          "Android SDK and reproduce the crash on the successor runtime.",
+      );
+      return;
+    }
+
     const symbols = await env.DB.prepare(
       `SELECT ba.r2_key FROM build_assets ba
        JOIN builds b ON b.id = ba.build_id
@@ -1035,7 +1051,16 @@ export async function symbolicateNativeCrashTicket(
         },
       }),
     );
-    if (!res.ok) return;
+    if (!res.ok) {
+      await appendSymbolication(
+        env,
+        ticketId,
+        "native",
+        "unsymbolicated",
+        `Native symbolicator rejected the evidence (HTTP ${res.status}); no unverified fallback was used.`,
+      );
+      return;
+    }
     const parsed = (await res.json()) as {
       frames?: Array<{ index: number; resolved?: string; error?: string }>;
     };
@@ -1052,7 +1077,9 @@ export async function symbolicateNativeCrashTicket(
       env,
       ticketId,
       "native",
-      "symbolicated",
+      resolved.some((frame) => Boolean(frame.resolved && frame.resolved !== "??"))
+        ? "symbolicated"
+        : "unsymbolicated",
       lines.join("\n").slice(0, 20_000),
     );
   } catch (err) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -1162,7 +1162,11 @@ describe("quiver route handlers — SQL smoke", () => {
       { id: "lane-app", platform: "android" },
       "lane-android-native",
       42,
-      { crash_native_frames: [{ index: 0, offset: "0x1234", soname: "libapp.so" }] },
+      {
+        crash_native_frames: [
+          { index: 0, offset: "0x1234", soname: "libapp.so", build_id: "abcd1234" },
+        ],
+      },
       null,
     );
     row = await readSym("lane-android-native");
@@ -6013,6 +6017,27 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(row.symbolicated_stack).toContain("native-symbols");
     expect(row.symbolicated_stack).toContain("1000200");
     expect(row.symbolicated_stack).toContain("abcd1234");
+  });
+
+  it("symbolicateNativeCrashTicket fails closed when every frame lacks a BuildId", async () => {
+    const env = makeEnv();
+    const { symbolicateNativeCrashTicket } = await import("../src/routes/feedback");
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?1, ?2, 'crash', 'open', 'legacy native crash', '{}', ?3, ?4)`,
+    ).bind("tick-nat-no-build-id", "app-scope", 1, 1).run();
+    await symbolicateNativeCrashTicket(env as any, "app-scope", "tick-nat-no-build-id", 1000200, [
+      { index: 0, offset: "0x1a2b", soname: "libraft.so" },
+    ]);
+    const row = (await env.DB.prepare(
+      "SELECT symbolication_status, symbolicated_stack FROM feedback_tickets WHERE id = ?1",
+    ).bind("tick-nat-no-build-id").first()) as {
+      symbolication_status: string;
+      symbolicated_stack: string;
+    };
+    expect(row.symbolication_status).toBe("unsymbolicated");
+    expect(row.symbolicated_stack).toContain("did not include an ELF BuildId");
+    expect(row.symbolicated_stack).toContain("QNC2-capable Android SDK");
   });
 
   it("parseOhosNativeFrames extracts frames from a debuggerd-style HarmonyOS fault log", async () => {


### PR DESCRIPTION
## Summary

Closes the source-level Android native-depth gap tracked by task #120 and exposed by production ticket `25fbfda0`.

- replace QNC1's signal-handler `_Unwind_Backtrace` with QNC2 kernel `ucontext` capture: crash-thread PC/LR/SP, relevant registers, siginfo, pid/tid/thread name, context-derived frames, loaded-image ELF BuildIds, and `/proc/self/maps`
- keep QNC1 readable but never invent identity; legacy frames remain diagnosable and fail closed at symbolication
- attach matching Android 11+ `ApplicationExitInfo` exit metadata and retained trace/tombstone evidence when available
- make native symbolication strictly BuildId-based: index all same-soname ABI candidates and resolve only an exact per-frame ELF BuildId match; missing, unreadable, or mismatched IDs produce an unsymbolicated evidence block with no basename/version fallback
- document the source/runtime boundary and keep successor-runtime reproduction/soak as a required closure gate

## Why

The 1.6.0 arm64 QNC1 record discarded `ucontext` and unwound from `quiver_signal_handler`, so its only resolvable frame was the recorder itself. Asset pairing was exact, but the record lacked the crash origin, thread/register context, abort/tombstone evidence, and per-image build identity.

## Verification

- Android `assembleRelease` for arm64-v8a, armeabi-v7a, x86_64: PASS
- Android `testReleaseUnitTest`: 4/4 PASS
- Container native BuildId selector tests: 3/3 PASS
- Full workspace builds: PASS
- Full workspace tests: Worker 220, Admin 5, CLI 25, Node 13, Electron 3, Container 3: PASS
- `git diff --check`: PASS

## Boundaries

This PR does not deploy Worker/Container, publish an Android SDK, change the current 1.6.0 binary, claim the existing ticket's cause is fixed, or close runtime validation. After review/merge, a successor SDK/runtime must be built and exercised; same-device recurrence/causal-fix soak remains required.
