### PR TITLE
feat(agent): expose safe app cleanup actions

### DIFF
--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -909,6 +909,36 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "archive-app",
+        description:
+          "Archive or unarchive an app without deleting it. Requires app admin. Archiving activates nothing and is required before purge-app.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/archive" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          archived: {
+            type: "boolean",
+            in: "body",
+            required: false,
+            description: "Archive when true or omitted; unarchive when false.",
+          },
+        },
+      },
+      {
+        name: "purge-app",
+        description:
+          "Irreversibly delete an archived app, all child rows, and owned R2 objects. Requires app admin and an exact confirm_slug. This cannot be undone.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/purge" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          confirm_slug: {
+            type: "string",
+            in: "body",
+            required: true,
+            description: "Exact current app slug; a mismatch fails closed.",
+          },
+        },
+      },
+      {
         name: "get-client-key",
         description:
           "Read an app's public SDK client key. Requires app admin. This never returns deploy tokens or other secrets and does not rotate the key.",

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -8414,6 +8414,14 @@ describe("Hands iOS simulator QA artifacts", () => {
         method: "POST",
         path: "/api/apps",
       },
+      "archive-app": {
+        method: "POST",
+        path: "/api/apps/{app_id}/archive",
+      },
+      "purge-app": {
+        method: "POST",
+        path: "/api/apps/{app_id}/purge",
+      },
       "get-client-key": {
         method: "GET",
         path: "/api/apps/{app_id}/client-key",
@@ -8505,6 +8513,14 @@ describe("Hands iOS simulator QA artifacts", () => {
       name: { type: "string", in: "body", required: true },
       platform: { type: "string", in: "body", required: true },
       description: { type: "string", in: "body", required: false },
+    });
+    expect(byName["archive-app"].parameters).toMatchObject({
+      app_id: { type: "string", in: "path", required: true },
+      archived: { type: "boolean", in: "body", required: false },
+    });
+    expect(byName["purge-app"].parameters).toMatchObject({
+      app_id: { type: "string", in: "path", required: true },
+      confirm_slug: { type: "string", in: "body", required: true },
     });
     expect(byName["get-client-key"].parameters.app_id).toMatchObject({
       type: "string",


### PR DESCRIPTION
## Summary

- expose the existing admin-only app archive/unarchive endpoint as `archive-app`
- expose the existing irreversible app purge endpoint as `purge-app`
- preserve existing app-admin RBAC and exact `confirm_slug` fail-closed guard
- pin both actions, methods, paths, and body requirements in the Agent manifest test

## Why

Agents can create isolated synthetic apps and clean their child releases/groups/tokens, but could not complete the final app cleanup through any supported Agent Login action. This left a safe workflow dependent on a human browser session.

## Verification

- focused Agent manifest test: 1/1 PASS
- Worker: 226/226 PASS
- full workspace build: PASS
- existing purge route test already covers archived requirement, exact slug confirmation, R2 sweep, and child-row cascade
- diff-check and parsed sign-off: PASS

Task: #189
