### PR TITLE
fix(releases): guard scoped activation

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1403,10 +1403,19 @@ export const updateRelease = (
     body: JSON.stringify(input),
   });
 
-export const publishRelease = (appId: string, releaseId: string) =>
+export const publishRelease = (
+  appId: string,
+  releaseId: string,
+  expectedScope?: { scope_type: string; scope_value: string },
+) =>
   request<Release>(`/api/apps/${appId}/releases/${releaseId}/publish`, {
     method: "POST",
     admin: true,
+    body: JSON.stringify(
+      expectedScope
+        ? { expected_scope: expectedScope }
+        : {},
+    ),
   });
 
 export const deleteRelease = (appId: string, releaseId: string) =>

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -342,7 +342,13 @@ function ReleaseRow({
   });
 
   const publish = useMutation({
-    mutationFn: () => publishRelease(appId, r.id),
+    mutationFn: () => {
+      const scopes = detail.data?.scopes ?? [];
+      const expectedScope = scopes.length === 1 && scopes[0]?.scope_type !== "full"
+        ? { scope_type: scopes[0].scope_type, scope_value: scopes[0].scope_value }
+        : undefined;
+      return publishRelease(appId, r.id, expectedScope);
+    },
     onSuccess: () => {
       toast.show({ kind: "success", title: `Published ${channelSlug}` });
       onAction();
@@ -490,9 +496,9 @@ function ReleaseRow({
             variant="primary"
             className="text-xs"
             onClick={() => publish.mutate()}
-            disabled={publish.isPending}
+            disabled={publish.isPending || !detail.data}
           >
-            {publish.isPending ? "Publishing..." : "Publish"}
+            {publish.isPending ? "Publishing..." : !detail.data ? "Loading scope..." : "Publish"}
           </Button>
         )}
         {(r.status === "draft" || r.status === "active") && (
@@ -1019,7 +1025,10 @@ function NewReleaseDialog({
         }
       }
       if (mode === "publish") {
-        const published = await publishRelease(appId, release.id);
+        const expectedScope = scopeType === "full"
+          ? undefined
+          : { scope_type: scopeType, scope_value: scopeValue.trim() };
+        const published = await publishRelease(appId, release.id, expectedScope);
         return { release: published, assetFailures, mode };
       }
       return { release, assetFailures, mode };

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -435,14 +435,21 @@ hands device-groups add-member raft-android <group-id> \
 hands device-groups update raft-android <group-id> \
   --name "Artin test tablets" --description "Physical acceptance devices"
 hands releases update raft-android <release-id> --device-group <group-id>
-hands releases publish raft-android <release-id>
+hands releases publish raft-android <release-id> --device-group <group-id>
 ```
 
-The final publish remains an explicit authorization step. Only exact group
-members receive the release; other devices fall back to the prior active
-release. List groups with `hands device-groups list <app>` and remove members
-with `device-groups remove-member`. Rename or change the operator note with
-`device-groups update`. Do not use IMEI or hardware serial numbers.
+The final publish remains an explicit authorization step. The CLI first reads
+release detail and sends the exact stored non-full scope as an expected-scope
+precondition; zero, mixed, empty, or unsupported scope state is rejected
+locally without a publish request. `--device-group` adds an explicit assertion
+that the stored scope is that exact group. Activation returns `409` if the
+scope then drifts between detail read and the guarded server transition.
+Publishing an exact `full:all` release sends no precondition.
+Only exact group members receive the release; other devices fall back to the
+prior active release. List groups with `hands device-groups list <app>` and
+remove members with `device-groups remove-member`. Rename or change the
+operator note with `device-groups update`. Do not use IMEI or hardware serial
+numbers.
 
 ## Share Links
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -50,6 +50,17 @@ receives or chooses the group name. A non-member falls through to the previous
 matching active release. Device groups use installation identifiers, not IMEI,
 hardware serial numbers, or account identities.
 
+Scope writes are fail-closed: omitting `scopes` when creating a generic
+release defaults to `full:all`, but explicitly supplying `scopes` requires a
+non-empty array whose every entry has a non-empty `scope_type` and
+`scope_value`. To activate any non-full scoped draft, publish with
+`{"expected_scope":{"scope_type":"device_group","scope_value":"<group UUID>"}}`
+(or the exact `platform`, `user_cohort`, or `ip_range` scope). Hands rechecks
+that the draft still has exactly that one scope in the guarded activation
+operation and returns `409 RELEASE_SCOPE_PRECONDITION_FAILED` on missing,
+malformed, mixed, empty, or drifted scope state. Omitting the precondition can
+activate only an exact `full:all` release.
+
 ### Update Available
 
 ```json

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -259,6 +259,15 @@ describe("device-group rollout commands", () => {
       if (req.url === "/api/apps/app-1/releases/release-1" && req.method === "PATCH") {
         return res.end(JSON.stringify({ id: "release-1", status: "draft" }));
       }
+      if (req.url === "/api/apps/app-1/releases/release-1" && req.method === "GET") {
+        return res.end(JSON.stringify({
+          release: { id: "release-1", status: "draft" },
+          scopes: [{ scope_type: "device_group", scope_value: "group-1" }],
+        }));
+      }
+      if (req.url === "/api/apps/app-1/releases/release-1/publish" && req.method === "POST") {
+        return res.end(JSON.stringify({ id: "release-1", status: "active" }));
+      }
       res.statusCode = 404;
       return res.end(JSON.stringify({ error: "not found" }));
     });
@@ -295,6 +304,12 @@ describe("device-group rollout commands", () => {
         "node", "hands", "releases", "update", "raft-android", "release-1",
         "--device-group", "group-1",
       ]);
+      const publishProgram = new Command();
+      registerReleaseCommands(publishProgram);
+      await publishProgram.parseAsync([
+        "node", "hands", "releases", "publish", "raft-android", "release-1",
+        "--device-group", "group-1",
+      ]);
 
       expect(requests.find((request) => request.url.endsWith("/device-groups"))).toMatchObject({
         method: "POST",
@@ -311,6 +326,105 @@ describe("device-group rollout commands", () => {
         method: "PATCH",
         body: { scopes: [{ scope_type: "device_group", scope_value: "group-1" }] },
       });
+      expect(requests.find((request) => request.url.endsWith("/releases/release-1/publish"))).toMatchObject({
+        method: "POST",
+        body: { expected_scope: { scope_type: "device_group", scope_value: "group-1" } },
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("derives every exact scoped publish precondition from detail and refuses invalid stored scopes", async () => {
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    const details: Record<string, unknown[]> = {
+      "release-platform": [{ scope_type: "platform", scope_value: "android" }],
+      "release-cohort": [{ scope_type: "user_cohort", scope_value: "internal-qa" }],
+      "release-ip": [{ scope_type: "ip_range", scope_value: "203.0.113.0/24" }],
+      "release-full": [{ scope_type: "full", scope_value: "all" }],
+      "release-zero": [],
+      "release-mixed": [
+        { scope_type: "platform", scope_value: "android" },
+        { scope_type: "user_cohort", scope_value: "internal-qa" },
+      ],
+      "release-unknown": [{ scope_type: "future_scope", scope_value: "value" }],
+    };
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      const detailMatch = req.url?.match(/^\/api\/apps\/app-1\/releases\/([^/]+)$/);
+      if (detailMatch && req.method === "GET") {
+        const releaseId = detailMatch[1] ?? "";
+        return res.end(JSON.stringify({
+          release: { id: releaseId, status: "draft" },
+          scopes: details[releaseId],
+        }));
+      }
+      const publishMatch = req.url?.match(/^\/api\/apps\/app-1\/releases\/([^/]+)\/publish$/);
+      if (publishMatch && req.method === "POST") {
+        return res.end(JSON.stringify({ id: publishMatch[1], status: "active" }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    const runPublish = async (releaseId: string, extra: string[] = []) => {
+      const program = new Command();
+      const { registerReleaseCommands } = await import("../src/commands/releases.js");
+      registerReleaseCommands(program);
+      return program.parseAsync([
+        "node", "hands", "releases", "publish", "raft-android", releaseId, ...extra,
+      ]);
+    };
+
+    try {
+      for (const releaseId of ["release-platform", "release-cohort", "release-ip", "release-full"]) {
+        await runPublish(releaseId);
+      }
+      const publishBodies = Object.fromEntries(
+        requests
+          .filter((request) => request.method === "POST" && request.url.endsWith("/publish"))
+          .map((request) => [request.url.split("/").at(-2), request.body]),
+      );
+      expect(publishBodies).toMatchObject({
+        "release-platform": { expected_scope: { scope_type: "platform", scope_value: "android" } },
+        "release-cohort": { expected_scope: { scope_type: "user_cohort", scope_value: "internal-qa" } },
+        "release-ip": { expected_scope: { scope_type: "ip_range", scope_value: "203.0.113.0/24" } },
+        "release-full": {},
+      });
+
+      const postsBeforeInvalid = requests.filter(
+        (request) => request.method === "POST" && request.url.endsWith("/publish"),
+      ).length;
+      for (const releaseId of ["release-zero", "release-mixed", "release-unknown"]) {
+        await expect(runPublish(releaseId)).rejects.toThrow(/refusing|exactly one/);
+      }
+      await expect(runPublish("release-platform", ["--device-group", "group-wrong"]))
+        .rejects.toThrow("does not match stored platform:android");
+      expect(requests.filter(
+        (request) => request.method === "POST" && request.url.endsWith("/publish"),
+      )).toHaveLength(postsBeforeInvalid);
     } finally {
       if (originalApi === undefined) delete process.env.HANDS_API;
       else process.env.HANDS_API = originalApi;

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -21,6 +21,13 @@ interface ReleaseShare {
   revoked_at: number | null;
 }
 
+interface ReleaseScope {
+  scope_type: string;
+  scope_value: string;
+}
+
+const RELEASE_SCOPE_TYPES = new Set(["full", "platform", "user_cohort", "ip_range", "device_group"]);
+
 const DEFAULT_SHARE_TTL_SECONDS = "604800";
 
 export function registerReleaseCommands(program: Command): void {
@@ -137,18 +144,52 @@ export function registerReleaseCommands(program: Command): void {
   releases
     .command("publish <appIdOrSlug> <releaseId>")
     .description("Publish a draft release (the explicit human/agent step after changelog review).")
+    .option(
+      "--device-group <groupId>",
+      "Assert that the stored release scope is exactly this device group before activation.",
+    )
     .option("--json", "Output JSON.", false)
-    .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }) => {
+    .action(async (
+      appIdOrSlug: string,
+      releaseId: string,
+      opts: { deviceGroup?: string; json?: boolean },
+    ) => {
       const appId = await resolveAppId(appIdOrSlug);
+      const detail = await apiRequest<{ scopes?: unknown }>(
+        `/api/apps/${appId}/releases/${releaseId}`,
+      );
+      if (!Array.isArray(detail.scopes) || detail.scopes.length !== 1) {
+        throw new Error("publish requires exactly one stored release scope; refusing zero or mixed scopes");
+      }
+      const rawScope = detail.scopes[0] as Partial<ReleaseScope> | null;
+      const scopeType = typeof rawScope?.scope_type === "string" ? rawScope.scope_type.trim() : "";
+      const scopeValue = typeof rawScope?.scope_value === "string" ? rawScope.scope_value.trim() : "";
+      if (!scopeType || !scopeValue || !RELEASE_SCOPE_TYPES.has(scopeType)) {
+        throw new Error("stored release scope is empty or unsupported; refusing publish");
+      }
+      if (scopeType === "full" && scopeValue !== "all") {
+        throw new Error("stored full release scope must be exactly full:all; refusing publish");
+      }
+      if (opts.deviceGroup && (scopeType !== "device_group" || scopeValue !== opts.deviceGroup)) {
+        throw new Error(`--device-group ${opts.deviceGroup} does not match stored ${scopeType}:${scopeValue}`);
+      }
+
+      const body: Record<string, unknown> = {};
+      if (scopeType !== "full") {
+        body.expected_scope = {
+          scope_type: scopeType,
+          scope_value: scopeValue,
+        };
+      }
       const result = await apiRequest<Record<string, unknown>>(
         `/api/apps/${appId}/releases/${releaseId}/publish`,
-        { method: "POST", body: {} },
+        { method: "POST", body },
       );
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
         return;
       }
-      console.log(`Published release ${releaseId}.`);
+      console.log(`Published release ${releaseId}${opts.deviceGroup ? ` to device_group:${opts.deviceGroup}` : ""}.`);
     });
 
   releases

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -942,6 +942,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          expected_scope: { type: "object", in: "body", required: false, description: "Required for any non-full scoped activation, e.g. {\"scope_type\":\"device_group\",\"scope_value\":\"<group UUID>\"}. Publish fails with 409 unless the draft has exactly this one scope. Omit only for an exact full:all release." },
         },
       },
       {

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -75,13 +75,46 @@ function jsonString(value: unknown, fallback: Record<string, unknown> | unknown[
 }
 
 function normalizeScopes(scopes: ReleaseScopeInput[] | undefined): ReleaseScopeInput[] {
-  const filtered = (scopes ?? [])
-    .map((scope) => ({
-      scope_type: String(scope.scope_type ?? "").trim(),
-      scope_value: String(scope.scope_value ?? "").trim(),
-    }))
-    .filter((scope) => scope.scope_type && scope.scope_value);
-  return filtered.length > 0 ? filtered : [{ scope_type: "full", scope_value: "all" }];
+  // An omitted scope keeps the generic release default. An explicitly supplied
+  // scope list is an operator boundary: never filter invalid entries and then
+  // silently widen an empty result to full rollout.
+  if (scopes === undefined) return [{ scope_type: "full", scope_value: "all" }];
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    throw new Error("release scopes must be a non-empty array when provided");
+  }
+  return scopes.map((scope, index) => {
+    if (!scope || typeof scope !== "object") {
+      throw new Error(`release scope at index ${index} must be an object`);
+    }
+    const scopeType = typeof scope.scope_type === "string" ? scope.scope_type.trim() : "";
+    const scopeValue = typeof scope.scope_value === "string" ? scope.scope_value.trim() : "";
+    if (!scopeType || !scopeValue) {
+      throw new Error(`release scope at index ${index} requires non-empty scope_type and scope_value`);
+    }
+    return { scope_type: scopeType, scope_value: scopeValue };
+  });
+}
+
+function matchesPublishScopeExpectation(
+  scopes: ReleaseScopeInput[],
+  expectedScope: ReleaseScopeInput | null,
+): boolean {
+  if (scopes.length !== 1) return false;
+  const scope = scopes[0];
+  if (expectedScope !== null) {
+    return scope?.scope_type === expectedScope.scope_type && scope.scope_value === expectedScope.scope_value;
+  }
+  return scope?.scope_type === "full" && scope.scope_value === "all";
+}
+
+function parseExpectedPublishScope(raw: unknown): ReleaseScopeInput | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const candidate = raw as Partial<ReleaseScopeInput>;
+  const scopeType = typeof candidate.scope_type === "string" ? candidate.scope_type.trim() : "";
+  const scopeValue = typeof candidate.scope_value === "string" ? candidate.scope_value.trim() : "";
+  if (!scopeType || !scopeValue || !RELEASE_SCOPE_TYPES.has(scopeType)) return null;
+  if (scopeType === "full" && scopeValue !== "all") return null;
+  return { scope_type: scopeType, scope_value: scopeValue };
 }
 
 async function validateScopes(
@@ -1039,62 +1072,129 @@ export async function handlePublishRelease(c: AdminContext) {
   if (!existing) return c.json({ error: "not found" }, 404);
   // The external-target gate runs on EVERY publish attempt — including
   // already-active replays — before any no-op shortcut.
-  const publishBody = (await c.req.json().catch(() => ({}))) as { required_external_targets?: unknown };
+  const publishBody = (await c.req.json().catch(() => ({}))) as {
+    required_external_targets?: unknown;
+    expected_scope?: unknown;
+  };
   const gateFail = await assertExternalTargetGate(c, existing, publishBody.required_external_targets);
   if (gateFail) return gateFail;
-  if (existing.status === "active") return c.json(existing);
-  if (existing.status !== "draft") {
-    return c.json({ error: `cannot publish ${existing.status} release` }, 409);
+
+  let expectedScope: ReleaseScopeInput | null = null;
+  if (Object.prototype.hasOwnProperty.call(publishBody, "expected_scope")) {
+    expectedScope = parseExpectedPublishScope(publishBody.expected_scope);
+    if (!expectedScope) {
+      return c.json({
+        error: "expected_scope must contain a supported non-empty scope_type and scope_value",
+        code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+      }, 409);
+    }
   }
-  const now = Date.now();
+
   const { results: releaseScopes } = await c.env.DB.prepare(
     "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
   ).bind(releaseId).all<ReleaseScopeInput>();
+  if (!matchesPublishScopeExpectation(releaseScopes, expectedScope)) {
+    return c.json({
+      error: expectedScope === null
+        ? "publish without an expected_scope precondition requires exactly one full:all scope"
+        : "release scope does not exactly match expected_scope",
+      code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+    }, 409);
+  }
+  if (existing.status === "active") return c.json(withReleaseNotes(existing));
+  if (existing.status !== "draft") {
+    return c.json({ error: `cannot publish ${existing.status} release` }, 409);
+  }
+
+  const now = Date.now();
+  const auditId = crypto.randomUUID();
+  const auditPayload = JSON.stringify({
+    release_id: releaseId,
+    build_id: existing.build_id,
+    expected_scope: expectedScope,
+  });
+
+  // D1 batch is transactional. Every side effect is gated by the conditional
+  // audit insert, whose SELECT re-checks draft state and the exact stored scope
+  // inside the same batch. A stale preflight read therefore becomes a clean
+  // 409 with zero audit, fallback, activation, or webhook side effects.
   const statements = [
+    c.env.DB
+      .prepare(
+        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+         SELECT ?1, ?2, 'release.publish', ?3, ?4, ?5
+         FROM releases r
+         WHERE r.id = ?6 AND r.app_id = ?2 AND r.status = 'draft'
+           AND (
+             (?7 IS NULL AND ?8 IS NULL
+               AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = 1
+               AND EXISTS (
+                 SELECT 1 FROM release_scopes s
+                 WHERE s.release_id = r.id AND s.scope_type = 'full' AND s.scope_value = 'all'
+               ))
+             OR
+             (?7 IS NOT NULL AND ?8 IS NOT NULL
+               AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = 1
+               AND EXISTS (
+                 SELECT 1 FROM release_scopes s
+                 WHERE s.release_id = r.id AND s.scope_type = ?7 AND s.scope_value = ?8
+               ))
+           )`,
+      )
+      .bind(
+        auditId,
+        appId,
+        currentActor(c),
+        auditPayload,
+        now,
+        releaseId,
+        expectedScope?.scope_type ?? null,
+        expectedScope?.scope_value ?? null,
+      ),
+    c.env.DB
+      .prepare(
+        `UPDATE releases
+         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+         WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
+           AND release_type = ?6 AND status = 'active' AND id <> ?1
+           AND EXISTS (
+             SELECT 1 FROM releases next
+             WHERE next.id = ?1 AND next.app_id = ?3 AND next.status = 'draft'
+               AND (next.rollout_cohort_count IS NULL OR next.rollout_cohort_count >= 100)
+               AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = next.id) = 1
+               AND EXISTS (
+                 SELECT 1 FROM release_scopes s
+                 WHERE s.release_id = next.id AND s.scope_type = 'full' AND s.scope_value = 'all'
+               )
+               AND EXISTS (SELECT 1 FROM audit_logs a WHERE a.id = ?7)
+           )`,
+      )
+      .bind(
+        releaseId,
+        now,
+        appId,
+        existing.channel_id,
+        existing.product_type,
+        existing.release_type,
+        auditId,
+      ),
     c.env.DB
       .prepare(
         `UPDATE releases
          SET status = 'active', updated_at = ?1
-         WHERE id = ?2 AND app_id = ?3 AND status = 'draft'`,
+         WHERE id = ?2 AND app_id = ?3 AND status = 'draft'
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
       )
-      .bind(now, releaseId, appId),
-    c.env.DB
-      .prepare(
-        "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-      )
-      .bind(
-        crypto.randomUUID(),
-        appId,
-        "release.publish",
-        currentActor(c),
-        JSON.stringify({ release_id: releaseId, build_id: existing.build_id }),
-        now,
-      ),
+      .bind(now, releaseId, appId, auditId),
   ];
-  // Scoped and partial-rollout releases must coexist with the previous full
-  // active release so non-members can fall back. A full-coverage activation is
-  // the only event that supersedes every older active release in the lane.
-  if (isFullCoverage(releaseScopes, existing.rollout_cohort_count)) {
-    statements.splice(1, 0,
-      c.env.DB
-        .prepare(
-          `UPDATE releases
-           SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
-           WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
-             AND release_type = ?6 AND status = 'active' AND id <> ?7`,
-        )
-        .bind(
-          releaseId,
-          now,
-          appId,
-          existing.channel_id,
-          existing.product_type,
-          existing.release_type,
-          releaseId,
-        ),
-    );
+  const batchResults = await c.env.DB.batch(statements);
+  if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+      Number(batchResults[2]?.meta?.changes ?? 0) !== 1) {
+    return c.json({
+      error: "release status or scope changed before publish",
+      code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+    }, 409);
   }
-  await c.env.DB.batch(statements);
 
   const orgId = c.get("org_id");
   if (orgId) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3387,7 +3387,9 @@ describe("quiver releases — draft lifecycle", () => {
       scopes: [{ scope_type: "device_group", scope_value: "group-release-test" }],
     }, "tester", "rel-group-draft");
 
-    const response = await handlePublishRelease(makeReleaseContext("rel-group-draft"));
+    const response = await handlePublishRelease(makeReleaseContext("rel-group-draft", {
+      expected_scope: { scope_type: "device_group", scope_value: "group-release-test" },
+    }));
     expect(response.status).toBe(200);
     const { results } = await env.DB.prepare(
       "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
@@ -3398,7 +3400,7 @@ describe("quiver releases — draft lifecycle", () => {
     ]);
   });
 
-  it("treats a legacy mixed scope containing full:all as full coverage when publishing", async () => {
+  it("rejects a legacy mixed scope at publish without activation side effects", async () => {
     const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
     const now = Date.now();
     await env.DB.prepare(
@@ -3419,15 +3421,23 @@ describe("quiver releases — draft lifecycle", () => {
        VALUES (?, ?, 'full', 'all', ?)`,
     ).bind("scope-legacy-full", "rel-legacy-mixed", now).run();
 
-    const response = await handlePublishRelease(makeReleaseContext("rel-legacy-mixed"));
-    expect(response.status).toBe(200);
+    const response = await handlePublishRelease(makeReleaseContext("rel-legacy-mixed", {
+      expected_scope: { scope_type: "device_group", scope_value: "group-legacy-mixed" },
+    }));
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+    });
     const { results } = await env.DB.prepare(
       "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
     ).all();
     expect(results).toEqual([
-      { id: "rel-fallback", status: "superseded", superseded_by_release_id: "rel-legacy-mixed" },
-      { id: "rel-legacy-mixed", status: "active", superseded_by_release_id: null },
+      { id: "rel-fallback", status: "active", superseded_by_release_id: null },
+      { id: "rel-legacy-mixed", status: "draft", superseded_by_release_id: null },
     ]);
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+    ).first()).resolves.toEqual({ count: 0 });
   });
 
   it("publishes a partial full-scope rollout without superseding the full fallback release", async () => {
@@ -3539,6 +3549,279 @@ describe("quiver releases — draft lifecycle", () => {
       status: "draft",
       scopes: [{ scope_type: "device_group", scope_value: "group-other-app" }],
     }, "tester", "rel-cross-app-group")).rejects.toThrow("device group not found for app");
+  });
+
+  it("defaults omitted scopes to full but rejects every explicit empty or malformed scope list", async () => {
+    const { createRelease, handleUpdateRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-scope-validation", "app-release", "Scope validation", null, now, now).run();
+
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+    }, "tester", "rel-omitted-scope");
+    await expect(env.DB.prepare(
+      "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = 'rel-omitted-scope'",
+    ).first()).resolves.toEqual({ scope_type: "full", scope_value: "all" });
+
+    const invalidLists: unknown[] = [
+      [],
+      [{ scope_type: "", scope_value: "all" }],
+      [{ scope_type: "full", scope_value: "   " }],
+      [
+        { scope_type: "device_group", scope_value: "group-scope-validation" },
+        { scope_type: "", scope_value: "discard-me" },
+      ],
+    ];
+    for (const [index, scopes] of invalidLists.entries()) {
+      await expect(createRelease(env.DB as any, "app-release", {
+        build_id: "build-draft",
+        status: "draft",
+        scopes: scopes as any,
+      }, "tester", `rel-invalid-scope-${index}`)).rejects.toThrow(/release scope/);
+    }
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM releases WHERE id LIKE 'rel-invalid-scope-%'",
+    ).first()).resolves.toEqual({ count: 0 });
+
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "group-scope-validation" }],
+    }, "tester", "rel-scope-update-guard");
+    const beforeAudit = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.update'",
+    ).first();
+    for (const scopes of invalidLists) {
+      const response = await handleUpdateRelease(makeReleaseContext("rel-scope-update-guard", {
+        scopes,
+      }));
+      expect(response.status).toBe(400);
+    }
+    await expect(env.DB.prepare(
+      "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = 'rel-scope-update-guard'",
+    ).all()).resolves.toMatchObject({
+      results: [{ scope_type: "device_group", scope_value: "group-scope-validation" }],
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.update'",
+    ).first()).resolves.toEqual(beforeAudit);
+  });
+
+  it("requires an exact device-group publish precondition and rechecks it on replay", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-publish-guard", "app-release", "Publish guard", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-publish-guard-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "group-publish-guard" }],
+    }, "tester", "rel-publish-guard-draft");
+
+    for (const body of [
+      {},
+      { expected_scope: {} },
+      { expected_scope: { scope_type: "device_group", scope_value: "wrong-group" } },
+    ]) {
+      const response = await handlePublishRelease(makeReleaseContext("rel-publish-guard-draft", body));
+      expect(response.status).toBe(409);
+      await expect(responseJson<any>(response)).resolves.toMatchObject({
+        code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+      });
+    }
+    await expect(env.DB.prepare(
+      "SELECT status FROM releases WHERE id = 'rel-publish-guard-draft'",
+    ).first()).resolves.toEqual({ status: "draft" });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-publish-guard-fallback'",
+    ).first()).resolves.toEqual({ status: "active", superseded_by_release_id: null });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+    ).first()).resolves.toEqual({ count: 0 });
+
+    const exactBody = {
+      expected_scope: { scope_type: "device_group", scope_value: "group-publish-guard" },
+    };
+    const published = await handlePublishRelease(makeReleaseContext("rel-publish-guard-draft", exactBody));
+    expect(published.status).toBe(200);
+    await expect(env.DB.prepare(
+      "SELECT status FROM releases WHERE id = 'rel-publish-guard-draft'",
+    ).first()).resolves.toEqual({ status: "active" });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-publish-guard-fallback'",
+    ).first()).resolves.toEqual({ status: "active", superseded_by_release_id: null });
+
+    const replayWithoutExpectation = await handlePublishRelease(
+      makeReleaseContext("rel-publish-guard-draft"),
+    );
+    expect(replayWithoutExpectation.status).toBe(409);
+    const exactReplay = await handlePublishRelease(
+      makeReleaseContext("rel-publish-guard-draft", exactBody),
+    );
+    expect(exactReplay.status).toBe(200);
+  });
+
+  it("publishes platform, cohort, and IP scopes only with their exact generic expectation", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-generic-scope-fallback");
+
+    const scopeCases = [
+      { scope_type: "platform", scope_value: "android" },
+      { scope_type: "user_cohort", scope_value: "internal-qa" },
+      { scope_type: "ip_range", scope_value: "203.0.113.0/24" },
+    ];
+    for (const [index, scope] of scopeCases.entries()) {
+      const releaseId = `rel-generic-scope-${index}`;
+      await createRelease(env.DB as any, "app-release", {
+        build_id: "build-draft",
+        status: "draft",
+        scopes: [scope],
+      }, "tester", releaseId);
+      const auditBefore = await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+      ).first();
+
+      for (const expected_scope of [
+        undefined,
+        { scope_type: "device_group", scope_value: scope.scope_value },
+        { scope_type: scope.scope_type, scope_value: `${scope.scope_value}-wrong` },
+      ]) {
+        const body = expected_scope ? { expected_scope } : {};
+        const rejected = await handlePublishRelease(makeReleaseContext(releaseId, body));
+        expect(rejected.status).toBe(409);
+      }
+      await expect(env.DB.prepare(
+        "SELECT status FROM releases WHERE id = ?1",
+      ).bind(releaseId).first()).resolves.toEqual({ status: "draft" });
+      await expect(env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+      ).first()).resolves.toEqual(auditBefore);
+
+      const exactBody = { expected_scope: scope };
+      const published = await handlePublishRelease(makeReleaseContext(releaseId, exactBody));
+      expect(published.status).toBe(200);
+      await expect(env.DB.prepare(
+        "SELECT status FROM releases WHERE id = ?1",
+      ).bind(releaseId).first()).resolves.toEqual({ status: "active" });
+      await expect(env.DB.prepare(
+        "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-generic-scope-fallback'",
+      ).first()).resolves.toEqual({ status: "active", superseded_by_release_id: null });
+
+      const replayMissing = await handlePublishRelease(makeReleaseContext(releaseId));
+      expect(replayMissing.status).toBe(409);
+      const replayWrong = await handlePublishRelease(makeReleaseContext(releaseId, {
+        expected_scope: { scope_type: scope.scope_type, scope_value: `${scope.scope_value}-wrong` },
+      }));
+      expect(replayWrong.status).toBe(409);
+      const replayExact = await handlePublishRelease(makeReleaseContext(releaseId, exactBody));
+      expect(replayExact.status).toBe(200);
+    }
+  });
+
+  it("rejects full-scope drift and zero scope rows when device-group activation is expected", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-drift-guard", "app-release", "Drift guard", null, now, now).run();
+
+    for (const releaseId of ["rel-scope-drift-full", "rel-scope-drift-zero"]) {
+      await createRelease(env.DB as any, "app-release", {
+        build_id: "build-draft",
+        status: "draft",
+        scopes: [{ scope_type: "device_group", scope_value: "group-drift-guard" }],
+      }, "tester", releaseId);
+    }
+    await env.DB.prepare(
+      `UPDATE release_scopes SET scope_type = 'full', scope_value = 'all'
+       WHERE release_id = 'rel-scope-drift-full'`,
+    ).run();
+    await env.DB.prepare(
+      "DELETE FROM release_scopes WHERE release_id = 'rel-scope-drift-zero'",
+    ).run();
+
+    for (const releaseId of ["rel-scope-drift-full", "rel-scope-drift-zero"]) {
+      const response = await handlePublishRelease(makeReleaseContext(releaseId, {
+        expected_scope: { scope_type: "device_group", scope_value: "group-drift-guard" },
+      }));
+      expect(response.status).toBe(409);
+      await expect(env.DB.prepare(
+        "SELECT status FROM releases WHERE id = ?1",
+      ).bind(releaseId).first()).resolves.toEqual({ status: "draft" });
+    }
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+    ).first()).resolves.toEqual({ count: 0 });
+  });
+
+  it("fails the transactional publish CAS when scope drifts after preflight but before the batch", async () => {
+    const { createRelease, handlePublishRelease } = await import("../src/routes/releases");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-cas-race", "app-release", "CAS race", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-cas-race-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+      scopes: [{ scope_type: "device_group", scope_value: "group-cas-race" }],
+    }, "tester", "rel-cas-race-draft");
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        await env.DB.prepare(
+          `UPDATE release_scopes SET scope_type = 'full', scope_value = 'all'
+           WHERE release_id = 'rel-cas-race-draft'`,
+        ).run();
+      }
+      return originalBatch(statements);
+    };
+    const waitUntil = vi.fn();
+    const context = makeReleaseContext("rel-cas-race-draft", {
+      expected_scope: { scope_type: "device_group", scope_value: "group-cas-race" },
+    });
+    context.executionCtx.waitUntil = waitUntil;
+
+    const response = await handlePublishRelease(context);
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+    });
+    expect(waitUntil).not.toHaveBeenCalled();
+    await expect(env.DB.prepare(
+      "SELECT status FROM releases WHERE id = 'rel-cas-race-draft'",
+    ).first()).resolves.toEqual({ status: "draft" });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-cas-race-fallback'",
+    ).first()).resolves.toEqual({ status: "active", superseded_by_release_id: null });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+    ).first()).resolves.toEqual({ count: 0 });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM release_shares WHERE release_id = 'rel-cas-race-draft'",
+    ).first()).resolves.toEqual({ count: 0 });
   });
 
   it("rejects mixing full:all with a device-group scope on create and active update", async () => {
@@ -4330,6 +4613,10 @@ describe("quiver public API v2 — scope resolution", () => {
       `INSERT INTO releases (id, app_id, build_id, channel_id, product_type, release_type, status,
                              is_full, changelog, created_by, created_at, updated_at)
        VALUES ('rel-ext', 'app-scope', 'b-ext', 'ch-scope-prod', 'cli-binary', 'stable', 'draft', 1, NULL, 'tester', ?1, ?1)`,
+    ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+       VALUES ('scope-rel-ext-full', 'rel-ext', 'full', 'all', ?1)`,
     ).bind(now).run();
 
     const { handlePublishRelease, handleGetRelease } = await import("../src/routes/releases");


### PR DESCRIPTION
## Summary

- reject explicitly empty or malformed release scope lists instead of widening them to `full:all`
- require an exact canonical `expected_scope` precondition to publish any non-full scoped draft (`platform`, `user_cohort`, `ip_range`, or `device_group`)
- recheck draft state and exact stored scope inside the transactional D1 publish batch before audit, fallback supersede, or activation side effects
- make CLI publish read release detail and automatically serialize the unique canonical scope; reject zero/mixed/unsupported scopes before POST
- keep `hands releases publish --device-group <id>` as an explicit assertion and wire Console detail scopes
- document the fail-closed create/update/publish contract

## Safety behavior

- omitted scopes keep the generic `full:all` create default
- explicit `[]`, blank/incomplete entries, or mixed valid+invalid entries return 400 and preserve stored scope
- any scoped publish without an expectation, with an empty/wrong type/value expectation, or after full/mixed/zero-row drift returns `409 RELEASE_SCOPE_PRECONDITION_FAILED`
- a precondition failure leaves the draft, full fallback, audit log, webhook, and share state unchanged
- exact scoped activations keep the previous full release active for non-matching/no-device clients
- active publish replay must repeat the exact same scope expectation

## Validation

- `git diff --check`
- `pnpm -w build`
- `pnpm -w test`
  - Worker 225
  - Admin 15
  - CLI 26
  - Node 13
  - Electron 3
  - Container 3

Task: #171

Signed-off-by: Quinn Rafferty <cc-quiver-owner@mail.build>