### PR TITLE
chore(android-sdk): prepare 0.12.0 release

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.11.2"
+        default: "0.12.0"
   push:
     tags:
       - "android-sdk-v*"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.11.0")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.0")
 }
 ```
 
@@ -94,7 +94,7 @@ to catch that.
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.11.0`). That publishes to
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.0`). That publishes to
 GitHub Packages (`build.hands:hands-android-sdk:<version>`, including the
 `native-symbols` classifier) and, on the first
 request, builds the same version on JitPack

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.11.2"
+        const val SDK_VERSION = "0.12.0"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.11.0")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.0")
 }
 ```
 


### PR DESCRIPTION
## Summary
- bump the SDK-reported version to 0.12.0 for the QNC2 release
- make 0.12.0 the publish-workflow default
- update Android SDK dependency examples to the immutable 0.12.0 tag

## Verification
- `testReleaseUnitTest` PASS (7 Kotlin tests + production native collision test)
- `assembleRelease` PASS for arm64-v8a, armeabi-v7a, and x86_64
- `packageReleaseNativeSymbols -PVERSION_NAME=0.12.0` PASS (3 ABI symbol files)
- `git diff --check` PASS

This PR only prepares the immutable release coordinate. Publication happens after merge by pushing `android-sdk-v0.12.0`, which runs the official publish workflow and produces the matching native-symbols classifier.
