### PR TITLE
fix(access): support cross-server app member grants

### DIFF
--- a/admin/src/pages/AppAccess.tsx
+++ b/admin/src/pages/AppAccess.tsx
@@ -1116,18 +1116,21 @@ function AddAppMemberDialog({
   });
 
   const [selectedAccount, setSelectedAccount] = useState<string>("");
+  const [accountId, setAccountId] = useState("");
   const [role, setRole] = useState<AppMember["app_role"]>("viewer");
+  const targetAccountId = accountId.trim() || selectedAccount;
 
   const add = useMutation({
     mutationFn: () =>
       addAppMember(appId, {
-        account_id: selectedAccount,
+        account_id: targetAccountId,
         app_role: role,
       }),
     onSuccess: () => {
       toast.show({ kind: "success", title: "App member added" });
       qc.invalidateQueries({ queryKey: ["app-members", appId] });
       setSelectedAccount("");
+      setAccountId("");
       onAdded();
     },
     onError: (e) =>
@@ -1151,45 +1154,6 @@ function AddAppMemberDialog({
       m.org_role !== "admin",
     ) ??
     [];
-
-  if (candidates.length === 0) {
-    return (
-      <Dialog
-        open
-        onOpenChange={(open) => {
-          if (!open) onClose();
-        }}
-      >
-        <DialogContent className="max-w-md text-sm">
-          <DialogClose
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Close"
-                className="absolute top-3 right-3 text-slate-400 hover:text-slate-700"
-              />
-            }
-          >
-            ×
-          </DialogClose>
-          <DialogHeader>
-            <DialogTitle>Add direct app member</DialogTitle>
-          </DialogHeader>
-          <DialogBody>
-            <p className="text-slate-500">
-              No eligible org members need a direct app grant.
-            </p>
-          </DialogBody>
-          <DialogFooter>
-            <Button variant="outline" type="button" onClick={onClose}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    );
-  }
 
   return (
     <Dialog
@@ -1223,34 +1187,63 @@ function AddAppMemberDialog({
               add.mutate();
             }}
           >
+            {candidates.length > 0 ? (
+              <div>
+                <label className="label">Same-organization principal</label>
+                <Select
+                  items={{
+                    "": "— select —",
+                    ...Object.fromEntries(
+                      candidates.map((m) => [
+                        m.account_id,
+                        `${m.display_name} (${m.username ?? m.provider_subject.slice(0, 8)})`,
+                      ]),
+                    ),
+                  }}
+                  value={selectedAccount}
+                  onValueChange={(v) => {
+                    setSelectedAccount(v as string);
+                    if (v) setAccountId("");
+                  }}
+                >
+                  <SelectTrigger autoFocus>
+                    <SelectValue />
+                    <SelectIcon />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">— select —</SelectItem>
+                    {candidates.map((m) => (
+                      <SelectItem key={m.account_id} value={m.account_id}>
+                        {m.display_name} ({m.username ?? m.provider_subject.slice(0, 8)})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">
+                No same-organization principal needs a direct grant. You can still grant an
+                existing account from another linked Raft server below.
+              </p>
+            )}
             <div>
-              <label className="label">Principal</label>
-              <Select
-                items={{
-                  "": "— select —",
-                  ...Object.fromEntries(
-                    candidates.map((m) => [
-                      m.account_id,
-                      `${m.display_name} (${m.username ?? m.provider_subject.slice(0, 8)})`,
-                    ]),
-                  ),
+              <label className="label">Hands account ID</label>
+              <Input
+                value={accountId}
+                onChange={(e) => {
+                  setAccountId(e.target.value);
+                  if (e.target.value.trim()) setSelectedAccount("");
                 }}
-                value={selectedAccount}
-                onValueChange={(v) => setSelectedAccount(v as string)}
-              >
-                <SelectTrigger autoFocus>
-                  <SelectValue />
-                  <SelectIcon />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">— select —</SelectItem>
-                  {candidates.map((m) => (
-                    <SelectItem key={m.account_id} value={m.account_id}>
-                      {m.display_name} ({m.username ?? m.provider_subject.slice(0, 8)})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder="Account UUID from the principal's Hands whoami"
+                autoFocus={candidates.length === 0}
+                spellCheck={false}
+                className="font-mono"
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Use this for a human or agent on another Raft server. The account must have
+                logged into Hands once; the grant adds missing org viewer membership and the
+                selected app role.
+              </p>
             </div>
             <div>
               <label className="label">Role</label>
@@ -1271,8 +1264,8 @@ function AddAppMemberDialog({
               </Select>
             </div>
             <p className="text-xs text-slate-500">
-              Direct app members are for org members who need app-scoped access.
-              Owners and org admins already inherit app administration.
+              Direct app members receive access only to this app. Owners and org admins already
+              inherit app administration.
             </p>
           </form>
         </DialogBody>
@@ -1284,7 +1277,7 @@ function AddAppMemberDialog({
             type="submit"
             form="add-app-member-form"
             variant="primary"
-            disabled={!selectedAccount || add.isPending}
+            disabled={!targetAccountId || add.isPending}
           >
             {add.isPending ? "Adding…" : "Add"}
           </Button>

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -121,6 +121,12 @@ The Access page controls who can see or publish an app.
 | Raft server visibility | Make the app visible to accounts from another Raft server. |
 | Deploy token | Give CI or an agent scoped API access to this app. |
 
+For a principal on another linked Raft server, ask them to run the Hands
+`whoami` Agent Login action and send the non-secret Hands account id. In
+**Add direct app member**, paste that id instead of selecting a same-org
+principal. The account must have logged into Hands at least once. Hands adds
+missing org `viewer` membership and the selected app-scoped role atomically.
+
 Deploy tokens are app-scoped bearer tokens. Create them for automation instead of reusing a human browser session. Copy the token when it is created; Hands only shows the raw token once. Each token records who created it, and actions performed with it are attributed as `deploy-token:<name>@<app>` in audit logs and release provenance.
 
 Roles range from `viewer` (read) through `member` (collaborate — e.g. triage feedback), `publisher` (ship builds/releases), to `admin` (configure, manage members, hold secrets). See the [permissions reference](../rbac-permissions.md) for the full role model and the endpoint→role matrix.

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -36,6 +36,27 @@ for CLI/CI automation.
 Your capabilities follow your Hands org role. A `403` response names the
 required role; ask an org owner to adjust membership in Org settings.
 
+### Cross-server app access
+
+A Hands account is scoped to the Raft server identity that first created it.
+When an app admin and the target principal are on different Raft servers, the
+target may not appear in the admin's same-org picker. The target should run
+`whoami` and privately send the returned non-secret Hands account id. An app
+admin can then grant direct access without sharing a login token:
+
+```bash
+raft integration invoke --service hands-4cc7a2 \
+  --action add-app-member \
+  --param app_id=<app-uuid> \
+  --data-json '{"account_id":"<hands-account-uuid>","app_role":"viewer"}' \
+  --json
+```
+
+Use `list-app-members` to verify the exact account id, server identity, and
+app role. `update-app-member` changes the direct role and
+`remove-app-member` removes only the direct grant; inherited org/server access
+is unchanged.
+
 ### Deploy tokens
 
 Created in an app's **Settings -> Deploy Tokens** UI, by the CLI when it

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -810,6 +810,72 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         endpoint: { method: "GET", path: "/api/apps" },
       },
       {
+        name: "list-app-members",
+        description:
+          "List direct members of an app, including Hands account id, Raft server identity, principal type, and app role. Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/members" },
+        parameters: {
+          app_id: {
+            type: "string",
+            in: "path",
+            required: true,
+            description: "Hands app id.",
+          },
+        },
+      },
+      {
+        name: "add-app-member",
+        description:
+          "Grant one existing Hands account direct app access by account id. This supports principals from another linked Raft server and adds missing org viewer membership automatically. Requires app admin.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/members" },
+        parameters: {
+          app_id: {
+            type: "string",
+            in: "path",
+            required: true,
+            description: "Hands app id.",
+          },
+          account_id: {
+            type: "string",
+            in: "body",
+            required: true,
+            description: "Existing Hands account id returned by the target principal's whoami action.",
+          },
+          app_role: {
+            type: "string",
+            in: "body",
+            required: true,
+            description: "Direct app role: admin, publisher, or viewer.",
+          },
+        },
+      },
+      {
+        name: "update-app-member",
+        description:
+          "Change one direct app member's role by Hands account id. Requires app admin.",
+        endpoint: { method: "PATCH", path: "/api/apps/{app_id}/members/{account_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app id." },
+          account_id: { type: "string", in: "path", required: true, description: "Hands account id." },
+          app_role: {
+            type: "string",
+            in: "body",
+            required: true,
+            description: "Direct app role: admin, publisher, or viewer.",
+          },
+        },
+      },
+      {
+        name: "remove-app-member",
+        description:
+          "Remove one direct app member by Hands account id. Inherited org or server access is unchanged. Requires app admin.",
+        endpoint: { method: "DELETE", path: "/api/apps/{app_id}/members/{account_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app id." },
+          account_id: { type: "string", in: "path", required: true, description: "Hands account id." },
+        },
+      },
+      {
         name: "create-app",
         description:
           "Create an app in the caller's current Hands organization. Requires org member or higher. This creates no release and activates nothing.",

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -8378,6 +8378,22 @@ describe("Hands iOS simulator QA artifacts", () => {
         method: "GET",
         path: "/api/apps/{app_id}/client-key",
       },
+      "list-app-members": {
+        method: "GET",
+        path: "/api/apps/{app_id}/members",
+      },
+      "add-app-member": {
+        method: "POST",
+        path: "/api/apps/{app_id}/members",
+      },
+      "update-app-member": {
+        method: "PATCH",
+        path: "/api/apps/{app_id}/members/{account_id}",
+      },
+      "remove-app-member": {
+        method: "DELETE",
+        path: "/api/apps/{app_id}/members/{account_id}",
+      },
       "list-device-groups": {
         method: "GET",
         path: "/api/apps/{app_id}/device-groups",
@@ -8454,6 +8470,11 @@ describe("Hands iOS simulator QA artifacts", () => {
       type: "string",
       in: "path",
       required: true,
+    });
+    expect(byName["add-app-member"].parameters).toMatchObject({
+      app_id: { type: "string", in: "path", required: true },
+      account_id: { type: "string", in: "body", required: true },
+      app_role: { type: "string", in: "body", required: true },
     });
     expect(byName["create-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
     expect(byName["update-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });


### PR DESCRIPTION
## Summary

- expose list/add/update/remove app-member operations through the Hands Agent Login manifest
- let app admins grant an existing Hands account by account ID when the principal belongs to another linked Raft server
- keep the existing atomic org-viewer plus direct app-role grant semantics
- document the cross-server Agent Login workflow

## Why

The Console picker only enumerated same-organization members. A valid Hands account from another linked Raft server could be granted by the existing API, but there was no supported Console or Agent Login action for supplying its account ID.

## Validation

- `git diff --check`
- manifest route/parameter assertions added to the Worker test suite
- local Node/pnpm toolchain is unavailable on the author VM; hosted typecheck/build/test gates are required before review or merge

Signed-off-by: Volta <volta@mail.build>
