### PR TITLE
fix(releases): resolve IP scopes at Cloudflare edge

### DIFF
--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -84,9 +84,10 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   const deviceId =
     c.req.header("X-Hands-Device-Id") ?? c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
   const clientPlatform = effectiveClientPlatform(c);
-  // cf.clientIp is server-only (we never trust X-Forwarded-For here).
-  const clientIp =
-    (c.req.raw?.cf as { clientIp?: string } | undefined)?.clientIp ?? null;
+  // Cloudflare overwrites CF-Connecting-IP at the Worker edge. Request.cf does
+  // not expose a clientIp field in production. Never fall back to the
+  // client-controlled X-Forwarded-For header.
+  const clientIp = c.req.header("CF-Connecting-IP") ?? null;
 
   if (!slug) return c.json({ error: "slug required" }, 400);
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -4161,6 +4161,7 @@ describe("quiver public API v2 — scope resolution", () => {
     env: MockEnv,
     query: Record<string, string | undefined>,
     headers: Record<string, string | undefined> = {},
+    rawClientIp: string | null = "10.0.0.5",
   ) {
     return {
       env,
@@ -4168,8 +4169,8 @@ describe("quiver public API v2 — scope resolution", () => {
         url: "https://quiver-worker.test/public/v2/apps/scope-app/updates/check",
         param: (name: string) => (name === "slug" ? "scope-app" : ""),
         query: (name: string) => query[name],
-        header: (name: string) => headers[name],
-        raw: { cf: { clientIp: "10.0.0.5" } },
+        header: (name: string) => headers[name] ?? (name === "CF-Connecting-IP" ? rawClientIp ?? undefined : undefined),
+        raw: { cf: {} },
       },
       json: (data: unknown, status = 200) =>
         new Response(JSON.stringify(data), {
@@ -5247,6 +5248,45 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(otherResponse.status).toBe(200);
     await expect(responseJson<any>(otherResponse)).resolves.toMatchObject({
       build: { version_code: 10 },
+      scoped: { scope_type: "full", scope_value: "all" },
+    });
+  });
+
+  it("resolves ip_range from Cloudflare's edge-owned client IP header, never X-Forwarded-For", async () => {
+    const env = makeEnv();
+    configureR2Presign(env);
+    const now = Date.now();
+    await seedRelease(env, "rel-ip-header-fallback", "build-ip-header-fallback", [["full", "all"]], {
+      createdAt: now - 1000,
+      versionCode: 20,
+    });
+    await seedAsset(env, "build-ip-header-fallback", "asset-ip-header-fallback", { arch: "arm64-v8a" });
+    await seedRelease(env, "rel-ip-header-target", "build-ip-header-target", [["ip_range", "203.0.113.0/24"]], {
+      createdAt: now,
+      versionCode: 21,
+    });
+    await seedAsset(env, "build-ip-header-target", "asset-ip-header-target", { arch: "arm64-v8a" });
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+    const query = {
+      channel: "production",
+      product_type: "android-apk",
+      platform: "android",
+      arch: "arm64-v8a",
+    };
+
+    const edgeHeaderResponse = await handlePublicV2Latest(makePublicContext(env, query, {
+      "CF-Connecting-IP": "203.0.113.42",
+    }, null));
+    await expect(responseJson<any>(edgeHeaderResponse)).resolves.toMatchObject({
+      build: { version_code: 21 },
+      scoped: { scope_type: "ip_range", scope_value: "203.0.113.0/24" },
+    });
+
+    const spoofedForwardedResponse = await handlePublicV2Latest(makePublicContext(env, query, {
+      "X-Forwarded-For": "203.0.113.42",
+    }, null));
+    await expect(responseJson<any>(spoofedForwardedResponse)).resolves.toMatchObject({
+      build: { version_code: 20 },
       scoped: { scope_type: "full", scope_value: "all" },
     });
   });


### PR DESCRIPTION
## Summary

- resolve IP-scoped releases from Cloudflare's edge-owned `CF-Connecting-IP` header
- never fall back to client-controlled `X-Forwarded-For`
- add an end-to-end resolver regression proving the edge header selects `ip_range` while spoofed forwarding falls back to `full`

## Production finding

The synthetic task #171 smoke could publish an exact `ip_range` release, but production always resolved the full fallback. Cloudflare Workers do not expose `Request.cf.clientIp`; the prior resolver therefore always saw `null` in production.

## Verification

- focused production-shape resolver test: PASS
- Worker suite: 226/226 PASS
- Worker TypeScript build: PASS
- workspace full build: PASS on the same two-file patch lineage
- diff-check/sign-off: PASS

Task: #171
