### PR TITLE
fix(admin): remove Apps transition navigation

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -62,8 +62,9 @@ import { isOrgSettingsTab, OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
 import { OrgSwitcher, useClearOrgCache } from "./components/OrgSwitcher";
-import { consoleRootTarget, dashboardHref, defaultAppResolverState } from "./lib/authNavigation";
+import { consoleRootAuthState, dashboardHref, defaultAppResolverState } from "./lib/authNavigation";
 import {
+  ApiError,
   clearActiveOrgId,
   getAuthToken,
   getAuthMe,
@@ -830,10 +831,18 @@ function AuthGate() {
     );
   }
 
-  const consoleTarget = consoleRootTarget(window.location, me.data?.account);
-  if (consoleTarget) {
-    if (consoleTarget.startsWith("/api/")) return <BrowserReplace to={consoleTarget} />;
-    return <Navigate to={consoleTarget} replace />;
+  const consoleState = consoleRootAuthState({
+    location: window.location,
+    account: me.data?.account,
+    isPending: me.isLoading,
+    errorStatus: me.error instanceof ApiError ? me.error.status : undefined,
+  });
+  if (consoleState.kind === "redirect") {
+    if (consoleState.href.startsWith("/api/")) return <BrowserReplace to={consoleState.href} />;
+    return <Navigate to={consoleState.href} replace />;
+  }
+  if (consoleState.kind === "error") {
+    return <AuthError onRetry={() => void me.refetch()} />;
   }
 
   if (me.isError || !me.data?.authenticated) {
@@ -849,6 +858,20 @@ function AuthGate() {
   }
 
   return <AuthenticatedApp account={me.data.account} />;
+}
+
+function AuthError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-50 px-4">
+      <section role="alert" className="w-full max-w-md rounded-md border border-red-200 bg-white p-6 shadow-xs">
+        <h1 className="text-lg font-semibold text-slate-950">Unable to check your Raft session</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Hands could not reach the authentication service. Check your connection and try again.
+        </p>
+        <Button className="mt-4" onClick={onRetry}>Retry</Button>
+      </section>
+    </main>
+  );
 }
 
 function BrowserReplace({ to }: { to: string }) {

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -62,7 +62,7 @@ import { isOrgSettingsTab, OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
 import { OrgSwitcher, useClearOrgCache } from "./components/OrgSwitcher";
-import { dashboardHref } from "./lib/authNavigation";
+import { consoleRootTarget, dashboardHref, defaultAppResolverState } from "./lib/authNavigation";
 import {
   clearActiveOrgId,
   getAuthToken,
@@ -199,25 +199,6 @@ function Header({ account }: { account: AuthAccount }) {
         )}
       </div>
       <nav className="flex min-h-0 w-full flex-1 flex-col items-stretch gap-1 px-2">
-        {!appId &&
-          (collapsed ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <NavLink to="/apps" end className={railItem}>
-                    <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-                    {!collapsed && <span className="hidden md:inline">Apps</span>}
-                  </NavLink>
-                }
-              />
-              <TooltipContent side="right">Apps</TooltipContent>
-            </Tooltip>
-          ) : (
-            <NavLink to="/apps" end className={railItem}>
-              <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-              {!collapsed && <span className="hidden md:inline">Apps</span>}
-            </NavLink>
-          ))}
         <div className="relative w-full">
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -632,12 +613,7 @@ function MobileTopNav({ account }: { account: AuthAccount }) {
               </NavLink>
             );
           })
-        ) : (
-          <NavLink to="/apps" end className={chip}>
-            <LayoutGrid className="h-4 w-4 flex-none" aria-hidden="true" />
-            <span className="whitespace-nowrap">Apps</span>
-          </NavLink>
-        )}
+        ) : null}
       </nav>
     </header>
   );
@@ -854,6 +830,12 @@ function AuthGate() {
     );
   }
 
+  const consoleTarget = consoleRootTarget(window.location, me.data?.account);
+  if (consoleTarget) {
+    if (consoleTarget.startsWith("/api/")) return <BrowserReplace to={consoleTarget} />;
+    return <Navigate to={consoleTarget} replace />;
+  }
+
   if (me.isError || !me.data?.authenticated) {
     return <PublicLanding />;
   }
