### PR TITLE
feat(feedback): add stateless reporter routing provider

### DIFF
--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -70,7 +70,8 @@ Trusted integrations may use one custom token with this feedback-only grant:
   "scopes": [
     "feedback:write",
     "feedback:read",
-    "feedback:comment"
+    "feedback:comment",
+    "feedback:route"
   ],
   "reporter_integration_id": "integration-uuid"
 }
@@ -78,9 +79,10 @@ Trusted integrations may use one custom token with this feedback-only grant:
 
 The grant must be valid, app-scoped, role-free, bound to an active reporter
 integration on the same app, and contain only recognized feedback-proxy scopes
-from the allowlist `feedback:write`, `feedback:read`, and `feedback:comment`.
-Existing tokens granted only `feedback:write` remain valid for submission after
-the legacy integration backfill. Role tokens, role-plus-scope grants, empty or
+from the allowlist `feedback:write`, `feedback:read`, `feedback:comment`, and
+`feedback:route`. T5 trusted submissions require an immutable route binding;
+legacy write-only tokens remain valid only for tickets already created before
+that gate. Role tokens, role-plus-scope grants, empty or
 unknown scopes, and grants containing app read, publish, or admin permissions
 are rejected by trusted reporter routes.
 

--- a/docs/rbac-permissions.md
+++ b/docs/rbac-permissions.md
@@ -21,6 +21,7 @@ The initial registry is:
 | `feedback:write` | Submit feedback tickets for the app. |
 | `feedback:read` | Token-only: read tickets owned by a reporter integration. |
 | `feedback:comment` | Token-only: comment on tickets owned by a reporter integration. |
+| `feedback:route` | Token-only: bind an opaque immutable route subject for webhook routing. |
 
 App roles are centrally defined bundles:
 
@@ -34,10 +35,10 @@ App roles are centrally defined bundles:
 the Console. Adding a permission happens in the registry, not in a UI-specific
 role/permission union.
 
-`feedback:read` and `feedback:comment` intentionally appear in no role bundle.
+`feedback:read`, `feedback:comment`, and `feedback:route` intentionally appear in no role bundle.
 They are accepted only by the dedicated reporter Bearer guard, which rejects
 cookies, human sessions, dev-token bypass, role fallback, mixed role grants,
-and any explicit scope outside the three feedback capabilities. Reporter
+and any explicit scope outside the four feedback capabilities. Reporter
 credentials also carry a stable `reporter_integration_id`; rotating a token
 keeps that principal while archiving it revokes active credentials.
 

--- a/migrations/sql/0052_feedback_route_subjects.sql
+++ b/migrations/sql/0052_feedback_route_subjects.sql
@@ -1,0 +1,73 @@
+CREATE TABLE app_reporter_routes (
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  reporter_integration_id TEXT NOT NULL REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+  reporter_id TEXT NOT NULL,
+  route_subject TEXT NOT NULL,
+  subject_version TEXT NOT NULL CHECK (subject_version = 'v1'),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (app_id, reporter_integration_id, reporter_id),
+  CHECK (length(route_subject) BETWEEN 8 AND 160),
+  CHECK (substr(route_subject, 1, 7) = 'rfr_v1_'),
+  CHECK (route_subject NOT GLOB '*[^A-Za-z0-9_-]*')
+);
+
+CREATE INDEX idx_app_reporter_routes_integration
+  ON app_reporter_routes(app_id, reporter_integration_id, created_at);
+
+CREATE TRIGGER app_reporter_routes_owner_insert
+BEFORE INSERT ON app_reporter_routes
+WHEN NOT EXISTS (
+  SELECT 1 FROM app_reporter_integrations ri
+  WHERE ri.id = NEW.reporter_integration_id
+    AND ri.app_id = NEW.app_id
+    AND ri.archived_at IS NULL
+)
+BEGIN SELECT RAISE(ABORT, 'reporter route integration mismatch'); END;
+
+CREATE TRIGGER app_reporter_routes_no_update
+BEFORE UPDATE ON app_reporter_routes
+BEGIN SELECT RAISE(ABORT, 'v1 reporter routes are immutable'); END;
+
+CREATE TRIGGER app_reporter_routes_no_delete
+BEFORE DELETE ON app_reporter_routes
+BEGIN SELECT RAISE(ABORT, 'v1 reporter routes are immutable'); END;
+
+CREATE TABLE app_reporter_webhook_subscriptions (
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  reporter_integration_id TEXT NOT NULL REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+  webhook_id TEXT NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (app_id, reporter_integration_id, webhook_id)
+);
+
+CREATE INDEX idx_app_reporter_webhook_subscriptions_webhook
+  ON app_reporter_webhook_subscriptions(webhook_id, app_id, reporter_integration_id);
+
+CREATE TRIGGER app_reporter_webhook_subscriptions_owner_insert
+BEFORE INSERT ON app_reporter_webhook_subscriptions
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM app_reporter_integrations ri
+  JOIN apps a ON a.id = ri.app_id
+  JOIN webhooks w ON w.id = NEW.webhook_id
+  WHERE ri.id = NEW.reporter_integration_id
+    AND ri.app_id = NEW.app_id
+    AND ri.archived_at IS NULL
+    AND w.app_id = NEW.app_id
+    AND w.org_id = a.org_id
+    AND w.enabled = 1
+    AND w.archived_at IS NULL
+)
+BEGIN SELECT RAISE(ABORT, 'reporter webhook subscription mismatch'); END;
+
+ALTER TABLE feedback_events
+  ADD COLUMN route_outcome TEXT NOT NULL DEFAULT 'route_unbound'
+    CHECK (route_outcome IN ('route_bound', 'route_unbound'));
+
+ALTER TABLE feedback_events
+  ADD COLUMN route_subject TEXT;
+
+CREATE TRIGGER feedback_events_route_snapshot_insert
+BEFORE INSERT ON feedback_events
+WHEN (NEW.route_outcome = 'route_bound') != (NEW.route_subject IS NOT NULL)
+BEGIN SELECT RAISE(ABORT, 'feedback event route snapshot mismatch'); END;

--- a/migrations/sql/0052_feedback_route_subjects.sql
+++ b/migrations/sql/0052_feedback_route_subjects.sql
@@ -18,9 +18,11 @@ CREATE TRIGGER app_reporter_routes_owner_insert
 BEFORE INSERT ON app_reporter_routes
 WHEN NOT EXISTS (
   SELECT 1 FROM app_reporter_integrations ri
+  JOIN apps a ON a.id = ri.app_id
   WHERE ri.id = NEW.reporter_integration_id
     AND ri.app_id = NEW.app_id
     AND ri.archived_at IS NULL
+    AND a.archived = 0
 )
 BEGIN SELECT RAISE(ABORT, 'reporter route integration mismatch'); END;
 
@@ -30,6 +32,7 @@ BEGIN SELECT RAISE(ABORT, 'v1 reporter routes are immutable'); END;
 
 CREATE TRIGGER app_reporter_routes_no_delete
 BEFORE DELETE ON app_reporter_routes
