### PR TITLE
feat(releases): show unique devices with PV details

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -226,6 +226,8 @@ export interface Release {
   // release_metrics (nullable when never checked)
   offered_count?: number | null;
   current_count?: number | null;
+  offered_uv?: number | null;
+  current_uv?: number | null;
   last_checked_at?: number | null;
 }
 

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -344,8 +344,9 @@ function ReleaseRow({
   const publish = useMutation({
     mutationFn: () => {
       const scopes = detail.data?.scopes ?? [];
-      const expectedScope = scopes.length === 1 && scopes[0]?.scope_type !== "full"
-        ? { scope_type: scopes[0].scope_type, scope_value: scopes[0].scope_value }
+      const onlyScope = scopes.length === 1 ? scopes[0] : undefined;
+      const expectedScope = onlyScope && onlyScope.scope_type !== "full"
+        ? { scope_type: onlyScope.scope_type, scope_value: onlyScope.scope_value }
         : undefined;
       return publishRelease(appId, r.id, expectedScope);
     },
@@ -456,27 +457,31 @@ function ReleaseRow({
       <div className="text-xs text-slate-500 font-mono mt-1 truncate">
         {r.id} (build {r.build_id.slice(0, 8)}…)
       </div>
-      {(r.offered_count || r.current_count) ? (
+      {(r.offered_count || r.current_count || r.offered_uv || r.current_uv) ? (
         <div className="mt-1 flex items-center gap-3 text-xs text-slate-500">
           <Tooltip>
             <TooltipTrigger
               render={
                 <span>
-                  <strong className="text-slate-700">{r.current_count ?? 0}</strong> on this version
+                  <strong className="text-slate-700">{r.current_uv ?? 0}</strong> on this version
                 </span>
               }
             />
-            <TooltipContent>Devices already on this version at update check</TooltipContent>
+            <TooltipContent>
+              {r.current_count ?? 0} update checks (PV)
+            </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger
               render={
                 <span>
-                  <strong className="text-slate-700">{r.offered_count ?? 0}</strong> offered
+                  <strong className="text-slate-700">{r.offered_uv ?? 0}</strong> offered
                 </span>
               }
             />
-            <TooltipContent>Update-check responses offering this version to older clients</TooltipContent>
+            <TooltipContent>
+              {r.offered_count ?? 0} update offers (PV)
+            </TooltipContent>
           </Tooltip>
           {r.last_checked_at ? (
             <span className="text-slate-400">

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -42,9 +42,11 @@ For Android, Hands selects updates by `version_code`. A device receives an updat
 
 Set a rollout percentage when creating or editing a release (number input with 5/25/50/100 presets), and raise it with **Bump rollout**. Devices are bucketed by their stable device id, keep their bucket while the percentage climbs, and gated-out devices receive the previous active release. Clients without a device id (older SDKs) only receive fully rolled-out releases.
 
-Each release row shows update-check analytics: how many devices are already
-**on this version** and how many were **offered** it (update checks from older
-clients), so you can see real rollout coverage as the percentage climbs.
+Each release row shows unique per-install devices (UV): how many devices have
+checked while already **on this version** and how many unique older devices
+were **offered** it. Hover either number to see the all-time update-check event
+count (PV). UV collection requires a stable device id and starts at the metric
+upgrade; historical PV aggregates cannot be converted into exact historical UV.
 
 The app overview also exposes version-level metrics from
 `GET /api/apps/:id/analytics/versions`: devices that reported in the selected

--- a/migrations/sql/0052_release_metric_devices.sql
+++ b/migrations/sql/0052_release_metric_devices.sql
@@ -1,0 +1,14 @@
+-- Exact per-release update-check UVs. Existing release_metrics counters remain
+-- the all-time request/event totals (PV). Historical UV cannot be reconstructed
+-- from those aggregates, so this set starts collecting at migration time.
+CREATE TABLE IF NOT EXISTS release_metric_devices (
+  release_id     TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  metric_kind    TEXT NOT NULL CHECK(metric_kind IN ('current', 'offered')),
+  device_id      TEXT NOT NULL,
+  first_checked_at INTEGER NOT NULL,
+  last_checked_at  INTEGER NOT NULL,
+  PRIMARY KEY (release_id, metric_kind, device_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_release_metric_devices_release_kind
+  ON release_metric_devices(release_id, metric_kind);

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -363,19 +363,31 @@ function bumpReleaseMetric(
   c: Context<{ Bindings: Env }>,
   releaseId: string | undefined,
   kind: "offered" | "current",
+  deviceId: string | null,
 ): void {
   if (!releaseId) return;
   const column = kind === "offered" ? "offered_count" : "current_count";
   const now = Date.now();
-  const run = c.env.DB.prepare(
+  const statements = [c.env.DB.prepare(
     `INSERT INTO release_metrics (release_id, ${column}, last_checked_at)
      VALUES (?1, 1, ?2)
      ON CONFLICT(release_id) DO UPDATE SET
        ${column} = ${column} + 1,
        last_checked_at = ?3`,
   )
-    .bind(releaseId, now, now)
-    .run();
+    .bind(releaseId, now, now)];
+  if (deviceId) {
+    statements.push(c.env.DB.prepare(
+      `INSERT INTO release_metric_devices
+       (release_id, metric_kind, device_id, first_checked_at, last_checked_at)
+       VALUES (?1, ?2, ?3, ?4, ?4)
+       ON CONFLICT(release_id, metric_kind, device_id) DO UPDATE SET
+         last_checked_at = excluded.last_checked_at`,
+    ).bind(releaseId, kind, deviceId, now));
+  }
+  const run = statements.length === 1
+    ? statements[0]!.run()
+    : c.env.DB.batch(statements);
   try {
     c.executionCtx.waitUntil(run.catch(() => {}));
   } catch {
@@ -400,13 +412,22 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
     );
   }
 
+  const rawDeviceId =
+    c.req.header("X-Hands-Device-Id") ?? c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
+  const trimmedDeviceId = rawDeviceId?.trim() ?? "";
+  // Stable SDK ids are bounded per-install identifiers. Missing/blank/oversize
+  // legacy values still contribute to PV but must not fabricate a UV row.
+  const metricDeviceId = trimmedDeviceId.length > 0 && trimmedDeviceId.length <= 256
+    ? trimmedDeviceId
+    : null;
+
   const latestResponse = await handlePublicV2Latest(c);
   if (latestResponse.status !== 200) return latestResponse;
   const latest = (await latestResponse.json()) as PublicLatestResponse;
 
   if (latest.build.version_code <= currentVersionCode) {
     if (latest.build.version_code === currentVersionCode) {
-      bumpReleaseMetric(c, latest.scoped?.release_id, "current");
+      bumpReleaseMetric(c, latest.scoped?.release_id, "current", metricDeviceId);
     }
     return c.json({
       update_available: false,
@@ -451,13 +472,12 @@ export async function handlePublicV2UpdateCheck(c: Context<{ Bindings: Env }>) {
     );
   }
 
-  bumpReleaseMetric(c, latest.scoped?.release_id, "offered");
+  bumpReleaseMetric(c, latest.scoped?.release_id, "offered", metricDeviceId);
   // Delta (differential) download offer: if the client's installed version has
   // a patch to the latest build for its arch, and that patch is meaningfully
   // smaller than the full APK, offer it. The full `asset` stays the fallback;
   // old SDKs ignore the extra `patch` field. See docs/delta-download-design.md.
-  const deviceId =
-    c.req.header("X-Hands-Device-Id") ?? c.req.header("X-Quiver-Device-Id") ?? c.req.query("device_id") ?? null;
+  const deviceId = rawDeviceId;
   const patch =
     currentVersionCode > 0
       ? await findDeltaPatch(c, {

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -491,7 +491,11 @@ export async function handleListReleases(c: Context<{ Bindings: Env }>) {
 
   const { results } = await c.env.DB.prepare(
     `SELECT r.*, c.slug AS channel, b.version_name, b.version_code,
-            rm.offered_count, rm.current_count, rm.last_checked_at
+            rm.offered_count, rm.current_count, rm.last_checked_at,
+            (SELECT COUNT(*) FROM release_metric_devices rmd
+             WHERE rmd.release_id = r.id AND rmd.metric_kind = 'offered') AS offered_uv,
+            (SELECT COUNT(*) FROM release_metric_devices rmd
+             WHERE rmd.release_id = r.id AND rmd.metric_kind = 'current') AS current_uv
      FROM releases r
      JOIN builds b ON b.id = r.build_id
      LEFT JOIN channels c ON c.id = r.channel_id
@@ -510,7 +514,11 @@ export async function handleGetRelease(c: Context<{ Bindings: Env }>) {
   const releaseId = c.req.param("releaseId") ?? "";
   const release = await c.env.DB.prepare(
     `SELECT r.*, c.slug AS channel,
-            rm.offered_count, rm.current_count, rm.last_checked_at
+            rm.offered_count, rm.current_count, rm.last_checked_at,
+            (SELECT COUNT(*) FROM release_metric_devices rmd
+             WHERE rmd.release_id = r.id AND rmd.metric_kind = 'offered') AS offered_uv,
+            (SELECT COUNT(*) FROM release_metric_devices rmd
+             WHERE rmd.release_id = r.id AND rmd.metric_kind = 'current') AS current_uv
      FROM releases r
      LEFT JOIN channels c ON c.id = r.channel_id
      LEFT JOIN release_metrics rm ON rm.release_id = r.id

--- a/worker/test/release_metric_devices_migration.test.ts
+++ b/worker/test/release_metric_devices_migration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0052_release_metric_devices.sql", import.meta.url),
+);
+
+describe("release metric device migration", () => {
+  it("deduplicates one device per release and metric kind and cascades with release", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec("CREATE TABLE releases(id TEXT PRIMARY KEY)");
+    db.exec("INSERT INTO releases(id) VALUES ('release-1')");
+    db.exec(readFileSync(migrationPath, "utf8"));
+
+    const insert = db.prepare(
+      `INSERT INTO release_metric_devices
+       (release_id, metric_kind, device_id, first_checked_at, last_checked_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(release_id, metric_kind, device_id) DO UPDATE SET
+         last_checked_at = excluded.last_checked_at`,
+    );
+    insert.run("release-1", "offered", "device-1", 10, 10);
+    insert.run("release-1", "offered", "device-1", 20, 20);
+    insert.run("release-1", "current", "device-1", 30, 30);
+    expect(db.prepare(
+      "SELECT metric_kind, first_checked_at, last_checked_at FROM release_metric_devices ORDER BY metric_kind",
+    ).all()).toEqual([
+      { metric_kind: "current", first_checked_at: 30, last_checked_at: 30 },
+      { metric_kind: "offered", first_checked_at: 10, last_checked_at: 20 },
+    ]);
+    expect(() => insert.run("release-1", "invalid", "device-2", 40, 40)).toThrow();
+
+    db.exec("DELETE FROM releases WHERE id = 'release-1'");
+    expect(db.prepare("SELECT COUNT(*) AS n FROM release_metric_devices").get()).toEqual({ n: 0 });
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -317,6 +317,14 @@ function makeMockDb() {
       current_count INTEGER NOT NULL DEFAULT 0,
       last_checked_at INTEGER
     );
+    CREATE TABLE release_metric_devices (
+      release_id TEXT NOT NULL,
+      metric_kind TEXT NOT NULL CHECK(metric_kind IN ('current', 'offered')),
+      device_id TEXT NOT NULL,
+      first_checked_at INTEGER NOT NULL,
+      last_checked_at INTEGER NOT NULL,
+      PRIMARY KEY (release_id, metric_kind, device_id)
+    );
     CREATE TABLE release_checks (
       id TEXT PRIMARY KEY,
       release_id TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
@@ -5350,7 +5358,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(rolloutIncludes("rel-x", bucket, "device-1")).toBe(false);
   });
 
-  it("updates/check records offered/current release metrics", async () => {
+  it("update checks retain PV while deduplicating stable-device UV by release and kind", async () => {
     const env = makeEnv();
     const { handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
     await seedRelease(env, "rel-metric", "build-metric", [["full", "all"]], {
@@ -5366,18 +5374,47 @@ describe("quiver public API v2 — scope resolution", () => {
       platform: "android",
       arch: "arm64-v8a",
     });
-    // Two older clients (offered) + one already-current client.
-    await handlePublicV2UpdateCheck(makePublicContext(env, query("10")));
+    // Six offered events: one stable device repeats, one second device, and
+    // three legacy/invalid ids. Only two exact UV rows are allowed.
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("10"), { "X-Quiver-Device-Id": "device-a" }));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("15"), { "X-Quiver-Device-Id": "device-a" }));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("15"), { "X-Hands-Device-Id": "device-b" }));
     await handlePublicV2UpdateCheck(makePublicContext(env, query("15")));
-    await handlePublicV2UpdateCheck(makePublicContext(env, query("20")));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("15"), { "X-Hands-Device-Id": "   " }));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("15"), { "X-Hands-Device-Id": "x".repeat(257) }));
+    // The same device is independently unique for the current kind; a repeat
+    // increments PV while preserving one current UV row.
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("20"), { "X-Quiver-Device-Id": "device-a" }));
+    await handlePublicV2UpdateCheck(makePublicContext(env, query("20"), { "X-Quiver-Device-Id": "device-a" }));
 
     const row = (await env.DB.prepare(
       "SELECT offered_count, current_count FROM release_metrics WHERE release_id = ?1",
     )
       .bind("rel-metric")
       .first()) as { offered_count: number; current_count: number } | null;
-    expect(row?.offered_count).toBe(2);
-    expect(row?.current_count).toBe(1);
+    expect(row?.offered_count).toBe(6);
+    expect(row?.current_count).toBe(2);
+    const uv = await env.DB.prepare(
+      `SELECT metric_kind, COUNT(*) AS n FROM release_metric_devices
+       WHERE release_id = ?1 GROUP BY metric_kind ORDER BY metric_kind`,
+    ).bind("rel-metric").all();
+    expect(uv.results).toEqual([
+      { metric_kind: "current", n: 1 },
+      { metric_kind: "offered", n: 2 },
+    ]);
+
+    const { handleListReleases } = await import("../src/routes/releases");
+    const listed = await responseJson<any>(await handleListReleases({
+      env,
+      req: { param: () => "app-scope", query: () => undefined },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    } as any));
+    expect(listed.releases.find((release: any) => release.id === "rel-metric")).toMatchObject({
+      offered_count: 6,
+      current_count: 2,
+      offered_uv: 2,
+      current_uv: 1,
+    });
   });
 
   it("updates/check gates a partial rollout by device bucket and falls back to the previous release", async () => {


### PR DESCRIPTION
Task #191. Keeps the existing release update-check counters as all-time PV, adds an exact per-release/per-kind/per-install set for UV, returns both values, and shows UV in the release row with PV on hover. Legacy or invalid device ids still increment PV but never fabricate UV. Historical PV remains intact; exact UV starts at migration 0052 because old aggregates cannot be backfilled.\n\nAlso closes the existing Releases.tsx strict-index typecheck error in the touched component.\n\nValidation: worker full 227/227 PASS; focused 155/155 PASS; worker typecheck PASS; admin tests 15/15 PASS; admin typecheck and production build PASS; migration constraints/cascade test PASS; diff-check PASS.