@@ -867,6 +849,17 @@ function AuthGate() {
   }
 
   return <AuthenticatedApp account={me.data.account} />;
+}
+
+function BrowserReplace({ to }: { to: string }) {
+  useEffect(() => {
+    window.location.replace(to);
+  }, [to]);
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-50">
+      <div className="text-sm text-slate-500">Opening Hands console...</div>
+    </div>
+  );
 }
 
 function CliCallback({ token }: { token: string }) {
@@ -1282,22 +1275,36 @@ function AppsListWithNav() {
   const openNew = params.get("new") === "1";
   const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
 
-  // Default behavior per artin: /apps drops you into the first app; the
-  // full list is reachable via ?all=1 (sidebar "All apps"), and with zero
-  // apps we go straight to the creation wizard.
-  if (!showAll && !openNew && apps.data) {
-    const active = apps.data.apps.filter((a) => !a.archived);
-    if (active.length > 0) {
-      // Remember the last app the operator was in; fall back to the first
-      // active app when there's no stored choice or it no longer exists.
-      let target = active[0]!.id;
-      try {
-        const last = window.localStorage.getItem(LAST_APP_KEY);
-        if (last && active.some((a) => a.id === last)) target = last;
-      } catch {
-        // storage disabled — use the default
-      }
-      return <Navigate to={`/apps/${target}`} replace />;
+  // The default route is a resolver, not an Apps landing page. Keep the
+  // shell empty while the app list loads so the removed nav/page does not
+  // flash before the last (or first) active app is known.
+  if (!showAll && !openNew) {
+    let last: string | null = null;
+    try {
+      last = window.localStorage.getItem(LAST_APP_KEY);
+    } catch {
+      // storage disabled — use the first active app
+    }
+    const resolver = defaultAppResolverState({
+      apps: apps.data?.apps,
+      lastAppId: last,
+      isPending: apps.isPending,
+      isError: apps.isError,
+    });
+    if (resolver.kind === "loading") return null;
+    if (resolver.kind === "redirect") return <Navigate to={resolver.href} replace />;
+    if (resolver.kind === "error") {
+      return (
+        <StandardPageShell>
+          <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            <p className="font-medium">Could not load apps</p>
+            <p className="mt-1 text-red-700">Check your connection and try again.</p>
+            <Button className="mt-3" variant="outline" onClick={() => void apps.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </StandardPageShell>
+      );
     }
   }
   const zeroApps = apps.data ? apps.data.apps.filter((a) => !a.archived).length === 0 : false;

--- a/admin/src/lib/authNavigation.test.ts
+++ b/admin/src/lib/authNavigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dashboardHref } from "./authNavigation";
+import { consoleRootTarget, dashboardHref, defaultAppHref, defaultAppResolverState } from "./authNavigation";
 import type { AuthAccount } from "./api";
 
 describe("dashboardHref", () => {
@@ -9,5 +9,64 @@ describe("dashboardHref", () => {
 
   it("opens the dashboard directly for authenticated accounts", () => {
     expect(dashboardHref({} as AuthAccount)).toBe("/apps");
+  });
+});
+
+describe("consoleRootTarget", () => {
+  it("turns the exact console-domain root into the dashboard or Raft login", () => {
+    const root = { hostname: "app.hands.build", pathname: "/" };
+    expect(consoleRootTarget(root, {} as AuthAccount)).toBe("/apps");
+    expect(consoleRootTarget(root)).toBe("/api/auth/login?return=%2Fapps");
+  });
+
+  it("does not redirect the public site, previews, localhost, or deep links", () => {
+    for (const location of [
+      { hostname: "hands.build", pathname: "/" },
+      { hostname: "www.app.hands.build", pathname: "/" },
+      { hostname: "preview.app.hands.build", pathname: "/" },
+      { hostname: "localhost", pathname: "/" },
+      { hostname: "app.hands.build", pathname: "/docs" },
+      { hostname: "app.hands.build", pathname: "/apps/app-1" },
+    ]) expect(consoleRootTarget(location, {} as AuthAccount)).toBeNull();
+  });
+});
+
+describe("defaultAppHref", () => {
+  const apps = [
+    { id: "archived", archived: 1 },
+    { id: "first", archived: 0 },
+    { id: "last", archived: 0 },
+  ];
+
+  it("returns the last active app without exposing an Apps landing page", () => {
+    expect(defaultAppHref(apps, "last")).toBe("/apps/last");
+  });
+
+  it("falls back to the first active app when the stored app is unavailable", () => {
+    expect(defaultAppHref(apps, "missing")).toBe("/apps/first");
+    expect(defaultAppHref(apps, "archived")).toBe("/apps/first");
+  });
+
+  it("returns null only when onboarding is required", () => {
+    expect(defaultAppHref([{ id: "archived", archived: true }], "archived")).toBeNull();
+    expect(defaultAppHref([], null)).toBeNull();
+  });
+});
+
+describe("defaultAppResolverState", () => {
+  it("keeps only the loading state blank", () => {
+    expect(defaultAppResolverState({ isPending: true, isError: false })).toEqual({ kind: "loading" });
+  });
+
+  it("makes a terminal app-list error observable instead of leaving a blank shell", () => {
+    expect(defaultAppResolverState({ isPending: false, isError: true })).toEqual({ kind: "error" });
+    expect(defaultAppResolverState({ isPending: false, isError: false })).toEqual({ kind: "error" });
+  });
+
+  it("redirects once on success and reserves onboarding for a real empty list", () => {
+    expect(defaultAppResolverState({
+      apps: [{ id: "first" }, { id: "last" }], lastAppId: "last", isPending: false, isError: false,
+    })).toEqual({ kind: "redirect", href: "/apps/last" });
+    expect(defaultAppResolverState({ apps: [], isPending: false, isError: false })).toEqual({ kind: "onboarding" });
   });
 });

--- a/admin/src/lib/authNavigation.test.ts
+++ b/admin/src/lib/authNavigation.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { consoleRootTarget, dashboardHref, defaultAppHref, defaultAppResolverState } from "./authNavigation";
+import {
+  consoleRootAuthState,
+  consoleRootTarget,
+  dashboardHref,
+  defaultAppHref,
+  defaultAppResolverState,
+} from "./authNavigation";
 import type { AuthAccount } from "./api";
 
 describe("dashboardHref", () => {
@@ -16,7 +22,8 @@ describe("consoleRootTarget", () => {
   it("turns the exact console-domain root into the dashboard or Raft login", () => {
     const root = { hostname: "app.hands.build", pathname: "/" };
     expect(consoleRootTarget(root, {} as AuthAccount)).toBe("/apps");
-    expect(consoleRootTarget(root)).toBe("/api/auth/login?return=%2Fapps");
+    expect(consoleRootTarget(root, undefined, true)).toBe("/api/auth/login?return=%2Fapps");
+    expect(consoleRootTarget(root)).toBeNull();
   });
 
   it("does not redirect the public site, previews, localhost, or deep links", () => {
@@ -28,6 +35,35 @@ describe("consoleRootTarget", () => {
       { hostname: "app.hands.build", pathname: "/docs" },
       { hostname: "app.hands.build", pathname: "/apps/app-1" },
     ]) expect(consoleRootTarget(location, {} as AuthAccount)).toBeNull();
+  });
+});
+
+describe("consoleRootAuthState", () => {
+  const root = { hostname: "app.hands.build", pathname: "/" };
+
+  it("separates authenticated, confirmed 401, and unresolved auth failures", () => {
+    expect(consoleRootAuthState({
+      location: root, account: {} as AuthAccount, isPending: false,
+    })).toEqual({ kind: "redirect", href: "/apps" });
+    expect(consoleRootAuthState({
+      location: root, isPending: false, errorStatus: 401,
+    })).toEqual({ kind: "redirect", href: "/api/auth/login?return=%2Fapps" });
+    expect(consoleRootAuthState({
+      location: root, isPending: false, errorStatus: 503,
+    })).toEqual({ kind: "error" });
+    expect(consoleRootAuthState({
+      location: root, isPending: false,
+    })).toEqual({ kind: "error" });
+  });
+
+  it("keeps loading bounded and never applies the console contract to other hosts or paths", () => {
+    expect(consoleRootAuthState({ location: root, isPending: true })).toEqual({ kind: "loading" });
+    expect(consoleRootAuthState({
+      location: { hostname: "hands.build", pathname: "/" }, isPending: false, errorStatus: 401,
+    })).toEqual({ kind: "not-console-root" });
+    expect(consoleRootAuthState({
+      location: { hostname: "app.hands.build", pathname: "/apps" }, isPending: false, errorStatus: 401,
+    })).toEqual({ kind: "not-console-root" });
   });
 });
 

--- a/admin/src/lib/authNavigation.ts
+++ b/admin/src/lib/authNavigation.ts
@@ -7,9 +7,31 @@ export function dashboardHref(account?: AuthAccount): string {
 export function consoleRootTarget(
   location: { hostname: string; pathname: string },
   account?: AuthAccount,
+  confirmedUnauthorized = false,
 ): string | null {
   if (location.hostname !== "app.hands.build" || location.pathname !== "/") return null;
-  return dashboardHref(account);
+  if (account) return dashboardHref(account);
+  return confirmedUnauthorized ? dashboardHref() : null;
+}
+
+export type ConsoleRootAuthState =
+  | { kind: "not-console-root" }
+  | { kind: "loading" }
+  | { kind: "redirect"; href: string }
+  | { kind: "error" };
+
+export function consoleRootAuthState(input: {
+  location: { hostname: string; pathname: string };
+  account?: AuthAccount | undefined;
+  isPending: boolean;
+  errorStatus?: number | undefined;
+}): ConsoleRootAuthState {
+  const isConsoleRoot = input.location.hostname === "app.hands.build"
+    && input.location.pathname === "/";
+  if (!isConsoleRoot) return { kind: "not-console-root" };
+  if (input.isPending) return { kind: "loading" };
+  const href = consoleRootTarget(input.location, input.account, input.errorStatus === 401);
+  return href ? { kind: "redirect", href } : { kind: "error" };
 }
 
 export function defaultAppHref(
@@ -31,7 +53,7 @@ export type DefaultAppResolverState =
   | { kind: "onboarding" };
 
 export function defaultAppResolverState(input: {
-  apps?: Array<{ id: string; archived?: number | boolean | null }>;
+  apps?: Array<{ id: string; archived?: number | boolean | null }> | undefined;
   lastAppId?: string | null;
   isPending: boolean;
   isError: boolean;

--- a/admin/src/lib/authNavigation.ts
+++ b/admin/src/lib/authNavigation.ts
@@ -3,3 +3,41 @@ import { loginUrl, type AuthAccount } from "./api";
 export function dashboardHref(account?: AuthAccount): string {
   return account ? "/apps" : loginUrl("/apps");
 }
+
+export function consoleRootTarget(
+  location: { hostname: string; pathname: string },
+  account?: AuthAccount,
+): string | null {
+  if (location.hostname !== "app.hands.build" || location.pathname !== "/") return null;
+  return dashboardHref(account);
+}
+
+export function defaultAppHref(
+  apps: Array<{ id: string; archived?: number | boolean | null }>,
+  lastAppId?: string | null,
+): string | null {
+  const active = apps.filter((app) => !app.archived);
+  if (active.length === 0) return null;
+  const target = lastAppId && active.some((app) => app.id === lastAppId)
+    ? lastAppId
+    : active[0]!.id;
+  return `/apps/${target}`;
+}
+
+export type DefaultAppResolverState =
+  | { kind: "loading" }
+  | { kind: "error" }
+  | { kind: "redirect"; href: string }
+  | { kind: "onboarding" };
+
+export function defaultAppResolverState(input: {
+  apps?: Array<{ id: string; archived?: number | boolean | null }>;
+  lastAppId?: string | null;
+  isPending: boolean;
+  isError: boolean;
+}): DefaultAppResolverState {
+  if (input.isPending) return { kind: "loading" };
+  if (input.isError || !input.apps) return { kind: "error" };
+  const href = defaultAppHref(input.apps, input.lastAppId);
+  return href ? { kind: "redirect", href } : { kind: "onboarding" };
+}


### PR DESCRIPTION
Task #190. Removes the transient Apps sidebar/mobile nav item and keeps the default /apps route blank while it resolves directly to the last active app (or first active app). Explicit All apps/New app management and zero-app onboarding remain available. Adds deterministic routing tests.\n\nValidation: admin tests 18/18 PASS; admin production build PASS; diff-check PASS. Admin typecheck is currently blocked by the existing origin/main Releases.tsx line 348 possibly-undefined error; this PR does not touch that file.