+WHEN EXISTS (SELECT 1 FROM apps WHERE id = OLD.app_id)
 BEGIN SELECT RAISE(ABORT, 'v1 reporter routes are immutable'); END;
 
 CREATE TABLE app_reporter_webhook_subscriptions (
@@ -53,6 +56,7 @@ WHEN NOT EXISTS (
   WHERE ri.id = NEW.reporter_integration_id
     AND ri.app_id = NEW.app_id
     AND ri.archived_at IS NULL
+    AND a.archived = 0
     AND w.app_id = NEW.app_id
     AND w.org_id = a.org_id
     AND w.enabled = 1
@@ -71,3 +75,64 @@ CREATE TRIGGER feedback_events_route_snapshot_insert
 BEFORE INSERT ON feedback_events
 WHEN (NEW.route_outcome = 'route_bound') != (NEW.route_subject IS NOT NULL)
 BEGIN SELECT RAISE(ABORT, 'feedback event route snapshot mismatch'); END;
+
+-- Initial trusted submissions use a separate immutable ledger because the
+-- already-deployed feedback_events CHECK cannot be widened in place safely.
+CREATE TABLE feedback_submission_events (
+  id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL CHECK (event_type = 'feedback:new'),
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  reporter_integration_id TEXT NOT NULL REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+  reporter_id TEXT NOT NULL,
+  payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+  route_outcome TEXT NOT NULL CHECK (route_outcome = 'route_bound'),
+  route_subject TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_feedback_submission_events_ticket
+  ON feedback_submission_events(ticket_id);
+
+CREATE TRIGGER feedback_submission_events_no_update
+BEFORE UPDATE ON feedback_submission_events
+BEGIN SELECT RAISE(ABORT, 'feedback submission events are immutable'); END;
+
+CREATE TRIGGER feedback_submission_events_owner_insert
+BEFORE INSERT ON feedback_submission_events
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM feedback_tickets t
+  JOIN apps a ON a.id = t.app_id AND a.archived = 0
+  JOIN app_reporter_integrations ri
+    ON ri.id = t.reporter_integration_id
+   AND ri.app_id = t.app_id
+   AND ri.archived_at IS NULL
+  JOIN app_reporter_routes r
+    ON r.app_id = t.app_id
+   AND r.reporter_integration_id = t.reporter_integration_id
+   AND r.reporter_id = t.reporter_id
+   AND r.route_subject = NEW.route_subject
+  WHERE t.id = NEW.ticket_id
+    AND t.app_id = NEW.app_id
+    AND t.reporter_integration_id = NEW.reporter_integration_id
+    AND t.reporter_id = NEW.reporter_id
+)
+BEGIN SELECT RAISE(ABORT, 'feedback submission event owner mismatch'); END;
+
+ALTER TABLE webhooks
+  ADD COLUMN signature_key_version TEXT NOT NULL DEFAULT 'v1';
+
+ALTER TABLE webhook_deliveries
+  ADD COLUMN feedback_submission_event_id TEXT
+    REFERENCES feedback_submission_events(id) ON DELETE SET NULL;
+
+ALTER TABLE webhook_deliveries
+  ADD COLUMN signing_secret TEXT;
+
+ALTER TABLE webhook_deliveries
+  ADD COLUMN signature_key_version TEXT NOT NULL DEFAULT 'legacy-v1';
+
+CREATE UNIQUE INDEX idx_webhook_deliveries_submission_event
+  ON webhook_deliveries(webhook_id, feedback_submission_event_id)
+  WHERE feedback_submission_event_id IS NOT NULL;

--- a/migrations/sql/0052_feedback_route_subjects.sql
+++ b/migrations/sql/0052_feedback_route_subjects.sql
@@ -133,6 +133,10 @@ ALTER TABLE webhook_deliveries
 ALTER TABLE webhook_deliveries
   ADD COLUMN signature_key_version TEXT NOT NULL DEFAULT 'legacy-v1';
 
+ALTER TABLE webhook_deliveries
+  ADD COLUMN reporter_delivery INTEGER NOT NULL DEFAULT 0
+    CHECK (reporter_delivery IN (0, 1));
+
 CREATE UNIQUE INDEX idx_webhook_deliveries_submission_event
   ON webhook_deliveries(webhook_id, feedback_submission_event_id)
   WHERE feedback_submission_event_id IS NOT NULL;

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -30,6 +30,8 @@ declare global {
     AGC_CRED_ENC_KEY?: string;
     RAFT_ALLOWED_SERVER_IDS?: string;
     RAFT_ALLOWED_SERVER_SLUGS?: string;
+    FEEDBACK_AUDIT_HMAC_KEY?: string;
+    FEEDBACK_AUDIT_KEY_VERSION?: string;
   }
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -113,6 +113,11 @@ import {
   cleanupReporterFeedbackData,
 } from "./routes/reporter_feedback";
 import {
+  handleBindReporterRouteSubject,
+  handleBindReporterWebhook,
+  handleGetReporterRouteMetadata,
+} from "./routes/reporter_routes";
+import {
   handleGetAscCredentials,
   handleSetAscCredentials,
   handleDeleteAscCredentials,
@@ -562,6 +567,7 @@ app.post("/public/v2/apps/:slug/metrics", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/sessions", handleSessionEvent);
 app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
 app.get("/api/apps/:appId/reporter-feedback", handleListReporterFeedback);
+app.put("/api/apps/:appId/reporter-feedback/route-subject", handleBindReporterRouteSubject);
 app.get("/api/apps/:appId/reporter-feedback/:ticketId", handleGetReporterFeedback);
 app.post("/api/apps/:appId/reporter-feedback/:ticketId/comments", handleAddReporterComment);
 app.get(
@@ -657,6 +663,12 @@ admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);
 admin.post("/api/apps/:appId/purge", requireAppRole("admin"), handlePurgeApp);
 admin.get("/api/apps/:appId/feature-flags/:key", requireAppRole("viewer"), handleGetFeatureFlag);
+admin.get("/api/apps/:appId/reporter-feedback-metadata", requireAppRole("viewer"), handleGetReporterRouteMetadata);
+admin.put(
+  "/api/apps/:appId/reporter-integrations/:integrationId/webhooks/:webhookId",
+  requireAppRole("admin"),
+  handleBindReporterWebhook,
+);
 // Feature flags are rollout controls (like bump-rollout / force-update), so they
 // sit at the publisher (ship) tier rather than admin.
 admin.put("/api/apps/:appId/feature-flags/:key", requireAppRole("publisher"), handleUpdateFeatureFlag);

--- a/worker/src/lib/app_permissions.ts
+++ b/worker/src/lib/app_permissions.ts
@@ -7,6 +7,7 @@ export const APP_PERMISSIONS = [
   "feedback:write",
   "feedback:read",
   "feedback:comment",
+  "feedback:route",
 ] as const;
 
 export type AppPermission = (typeof APP_PERMISSIONS)[number];
@@ -18,6 +19,7 @@ export const APP_PERMISSION_LABELS: Record<AppPermission, string> = {
   "feedback:write": "Feedback write",
   "feedback:read": "Reporter feedback read",
   "feedback:comment": "Reporter feedback comment",
+  "feedback:route": "Reporter route binding",
 };
 
 export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
@@ -27,6 +29,7 @@ export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
   "feedback:write": "Submit feedback tickets for this app.",
   "feedback:read": "Read tickets owned by a reporter integration.",
   "feedback:comment": "Comment on tickets owned by a reporter integration.",
+  "feedback:route": "Bind an opaque route subject to a reporter integration.",
 };
 
 export const APP_ROLE_PERMISSIONS: Record<AppRole, readonly AppPermission[]> = {
@@ -52,6 +55,7 @@ export const FEEDBACK_TOKEN_PERMISSIONS = [
   "feedback:write",
   "feedback:read",
   "feedback:comment",
+  "feedback:route",
 ] as const satisfies readonly AppPermission[];
 
 export type FeedbackTokenPermission = (typeof FEEDBACK_TOKEN_PERMISSIONS)[number];

--- a/worker/src/openapi/common.ts
+++ b/worker/src/openapi/common.ts
@@ -169,6 +169,7 @@ export const AppPermission = z.enum([
   "feedback:write",
   "feedback:read",
   "feedback:comment",
+  "feedback:route",
 ]);
 
 export const auth = [{ bearerAuth: [] }];

--- a/worker/src/openapi/feedback.ts
+++ b/worker/src/openapi/feedback.ts
@@ -43,6 +43,11 @@ const ReporterRouteInput = z.object({
   route_subject: z.string().regex(/^rfr_v1_[A-Za-z0-9_-]+$/).max(160),
 }).strict().openapi("ReporterRouteSubjectInput");
 
+const ReporterWebhookParams = AppIdParam.extend({
+  integrationId: z.string().min(1),
+  webhookId: z.string().min(1),
+});
+
 export function registerFeedbackRoutes(registry: OpenApiRegistry) {
   register(registry, {
     method: "put",
@@ -62,6 +67,43 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
       401: error("Missing or invalid bearer token."),
       403: error("Invalid reporter integration grant."),
       409: error("A different immutable v1 subject already exists."),
+    },
+  });
+
+  register(registry, {
+    method: "put",
+    path: "/api/apps/{appId}/reporter-integrations/{integrationId}/webhooks/{webhookId}",
+    tags: ["Reporter Feedback"],
+    summary: "Bind one active webhook as the exact reporter-integration subscriber",
+    security: auth,
+    request: { params: ReporterWebhookParams },
+    responses: {
+      200: success("Exact idempotent replay.", GenericObject),
+      201: success("Dedicated reporter webhook subscription created.", GenericObject),
+      403: error("Current principal cannot administer this app."),
+      409: error("App, integration, or webhook is inactive or mismatched."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/reporter-feedback-metadata",
+    tags: ["Reporter Feedback"],
+    summary: "Read safe route, grant, audit, and delivery metadata",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      query: z.object({
+        reporter_integration_id: z.string().min(1),
+        reporter_id: z.string().min(16).max(200),
+        token_id: z.string().min(1),
+      }),
+    },
+    responses: {
+      200: success("Safe metadata; never returns route subject, reporter id, body, or token secret.", GenericObject),
+      400: error("Required coordinate or token id is missing."),
+      403: error("Current principal cannot view this app."),
+      503: error("Reporter audit metadata is not configured."),
     },
   });
 

--- a/worker/src/openapi/feedback.ts
+++ b/worker/src/openapi/feedback.ts
@@ -39,7 +39,32 @@ const ReporterCommentInput = z.object({
   submission_id: z.string().uuid(),
 }).openapi("ReporterFeedbackCommentInput");
 
+const ReporterRouteInput = z.object({
+  route_subject: z.string().regex(/^rfr_v1_[A-Za-z0-9_-]+$/).max(160),
+}).strict().openapi("ReporterRouteSubjectInput");
+
 export function registerFeedbackRoutes(registry: OpenApiRegistry) {
+  register(registry, {
+    method: "put",
+    path: "/api/apps/{appId}/reporter-feedback/route-subject",
+    tags: ["Reporter Feedback"],
+    summary: "Bind an immutable opaque v1 reporter route subject",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      headers: ReporterHeaders,
+      body: { content: json(ReporterRouteInput), required: true },
+    },
+    responses: {
+      200: success("Exact idempotent replay; subject is not returned.", GenericObject),
+      201: success("Route binding created; subject is not returned.", GenericObject),
+      400: error("Malformed route subject."),
+      401: error("Missing or invalid bearer token."),
+      403: error("Invalid reporter integration grant."),
+      409: error("A different immutable v1 subject already exists."),
+    },
+  });
+
   register(registry, {
     method: "get",
     path: "/api/apps/{appId}/reporter-feedback",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1374,6 +1374,32 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "bind-reporter-webhook",
+        description:
+          "Bind one active app webhook as the exact subscriber for one active reporter integration. Requires app admin and does not create or enable a webhook.",
+        endpoint: {
+          method: "PUT",
+          path: "/api/apps/{app_id}/reporter-integrations/{reporter_integration_id}/webhooks/{webhook_id}",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app id." },
+          reporter_integration_id: { type: "string", in: "path", required: true, description: "Reporter integration id." },
+          webhook_id: { type: "string", in: "path", required: true, description: "Existing active app webhook id." },
+        },
+      },
+      {
+        name: "get-reporter-feedback-metadata",
+        description:
+          "Read safe exact grant, route, audit, subscriber, event, delivery, payload-digest, and signature metadata without returning route subject, reporter id, body, or token secret. Requires app viewer.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/reporter-feedback-metadata" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app id." },
+          reporter_integration_id: { type: "string", in: "query", required: true, description: "Exact reporter integration id." },
+          reporter_id: { type: "string", in: "query", required: true, description: "Exact opaque reporter id; never echoed." },
+          token_id: { type: "string", in: "query", required: true, description: "Exact app token id; token secret/prefix is never returned." },
+        },
+      },
+      {
         name: "get-feedback",
         description:
           "Get a feedback/crash ticket with device context, attachments, and comments. ticket_id may be a full UUID or a unique short-id prefix.",

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -205,6 +205,13 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       return c.json({ error: "trusted reporter identity requires an active reporter integration" }, 401);
     }
     reporterIntegrationId = deployToken.reporter_integration_id;
+    const route = await c.env.DB.prepare(
+      `SELECT 1 AS ok FROM app_reporter_routes
+       WHERE app_id = ?1 AND reporter_integration_id = ?2 AND reporter_id = ?3`,
+    ).bind(app.id, reporterIntegrationId, reporterId).first<{ ok: number }>();
+    if (!route) {
+      return c.json({ error: "route_required" }, 409);
+    }
     rateLimitHashInput = `feedback:${app.id}:integration:${reporterIntegrationId}:reporter:${reporterId}`;
     rateLimitPerHour = TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR;
   }
@@ -372,7 +379,13 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
         channel, device_id, device_model, os_version, arch, locale,
         metadata_json, client_ip_hash, signature, submission_id,
         submission_fingerprint, reporter_id, reporter_integration_id, created_at, updated_at)
-       VALUES (?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)`,
+       SELECT ?1, ?2, ?3, 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+              ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+       WHERE ?20 IS NULL OR EXISTS (
+         SELECT 1 FROM app_reporter_routes r
+         WHERE r.app_id = ?2 AND r.reporter_integration_id = ?20
+           AND r.reporter_id = ?19
+       )`,
     ).bind(
       ticketId,
       app.id,
@@ -433,6 +446,13 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     }
     await cleanupInlineUploads();
     throw error;
+  }
+  const committedTicket = await c.env.DB.prepare(
+    "SELECT 1 AS ok FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
+  ).bind(app.id, ticketId).first<{ ok: number }>();
+  if (!committedTicket) {
+    await cleanupInlineUploads();
+    return c.json({ error: "route_required" }, 409);
   }
 
   // Crash tickets: symbolicate in the background (retrace / native / OHOS / dSYM
@@ -2077,17 +2097,26 @@ function feedbackReporterEventStatements(
     db.prepare(
       `INSERT INTO feedback_events
        (id, event_type, app_id, ticket_id, reporter_integration_id,
-        reporter_id, payload_json, created_at)
-       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
-       WHERE (?9 IS NULL OR EXISTS (SELECT 1 FROM audit_logs WHERE id = ?9))
-         AND EXISTS (
-           SELECT 1 FROM feedback_tickets t
-           JOIN app_reporter_integrations ri
-             ON ri.id = t.reporter_integration_id
-            AND ri.app_id = t.app_id AND ri.archived_at IS NULL
-           WHERE t.id = ?4 AND t.app_id = ?3
-             AND t.reporter_integration_id = ?5 AND t.reporter_id = ?6
-         )`,
+        reporter_id, payload_json, route_outcome, route_subject, created_at)
+       SELECT ?1, ?2, ?3, ?4, ?5, ?6,
+              CASE WHEN r.route_subject IS NULL
+                THEN json_set(?7, '$.payload.route_outcome', 'route_unbound')
+                ELSE json_set(?7, '$.payload.route_outcome', 'route_bound',
+                                   '$.payload.route_subject', r.route_subject)
+              END,
+              CASE WHEN r.route_subject IS NULL THEN 'route_unbound' ELSE 'route_bound' END,
+              r.route_subject, ?8
+       FROM feedback_tickets t
+       JOIN app_reporter_integrations ri
+         ON ri.id = t.reporter_integration_id
+        AND ri.app_id = t.app_id AND ri.archived_at IS NULL
+       LEFT JOIN app_reporter_routes r
+         ON r.app_id = t.app_id
+        AND r.reporter_integration_id = t.reporter_integration_id
+        AND r.reporter_id = t.reporter_id
+       WHERE t.id = ?4 AND t.app_id = ?3
+         AND t.reporter_integration_id = ?5 AND t.reporter_id = ?6
+         AND (?9 IS NULL OR EXISTS (SELECT 1 FROM audit_logs WHERE id = ?9))`,
     ).bind(
       eventId,
       input.eventType,
@@ -2115,8 +2144,38 @@ function feedbackReporterEventStatements(
            OR EXISTS (SELECT 1 FROM json_each(w.events_json) e
                       WHERE e.value IN (?2, '*'))
          ) ELSE 0 END
+         AND NOT EXISTS (
+           SELECT 1 FROM app_reporter_webhook_subscriptions s
+           WHERE s.webhook_id = w.id AND s.app_id = ?6
+             AND s.reporter_integration_id = fe.reporter_integration_id
+         )
        ON CONFLICT(webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING`,
     ).bind(eventId, input.eventType, payloadJson, input.createdAt, input.orgId, input.appId),
+    db.prepare(
+      `INSERT INTO webhook_deliveries
+       (id, webhook_id, event_type, event_id, payload_json, status,
+        attempts, max_attempts, next_attempt_at, created_at, updated_at)
+       SELECT ?1 || ':' || w.id, w.id, ?2, ?1, fe.payload_json, 'pending', 0, 3,
+              ?3, ?3, ?3
+       FROM feedback_events fe
+       JOIN app_reporter_webhook_subscriptions s
+         ON s.app_id = fe.app_id
+        AND s.reporter_integration_id = fe.reporter_integration_id
+       JOIN webhooks w ON w.id = s.webhook_id
+       JOIN app_reporter_integrations ri
+         ON ri.id = s.reporter_integration_id AND ri.app_id = s.app_id
+       WHERE fe.id = ?1 AND fe.route_outcome = 'route_bound'
+         AND fe.route_subject IS NOT NULL
+         AND w.app_id = fe.app_id AND w.org_id = ?4
+         AND w.enabled = 1 AND w.archived_at IS NULL
+         AND ri.archived_at IS NULL
+         AND CASE WHEN json_valid(w.events_json) THEN (
+           json_array_length(w.events_json) = 0
+           OR EXISTS (SELECT 1 FROM json_each(w.events_json) e
+                      WHERE e.value IN (?2, '*'))
+         ) ELSE 0 END
+       ON CONFLICT(webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING`,
+    ).bind(eventId, input.eventType, input.createdAt, input.orgId),
   ];
 }
 

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -486,10 +486,10 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
           c.env.DB.prepare(
             `INSERT INTO webhook_deliveries
              (id, webhook_id, event_type, feedback_submission_event_id,
-              payload_json, signing_secret, signature_key_version, status,
+              payload_json, signing_secret, signature_key_version, reporter_delivery, status,
               attempts, max_attempts, next_attempt_at, created_at, updated_at)
              SELECT ?1 || ':' || w.id, w.id, 'feedback:new', ?1, ?2,
-                    w.secret, w.signature_key_version, 'pending', 0, 3, ?3, ?3, ?3
+                    w.secret, w.signature_key_version, 0, 'pending', 0, 3, ?3, ?3, ?3
              FROM feedback_submission_events fe
              JOIN apps a ON a.id = fe.app_id AND a.archived = 0
              JOIN app_reporter_integrations ri
@@ -514,10 +514,10 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
           c.env.DB.prepare(
             `INSERT INTO webhook_deliveries
              (id, webhook_id, event_type, feedback_submission_event_id,
-              payload_json, signing_secret, signature_key_version, status,
+              payload_json, signing_secret, signature_key_version, reporter_delivery, status,
               attempts, max_attempts, next_attempt_at, created_at, updated_at)
              SELECT ?1 || ':' || w.id, w.id, 'feedback:new', ?1, fe.payload_json,
-                    w.secret, w.signature_key_version, 'pending', 0, 3, ?2, ?2, ?2
+                    w.secret, w.signature_key_version, 1, 'pending', 0, 3, ?2, ?2, ?2
              FROM feedback_submission_events fe
              JOIN apps a ON a.id = fe.app_id AND a.archived = 0
              JOIN app_reporter_webhook_subscriptions s
@@ -2254,10 +2254,10 @@ function feedbackReporterEventStatements(
     db.prepare(
       `INSERT INTO webhook_deliveries
        (id, webhook_id, event_type, event_id, payload_json,
-        signing_secret, signature_key_version, status,
+        signing_secret, signature_key_version, reporter_delivery, status,
         attempts, max_attempts, next_attempt_at, created_at, updated_at)
        SELECT ?1 || ':' || w.id, w.id, ?2, ?1, ?3,
-              w.secret, w.signature_key_version, 'pending', 0, 3,
+              w.secret, w.signature_key_version, 0, 'pending', 0, 3,
               ?4, ?4, ?4
        FROM feedback_events fe
        JOIN webhooks w ON w.org_id = ?5
@@ -2280,10 +2280,10 @@ function feedbackReporterEventStatements(
     db.prepare(
       `INSERT INTO webhook_deliveries
        (id, webhook_id, event_type, event_id, payload_json,
-        signing_secret, signature_key_version, status,
+        signing_secret, signature_key_version, reporter_delivery, status,
         attempts, max_attempts, next_attempt_at, created_at, updated_at)
        SELECT ?1 || ':' || w.id, w.id, ?2, ?1, fe.payload_json,
-              w.secret, w.signature_key_version, 'pending', 0, 3,
+              w.secret, w.signature_key_version, 1, 'pending', 0, 3,
               ?3, ?3, ?3
        FROM feedback_events fe
        JOIN app_reporter_webhook_subscriptions s

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -363,6 +363,38 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
 
   const now = Date.now();
   const ticketId = crypto.randomUUID();
+  const submissionEventId = reporterIntegrationId ? crypto.randomUUID() : null;
+  const genericSubmissionPayload = app.org_id ? JSON.stringify({
+    event: "feedback:new",
+    delivered_at: now,
+    org_id: app.org_id,
+    app_id: app.id,
+    payload: {
+      ticket_id: ticketId,
+      app_slug: app.slug,
+      kind,
+      message: message.slice(0, 500),
+      version_name: meta("version_name"),
+      version_code: versionCode,
+      attachments: attachmentRows.length,
+      reporter_id: reporterId || null,
+      reporter_integration_id: reporterIntegrationId,
+    },
+  }) : null;
+  const dedicatedSubmissionPayload = submissionEventId ? JSON.stringify({
+    id: submissionEventId,
+    event: "feedback:new",
+    created_at: now,
+    delivered_at: now,
+    org_id: app.org_id,
+    app_id: app.id,
+    payload: {
+      ticket_id: ticketId,
+      kind,
+      reporter_integration_id: reporterIntegrationId,
+      reporter_id: reporterId,
+    },
+  }) : null;
 
   for (const [index, attachment] of attachmentRows.entries()) {
     if (!attachment.inlineFile) continue;
@@ -383,6 +415,10 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
               ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
        WHERE ?20 IS NULL OR EXISTS (
          SELECT 1 FROM app_reporter_routes r
+         JOIN apps active_app ON active_app.id = r.app_id AND active_app.archived = 0
+         JOIN app_reporter_integrations active_ri
+           ON active_ri.id = r.reporter_integration_id
+          AND active_ri.app_id = r.app_id AND active_ri.archived_at IS NULL
          WHERE r.app_id = ?2 AND r.reporter_integration_id = ?20
            AND r.reporter_id = ?19
        )`,
@@ -417,6 +453,92 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
       ).bind(a.id, ticketId, a.r2Key, a.filename, a.contentType, a.sizeBytes, now),
     ),
+    ...(submissionEventId && dedicatedSubmissionPayload
+      ? [
+          ...(genericSubmissionPayload && app.org_id ? [c.env.DB.prepare(
+            `INSERT INTO feedback_submission_events
+             (id, event_type, app_id, ticket_id, reporter_integration_id,
+              reporter_id, payload_json, route_outcome, route_subject, created_at)
+             SELECT ?1, 'feedback:new', ?2, ?3, ?4, ?5,
+                    json_set(?6, '$.payload.route_outcome', 'route_bound',
+                                 '$.payload.route_subject', r.route_subject),
+                    'route_bound', r.route_subject, ?7
+             FROM feedback_tickets t
+             JOIN apps a ON a.id = t.app_id AND a.archived = 0
+             JOIN app_reporter_integrations ri
+               ON ri.id = t.reporter_integration_id
+              AND ri.app_id = t.app_id AND ri.archived_at IS NULL
+             JOIN app_reporter_routes r
+               ON r.app_id = t.app_id
+              AND r.reporter_integration_id = t.reporter_integration_id
+              AND r.reporter_id = t.reporter_id
+             WHERE t.id = ?3 AND t.app_id = ?2
+               AND t.reporter_integration_id = ?4 AND t.reporter_id = ?5`,
+          ).bind(
+            submissionEventId,
+            app.id,
+            ticketId,
+            reporterIntegrationId,
+            reporterId,
+            dedicatedSubmissionPayload,
+            now,
+          ),
+          c.env.DB.prepare(
+            `INSERT INTO webhook_deliveries
+             (id, webhook_id, event_type, feedback_submission_event_id,
+              payload_json, signing_secret, signature_key_version, status,
+              attempts, max_attempts, next_attempt_at, created_at, updated_at)
+             SELECT ?1 || ':' || w.id, w.id, 'feedback:new', ?1, ?2,
+                    w.secret, w.signature_key_version, 'pending', 0, 3, ?3, ?3, ?3
+             FROM feedback_submission_events fe
+             JOIN apps a ON a.id = fe.app_id AND a.archived = 0
+             JOIN app_reporter_integrations ri
+               ON ri.id = fe.reporter_integration_id
+              AND ri.app_id = fe.app_id AND ri.archived_at IS NULL
+             JOIN webhooks w ON w.org_id = ?4
+             WHERE fe.id = ?1 AND w.enabled = 1 AND w.archived_at IS NULL
+               AND (w.app_id IS NULL OR w.app_id = ?5)
+               AND CASE WHEN json_valid(w.events_json) THEN (
+                 json_array_length(w.events_json) = 0
+                 OR EXISTS (SELECT 1 FROM json_each(w.events_json) e
+                            WHERE e.value IN ('feedback:new', '*'))
+               ) ELSE 0 END
+               AND NOT EXISTS (
+                 SELECT 1 FROM app_reporter_webhook_subscriptions s
+                 WHERE s.webhook_id = w.id AND s.app_id = fe.app_id
+                   AND s.reporter_integration_id = fe.reporter_integration_id
+               )
+             ON CONFLICT(webhook_id, feedback_submission_event_id)
+               WHERE feedback_submission_event_id IS NOT NULL DO NOTHING`,
+          ).bind(submissionEventId, genericSubmissionPayload, now, app.org_id, app.id),
+          c.env.DB.prepare(
+            `INSERT INTO webhook_deliveries
+             (id, webhook_id, event_type, feedback_submission_event_id,
+              payload_json, signing_secret, signature_key_version, status,
+              attempts, max_attempts, next_attempt_at, created_at, updated_at)
+             SELECT ?1 || ':' || w.id, w.id, 'feedback:new', ?1, fe.payload_json,
+                    w.secret, w.signature_key_version, 'pending', 0, 3, ?2, ?2, ?2
+             FROM feedback_submission_events fe
+             JOIN apps a ON a.id = fe.app_id AND a.archived = 0
+             JOIN app_reporter_webhook_subscriptions s
+               ON s.app_id = fe.app_id
+              AND s.reporter_integration_id = fe.reporter_integration_id
+             JOIN app_reporter_integrations ri
+               ON ri.id = s.reporter_integration_id
+              AND ri.app_id = s.app_id AND ri.archived_at IS NULL
+             JOIN webhooks w ON w.id = s.webhook_id
+             WHERE fe.id = ?1 AND w.app_id = fe.app_id AND w.org_id = ?3
+               AND w.enabled = 1 AND w.archived_at IS NULL
+               AND CASE WHEN json_valid(w.events_json) THEN (
+                 json_array_length(w.events_json) = 0
+                 OR EXISTS (SELECT 1 FROM json_each(w.events_json) e
+                            WHERE e.value IN ('feedback:new', '*'))
+               ) ELSE 0 END
+             ON CONFLICT(webhook_id, feedback_submission_event_id)
+               WHERE feedback_submission_event_id IS NOT NULL DO NOTHING`,
+          ).bind(submissionEventId, now, app.org_id)] : []),
+        ]
+      : []),
   ];
   const cleanupInlineUploads = () => Promise.allSettled(
     attachmentRows
@@ -531,7 +653,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     }
   }
 
-  if (app.org_id) {
+  if (app.org_id && !reporterIntegrationId) {
     await emitWebhookEvent(c.env.DB, {
       orgId: app.org_id,
       appId: app.id,
@@ -2107,6 +2229,7 @@ function feedbackReporterEventStatements(
               CASE WHEN r.route_subject IS NULL THEN 'route_unbound' ELSE 'route_bound' END,
               r.route_subject, ?8
        FROM feedback_tickets t
+       JOIN apps a ON a.id = t.app_id AND a.archived = 0
        JOIN app_reporter_integrations ri
          ON ri.id = t.reporter_integration_id
         AND ri.app_id = t.app_id AND ri.archived_at IS NULL
@@ -2130,12 +2253,15 @@ function feedbackReporterEventStatements(
     ),
     db.prepare(
       `INSERT INTO webhook_deliveries
-       (id, webhook_id, event_type, event_id, payload_json, status,
+       (id, webhook_id, event_type, event_id, payload_json,
+        signing_secret, signature_key_version, status,
         attempts, max_attempts, next_attempt_at, created_at, updated_at)
-       SELECT ?1 || ':' || w.id, w.id, ?2, ?1, ?3, 'pending', 0, 3,
+       SELECT ?1 || ':' || w.id, w.id, ?2, ?1, ?3,
+              w.secret, w.signature_key_version, 'pending', 0, 3,
               ?4, ?4, ?4
        FROM feedback_events fe
        JOIN webhooks w ON w.org_id = ?5
+       JOIN apps a ON a.id = fe.app_id AND a.archived = 0
        WHERE fe.id = ?1
          AND w.enabled = 1 AND w.archived_at IS NULL
          AND (w.app_id IS NULL OR w.app_id = ?6)
@@ -2153,9 +2279,11 @@ function feedbackReporterEventStatements(
     ).bind(eventId, input.eventType, payloadJson, input.createdAt, input.orgId, input.appId),
     db.prepare(
       `INSERT INTO webhook_deliveries
-       (id, webhook_id, event_type, event_id, payload_json, status,
+       (id, webhook_id, event_type, event_id, payload_json,
+        signing_secret, signature_key_version, status,
         attempts, max_attempts, next_attempt_at, created_at, updated_at)
-       SELECT ?1 || ':' || w.id, w.id, ?2, ?1, fe.payload_json, 'pending', 0, 3,
+       SELECT ?1 || ':' || w.id, w.id, ?2, ?1, fe.payload_json,
+              w.secret, w.signature_key_version, 'pending', 0, 3,
               ?3, ?3, ?3
        FROM feedback_events fe
        JOIN app_reporter_webhook_subscriptions s
@@ -2164,6 +2292,7 @@ function feedbackReporterEventStatements(
        JOIN webhooks w ON w.id = s.webhook_id
        JOIN app_reporter_integrations ri
          ON ri.id = s.reporter_integration_id AND ri.app_id = s.app_id
+       JOIN apps a ON a.id = s.app_id AND a.archived = 0
        WHERE fe.id = ?1 AND fe.route_outcome = 'route_bound'
          AND fe.route_subject IS NOT NULL
          AND w.app_id = fe.app_id AND w.org_id = ?4

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -383,8 +383,21 @@ export async function handleAddReporterComment(c: ReporterContext) {
       c.env.DB.prepare(
         `INSERT INTO feedback_events
          (id, event_type, app_id, ticket_id, reporter_integration_id,
-          reporter_id, payload_json, created_at)
-         VALUES (?1, 'feedback:comment_created', ?2, ?3, ?4, ?5, ?6, ?7)`,
+          reporter_id, payload_json, route_outcome, route_subject, created_at)
+         SELECT ?1, 'feedback:comment_created', ?2, ?3, ?4, ?5,
+                CASE WHEN r.route_subject IS NULL
+                  THEN json_set(?6, '$.payload.route_outcome', 'route_unbound')
+                  ELSE json_set(?6, '$.payload.route_outcome', 'route_bound',
+                                     '$.payload.route_subject', r.route_subject)
+                END,
+                CASE WHEN r.route_subject IS NULL THEN 'route_unbound' ELSE 'route_bound' END,
+                r.route_subject, ?7
+         FROM feedback_tickets t
+         LEFT JOIN app_reporter_routes r
+           ON r.app_id = t.app_id AND r.reporter_integration_id = t.reporter_integration_id
+          AND r.reporter_id = t.reporter_id
+         WHERE t.id = ?3 AND t.app_id = ?2
+           AND t.reporter_integration_id = ?4 AND t.reporter_id = ?5`,
       ).bind(
         eventId,
         authorized.principal.appId,
@@ -400,16 +413,47 @@ export async function handleAddReporterComment(c: ReporterContext) {
           attempts, max_attempts, next_attempt_at, created_at, updated_at)
          SELECT ?1 || ':' || w.id, w.id, 'feedback:comment_created', ?1, ?2,
                 'pending', 0, 3, ?3, ?3, ?3
-         FROM webhooks w
-         WHERE w.org_id = ?4 AND w.enabled = 1 AND w.archived_at IS NULL
+         FROM feedback_events fe
+         JOIN webhooks w ON w.org_id = ?4
+         WHERE fe.id = ?1 AND w.enabled = 1 AND w.archived_at IS NULL
            AND (w.app_id IS NULL OR w.app_id = ?5)
            AND CASE WHEN json_valid(w.events_json) THEN (
              json_array_length(w.events_json) = 0
              OR EXISTS (SELECT 1 FROM json_each(w.events_json) e
                         WHERE e.value IN ('feedback:comment_created', '*'))
            ) ELSE 0 END
+           AND NOT EXISTS (
+             SELECT 1 FROM app_reporter_webhook_subscriptions s
+             WHERE s.webhook_id = w.id AND s.app_id = fe.app_id
+               AND s.reporter_integration_id = fe.reporter_integration_id
+           )
          ON CONFLICT(webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING`,
       ).bind(eventId, eventBody, now, ticket.org_id, authorized.principal.appId),
+      c.env.DB.prepare(
+        `INSERT INTO webhook_deliveries
+         (id, webhook_id, event_type, event_id, payload_json, status,
+          attempts, max_attempts, next_attempt_at, created_at, updated_at)
+         SELECT ?1 || ':' || w.id, w.id, 'feedback:comment_created', ?1,
+                fe.payload_json, 'pending', 0, 3, ?2, ?2, ?2
+         FROM feedback_events fe
+         JOIN app_reporter_webhook_subscriptions s
+           ON s.app_id = fe.app_id
+          AND s.reporter_integration_id = fe.reporter_integration_id
+         JOIN webhooks w ON w.id = s.webhook_id
+         JOIN app_reporter_integrations ri
+           ON ri.id = s.reporter_integration_id AND ri.app_id = s.app_id
+         WHERE fe.id = ?1 AND fe.route_outcome = 'route_bound'
+           AND fe.route_subject IS NOT NULL
+           AND w.app_id = fe.app_id AND w.org_id = ?3
+           AND w.enabled = 1 AND w.archived_at IS NULL
+           AND ri.archived_at IS NULL
+           AND CASE WHEN json_valid(w.events_json) THEN (
+             json_array_length(w.events_json) = 0
+             OR EXISTS (SELECT 1 FROM json_each(w.events_json) e
+                        WHERE e.value IN ('feedback:comment_created', '*'))
+           ) ELSE 0 END
+         ON CONFLICT(webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING`,
+      ).bind(eventId, now, ticket.org_id),
     ]);
   } catch (error) {
     const concurrent = await existingComment();

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -411,10 +411,10 @@ export async function handleAddReporterComment(c: ReporterContext) {
       c.env.DB.prepare(
         `INSERT INTO webhook_deliveries
          (id, webhook_id, event_type, event_id, payload_json,
-          signing_secret, signature_key_version, status,
+          signing_secret, signature_key_version, reporter_delivery, status,
           attempts, max_attempts, next_attempt_at, created_at, updated_at)
          SELECT ?1 || ':' || w.id, w.id, 'feedback:comment_created', ?1, ?2,
-                w.secret, w.signature_key_version, 'pending', 0, 3, ?3, ?3, ?3
+                w.secret, w.signature_key_version, 0, 'pending', 0, 3, ?3, ?3, ?3
          FROM feedback_events fe
          JOIN apps a ON a.id = fe.app_id AND a.archived = 0
          JOIN webhooks w ON w.org_id = ?4
@@ -435,11 +435,11 @@ export async function handleAddReporterComment(c: ReporterContext) {
       c.env.DB.prepare(
         `INSERT INTO webhook_deliveries
          (id, webhook_id, event_type, event_id, payload_json,
-          signing_secret, signature_key_version, status,
+          signing_secret, signature_key_version, reporter_delivery, status,
           attempts, max_attempts, next_attempt_at, created_at, updated_at)
          SELECT ?1 || ':' || w.id, w.id, 'feedback:comment_created', ?1,
                 fe.payload_json, w.secret, w.signature_key_version,
-                'pending', 0, 3, ?2, ?2, ?2
+                1, 'pending', 0, 3, ?2, ?2, ?2
          FROM feedback_events fe
          JOIN app_reporter_webhook_subscriptions s
            ON s.app_id = fe.app_id

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -393,6 +393,7 @@ export async function handleAddReporterComment(c: ReporterContext) {
                 CASE WHEN r.route_subject IS NULL THEN 'route_unbound' ELSE 'route_bound' END,
                 r.route_subject, ?7
          FROM feedback_tickets t
+         JOIN apps a ON a.id = t.app_id AND a.archived = 0
          LEFT JOIN app_reporter_routes r
            ON r.app_id = t.app_id AND r.reporter_integration_id = t.reporter_integration_id
           AND r.reporter_id = t.reporter_id
@@ -409,11 +410,13 @@ export async function handleAddReporterComment(c: ReporterContext) {
       ),
       c.env.DB.prepare(
         `INSERT INTO webhook_deliveries
-         (id, webhook_id, event_type, event_id, payload_json, status,
+         (id, webhook_id, event_type, event_id, payload_json,
+          signing_secret, signature_key_version, status,
           attempts, max_attempts, next_attempt_at, created_at, updated_at)
          SELECT ?1 || ':' || w.id, w.id, 'feedback:comment_created', ?1, ?2,
-                'pending', 0, 3, ?3, ?3, ?3
+                w.secret, w.signature_key_version, 'pending', 0, 3, ?3, ?3, ?3
          FROM feedback_events fe
+         JOIN apps a ON a.id = fe.app_id AND a.archived = 0
          JOIN webhooks w ON w.org_id = ?4
          WHERE fe.id = ?1 AND w.enabled = 1 AND w.archived_at IS NULL
            AND (w.app_id IS NULL OR w.app_id = ?5)
@@ -431,10 +434,12 @@ export async function handleAddReporterComment(c: ReporterContext) {
       ).bind(eventId, eventBody, now, ticket.org_id, authorized.principal.appId),
       c.env.DB.prepare(
         `INSERT INTO webhook_deliveries
-         (id, webhook_id, event_type, event_id, payload_json, status,
+         (id, webhook_id, event_type, event_id, payload_json,
+          signing_secret, signature_key_version, status,
           attempts, max_attempts, next_attempt_at, created_at, updated_at)
          SELECT ?1 || ':' || w.id, w.id, 'feedback:comment_created', ?1,
-                fe.payload_json, 'pending', 0, 3, ?2, ?2, ?2
+                fe.payload_json, w.secret, w.signature_key_version,
+                'pending', 0, 3, ?2, ?2, ?2
          FROM feedback_events fe
          JOIN app_reporter_webhook_subscriptions s
            ON s.app_id = fe.app_id
@@ -442,6 +447,7 @@ export async function handleAddReporterComment(c: ReporterContext) {
          JOIN webhooks w ON w.id = s.webhook_id
          JOIN app_reporter_integrations ri
            ON ri.id = s.reporter_integration_id AND ri.app_id = s.app_id
+         JOIN apps a ON a.id = s.app_id AND a.archived = 0
          WHERE fe.id = ?1 AND fe.route_outcome = 'route_bound'
            AND fe.route_subject IS NOT NULL
            AND w.app_id = fe.app_id AND w.org_id = ?3

--- a/worker/src/routes/reporter_routes.ts
+++ b/worker/src/routes/reporter_routes.ts
@@ -237,13 +237,12 @@ export async function handleGetReporterRouteMetadata(c: AdminContext) {
        FROM feedback_submission_events
      ) events
      LEFT JOIN webhook_deliveries wd
-       ON (events.submission = 0 AND wd.event_id = events.event_id)
-       OR (events.submission = 1 AND wd.feedback_submission_event_id = events.event_id)
-     LEFT JOIN app_reporter_webhook_subscriptions s
-       ON s.webhook_id = wd.webhook_id AND s.app_id = events.app_id
-      AND s.reporter_integration_id = events.reporter_integration_id
+       ON wd.reporter_delivery = 1 AND (
+         (events.submission = 0 AND wd.event_id = events.event_id)
+         OR (events.submission = 1 AND wd.feedback_submission_event_id = events.event_id)
+       )
      WHERE events.app_id = ?1 AND events.reporter_integration_id = ?2
-       AND events.reporter_id = ?3 AND (wd.id IS NULL OR s.webhook_id IS NOT NULL)
+       AND events.reporter_id = ?3
      ORDER BY events.created_at DESC, events.event_id DESC LIMIT 100`,
   ).bind(appId, integrationId, reporterId).all<{
     event_id: string;

--- a/worker/src/routes/reporter_routes.ts
+++ b/worker/src/routes/reporter_routes.ts
@@ -1,0 +1,136 @@
+import type { Context } from "hono";
+import type { AdminContext } from "../lib/permissions";
+import { authenticateReporter } from "../lib/reporter_auth";
+
+type ReporterContext = Context<{ Bindings: Env }>;
+
+const SUBJECT_RE = /^rfr_v1_[A-Za-z0-9_-]+$/;
+
+export async function handleBindReporterRouteSubject(c: ReporterContext) {
+  const auth = await authenticateReporter(c, "feedback:route");
+  if (!auth.ok) return auth.response;
+
+  const body = (await c.req.json().catch(() => null)) as { route_subject?: unknown } | null;
+  if (!body || Object.keys(body).length !== 1 || typeof body.route_subject !== "string") {
+    return c.json({ error: "exact route_subject body required" }, 400);
+  }
+  const subject = body.route_subject;
+  if (subject.length > 160 || !SUBJECT_RE.test(subject)) {
+    return c.json({ error: "invalid route_subject" }, 400);
+  }
+
+  const now = Date.now();
+  const result = await c.env.DB.prepare(
+    `INSERT OR IGNORE INTO app_reporter_routes
+     (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+     SELECT ?1, ?2, ?3, ?4, 'v1', ?5
+     FROM app_reporter_integrations
+     WHERE id = ?2 AND app_id = ?1 AND archived_at IS NULL`,
+  ).bind(
+    auth.principal.appId,
+    auth.principal.integrationId,
+    auth.principal.reporterId,
+    subject,
+    now,
+  ).run();
+  const row = await c.env.DB.prepare(
+    `SELECT route_subject FROM app_reporter_routes
+     WHERE app_id = ?1 AND reporter_integration_id = ?2 AND reporter_id = ?3`,
+  ).bind(
+    auth.principal.appId,
+    auth.principal.integrationId,
+    auth.principal.reporterId,
+  ).first<{ route_subject: string }>();
+  if (!row) return c.json({ error: "invalid reporter integration grant" }, 403);
+  if (row.route_subject !== subject) {
+    return c.json({ error: "route_subject_conflict", changed: false }, 409);
+  }
+  return c.json(
+    { changed: result.meta.changes === 1, subject_version: "v1" },
+    result.meta.changes === 1 ? 201 : 200,
+  );
+}
+
+export async function handleBindReporterWebhook(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const integrationId = c.req.param("integrationId") ?? "";
+  const webhookId = c.req.param("webhookId") ?? "";
+  const now = Date.now();
+  const result = await c.env.DB.prepare(
+    `INSERT OR IGNORE INTO app_reporter_webhook_subscriptions
+     (app_id, reporter_integration_id, webhook_id, created_at)
+     SELECT ?1, ?2, ?3, ?4
+     FROM app_reporter_integrations ri
+     JOIN apps a ON a.id = ri.app_id
+     JOIN webhooks w ON w.id = ?3
+     WHERE ri.id = ?2 AND ri.app_id = ?1 AND ri.archived_at IS NULL
+       AND w.app_id = ?1 AND w.org_id = a.org_id
+       AND w.enabled = 1 AND w.archived_at IS NULL`,
+  ).bind(appId, integrationId, webhookId, now).run();
+  const exists = await c.env.DB.prepare(
+    `SELECT 1 AS ok FROM app_reporter_webhook_subscriptions
+     WHERE app_id = ?1 AND reporter_integration_id = ?2 AND webhook_id = ?3`,
+  ).bind(appId, integrationId, webhookId).first<{ ok: number }>();
+  if (!exists) return c.json({ error: "reporter webhook subscription mismatch" }, 409);
+  return c.json({ changed: result.meta.changes === 1 }, result.meta.changes === 1 ? 201 : 200);
+}
+
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function handleGetReporterRouteMetadata(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const integrationId = c.req.query("reporter_integration_id") ?? "";
+  const reporterId = c.req.query("reporter_id") ?? "";
+  if (!integrationId || !reporterId) {
+    return c.json({ error: "reporter_integration_id and reporter_id are required" }, 400);
+  }
+  const route = await c.env.DB.prepare(
+    `SELECT subject_version, created_at FROM app_reporter_routes
+     WHERE app_id = ?1 AND reporter_integration_id = ?2 AND reporter_id = ?3`,
+  ).bind(appId, integrationId, reporterId).first<{
+    subject_version: string;
+    created_at: number;
+  }>();
+  const subscribers = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS count FROM app_reporter_webhook_subscriptions s
+     JOIN webhooks w ON w.id = s.webhook_id
+     WHERE s.app_id = ?1 AND s.reporter_integration_id = ?2
+       AND w.enabled = 1 AND w.archived_at IS NULL`,
+  ).bind(appId, integrationId).first<{ count: number }>();
+  const { results } = await c.env.DB.prepare(
+    `SELECT fe.id AS event_id, fe.event_type, fe.route_outcome, fe.payload_json,
+            fe.created_at, wd.id AS delivery_id, wd.status, wd.attempts,
+            wd.completed_at
+     FROM feedback_events fe
+     LEFT JOIN webhook_deliveries wd ON wd.event_id = fe.id
+       AND EXISTS (
+         SELECT 1 FROM app_reporter_webhook_subscriptions s
+         WHERE s.webhook_id = wd.webhook_id AND s.app_id = fe.app_id
+           AND s.reporter_integration_id = fe.reporter_integration_id
+       )
+     WHERE fe.app_id = ?1 AND fe.reporter_integration_id = ?2
+       AND fe.reporter_id = ?3
+     ORDER BY fe.created_at DESC, fe.id DESC LIMIT 100`,
+  ).bind(appId, integrationId, reporterId).all<{
+    event_id: string;
+    event_type: string;
+    route_outcome: string;
+    payload_json: string;
+    created_at: number;
+    delivery_id: string | null;
+    status: string | null;
+    attempts: number | null;
+    completed_at: number | null;
+  }>();
+  return c.json({
+    route: route ? { bound: true, subject_version: route.subject_version, created_at: route.created_at } : { bound: false },
+    matching_subscriber_count: subscribers?.count ?? 0,
+    events: await Promise.all(results.map(async ({ payload_json, ...event }) => ({
+      ...event,
+      payload_sha256: await sha256Hex(payload_json),
+    }))),
+  });
+}

--- a/worker/src/routes/reporter_routes.ts
+++ b/worker/src/routes/reporter_routes.ts
@@ -1,6 +1,8 @@
 import type { Context } from "hono";
 import type { AdminContext } from "../lib/permissions";
 import { authenticateReporter } from "../lib/reporter_auth";
+import { computeReporterAuditHash } from "../lib/reporter_audit";
+import { isFeedbackTokenPermission } from "../lib/app_permissions";
 
 type ReporterContext = Context<{ Bindings: Env }>;
 
@@ -20,22 +22,68 @@ export async function handleBindReporterRouteSubject(c: ReporterContext) {
   }
 
   const now = Date.now();
-  const result = await c.env.DB.prepare(
-    `INSERT OR IGNORE INTO app_reporter_routes
-     (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
-     SELECT ?1, ?2, ?3, ?4, 'v1', ?5
-     FROM app_reporter_integrations
-     WHERE id = ?2 AND app_id = ?1 AND archived_at IS NULL`,
-  ).bind(
-    auth.principal.appId,
-    auth.principal.integrationId,
-    auth.principal.reporterId,
-    subject,
-    now,
-  ).run();
+  const auditKey = c.env.FEEDBACK_AUDIT_HMAC_KEY;
+  const auditKeyVersion = c.env.FEEDBACK_AUDIT_KEY_VERSION?.trim();
+  const reporterHash = auditKey && auditKeyVersion
+    ? await computeReporterAuditHash({
+        key: auditKey,
+        appId: auth.principal.appId,
+        integrationId: auth.principal.integrationId,
+        reporterId: auth.principal.reporterId,
+      })
+    : null;
+  if (!reporterHash || !auditKeyVersion) {
+    return c.json({ error: "reporter audit is not configured" }, 503);
+  }
+  const auditPayload = JSON.stringify({
+    reporter_integration_id: auth.principal.integrationId,
+    reporter_hash: reporterHash,
+    audit_key_version: auditKeyVersion,
+  });
+  const [result] = await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT OR IGNORE INTO app_reporter_routes
+       (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+       SELECT ?1, ?2, ?3, ?4, 'v1', ?5
+       FROM app_reporter_integrations ri
+       JOIN apps a ON a.id = ri.app_id
+       WHERE ri.id = ?2 AND ri.app_id = ?1 AND ri.archived_at IS NULL
+         AND a.archived = 0`,
+    ).bind(
+      auth.principal.appId,
+      auth.principal.integrationId,
+      auth.principal.reporterId,
+      subject,
+      now,
+    ),
+    c.env.DB.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       SELECT ?1, ?2, 'feedback.route_bind', ?3, ?4, ?5
+       FROM app_reporter_routes r
+       JOIN apps a ON a.id = r.app_id AND a.archived = 0
+       JOIN app_reporter_integrations ri
+         ON ri.id = r.reporter_integration_id AND ri.app_id = r.app_id
+        AND ri.archived_at IS NULL
+       WHERE r.app_id = ?2 AND r.reporter_integration_id = ?6
+         AND r.reporter_id = ?7 AND r.route_subject = ?8`,
+    ).bind(
+      crypto.randomUUID(),
+      auth.principal.appId,
+      `reporter:${reporterHash}`,
+      auditPayload,
+      now,
+      auth.principal.integrationId,
+      auth.principal.reporterId,
+      subject,
+    ),
+  ]);
   const row = await c.env.DB.prepare(
-    `SELECT route_subject FROM app_reporter_routes
-     WHERE app_id = ?1 AND reporter_integration_id = ?2 AND reporter_id = ?3`,
+    `SELECT r.route_subject FROM app_reporter_routes r
+     JOIN apps a ON a.id = r.app_id AND a.archived = 0
+     JOIN app_reporter_integrations ri
+       ON ri.id = r.reporter_integration_id AND ri.app_id = r.app_id
+      AND ri.archived_at IS NULL
+     WHERE r.app_id = ?1 AND r.reporter_integration_id = ?2 AND r.reporter_id = ?3`,
   ).bind(
     auth.principal.appId,
     auth.principal.integrationId,
@@ -46,8 +94,8 @@ export async function handleBindReporterRouteSubject(c: ReporterContext) {
     return c.json({ error: "route_subject_conflict", changed: false }, 409);
   }
   return c.json(
-    { changed: result.meta.changes === 1, subject_version: "v1" },
-    result.meta.changes === 1 ? 201 : 200,
+    { changed: result?.meta.changes === 1, subject_version: "v1" },
+    result?.meta.changes === 1 ? 201 : 200,
   );
 }
 
@@ -64,12 +112,19 @@ export async function handleBindReporterWebhook(c: AdminContext) {
      JOIN apps a ON a.id = ri.app_id
      JOIN webhooks w ON w.id = ?3
      WHERE ri.id = ?2 AND ri.app_id = ?1 AND ri.archived_at IS NULL
+       AND a.archived = 0
        AND w.app_id = ?1 AND w.org_id = a.org_id
        AND w.enabled = 1 AND w.archived_at IS NULL`,
   ).bind(appId, integrationId, webhookId, now).run();
   const exists = await c.env.DB.prepare(
-    `SELECT 1 AS ok FROM app_reporter_webhook_subscriptions
-     WHERE app_id = ?1 AND reporter_integration_id = ?2 AND webhook_id = ?3`,
+    `SELECT 1 AS ok FROM app_reporter_webhook_subscriptions s
+     JOIN apps a ON a.id = s.app_id AND a.archived = 0
+     JOIN app_reporter_integrations ri
+       ON ri.id = s.reporter_integration_id AND ri.app_id = s.app_id
+      AND ri.archived_at IS NULL
+     JOIN webhooks w ON w.id = s.webhook_id AND w.app_id = s.app_id
+      AND w.org_id = a.org_id AND w.enabled = 1 AND w.archived_at IS NULL
+     WHERE s.app_id = ?1 AND s.reporter_integration_id = ?2 AND s.webhook_id = ?3`,
   ).bind(appId, integrationId, webhookId).first<{ ok: number }>();
   if (!exists) return c.json({ error: "reporter webhook subscription mismatch" }, 409);
   return c.json({ changed: result.meta.changes === 1 }, result.meta.changes === 1 ? 201 : 200);
@@ -80,40 +135,116 @@ async function sha256Hex(value: string) {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+async function hmacSha256Hex(secret: string, value: string) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(value));
+  return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
 export async function handleGetReporterRouteMetadata(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const integrationId = c.req.query("reporter_integration_id") ?? "";
   const reporterId = c.req.query("reporter_id") ?? "";
-  if (!integrationId || !reporterId) {
-    return c.json({ error: "reporter_integration_id and reporter_id are required" }, 400);
+  const tokenId = c.req.query("token_id") ?? "";
+  if (!integrationId || !reporterId || !tokenId) {
+    return c.json({ error: "reporter_integration_id, reporter_id, and token_id are required" }, 400);
   }
+  const auditKey = c.env.FEEDBACK_AUDIT_HMAC_KEY;
+  const auditKeyVersion = c.env.FEEDBACK_AUDIT_KEY_VERSION?.trim();
+  const reporterHash = auditKey && auditKeyVersion
+    ? await computeReporterAuditHash({ key: auditKey, appId, integrationId, reporterId })
+    : null;
+  if (!reporterHash || !auditKeyVersion) {
+    return c.json({ error: "reporter audit is not configured" }, 503);
+  }
+  const token = await c.env.DB.prepare(
+    `SELECT dt.id, dt.app_role, dt.scopes_json, dt.reporter_integration_id,
+            dt.revoked_at, dt.expires_at, a.archived AS app_archived,
+            ri.archived_at AS integration_archived_at
+     FROM app_deploy_tokens dt
+     JOIN apps a ON a.id = dt.app_id
+     LEFT JOIN app_reporter_integrations ri
+       ON ri.id = dt.reporter_integration_id AND ri.app_id = dt.app_id
+     WHERE dt.id = ?1 AND dt.app_id = ?2`,
+  ).bind(tokenId, appId).first<{
+    id: string;
+    app_role: string | null;
+    scopes_json: string | null;
+    reporter_integration_id: string | null;
+    revoked_at: number | null;
+    expires_at: number | null;
+    app_archived: number;
+    integration_archived_at: number | null;
+  }>();
+  let scopes: string[] = [];
+  try {
+    const parsed = token?.scopes_json === null ? null : JSON.parse(token?.scopes_json ?? "null");
+    scopes = Array.isArray(parsed) && parsed.every(isFeedbackTokenPermission) ? parsed : [];
+  } catch {
+    scopes = [];
+  }
+  const requiredPermissions = ["feedback:write", "feedback:read", "feedback:comment", "feedback:route"];
+  const effectivePermissions = [...new Set(scopes)].sort();
+  const grantValid = !!token
+    && token.app_role === null
+    && token.reporter_integration_id === integrationId
+    && token.revoked_at === null
+    && (token.expires_at === null || token.expires_at > Date.now())
+    && token.app_archived === 0
+    && token.integration_archived_at === null
+    && effectivePermissions.length === requiredPermissions.length
+    && requiredPermissions.every((permission) => effectivePermissions.includes(permission));
   const route = await c.env.DB.prepare(
-    `SELECT subject_version, created_at FROM app_reporter_routes
-     WHERE app_id = ?1 AND reporter_integration_id = ?2 AND reporter_id = ?3`,
+    `SELECT r.subject_version, r.created_at FROM app_reporter_routes r
+     JOIN apps a ON a.id = r.app_id AND a.archived = 0
+     JOIN app_reporter_integrations ri
+       ON ri.id = r.reporter_integration_id AND ri.app_id = r.app_id
+      AND ri.archived_at IS NULL
+     WHERE r.app_id = ?1 AND r.reporter_integration_id = ?2 AND r.reporter_id = ?3`,
   ).bind(appId, integrationId, reporterId).first<{
     subject_version: string;
     created_at: number;
   }>();
   const subscribers = await c.env.DB.prepare(
     `SELECT COUNT(*) AS count FROM app_reporter_webhook_subscriptions s
+     JOIN apps a ON a.id = s.app_id AND a.archived = 0
+     JOIN app_reporter_integrations ri
+       ON ri.id = s.reporter_integration_id AND ri.app_id = s.app_id
+      AND ri.archived_at IS NULL
      JOIN webhooks w ON w.id = s.webhook_id
      WHERE s.app_id = ?1 AND s.reporter_integration_id = ?2
+       AND w.app_id = s.app_id AND w.org_id = a.org_id
        AND w.enabled = 1 AND w.archived_at IS NULL`,
   ).bind(appId, integrationId).first<{ count: number }>();
   const { results } = await c.env.DB.prepare(
-    `SELECT fe.id AS event_id, fe.event_type, fe.route_outcome, fe.payload_json,
-            fe.created_at, wd.id AS delivery_id, wd.status, wd.attempts,
-            wd.completed_at
-     FROM feedback_events fe
-     LEFT JOIN webhook_deliveries wd ON wd.event_id = fe.id
-       AND EXISTS (
-         SELECT 1 FROM app_reporter_webhook_subscriptions s
-         WHERE s.webhook_id = wd.webhook_id AND s.app_id = fe.app_id
-           AND s.reporter_integration_id = fe.reporter_integration_id
-       )
-     WHERE fe.app_id = ?1 AND fe.reporter_integration_id = ?2
-       AND fe.reporter_id = ?3
-     ORDER BY fe.created_at DESC, fe.id DESC LIMIT 100`,
+    `SELECT events.event_id, events.event_type, events.route_outcome,
+            events.payload_json, events.created_at, wd.id AS delivery_id,
+            wd.status, wd.attempts, wd.completed_at, wd.signing_secret,
+            wd.signature_key_version
+     FROM (
+       SELECT id AS event_id, event_type, app_id, reporter_integration_id,
+              reporter_id, route_outcome, payload_json, created_at, 0 AS submission
+       FROM feedback_events
+       UNION ALL
+       SELECT id AS event_id, event_type, app_id, reporter_integration_id,
+              reporter_id, route_outcome, payload_json, created_at, 1 AS submission
+       FROM feedback_submission_events
+     ) events
+     LEFT JOIN webhook_deliveries wd
+       ON (events.submission = 0 AND wd.event_id = events.event_id)
+       OR (events.submission = 1 AND wd.feedback_submission_event_id = events.event_id)
+     LEFT JOIN app_reporter_webhook_subscriptions s
+       ON s.webhook_id = wd.webhook_id AND s.app_id = events.app_id
+      AND s.reporter_integration_id = events.reporter_integration_id
+     WHERE events.app_id = ?1 AND events.reporter_integration_id = ?2
+       AND events.reporter_id = ?3 AND (wd.id IS NULL OR s.webhook_id IS NOT NULL)
+     ORDER BY events.created_at DESC, events.event_id DESC LIMIT 100`,
   ).bind(appId, integrationId, reporterId).all<{
     event_id: string;
     event_type: string;
@@ -124,13 +255,39 @@ export async function handleGetReporterRouteMetadata(c: AdminContext) {
     status: string | null;
     attempts: number | null;
     completed_at: number | null;
+    signing_secret: string | null;
+    signature_key_version: string | null;
   }>();
+  const audit = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS count,
+            MAX(json_extract(payload, '$.audit_key_version')) AS audit_key_version
+     FROM audit_logs
+     WHERE app_id = ?1 AND action = 'feedback.route_bind'
+       AND json_extract(payload, '$.reporter_integration_id') = ?2
+       AND json_extract(payload, '$.reporter_hash') = ?3`,
+  ).bind(appId, integrationId, reporterHash).first<{ count: number; audit_key_version: string | null }>();
   return c.json({
+    grant: {
+      token_id: tokenId,
+      app_role: token?.app_role ?? null,
+      scopes,
+      grant_valid: grantValid,
+      effective_permissions: effectivePermissions,
+    },
     route: route ? { bound: true, subject_version: route.subject_version, created_at: route.created_at } : { bound: false },
     matching_subscriber_count: subscribers?.count ?? 0,
-    events: await Promise.all(results.map(async ({ payload_json, ...event }) => ({
+    active_exact_subscriber: (subscribers?.count ?? 0) > 0,
+    audit: {
+      action: "feedback.route_bind",
+      count: audit?.count ?? 0,
+      key_version: audit?.audit_key_version ?? auditKeyVersion,
+    },
+    events: await Promise.all(results.map(async ({ payload_json, signing_secret, ...event }) => ({
       ...event,
       payload_sha256: await sha256Hex(payload_json),
+      signature_sha256: signing_secret ? await hmacSha256Hex(signing_secret, payload_json) : null,
+      retry_stable: signing_secret !== null,
+      terminal: event.status === "succeeded" || event.status === "failed",
     }))),
   });
 }

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -279,7 +279,8 @@ export async function handleReapDeliveries(c: Context<{ Bindings: Env }>) {
   const now = Date.now();
   // Find all deliveries ready to attempt
   const { results: due } = await c.env.DB.prepare(
-    `SELECT id, webhook_id, event_id, attempts, max_attempts, payload_json
+    `SELECT id, webhook_id, COALESCE(event_id, feedback_submission_event_id) AS event_id,
+            attempts, max_attempts, payload_json, signing_secret
      FROM webhook_deliveries
      WHERE status = 'pending'
        AND (next_attempt_at IS NULL OR next_attempt_at <= ?1)
@@ -294,6 +295,7 @@ export async function handleReapDeliveries(c: Context<{ Bindings: Env }>) {
       attempts: number;
       max_attempts: number;
       payload_json: string;
+      signing_secret: string | null;
     }>();
 
   let succeeded = 0;
@@ -308,7 +310,7 @@ export async function handleReapDeliveries(c: Context<{ Bindings: Env }>) {
 
     const result = await postOnce(
       wh.url,
-      wh.secret,
+      d.signing_secret ?? wh.secret,
       d.payload_json,
       d.id,
       d.event_id,

--- a/worker/test/feedback_conversations_migration.test.ts
+++ b/worker/test/feedback_conversations_migration.test.ts
@@ -6,6 +6,9 @@ import { describe, expect, it } from "vitest";
 const migrationPath = fileURLToPath(
   new URL("../../migrations/sql/0051_feedback_conversations.sql", import.meta.url),
 );
+const routeMigrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0052_feedback_route_subjects.sql", import.meta.url),
+);
 
 function makeDb() {
   const db = new Database(":memory:");
@@ -13,6 +16,7 @@ function makeDb() {
   db.exec(`
     CREATE TABLE apps (
       id TEXT PRIMARY KEY,
+      org_id TEXT,
       created_at INTEGER NOT NULL
     );
     CREATE TABLE raft_accounts (id TEXT PRIMARY KEY);
@@ -238,5 +242,64 @@ describe("feedback conversations migration", () => {
     expect(() => db.prepare("DELETE FROM apps WHERE id = 'app-1'").run()).not.toThrow();
     expect(db.prepare("SELECT id FROM feedback_events WHERE id = 'event-1'").get()).toBeUndefined();
     expect(db.prepare("SELECT id FROM webhook_deliveries WHERE id = 'delivery-1'").get()).toBeUndefined();
+  });
+
+  it("freezes v1 route ownership, dedicated subscribers, and event snapshots", () => {
+    const db = makeDb();
+    db.exec(`
+      INSERT INTO apps (id, org_id, created_at) VALUES ('app-1', 'org-1', 1), ('app-2', 'org-2', 1);
+      INSERT INTO feedback_tickets
+        (id, app_id, message, reporter_id, created_at, updated_at)
+      VALUES ('ticket-1', 'app-1', 'hello', 'reporter_12345678', 2, 2);
+      INSERT INTO webhooks
+        (id, org_id, app_id, events_json, enabled)
+      VALUES
+        ('generic', 'org-1', 'app-1', '["feedback:comment_created"]', 1),
+        ('dedicated', 'org-1', 'app-1', '["feedback:comment_created"]', 1),
+        ('wrong-app', 'org-2', 'app-2', '["feedback:comment_created"]', 1);
+    `);
+    db.exec(readFileSync(migrationPath, "utf8"));
+    db.exec(readFileSync(routeMigrationPath, "utf8"));
+
+    const subject = `rfr_v1_${"A".repeat(64)}`;
+    db.prepare(`
+      INSERT INTO app_reporter_routes
+        (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+      VALUES ('app-1', 'legacy-feedback:app-1', 'reporter_12345678', ?, 'v1', 3)
+    `).run(subject);
+    expect(() => db.prepare(
+      "UPDATE app_reporter_routes SET route_subject = ? WHERE app_id = 'app-1'",
+    ).run(`rfr_v1_${"B".repeat(64)}`)).toThrow(/immutable/);
+    expect(() => db.prepare(
+      "DELETE FROM app_reporter_routes WHERE app_id = 'app-1'",
+    ).run()).toThrow(/immutable/);
+
+    db.prepare(`
+      INSERT INTO app_reporter_webhook_subscriptions
+        (app_id, reporter_integration_id, webhook_id, created_at)
+      VALUES ('app-1', 'legacy-feedback:app-1', 'dedicated', 4)
+    `).run();
+    expect(() => db.prepare(`
+      INSERT INTO app_reporter_webhook_subscriptions
+        (app_id, reporter_integration_id, webhook_id, created_at)
+      VALUES ('app-1', 'legacy-feedback:app-1', 'wrong-app', 4)
+    `).run()).toThrow(/mismatch/);
+
+    db.prepare(`
+      INSERT INTO feedback_events
+        (id, event_type, app_id, ticket_id, reporter_integration_id, reporter_id,
+         payload_json, route_outcome, route_subject, created_at)
+      VALUES ('bound-event', 'feedback:comment_created', 'app-1', 'ticket-1',
+              'legacy-feedback:app-1', 'reporter_12345678', '{}',
+              'route_bound', ?, 5)
+    `).run(subject);
+    expect(() => db.prepare(`
+      INSERT INTO feedback_events
+        (id, event_type, app_id, ticket_id, reporter_integration_id, reporter_id,
+         payload_json, route_outcome, route_subject, created_at)
+      VALUES ('bad-event', 'feedback:comment_created', 'app-1', 'ticket-1',
+              'legacy-feedback:app-1', 'reporter_12345678', '{}',
+              'route_unbound', ?, 5)
+    `).run(subject)).toThrow(/snapshot mismatch/);
   });
 });

--- a/worker/test/feedback_conversations_migration.test.ts
+++ b/worker/test/feedback_conversations_migration.test.ts
@@ -17,6 +17,7 @@ function makeDb() {
     CREATE TABLE apps (
       id TEXT PRIMARY KEY,
       org_id TEXT,
+      archived INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL
     );
     CREATE TABLE raft_accounts (id TEXT PRIMARY KEY);
@@ -77,6 +78,7 @@ function makeDb() {
       id TEXT PRIMARY KEY,
       org_id TEXT NOT NULL,
       app_id TEXT REFERENCES apps(id) ON DELETE CASCADE,
+      secret TEXT NOT NULL DEFAULT 'test-secret',
       events_json TEXT NOT NULL,
       enabled INTEGER NOT NULL,
       archived_at INTEGER
@@ -274,6 +276,19 @@ describe("feedback conversations migration", () => {
       "DELETE FROM app_reporter_routes WHERE app_id = 'app-1'",
     ).run()).toThrow(/immutable/);
 
+    db.prepare("UPDATE apps SET archived = 1 WHERE id = 'app-1'").run();
+    expect(() => db.prepare(`
+      INSERT INTO app_reporter_routes
+        (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+      VALUES ('app-1', 'legacy-feedback:app-1', 'other_reporter_1234', ?, 'v1', 3)
+    `).run(`rfr_v1_${"C".repeat(64)}`)).toThrow(/mismatch/);
+    expect(() => db.prepare(`
+      INSERT INTO app_reporter_webhook_subscriptions
+        (app_id, reporter_integration_id, webhook_id, created_at)
+      VALUES ('app-1', 'legacy-feedback:app-1', 'dedicated', 4)
+    `).run()).toThrow(/mismatch/);
+    db.prepare("UPDATE apps SET archived = 0 WHERE id = 'app-1'").run();
+
     db.prepare(`
       INSERT INTO app_reporter_webhook_subscriptions
         (app_id, reporter_integration_id, webhook_id, created_at)
@@ -301,5 +316,10 @@ describe("feedback conversations migration", () => {
               'legacy-feedback:app-1', 'reporter_12345678', '{}',
               'route_unbound', ?, 5)
     `).run(subject)).toThrow(/snapshot mismatch/);
+
+    db.prepare("UPDATE apps SET archived = 1 WHERE id = 'app-1'").run();
+    expect(() => db.prepare("DELETE FROM apps WHERE id = 'app-1'").run()).not.toThrow();
+    expect(db.prepare("SELECT 1 FROM app_reporter_routes WHERE app_id = 'app-1'").get()).toBeUndefined();
+    expect(db.prepare("SELECT 1 FROM app_reporter_webhook_subscriptions WHERE app_id = 'app-1'").get()).toBeUndefined();
   });
 });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -615,6 +615,7 @@ function makeMockDb() {
       payload_json TEXT NOT NULL,
       signing_secret TEXT,
       signature_key_version TEXT NOT NULL DEFAULT 'legacy-v1',
+      reporter_delivery INTEGER NOT NULL DEFAULT 0,
       status TEXT NOT NULL DEFAULT 'pending',
       attempts INTEGER NOT NULL DEFAULT 0,
       max_attempts INTEGER NOT NULL DEFAULT 3,
@@ -2979,10 +2980,10 @@ describe("quiver webhooks — SQL smoke", () => {
     await env.DB.prepare(
       `INSERT INTO webhook_deliveries
        (id, webhook_id, event_type, event_id, payload_json,
-        signing_secret, signature_key_version, status,
+        signing_secret, signature_key_version, reporter_delivery, status,
         attempts, max_attempts, next_attempt_at, created_at, updated_at)
        VALUES ('delivery-retry', 'wh-retry', 'feedback:status_changed',
-               'event-retry', ?1, 'retry-secret', 'retry-v1',
+               'event-retry', ?1, 'retry-secret', 'retry-v1', 1,
                'pending', 0, 3, 0, 1, 1)`,
     ).bind(payload).run();
     const calls: Array<{ body: string; headers: Headers }> = [];
@@ -7490,7 +7491,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect((await submit("h".repeat(64), credential.token, ownedSubmission)).status).toBe(409);
 
     const trustedDelivery = (await env.DB.prepare(
-      `SELECT payload_json, signing_secret, signature_key_version,
+      `SELECT payload_json, signing_secret, signature_key_version, reporter_delivery,
               feedback_submission_event_id
        FROM webhook_deliveries
        WHERE webhook_id = ?1 AND event_type = 'feedback:new'`,
@@ -7498,6 +7499,7 @@ describe("quiver public API v2 — scope resolution", () => {
       payload_json: string;
       signing_secret: string;
       signature_key_version: string;
+      reporter_delivery: number;
       feedback_submission_event_id: string;
     };
     expect(JSON.parse(trustedDelivery.payload_json).payload.reporter_id).toBe("g".repeat(64));
@@ -7510,6 +7512,7 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(trustedDelivery).toMatchObject({
       signing_secret: "secret",
       signature_key_version: "v1",
+      reporter_delivery: 1,
     });
     const submissionLedger = await env.DB.prepare(
       `SELECT id, ticket_id, route_outcome FROM feedback_submission_events
@@ -7517,10 +7520,11 @@ describe("quiver public API v2 — scope resolution", () => {
     ).bind(trustedDelivery.feedback_submission_event_id).first() as any;
     expect(submissionLedger).toMatchObject({ route_outcome: "route_bound" });
     const genericDelivery = await env.DB.prepare(
-      `SELECT payload_json FROM webhook_deliveries
+      `SELECT payload_json, reporter_delivery FROM webhook_deliveries
        WHERE webhook_id = 'generic-feedback-webhook' AND event_type = 'feedback:new'`,
-    ).first() as { payload_json: string } | null;
+    ).first() as { payload_json: string; reporter_delivery: number } | null;
     expect(genericDelivery).not.toBeNull();
+    expect(genericDelivery?.reporter_delivery).toBe(0);
     expect(JSON.stringify(genericDelivery)).not.toContain("route_subject");
     expect((await env.DB.prepare(
       `SELECT COUNT(*) AS count FROM webhook_deliveries
@@ -8858,10 +8862,10 @@ describe("Hands iOS simulator QA artifacts", () => {
     await env.DB.prepare(
       `INSERT INTO webhook_deliveries
        (id, webhook_id, event_type, feedback_submission_event_id, payload_json,
-        signing_secret, signature_key_version, status, attempts, max_attempts,
+        signing_secret, signature_key_version, reporter_delivery, status, attempts, max_attempts,
         created_at, updated_at, completed_at)
        VALUES ('route-metadata-delivery', 'route-hook', 'feedback:new',
-               'route-metadata-event', ?1, 'snapshot-secret', 'route-sign-v1',
+               'route-metadata-event', ?1, 'snapshot-secret', 'route-sign-v1', 1,
                'succeeded', 1, 3, ?2, ?2, ?2)`,
     ).bind(metadataEventPayload, now).run();
     const oracleBeforeRotation = await handleGetReporterRouteMetadata(adminContext("metadata"));
@@ -8886,6 +8890,37 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect(oracleAfterRotationBody.events[0].signature_key_version).toBe("route-sign-v1");
     expect(JSON.stringify(oracleAfterRotationBody)).not.toContain(subjectA);
     expect(JSON.stringify(oracleAfterRotationBody)).not.toContain(reporterId);
+
+    await env.DB.prepare(
+      `DELETE FROM app_reporter_webhook_subscriptions
+       WHERE app_id = 'app-ios' AND reporter_integration_id = ?1 AND webhook_id = 'route-hook'`,
+    ).bind(integrationId).run();
+    const unboundPayload = JSON.stringify({ id: "route-unbound-event", event: "feedback:status_changed" });
+    await env.DB.prepare(
+      `INSERT INTO feedback_events
+       (id, event_type, app_id, ticket_id, reporter_integration_id, reporter_id,
+        payload_json, route_outcome, route_subject, created_at)
+       VALUES ('route-unbound-event', 'feedback:status_changed', 'app-ios',
+               'route-metadata-ticket', ?1, ?2, ?3, 'route_unbound', NULL, ?4)`,
+    ).bind(integrationId, reporterId, unboundPayload, now + 1).run();
+    await env.DB.prepare(
+      `INSERT INTO webhook_deliveries
+       (id, webhook_id, event_type, event_id, payload_json, signing_secret,
+        signature_key_version, reporter_delivery, status, attempts, max_attempts,
+        created_at, updated_at)
+       VALUES ('route-unbound-generic', 'route-hook', 'feedback:status_changed',
+               'route-unbound-event', ?1, 'snapshot-secret', 'route-sign-v1', 0,
+               'pending', 0, 3, ?2, ?2)`,
+    ).bind(unboundPayload, now + 1).run();
+    const oracleBeforeLaterBind = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    const unboundBefore = (await oracleBeforeLaterBind.json() as any).events
+      .find((event: any) => event.event_id === "route-unbound-event");
+    expect(unboundBefore).toMatchObject({ route_outcome: "route_unbound", delivery_id: null });
+    expect((await handleBindReporterWebhook(adminContext("bind"))).status).toBe(201);
+    const oracleAfterLaterBind = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    const unboundAfter = (await oracleAfterLaterBind.json() as any).events
+      .find((event: any) => event.event_id === "route-unbound-event");
+    expect(unboundAfter).toMatchObject({ route_outcome: "route_unbound", delivery_id: null });
 
     await env.DB.prepare("UPDATE apps SET archived = 1 WHERE id = 'app-ios'").run();
     expect((await handleBindReporterRouteSubject(

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -633,7 +633,25 @@ function makeMockDb() {
       reporter_integration_id TEXT NOT NULL REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
       reporter_id TEXT NOT NULL,
       payload_json TEXT NOT NULL,
+      route_outcome TEXT NOT NULL DEFAULT 'route_unbound',
+      route_subject TEXT,
       created_at INTEGER NOT NULL
+    );
+    CREATE TABLE app_reporter_routes (
+      app_id TEXT NOT NULL,
+      reporter_integration_id TEXT NOT NULL,
+      reporter_id TEXT NOT NULL,
+      route_subject TEXT NOT NULL,
+      subject_version TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (app_id, reporter_integration_id, reporter_id)
+    );
+    CREATE TABLE app_reporter_webhook_subscriptions (
+      app_id TEXT NOT NULL,
+      reporter_integration_id TEXT NOT NULL,
+      webhook_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (app_id, reporter_integration_id, webhook_id)
     );
     CREATE TABLE feedback_reporter_rate_windows (
       app_id TEXT NOT NULL,
@@ -2435,6 +2453,7 @@ describe("quiver Hono app — auth + dispatch", () => {
       "feedback:write",
       "feedback:read",
       "feedback:comment",
+      "feedback:route",
     ]);
     expect(body.permissions.find((entry: any) => entry.permission === "app:read").label)
       .toBe("App read");
@@ -7222,7 +7241,8 @@ describe("quiver public API v2 — scope resolution", () => {
 
   it("feedback: trusted server proxy persists and rate-limits by pseudonymous reporter id", async () => {
     const env = makeEnv();
-    env.APK_BUCKET = { put: async () => {}, get: async () => null };
+    let r2Writes = 0;
+    env.APK_BUCKET = { put: async () => { r2Writes += 1; }, get: async () => null };
     const { handlePublicFeedbackSubmit } = await import("../src/routes/feedback");
     const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
     const credential = generateDeployToken();
@@ -7239,7 +7259,9 @@ describe("quiver public API v2 — scope resolution", () => {
       `INSERT INTO app_deploy_tokens
        (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
         created_by_actor, created_at, reporter_integration_id)
-       VALUES (?1, ?2, ?3, ?4, ?5, NULL, '["feedback:write"]', ?6, ?7, ?8)`,
+       VALUES (?1, ?2, ?3, ?4, ?5, NULL,
+               '["feedback:write","feedback:read","feedback:comment","feedback:route"]',
+               ?6, ?7, ?8)`,
     ).bind(
       "proxy-token",
       "app-scope",
@@ -7255,7 +7277,8 @@ describe("quiver public API v2 — scope resolution", () => {
        (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
         created_by_actor, created_at, reporter_integration_id)
        VALUES ('proxy-token-2', 'app-scope', 'feedback proxy 2', ?1, ?2, NULL,
-               '["feedback:write"]', 'test', ?3, 'integration-proxy-2')`,
+               '["feedback:write","feedback:read","feedback:comment","feedback:route"]',
+               'test', ?3, 'integration-proxy-2')`,
     ).bind(
       secondCredential.token_prefix,
       await hashDeployToken(secondCredential.token),
@@ -7292,11 +7315,17 @@ describe("quiver public API v2 — scope resolution", () => {
       reporterId: string,
       bearer = credential.token,
       submissionId?: string,
+      withAttachment = false,
     ) => {
       const responseHeaders = new Headers();
       const form = new FormData();
       form.set("message", "Proxy feedback");
       if (submissionId) form.set("submission_id", submissionId);
+      if (withAttachment) {
+        form.append("attachments", new File([new Uint8Array([1, 2, 3])], "route.txt", {
+          type: "text/plain",
+        }));
+      }
       return handlePublicFeedbackSubmit({
         env,
         executionCtx: { waitUntil: () => {} },
@@ -7321,6 +7350,26 @@ describe("quiver public API v2 — scope resolution", () => {
     };
 
     const reporterA = "a".repeat(64);
+    const missingRoute = await submit("z".repeat(64), credential.token, undefined, true);
+    expect(missingRoute.status).toBe(409);
+    expect(await missingRoute.json()).toMatchObject({ error: "route_required" });
+    expect(r2Writes).toBe(0);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_tickets WHERE reporter_id = ?1",
+    ).bind("z".repeat(64)).first() as any).count).toBe(0);
+    for (const [integrationId, reporterId, marker] of ([
+      ["integration-proxy", reporterA, "A"],
+      ["integration-proxy-2", reporterA, "B"],
+      ["integration-proxy", "b".repeat(64), "C"],
+      ["integration-proxy", "g".repeat(64), "D"],
+      ["integration-proxy", "h".repeat(64), "E"],
+    ] as const)) {
+      await env.DB.prepare(
+        `INSERT INTO app_reporter_routes
+         (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+         VALUES ('app-scope', ?1, ?2, ?3, 'v1', ?4)`,
+      ).bind(integrationId, reporterId, `rfr_v1_${marker.repeat(64)}`, Date.now()).run();
+    }
     for (let index = 0; index < 100; index += 1) expect((await submit(reporterA)).status).toBe(201);
     const limited = await submit(reporterA);
     expect(limited.status).toBe(429);
@@ -8544,6 +8593,83 @@ describe("Hands iOS simulator QA artifacts", () => {
     });
   });
 
+  it("binds immutable reporter routes and exact integration webhooks without subject disclosure", async () => {
+    const { env } = makeEnv() as any;
+    const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
+    const {
+      handleBindReporterRouteSubject,
+      handleBindReporterWebhook,
+      handleGetReporterRouteMetadata,
+    } = await import("../src/routes/reporter_routes");
+    const now = Date.now();
+    const integrationId = "91919191-9191-4191-8191-919191919191";
+    const reporterId = "route_reporter_123456789";
+    const credential = generateDeployToken();
+    await env.DB.prepare(
+      `INSERT INTO app_reporter_integrations
+       (id, app_id, name, created_at, updated_at)
+       VALUES (?1, 'app-ios', 'Route', ?2, ?2)`,
+    ).bind(integrationId, now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+        created_by_actor, created_at, reporter_integration_id)
+       VALUES ('route-token', 'app-ios', 'route', ?1, ?2, NULL,
+               '["feedback:write","feedback:read","feedback:comment","feedback:route"]',
+               'test', ?3, ?4)`,
+    ).bind(credential.token_prefix, await hashDeployToken(credential.token), now, integrationId).run();
+    const subjectA = `rfr_v1_${"A".repeat(64)}`;
+    const subjectB = `rfr_v1_${"B".repeat(64)}`;
+    const bindContext = (subject: string) => ({
+      env,
+      req: {
+        param: (name: string) => name === "appId" ? "app-ios" : undefined,
+        header: (name: string) => name === "X-Hands-Reporter-Id"
+          ? reporterId
+          : name === "authorization" ? `Bearer ${credential.token}` : undefined,
+        json: async () => ({ route_subject: subject }),
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    }) as any;
+    const created = await handleBindReporterRouteSubject(bindContext(subjectA));
+    expect(created.status).toBe(201);
+    expect(JSON.stringify(await created.json())).not.toContain(subjectA);
+    expect((await handleBindReporterRouteSubject(bindContext(subjectA))).status).toBe(200);
+    expect((await handleBindReporterRouteSubject(bindContext(subjectB))).status).toBe(409);
+    expect((await env.DB.prepare(
+      "SELECT route_subject FROM app_reporter_routes WHERE app_id = 'app-ios' AND reporter_integration_id = ?1",
+    ).bind(integrationId).first() as any).route_subject).toBe(subjectA);
+
+    await env.DB.prepare(
+      `INSERT INTO webhooks
+       (id, org_id, app_id, url, secret, events_json, enabled, created_at, updated_at)
+       VALUES ('route-hook', 'default', 'app-ios', 'https://example.test/route',
+               'secret', '["feedback:comment_created"]', 1, ?1, ?1)`,
+    ).bind(now).run();
+    const adminContext = (handler: "bind" | "metadata") => ({
+      env,
+      req: {
+        param: (name: string) => name === "appId" ? "app-ios"
+          : name === "integrationId" ? integrationId
+            : name === "webhookId" ? "route-hook" : undefined,
+        query: (name: string) => name === "reporter_integration_id" ? integrationId
+          : name === "reporter_id" ? reporterId : undefined,
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+    }) as any;
+    expect((await handleBindReporterWebhook(adminContext("bind"))).status).toBe(201);
+    expect((await handleBindReporterWebhook(adminContext("bind"))).status).toBe(200);
+    const metadata = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    const metadataBody = await metadata.json() as any;
+    expect(metadataBody).toMatchObject({
+      route: { bound: true, subject_version: "v1" },
+      matching_subscriber_count: 1,
+      events: [],
+    });
+    expect(JSON.stringify(metadataBody)).not.toContain(subjectA);
+    expect(JSON.stringify(metadataBody)).not.toContain(reporterId);
+  });
+
   it("reporter feedback bearer routes isolate integrations and converge comment replay", async () => {
     const { env } = makeEnv() as any;
     env.FEEDBACK_AUDIT_HMAC_KEY = "test-audit-key-with-enough-entropy";
@@ -8570,7 +8696,7 @@ describe("Hands iOS simulator QA artifacts", () => {
          (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
           created_by_actor, created_at, reporter_integration_id)
          VALUES (?1, 'app-ios', ?1, ?2, ?3, NULL,
-                 '["feedback:write","feedback:read","feedback:comment"]',
+                 '["feedback:write","feedback:read","feedback:comment","feedback:route"]',
                  'test', ?4, ?5)`,
       ).bind(id, credential.token_prefix, await hashDeployToken(credential.token), now, integrationId).run();
     };
@@ -8589,6 +8715,16 @@ describe("Hands iOS simulator QA artifacts", () => {
        VALUES ('reporter-hook', 'default', 'app-ios', 'https://example.test/hook',
                'secret', '["feedback:comment_created","feedback:status_changed"]', 1, ?1, ?1)`,
     ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_reporter_routes
+       (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+       VALUES ('app-ios', ?1, ?2, ?3, 'v1', ?4)`,
+    ).bind(integrationA, reporterId, `rfr_v1_${"A".repeat(64)}`, now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_reporter_webhook_subscriptions
+       (app_id, reporter_integration_id, webhook_id, created_at)
+       VALUES ('app-ios', ?1, 'reporter-hook', ?2)`,
+    ).bind(integrationA, now).run();
 
     const context = (
       handler: "list" | "detail" | "comment",
@@ -8664,6 +8800,10 @@ describe("Hands iOS simulator QA artifacts", () => {
     });
     expect(JSON.parse(reporterEvent!.payload_json).payload.comment).toHaveProperty("id");
     expect(JSON.parse(reporterEvent!.payload_json).payload.comment).toHaveProperty("created_at");
+    expect(JSON.parse(reporterEvent!.payload_json).payload).toMatchObject({
+      route_outcome: "route_bound",
+      route_subject: `rfr_v1_${"A".repeat(64)}`,
+    });
     expect((await env.DB.prepare(
       "SELECT COUNT(*) AS count FROM webhook_deliveries WHERE webhook_id = 'reporter-hook' AND event_id IS NOT NULL",
     ).first() as any).count).toBe(1);

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -594,6 +594,7 @@ function makeMockDb() {
       app_id TEXT REFERENCES apps(id) ON DELETE CASCADE,
       url TEXT NOT NULL,
       secret TEXT NOT NULL,
+      signature_key_version TEXT NOT NULL DEFAULT 'v1',
       events_json TEXT NOT NULL DEFAULT '[]',
       enabled INTEGER NOT NULL DEFAULT 1,
       created_by TEXT,
@@ -610,7 +611,10 @@ function makeMockDb() {
       webhook_id TEXT NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
       event_type TEXT NOT NULL,
       event_id TEXT REFERENCES feedback_events(id) ON DELETE SET NULL,
+      feedback_submission_event_id TEXT REFERENCES feedback_submission_events(id) ON DELETE SET NULL,
       payload_json TEXT NOT NULL,
+      signing_secret TEXT,
+      signature_key_version TEXT NOT NULL DEFAULT 'legacy-v1',
       status TEXT NOT NULL DEFAULT 'pending',
       attempts INTEGER NOT NULL DEFAULT 0,
       max_attempts INTEGER NOT NULL DEFAULT 3,
@@ -637,6 +641,21 @@ function makeMockDb() {
       route_subject TEXT,
       created_at INTEGER NOT NULL
     );
+    CREATE TABLE feedback_submission_events (
+      id TEXT PRIMARY KEY,
+      event_type TEXT NOT NULL,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+      reporter_integration_id TEXT NOT NULL REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+      reporter_id TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      route_outcome TEXT NOT NULL,
+      route_subject TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_webhook_deliveries_submission_event
+      ON webhook_deliveries(webhook_id, feedback_submission_event_id)
+      WHERE feedback_submission_event_id IS NOT NULL;
     CREATE TABLE app_reporter_routes (
       app_id TEXT NOT NULL,
       reporter_integration_id TEXT NOT NULL,
@@ -2959,10 +2978,12 @@ describe("quiver webhooks — SQL smoke", () => {
     ).run();
     await env.DB.prepare(
       `INSERT INTO webhook_deliveries
-       (id, webhook_id, event_type, event_id, payload_json, status,
+       (id, webhook_id, event_type, event_id, payload_json,
+        signing_secret, signature_key_version, status,
         attempts, max_attempts, next_attempt_at, created_at, updated_at)
        VALUES ('delivery-retry', 'wh-retry', 'feedback:status_changed',
-               'event-retry', ?1, 'pending', 0, 3, 0, 1, 1)`,
+               'event-retry', ?1, 'retry-secret', 'retry-v1',
+               'pending', 0, 3, 0, 1, 1)`,
     ).bind(payload).run();
     const calls: Array<{ body: string; headers: Headers }> = [];
     const originalFetch = globalThis.fetch;
@@ -2978,6 +2999,9 @@ describe("quiver webhooks — SQL smoke", () => {
         json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
       } as any;
       await handleReapDeliveries(context);
+      await env.DB.prepare(
+        "UPDATE webhooks SET secret = 'rotated-secret', signature_key_version = 'retry-v2' WHERE id = 'wh-retry'",
+      ).run();
       await env.DB.prepare(
         "UPDATE webhook_deliveries SET next_attempt_at = 0 WHERE id = 'delivery-retry'",
       ).run();
@@ -7370,6 +7394,65 @@ describe("quiver public API v2 — scope resolution", () => {
          VALUES ('app-scope', ?1, ?2, ?3, 'v1', ?4)`,
       ).bind(integrationId, reporterId, `rfr_v1_${marker.repeat(64)}`, Date.now()).run();
     }
+
+    const dbBeforeRace = env.DB;
+    const prepareBeforeRace = dbBeforeRace.prepare.bind(dbBeforeRace);
+    env.DB = {
+      ...dbBeforeRace,
+      prepare(sql: string) {
+        const prepared = prepareBeforeRace(sql);
+        if (!sql.includes("SELECT 1 AS ok FROM app_reporter_routes")) return prepared;
+        return {
+          ...prepared,
+          bind(...params: unknown[]) {
+            const bound = prepared.bind(...params);
+            return {
+              ...bound,
+              async first() {
+                const row = await bound.first();
+                await prepareBeforeRace("UPDATE apps SET archived = 1 WHERE id = 'app-scope'").run();
+                return row;
+              },
+            };
+          },
+        };
+      },
+    };
+    const raceTicketCountBefore = (await prepareBeforeRace(
+      "SELECT COUNT(*) AS count FROM feedback_tickets WHERE app_id = 'app-scope'",
+    ).first() as any).count;
+    const archivedRace = await submit("b".repeat(64));
+    expect(archivedRace.status).toBe(409);
+    expect(await archivedRace.json()).toMatchObject({ error: "route_required" });
+    env.DB = dbBeforeRace;
+    await env.DB.prepare("UPDATE apps SET archived = 0 WHERE id = 'app-scope'").run();
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_tickets WHERE app_id = 'app-scope'",
+    ).first() as any).count).toBe(raceTicketCountBefore);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_submission_events WHERE app_id = 'app-scope'",
+    ).first() as any).count).toBe(0);
+
+    const dbBeforeAtomicFailure = env.DB;
+    const prepareBeforeAtomicFailure = dbBeforeAtomicFailure.prepare.bind(dbBeforeAtomicFailure);
+    env.DB = {
+      ...dbBeforeAtomicFailure,
+      prepare(sql: string) {
+        if (sql.includes("INSERT INTO feedback_submission_events")) {
+          return prepareBeforeAtomicFailure("INSERT INTO definitely_missing_table VALUES (1)");
+        }
+        return prepareBeforeAtomicFailure(sql);
+      },
+    };
+    await expect(submit("g".repeat(64))).rejects.toThrow();
+    env.DB = dbBeforeAtomicFailure;
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_tickets WHERE app_id = 'app-scope' AND reporter_id = ?1",
+    ).bind("g".repeat(64)).first() as any).count).toBe(0);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_submission_events WHERE app_id = 'app-scope' AND reporter_id = ?1",
+    ).bind("g".repeat(64)).first() as any).count).toBe(0);
+
     for (let index = 0; index < 100; index += 1) expect((await submit(reporterA)).status).toBe(201);
     const limited = await submit(reporterA);
     expect(limited.status).toBe(429);
@@ -7384,7 +7467,9 @@ describe("quiver public API v2 — scope resolution", () => {
     await env.DB.prepare(
       `INSERT INTO webhooks
        (id, org_id, app_id, url, secret, events_json, enabled, created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8)`,
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8),
+              ('generic-feedback-webhook', ?2, ?3, 'https://example.test/generic-feedback',
+               'generic-secret', ?6, 1, ?7, ?8)`,
     ).bind(
       "trusted-feedback-webhook",
       "default",
@@ -7395,18 +7480,52 @@ describe("quiver public API v2 — scope resolution", () => {
       Date.now(),
       Date.now(),
     ).run();
+    await env.DB.prepare(
+      `INSERT INTO app_reporter_webhook_subscriptions
+       (app_id, reporter_integration_id, webhook_id, created_at)
+       VALUES ('app-scope', 'integration-proxy', 'trusted-feedback-webhook', ?1)`,
+    ).bind(Date.now()).run();
     const ownedSubmission = "55555555-5555-4555-8555-555555555555";
     expect((await submit("g".repeat(64), credential.token, ownedSubmission)).status).toBe(201);
     expect((await submit("h".repeat(64), credential.token, ownedSubmission)).status).toBe(409);
 
     const trustedDelivery = (await env.DB.prepare(
-      `SELECT payload_json
+      `SELECT payload_json, signing_secret, signature_key_version,
+              feedback_submission_event_id
        FROM webhook_deliveries
        WHERE webhook_id = ?1 AND event_type = 'feedback:new'`,
-    ).bind("trusted-feedback-webhook").first()) as { payload_json: string };
+    ).bind("trusted-feedback-webhook").first()) as {
+      payload_json: string;
+      signing_secret: string;
+      signature_key_version: string;
+      feedback_submission_event_id: string;
+    };
     expect(JSON.parse(trustedDelivery.payload_json).payload.reporter_id).toBe("g".repeat(64));
     expect(JSON.parse(trustedDelivery.payload_json).payload.reporter_integration_id)
       .toBe("integration-proxy");
+    expect(JSON.parse(trustedDelivery.payload_json).payload).toMatchObject({
+      route_outcome: "route_bound",
+      route_subject: `rfr_v1_${"D".repeat(64)}`,
+    });
+    expect(trustedDelivery).toMatchObject({
+      signing_secret: "secret",
+      signature_key_version: "v1",
+    });
+    const submissionLedger = await env.DB.prepare(
+      `SELECT id, ticket_id, route_outcome FROM feedback_submission_events
+       WHERE id = ?1`,
+    ).bind(trustedDelivery.feedback_submission_event_id).first() as any;
+    expect(submissionLedger).toMatchObject({ route_outcome: "route_bound" });
+    const genericDelivery = await env.DB.prepare(
+      `SELECT payload_json FROM webhook_deliveries
+       WHERE webhook_id = 'generic-feedback-webhook' AND event_type = 'feedback:new'`,
+    ).first() as { payload_json: string } | null;
+    expect(genericDelivery).not.toBeNull();
+    expect(JSON.stringify(genericDelivery)).not.toContain("route_subject");
+    expect((await env.DB.prepare(
+      `SELECT COUNT(*) AS count FROM webhook_deliveries
+       WHERE feedback_submission_event_id = ?1`,
+    ).bind(trustedDelivery.feedback_submission_event_id).first() as any).count).toBe(2);
 
     const reporterRows = await env.DB.prepare(
       `SELECT DISTINCT reporter_id
@@ -8571,6 +8690,21 @@ describe("Hands iOS simulator QA artifacts", () => {
       app_id: { type: "string", in: "path", required: true },
       confirm_slug: { type: "string", in: "body", required: true },
     });
+    expect(byName["bind-reporter-webhook"]).toMatchObject({
+      endpoint: {
+        method: "PUT",
+        path: "/api/apps/{app_id}/reporter-integrations/{reporter_integration_id}/webhooks/{webhook_id}",
+      },
+    });
+    expect(byName["get-reporter-feedback-metadata"]).toMatchObject({
+      endpoint: { method: "GET", path: "/api/apps/{app_id}/reporter-feedback-metadata" },
+      parameters: {
+        app_id: { type: "string", in: "path", required: true },
+        reporter_integration_id: { type: "string", in: "query", required: true },
+        reporter_id: { type: "string", in: "query", required: true },
+        token_id: { type: "string", in: "query", required: true },
+      },
+    });
     expect(byName["get-client-key"].parameters.app_id).toMatchObject({
       type: "string",
       in: "path",
@@ -8595,6 +8729,8 @@ describe("Hands iOS simulator QA artifacts", () => {
 
   it("binds immutable reporter routes and exact integration webhooks without subject disclosure", async () => {
     const { env } = makeEnv() as any;
+    env.FEEDBACK_AUDIT_HMAC_KEY = "test-audit-key-with-enough-entropy";
+    env.FEEDBACK_AUDIT_KEY_VERSION = "test-v1";
     const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
     const {
       handleBindReporterRouteSubject,
@@ -8620,12 +8756,12 @@ describe("Hands iOS simulator QA artifacts", () => {
     ).bind(credential.token_prefix, await hashDeployToken(credential.token), now, integrationId).run();
     const subjectA = `rfr_v1_${"A".repeat(64)}`;
     const subjectB = `rfr_v1_${"B".repeat(64)}`;
-    const bindContext = (subject: string) => ({
+    const bindContext = (subject: string, boundReporterId = reporterId) => ({
       env,
       req: {
         param: (name: string) => name === "appId" ? "app-ios" : undefined,
         header: (name: string) => name === "X-Hands-Reporter-Id"
-          ? reporterId
+          ? boundReporterId
           : name === "authorization" ? `Bearer ${credential.token}` : undefined,
         json: async () => ({ route_subject: subject }),
       },
@@ -8640,6 +8776,28 @@ describe("Hands iOS simulator QA artifacts", () => {
       "SELECT route_subject FROM app_reporter_routes WHERE app_id = 'app-ios' AND reporter_integration_id = ?1",
     ).bind(integrationId).first() as any).route_subject).toBe(subjectA);
 
+    const concurrentSameReporter = "same_writer_reporter_1234";
+    const concurrentSame = await Promise.all([
+      handleBindReporterRouteSubject(bindContext(subjectA, concurrentSameReporter)),
+      handleBindReporterRouteSubject(bindContext(subjectA, concurrentSameReporter)),
+    ]);
+    expect(concurrentSame.map((response) => response.status).sort()).toEqual([200, 201]);
+    expect((await env.DB.prepare(
+      `SELECT COUNT(*) AS count FROM app_reporter_routes
+       WHERE app_id = 'app-ios' AND reporter_integration_id = ?1 AND reporter_id = ?2`,
+    ).bind(integrationId, concurrentSameReporter).first() as any).count).toBe(1);
+
+    const concurrentDifferentReporter = "different_writer_reporter_1234";
+    const concurrentDifferent = await Promise.all([
+      handleBindReporterRouteSubject(bindContext(subjectA, concurrentDifferentReporter)),
+      handleBindReporterRouteSubject(bindContext(subjectB, concurrentDifferentReporter)),
+    ]);
+    expect(concurrentDifferent.map((response) => response.status).sort()).toEqual([201, 409]);
+    expect((await env.DB.prepare(
+      `SELECT COUNT(*) AS count FROM app_reporter_routes
+       WHERE app_id = 'app-ios' AND reporter_integration_id = ?1 AND reporter_id = ?2`,
+    ).bind(integrationId, concurrentDifferentReporter).first() as any).count).toBe(1);
+
     await env.DB.prepare(
       `INSERT INTO webhooks
        (id, org_id, app_id, url, secret, events_json, enabled, created_at, updated_at)
@@ -8653,7 +8811,8 @@ describe("Hands iOS simulator QA artifacts", () => {
           : name === "integrationId" ? integrationId
             : name === "webhookId" ? "route-hook" : undefined,
         query: (name: string) => name === "reporter_integration_id" ? integrationId
-          : name === "reporter_id" ? reporterId : undefined,
+          : name === "reporter_id" ? reporterId
+            : name === "token_id" ? "route-token" : undefined,
       },
       json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
     }) as any;
@@ -8663,11 +8822,100 @@ describe("Hands iOS simulator QA artifacts", () => {
     const metadataBody = await metadata.json() as any;
     expect(metadataBody).toMatchObject({
       route: { bound: true, subject_version: "v1" },
+      grant: {
+        token_id: "route-token",
+        app_role: null,
+        grant_valid: true,
+        effective_permissions: ["feedback:comment", "feedback:read", "feedback:route", "feedback:write"],
+      },
       matching_subscriber_count: 1,
+      active_exact_subscriber: true,
+      audit: { action: "feedback.route_bind", count: 2, key_version: "test-v1" },
       events: [],
     });
     expect(JSON.stringify(metadataBody)).not.toContain(subjectA);
     expect(JSON.stringify(metadataBody)).not.toContain(reporterId);
+
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+       VALUES ('route-metadata-ticket', 'app-ios', 'feedback', 'open', 'hidden', '{}',
+               ?1, ?2, ?3, ?3)`,
+    ).bind(reporterId, integrationId, now).run();
+    const metadataEventPayload = JSON.stringify({
+      id: "route-metadata-event",
+      event: "feedback:new",
+      payload: { route_subject: subjectA, reporter_id: reporterId },
+    });
+    await env.DB.prepare(
+      `INSERT INTO feedback_submission_events
+       (id, event_type, app_id, ticket_id, reporter_integration_id, reporter_id,
+        payload_json, route_outcome, route_subject, created_at)
+       VALUES ('route-metadata-event', 'feedback:new', 'app-ios', 'route-metadata-ticket',
+               ?1, ?2, ?3, 'route_bound', ?4, ?5)`,
+    ).bind(integrationId, reporterId, metadataEventPayload, subjectA, now).run();
+    await env.DB.prepare(
+      `INSERT INTO webhook_deliveries
+       (id, webhook_id, event_type, feedback_submission_event_id, payload_json,
+        signing_secret, signature_key_version, status, attempts, max_attempts,
+        created_at, updated_at, completed_at)
+       VALUES ('route-metadata-delivery', 'route-hook', 'feedback:new',
+               'route-metadata-event', ?1, 'snapshot-secret', 'route-sign-v1',
+               'succeeded', 1, 3, ?2, ?2, ?2)`,
+    ).bind(metadataEventPayload, now).run();
+    const oracleBeforeRotation = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    const oracleBeforeRotationBody = await oracleBeforeRotation.json() as any;
+    expect(oracleBeforeRotationBody.events[0]).toMatchObject({
+      event_id: "route-metadata-event",
+      delivery_id: "route-metadata-delivery",
+      route_outcome: "route_bound",
+      signature_key_version: "route-sign-v1",
+      retry_stable: true,
+      terminal: true,
+    });
+    expect(oracleBeforeRotationBody.events[0].payload_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(oracleBeforeRotationBody.events[0].signature_sha256).toMatch(/^[0-9a-f]{64}$/);
+    await env.DB.prepare(
+      "UPDATE webhooks SET secret = 'rotated-secret', signature_key_version = 'route-sign-v2' WHERE id = 'route-hook'",
+    ).run();
+    const oracleAfterRotation = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    const oracleAfterRotationBody = await oracleAfterRotation.json() as any;
+    expect(oracleAfterRotationBody.events[0].signature_sha256)
+      .toBe(oracleBeforeRotationBody.events[0].signature_sha256);
+    expect(oracleAfterRotationBody.events[0].signature_key_version).toBe("route-sign-v1");
+    expect(JSON.stringify(oracleAfterRotationBody)).not.toContain(subjectA);
+    expect(JSON.stringify(oracleAfterRotationBody)).not.toContain(reporterId);
+
+    await env.DB.prepare("UPDATE apps SET archived = 1 WHERE id = 'app-ios'").run();
+    expect((await handleBindReporterRouteSubject(
+      bindContext(subjectA, "archived_app_reporter_1234"),
+    )).status).toBe(403);
+    expect((await handleBindReporterWebhook(adminContext("bind"))).status).toBe(409);
+    const inactiveMetadata = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    expect(await inactiveMetadata.json()).toMatchObject({
+      grant: { grant_valid: false },
+      route: { bound: false },
+      matching_subscriber_count: 0,
+      active_exact_subscriber: false,
+    });
+    await env.DB.prepare("UPDATE apps SET archived = 0 WHERE id = 'app-ios'").run();
+    await env.DB.prepare(
+      "UPDATE app_reporter_integrations SET archived_at = ?1 WHERE id = ?2",
+    ).bind(now + 1, integrationId).run();
+    expect((await handleBindReporterRouteSubject(
+      bindContext(subjectA, "archived_integration_reporter_1234"),
+    )).status).toBe(403);
+    expect((await handleBindReporterWebhook(adminContext("bind"))).status).toBe(409);
+    const archivedIntegrationMetadata = await handleGetReporterRouteMetadata(adminContext("metadata"));
+    expect(await archivedIntegrationMetadata.json()).toMatchObject({
+      grant: { grant_valid: false },
+      route: { bound: false },
+      active_exact_subscriber: false,
+    });
+    await env.DB.prepare(
+      "UPDATE app_reporter_integrations SET archived_at = NULL WHERE id = ?1",
+    ).bind(integrationId).run();
   });
 
   it("reporter feedback bearer routes isolate integrations and converge comment replay", async () => {


### PR DESCRIPTION
## Summary

- add an explicit `feedback:route` permission and immutable reporter route bindings
- require trusted reporter submissions to have a route before ticket or attachment writes
- bind dedicated webhooks to one reporter integration while keeping generic webhook payloads redacted
- freeze route outcome and delivery bytes for retry-stable webhook processing
- expose a metadata-only route/event/delivery oracle without returning route subjects or payload bodies

## Safety properties

- a different v1 subject cannot overwrite an existing binding
- generic subscribers never receive route subjects
- route-unbound events are historical facts and are not backfilled
- route subjects are omitted from audit, logs, errors, and metadata responses

## Validation

- Worker TypeScript build
- Worker tests: 228/228
- focused migration, route-binding, reporter conversation, and direct-submit regression coverage

This PR is intentionally draft pending independent source review and rollout evidence.
