### PR TITLE
fix(agent): expose scoped publish precondition

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -942,7 +942,6 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
-          expected_scope: { type: "object", in: "body", required: false, description: "Required for any non-full scoped activation, e.g. {\"scope_type\":\"device_group\",\"scope_value\":\"<group UUID>\"}. Publish fails with 409 unless the draft has exactly this one scope. Omit only for an exact full:all release." },
         },
       },
       {
@@ -981,6 +980,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          expected_scope: { type: "object", in: "body", required: false, description: "Required for any non-full scoped activation, e.g. {\"scope_type\":\"device_group\",\"scope_value\":\"<group UUID>\"}. Publish fails with 409 unless the draft has exactly this one scope. Omit only for an exact full:all release." },
         },
       },
       {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -8457,6 +8457,14 @@ describe("Hands iOS simulator QA artifacts", () => {
     });
     expect(byName["create-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
     expect(byName["update-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
+    expect(byName["get-release"].endpoint.method).toBe("GET");
+    expect(byName["get-release"].parameters).not.toHaveProperty("expected_scope");
+    expect(byName["publish-release"].endpoint.method).toBe("POST");
+    expect(byName["publish-release"].parameters.expected_scope).toMatchObject({
+      type: "object",
+      in: "body",
+      required: false,
+    });
   });
 
   it("reporter feedback bearer routes isolate integrations and converge comment replay", async () => {


### PR DESCRIPTION
## Summary

- move the optional `expected_scope` body parameter from the read-only `get-release` Agent Login action to `publish-release`
- add exact manifest coverage proving GET exposes no body scope and POST exposes the optional object precondition

## Why

The release publish handler already fails closed on scoped activation, but the production Raft agent manifest could not transport the canonical precondition because the parameter was attached to the wrong action.

## Verification

- focused manifest test: 1 passed
- Worker suite: 225 passed
- full workspace build: PASS
- `git diff --check`: PASS

Task: #171
