### PR TITLE
fix(releases): enforce one lifecycle per version

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -212,6 +212,8 @@ export interface Release {
   product_type: string;
   release_type: string;
   status: string;            // 'draft' | 'active' | 'superseded' | 'cancelled'
+  activated_at: number | null;
+  revision: number;
   is_full: number;
   superseded_by_release_id: string | null;
   rollout_cohort_count: number | null;
@@ -1397,6 +1399,7 @@ export const updateRelease = (
     availability_at?: number | null | undefined;
     provenance_json?: unknown;
     scopes?: { scope_type: string; scope_value: string }[];
+    expected_revision: number;
   },
 ) =>
   request<Release>(`/api/apps/${appId}/releases/${releaseId}`, {
@@ -1409,16 +1412,20 @@ export const publishRelease = (
   appId: string,
   releaseId: string,
   expectedScopes: { scope_type: string; scope_value: string }[],
+  expectedRevision: number,
 ) =>
   request<Release>(`/api/apps/${appId}/releases/${releaseId}/publish`, {
     method: "POST",
     admin: true,
-    body: JSON.stringify({ expected_scopes: expectedScopes }),
+    body: JSON.stringify({
+      expected_scopes: expectedScopes,
+      expected_revision: expectedRevision,
+    }),
   });
 
-export const deleteRelease = (appId: string, releaseId: string) =>
-  request<{ ok: boolean; id: string; status: "cancelled" }>(
-    `/api/apps/${appId}/releases/${releaseId}`,
+export const deleteRelease = (appId: string, releaseId: string, expectedRevision: number) =>
+  request<{ ok: boolean; id: string; status: "cancelled"; revision: number }>(
+    `/api/apps/${appId}/releases/${releaseId}?expected_revision=${expectedRevision}`,
     { method: "DELETE", admin: true },
   );
 
@@ -1428,9 +1435,10 @@ export const rollbackRelease = (
   input?: {
     build_id?: string | undefined;
     scopes?: { scope_type: string; scope_value: string }[];
+    expected_revision: number;
   },
 ) =>
-  request<Release>(`/api/apps/${appId}/releases/${releaseId}/rollback`, {
+  request<Release & { restored_to_draft: boolean; reactivated: boolean }>(`/api/apps/${appId}/releases/${releaseId}/rollback`, {
     method: "POST",
     admin: true,
     body: JSON.stringify(input ?? {}),
@@ -1439,9 +1447,9 @@ export const rollbackRelease = (
 export const bumpRollout = (
   appId: string,
   releaseId: string,
-  input: { to?: number; by?: number },
+  input: { to?: number; by?: number; expected_revision: number },
 ) =>
-  request<{ ok: boolean; rollout_cohort_count: number | null }>(
+  request<{ ok: boolean; rollout_cohort_count: number | null; revision: number }>(
     `/api/apps/${appId}/releases/${releaseId}/bump-rollout`,
     { method: "POST", admin: true, body: JSON.stringify(input) },
   );
@@ -1449,9 +1457,9 @@ export const bumpRollout = (
 export const forceUpdate = (
   appId: string,
   releaseId: string,
-  input?: { enabled?: boolean },
+  input?: { enabled?: boolean; expected_revision: number },
 ) =>
-  request<{ ok: boolean; should_force_update: number }>(
+  request<{ ok: boolean; should_force_update: number; revision: number }>(
     `/api/apps/${appId}/releases/${releaseId}/force-update`,
     { method: "POST", admin: true, body: JSON.stringify(input ?? {}) },
   );

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1408,16 +1408,12 @@ export const updateRelease = (
 export const publishRelease = (
   appId: string,
   releaseId: string,
-  expectedScope?: { scope_type: string; scope_value: string },
+  expectedScopes: { scope_type: string; scope_value: string }[],
 ) =>
   request<Release>(`/api/apps/${appId}/releases/${releaseId}/publish`, {
     method: "POST",
     admin: true,
-    body: JSON.stringify(
-      expectedScope
-        ? { expected_scope: expectedScope }
-        : {},
-    ),
+    body: JSON.stringify({ expected_scopes: expectedScopes }),
   });
 
 export const deleteRelease = (appId: string, releaseId: string) =>

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -396,6 +396,7 @@ function ReleaseRow({
     queryKey: ["release-detail", r.id],
     queryFn: () => getRelease(appId, r.id),
   });
+  const currentRevision = detail.data?.release.revision ?? r.revision;
 
   const publish = useMutation({
     mutationFn: () => {
@@ -408,6 +409,7 @@ function ReleaseRow({
           scope_type: scope.scope_type,
           scope_value: scope.scope_value,
         })),
+        currentRevision,
       );
     },
     onSuccess: () => {
@@ -423,9 +425,16 @@ function ReleaseRow({
   });
 
   const rollback = useMutation({
-    mutationFn: () => rollbackRelease(appId, r.id, {}),
-    onSuccess: () => {
-      toast.show({ kind: "success", title: `Restored ${channelSlug}` });
+    mutationFn: () => rollbackRelease(appId, r.id, {
+      expected_revision: currentRevision,
+    }),
+    onSuccess: (data) => {
+      toast.show({
+        kind: "success",
+        title: data.restored_to_draft
+          ? `Restored ${channelSlug} draft`
+          : `Restored ${channelSlug} as active`,
+      });
       onAction();
     },
     onError: (e) =>
@@ -437,7 +446,10 @@ function ReleaseRow({
   });
 
   const bump = useMutation({
-    mutationFn: (target: number) => bumpRollout(appId, r.id, { to: target }),
+    mutationFn: (target: number) => bumpRollout(appId, r.id, {
+      to: target,
+      expected_revision: currentRevision,
+    }),
     onSuccess: (data) => {
       toast.show({
         kind: "success",
@@ -455,7 +467,10 @@ function ReleaseRow({
   });
 
   const toggleForce = useMutation({
-    mutationFn: () => forceUpdate(appId, r.id, { enabled: !r.should_force_update }),
+    mutationFn: () => forceUpdate(appId, r.id, {
+      enabled: !r.should_force_update,
+      expected_revision: currentRevision,
+    }),
     onSuccess: (data) => {
       toast.show({
         kind: "success",
@@ -474,7 +489,7 @@ function ReleaseRow({
   });
 
   const cancel = useMutation({
-    mutationFn: () => deleteRelease(appId, r.id),
+    mutationFn: () => deleteRelease(appId, r.id, currentRevision),
     onSuccess: () => {
       toast.show({
         kind: "success",
@@ -603,7 +618,9 @@ function ReleaseRow({
             onClick={() => rollback.mutate()}
             disabled={rollback.isPending}
           >
-            Restore as active
+            {r.status === "cancelled" && r.activated_at == null
+              ? "Restore draft"
+              : "Restore as active"}
           </Button>
         )}
         {(r.status === "draft" || r.status === "active") && (
@@ -822,6 +839,7 @@ function EditReleaseDialog({
   const save = useMutation({
     mutationFn: () =>
       updateRelease(appId, release.id, {
+        expected_revision: detail?.release.revision ?? release.revision,
         changelog: changelog.trim() || null,
         should_force_update: shouldForceUpdate,
         rollout_cohort_count:
@@ -1109,7 +1127,12 @@ function NewReleaseDialog({
         }
       }
       if (mode === "publish") {
-        const published = await publishRelease(appId, release.id, scopes);
+        const published = await publishRelease(
+          appId,
+          release.id,
+          scopes,
+          release.revision,
+        );
         return { release: published, assetFailures, mode };
       }
       return { release, assetFailures, mode };

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -63,6 +63,62 @@ import type { PendingFile } from "../lib/releaseFileDetect";
 
 const ROLLOUT_PRESETS = [5, 25, 50, 100];
 
+type EditableScopeType = "full" | "platform" | "user_cohort" | "ip_range" | "device_group";
+type ScopeInput = { scope_type: string; scope_value: string };
+
+function buildReleaseScopes(
+  scopeType: EditableScopeType,
+  scopeValue: string,
+  alwaysIncludedGroupIds: string[],
+): ScopeInput[] {
+  if (scopeType !== "full") {
+    return [{ scope_type: scopeType, scope_value: scopeValue.trim() }];
+  }
+  return [
+    { scope_type: "full", scope_value: "all" },
+    ...[...new Set(alwaysIncludedGroupIds)].sort().map((groupId) => ({
+      scope_type: "device_group",
+      scope_value: groupId,
+    })),
+  ];
+}
+
+function AlwaysIncludedDeviceGroups({
+  groups,
+  selectedIds,
+  onChange,
+}: {
+  groups: { id: string; name: string; member_count: number }[];
+  selectedIds: string[];
+  onChange: (next: string[]) => void;
+}) {
+  if (groups.length === 0) {
+    return <p className="text-xs text-slate-500">No device groups available.</p>;
+  }
+  return (
+    <div className="max-h-36 overflow-y-auto rounded-sm border border-slate-200 divide-y divide-slate-100">
+      {groups.map((group) => {
+        const checked = selectedIds.includes(group.id);
+        return (
+          <label key={group.id} className="flex items-center gap-2 px-2 py-1.5 text-xs">
+            <Checkbox
+              checked={checked}
+              onCheckedChange={(value) => {
+                const next = Boolean(value)
+                  ? [...selectedIds, group.id]
+                  : selectedIds.filter((id) => id !== group.id);
+                onChange([...new Set(next)].sort());
+              }}
+            />
+            <span className="min-w-0 flex-1 truncate">{group.name}</span>
+            <span className="font-mono text-slate-500">{group.member_count}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
 function RolloutPercentInput({
   value,
   onChange,
@@ -344,11 +400,15 @@ function ReleaseRow({
   const publish = useMutation({
     mutationFn: () => {
       const scopes = detail.data?.scopes ?? [];
-      const onlyScope = scopes.length === 1 ? scopes[0] : undefined;
-      const expectedScope = onlyScope && onlyScope.scope_type !== "full"
-        ? { scope_type: onlyScope.scope_type, scope_value: onlyScope.scope_value }
-        : undefined;
-      return publishRelease(appId, r.id, expectedScope);
+      if (scopes.length === 0) throw new Error("Release has no scope to publish");
+      return publishRelease(
+        appId,
+        r.id,
+        scopes.map((scope) => ({
+          scope_type: scope.scope_type,
+          scope_value: scope.scope_value,
+        })),
+      );
     },
     onSuccess: () => {
       toast.show({ kind: "success", title: `Published ${channelSlug}` });
@@ -365,7 +425,7 @@ function ReleaseRow({
   const rollback = useMutation({
     mutationFn: () => rollbackRelease(appId, r.id, {}),
     onSuccess: () => {
-      toast.show({ kind: "success", title: `Rolled back ${channelSlug}` });
+      toast.show({ kind: "success", title: `Restored ${channelSlug}` });
       onAction();
     },
     onError: (e) =>
@@ -515,36 +575,36 @@ function ReleaseRow({
             Edit
           </Button>
         )}
-        {(r.status === "active" || r.status === "superseded" || r.status === "cancelled") && (
+        {r.status === "active" && (
           <>
-            {r.status === "active" && (
-              <>
-                <Button
-                  variant="outline"
-                  className="text-xs"
-                  onClick={() => setShowRollout(!showRollout)}
-                >
-                  Bump rollout
-                </Button>
-                <Button
-                  variant="outline"
-                  className="text-xs"
-                  onClick={() => toggleForce.mutate()}
-                  disabled={toggleForce.isPending}
-                >
-                  {r.should_force_update ? "Unforce" : "Force"}
-                </Button>
-              </>
+            {Boolean(r.is_full) && (
+              <Button
+                variant="outline"
+                className="text-xs"
+                onClick={() => setShowRollout(!showRollout)}
+              >
+                Bump rollout
+              </Button>
             )}
             <Button
               variant="outline"
               className="text-xs"
-              onClick={() => rollback.mutate()}
-              disabled={rollback.isPending}
+              onClick={() => toggleForce.mutate()}
+              disabled={toggleForce.isPending}
             >
-              {r.status === "active" ? "Roll back" : "Restore as active"}
+              {r.should_force_update ? "Unforce" : "Force"}
             </Button>
           </>
+        )}
+        {(r.status === "superseded" || r.status === "cancelled") && (
+          <Button
+            variant="outline"
+            className="text-xs"
+            onClick={() => rollback.mutate()}
+            disabled={rollback.isPending}
+          >
+            Restore as active
+          </Button>
         )}
         {(r.status === "draft" || r.status === "active") && (
           <Button
@@ -723,18 +783,29 @@ function EditReleaseDialog({
     queryKey: ["device-groups", appId],
     queryFn: () => listDeviceGroups(appId),
   });
-  const [scopeType, setScopeType] = useState<"full" | "platform" | "user_cohort" | "ip_range" | "device_group">("full");
+  const [scopeType, setScopeType] = useState<EditableScopeType>("full");
   const [scopeValue, setScopeValue] = useState("all");
+  const [alwaysIncludedGroupIds, setAlwaysIncludedGroupIds] = useState<string[]>([]);
   const [shouldForceUpdate, setShouldForceUpdate] = useState(Boolean(release.should_force_update));
   const [rolloutPercent, setRolloutPercent] = useState<number>(release.rollout_cohort_count ?? 100);
 
   useEffect(() => {
     if (!detail) return;
+    const fullScope = detail.scopes.find((scope) => scope.scope_type === "full" && scope.scope_value === "all");
     const firstScope = detail.scopes[0];
     setChangelog(detail.release.changelog ?? "");
     setShouldForceUpdate(Boolean(detail.release.should_force_update));
     setRolloutPercent(detail.release.rollout_cohort_count ?? 100);
-    if (
+    if (fullScope) {
+      setScopeType("full");
+      setScopeValue("all");
+      setAlwaysIncludedGroupIds(
+        detail.scopes
+          .filter((scope) => scope.scope_type === "device_group")
+          .map((scope) => scope.scope_value)
+          .sort(),
+      );
+    } else if (
       firstScope &&
       (firstScope.scope_type === "full" ||
         firstScope.scope_type === "platform" ||
@@ -744,6 +815,7 @@ function EditReleaseDialog({
     ) {
       setScopeType(firstScope.scope_type);
       setScopeValue(firstScope.scope_value);
+      setAlwaysIncludedGroupIds([]);
     }
   }, [detail]);
 
@@ -752,11 +824,9 @@ function EditReleaseDialog({
       updateRelease(appId, release.id, {
         changelog: changelog.trim() || null,
         should_force_update: shouldForceUpdate,
-        rollout_cohort_count: rolloutPercent < 100 ? rolloutPercent : null,
-        scopes:
-          scopeType === "full"
-            ? [{ scope_type: "full", scope_value: "all" }]
-            : [{ scope_type: scopeType, scope_value: scopeValue.trim() }],
+        rollout_cohort_count:
+          scopeType === "full" && rolloutPercent < 100 ? rolloutPercent : null,
+        scopes: buildReleaseScopes(scopeType, scopeValue, alwaysIncludedGroupIds),
       }),
     onSuccess: () => {
       toast.show({ kind: "success", title: "Release updated" });
@@ -845,6 +915,16 @@ function EditReleaseDialog({
               )}
             </div>
           </div>
+          {scopeType === "full" && (
+            <div>
+              <label className="label">Always included device groups</label>
+              <AlwaysIncludedDeviceGroups
+                groups={deviceGroups.data?.groups ?? []}
+                selectedIds={alwaysIncludedGroupIds}
+                onChange={setAlwaysIncludedGroupIds}
+              />
+            </div>
+          )}
           <label className="flex items-center gap-2 text-xs">
             <Checkbox
               checked={shouldForceUpdate}
@@ -852,10 +932,12 @@ function EditReleaseDialog({
             />
             Force update
           </label>
-          <div className="flex items-center gap-2 text-xs">
-            <label className="flex-1">Rollout cohort %</label>
-            <RolloutPercentInput value={rolloutPercent} onChange={setRolloutPercent} />
-          </div>
+          {scopeType === "full" && (
+            <div className="flex items-center gap-2 text-xs">
+              <label className="flex-1">Rollout cohort %</label>
+              <RolloutPercentInput value={rolloutPercent} onChange={setRolloutPercent} />
+            </div>
+          )}
           </div>
         </DialogBody>
         <DialogFooter>
@@ -923,10 +1005,9 @@ function NewReleaseDialog({
   const [versionName, setVersionName] = useState<string>("");
   const [versionCode, setVersionCode] = useState<string>("");
   const [changelog, setChangelog] = useState<string>("");
-  const [scopeType, setScopeType] = useState<"full" | "platform" | "user_cohort" | "ip_range" | "device_group">(
-    "full",
-  );
+  const [scopeType, setScopeType] = useState<EditableScopeType>("full");
   const [scopeValue, setScopeValue] = useState<string>("all");
+  const [alwaysIncludedGroupIds, setAlwaysIncludedGroupIds] = useState<string[]>([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [shouldForceUpdate, setShouldForceUpdate] = useState(false);
   const [rolloutPercent, setRolloutPercent] = useState(100);
@@ -998,16 +1079,14 @@ function NewReleaseDialog({
       });
       // 2. create draft release. Publishing is an explicit lifecycle step,
       //    which keeps the release editable while assets are queued.
-      const scopes =
-        scopeType === "full"
-          ? [{ scope_type: "full", scope_value: "all" }]
-          : [{ scope_type: scopeType, scope_value: scopeValue.trim() }];
+      const scopes = buildReleaseScopes(scopeType, scopeValue, alwaysIncludedGroupIds);
       const release = await createRelease(appId, {
         build_id: build.id,
         status: "draft",
         scopes,
         should_force_update: shouldForceUpdate || undefined,
-        rollout_cohort_count: rolloutPercent < 100 ? rolloutPercent : undefined,
+        rollout_cohort_count:
+          scopeType === "full" && rolloutPercent < 100 ? rolloutPercent : undefined,
       });
       createdReleaseIdRef.current = release.id;
       // 3. upload + register each pending file. Failures do NOT abort — the
@@ -1030,10 +1109,7 @@ function NewReleaseDialog({
         }
       }
       if (mode === "publish") {
-        const expectedScope = scopeType === "full"
-          ? undefined
-          : { scope_type: scopeType, scope_value: scopeValue.trim() };
-        const published = await publishRelease(appId, release.id, expectedScope);
+        const published = await publishRelease(appId, release.id, scopes);
         return { release: published, assetFailures, mode };
       }
       return { release, assetFailures, mode };
@@ -1265,7 +1341,11 @@ function NewReleaseDialog({
                   k="Scope"
                   v={
                     scopeType === "full"
-                      ? "full (all users)"
+                      ? `full (${rolloutPercent}%)${alwaysIncludedGroupIds.length > 0
+                        ? `; always ${alwaysIncludedGroupIds.map((groupId) =>
+                          deviceGroups.data?.groups.find((group) => group.id === groupId)?.name ?? groupId
+                        ).join(", ")}`
+                        : ""}`
                       : `${scopeType}: ${scopeValue || "?"}`
                   }
                 />
@@ -1341,6 +1421,16 @@ function NewReleaseDialog({
                         )}
                       </div>
                     </div>
+                    {scopeType === "full" && (
+                      <div>
+                        <label className="label">Always included device groups</label>
+                        <AlwaysIncludedDeviceGroups
+                          groups={deviceGroups.data?.groups ?? []}
+                          selectedIds={alwaysIncludedGroupIds}
+                          onChange={setAlwaysIncludedGroupIds}
+                        />
+                      </div>
+                    )}
                     <label className="flex items-center gap-2 text-xs">
                       <Checkbox
                         checked={shouldForceUpdate}
@@ -1348,15 +1438,15 @@ function NewReleaseDialog({
                       />
                       Force update — clients must upgrade on next launch
                     </label>
-                    <div className="flex items-center gap-2 text-xs">
-                      <label className="flex-1">
-                        Rollout cohort % (default 100)
-                      </label>
-                      <RolloutPercentInput
-                        value={rolloutPercent}
-                        onChange={setRolloutPercent}
-                      />
-                    </div>
+                    {scopeType === "full" && (
+                      <div className="flex items-center gap-2 text-xs">
+                        <label className="flex-1">Rollout cohort %</label>
+                        <RolloutPercentInput
+                          value={rolloutPercent}
+                          onChange={setRolloutPercent}
+                        />
+                      </div>
+                    )}
                   </div>
                 )}
               </details>

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -38,9 +38,21 @@ The standard flow follows the draft-first policy: CI creates a **draft** release
 
 For Android, Hands selects updates by `version_code`. A device receives an update only when the published release has a higher `version_code` than the client reports.
 
+Hands keeps one release lifecycle per app, channel, product type, release type,
+and version code. Cancelling preserves the row and audit history and does not
+free the version for another release. **Restore as active** reactivates a
+superseded or cancelled row with the same release ID; active and draft rows do
+not expose that action.
+
 ### Staged rollouts
 
-Set a rollout percentage when creating or editing a release (number input with 5/25/50/100 presets), and raise it with **Bump rollout**. Devices are bucketed by their stable device id, keep their bucket while the percentage climbs, and gated-out devices receive the previous active release. Clients without a device id (older SDKs) only receive fully rolled-out releases.
+Set a rollout percentage when creating or editing a full release (number input
+with 5/25/50/100 presets), and raise it with **Bump rollout**. Select any number
+of **Always included device groups** on that same release for acceptance or QA
+devices. Group members receive the target regardless of their bucket; other
+devices keep a stable bucket while the percentage climbs. Gated-out and
+anonymous clients receive the previous eligible full release until rollout
+reaches 100%.
 
 Each release row shows unique per-install devices (UV): how many devices have
 checked while already **on this version** and how many unique older devices

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -126,7 +126,8 @@ raft integration invoke --service <hands-service> --action update-release \
 
 # ONLY after explicit human approval of the draft:
 raft integration invoke --service <hands-service> --action publish-release \
-  --param app_id=<app-uuid> --param release_id=<release-uuid>
+  --param app_id=<app-uuid> --param release_id=<release-uuid> \
+  --param expected_scopes='[{"scope_type":"full","scope_value":"all"}]'
 ```
 
 Also available: `list-releases`, `get-release`, `list-release-shares`
@@ -146,10 +147,20 @@ hands releases update <app> <releaseId> \
 hands releases publish <app> <releaseId>              # explicit go-live
 ```
 
-Staged rollout: publish, then raise `rollout_cohort_count` from the console
-or `PATCH /api/apps/:id/releases/:releaseId` (`{"rollout_cohort_count": 25}`)
-as confidence grows. Release rows expose `offered_count` / `current_count`
-so you can watch real coverage.
+Always derive `expected_scopes` from fresh release detail immediately before
+publish. The transition compares the complete set atomically. For a staged
+full rollout with mandatory acceptance devices, keep one release and set
+`scopes` to `full:all` plus each `device_group`; group members always receive
+the target while other identified clients remain percentage-gated. Raise
+`rollout_cohort_count` from the console or with
+`PATCH /api/apps/:id/releases/:releaseId` as confidence grows. Release rows
+expose `offered_count` / `current_count` so you can watch real coverage.
+
+Each app/channel/product/release-type/version code has one durable release
+lifecycle. A duplicate create, including after cancellation, returns
+`RELEASE_VERSION_ALREADY_EXISTS`; continue with the returned release or use a
+higher version code. Restoring a superseded or cancelled version reactivates
+that same release ID instead of creating a new row.
 
 For a fuller per-version view, call
 `GET /api/apps/:id/analytics/versions?window_days=30` with Agent Login or a

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -122,11 +122,13 @@ raft integration invoke --service <hands-service> --action create-release \
 # attach reviewed bilingual notes (change-logs/<version>/*.md is the source of truth)
 raft integration invoke --service <hands-service> --action update-release \
   --param app_id=<app-uuid> --param release_id=<release-uuid> \
+  --param expected_revision=<fresh-detail-revision> \
   --param release_notes='{"en":"...","zh-CN":"..."}'
 
 # ONLY after explicit human approval of the draft:
 raft integration invoke --service <hands-service> --action publish-release \
   --param app_id=<app-uuid> --param release_id=<release-uuid> \
+  --param expected_revision=<same-fresh-detail-revision> \
   --param expected_scopes='[{"scope_type":"full","scope_value":"all"}]'
 ```
 
@@ -147,8 +149,11 @@ hands releases update <app> <releaseId> \
 hands releases publish <app> <releaseId>              # explicit go-live
 ```
 
-Always derive `expected_scopes` from fresh release detail immediately before
-publish. The transition compares the complete set atomically. For a staged
+Always derive `expected_revision` and `expected_scopes` from the same fresh
+release detail immediately before a write. Every lifecycle mutation increments
+the revision; a stale write returns `409 RELEASE_REVISION_CONFLICT` with zero
+release, scope, fallback, or audit effects. Publish also compares the complete
+scope set atomically. For a staged
 full rollout with mandatory acceptance devices, keep one release and set
 `scopes` to `full:all` plus each `device_group`; group members always receive
 the target while other identified clients remain percentage-gated. Raise

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -439,17 +439,44 @@ hands releases publish raft-android <release-id> --device-group <group-id>
 ```
 
 The final publish remains an explicit authorization step. The CLI first reads
-release detail and sends the exact stored non-full scope as an expected-scope
-precondition; zero, mixed, empty, or unsupported scope state is rejected
-locally without a publish request. `--device-group` adds an explicit assertion
-that the stored scope is that exact group. Activation returns `409` if the
-scope then drifts between detail read and the guarded server transition.
-Publishing an exact `full:all` release sends no precondition.
+release detail, canonicalizes every stored scope, and sends the complete set as
+`expected_scopes`. Empty, duplicate, malformed, or unsupported scope state is
+rejected locally without a publish request. A repeatable `--device-group`
+asserts the exact stored device-group subset. Activation returns `409` if any
+scope drifts between the detail read and the guarded server transition.
 Only exact group members receive the release; other devices fall back to the
 prior active release. List groups with `hands device-groups list <app>` and
 remove members with `device-groups remove-member`. Rename or change the
 operator note with `device-groups update`. Do not use IMEI or hardware serial
 numbers.
+
+### Percentage rollout with mandatory groups
+
+One release can combine a percentage-gated `full:all` scope with device groups
+whose members are always included:
+
+```bash
+hands releases update raft-android <release-id> \
+  --full \
+  --rollout-percent 25 \
+  --always-include-group <acceptance-group-id> \
+  --always-include-group <qa-group-id>
+
+hands releases publish raft-android <release-id> \
+  --device-group <acceptance-group-id> \
+  --device-group <qa-group-id>
+```
+
+`--always-include-group` is repeatable and implies `full:all`; `--full` by
+itself resets the scope to full only. `--rollout-percent` accepts integers from
+0 through 100, with 100 stored as an unrestricted full rollout. The legacy
+update form `--device-group <id>` still replaces the scope with one exact
+group-only rollout and cannot be combined with the full-rollout options.
+
+There is one release lifecycle per app/channel/product/release-type/version
+code. Cancelling does not free a version for a second release. Restoring a
+superseded or cancelled release reactivates its original ID; it does not create
+a replacement row for the same version.
 
 ## Share Links
 

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -440,10 +440,13 @@ hands releases publish raft-android <release-id> --device-group <group-id>
 
 The final publish remains an explicit authorization step. The CLI first reads
 release detail, canonicalizes every stored scope, and sends the complete set as
-`expected_scopes`. Empty, duplicate, malformed, or unsupported scope state is
+`expected_scopes` together with that detail's `expected_revision`. The update
+command also fresh-reads and sends the revision before PATCH. Empty, duplicate,
+malformed, or unsupported scope state is
 rejected locally without a publish request. A repeatable `--device-group`
 asserts the exact stored device-group subset. Activation returns `409` if any
-scope drifts between the detail read and the guarded server transition.
+scope or revision drifts between the detail read and the guarded server
+transition.
 Only exact group members receive the release; other devices fall back to the
 prior active release. List groups with `hands device-groups list <app>` and
 remove members with `device-groups remove-member`. Rename or change the

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -50,16 +50,40 @@ receives or chooses the group name. A non-member falls through to the previous
 matching active release. Device groups use installation identifiers, not IMEI,
 hardware serial numbers, or account identities.
 
+A single release may contain `full:all` plus one or more `device_group` scopes.
+Group members always receive that release, even when their percentage bucket is
+outside `rollout_cohort_count`. Non-members remain percentage-gated, and
+anonymous clients use the prior eligible full release until rollout reaches
+100%. Do not model these two audiences as separate releases of the same version.
+
 Scope writes are fail-closed: omitting `scopes` when creating a generic
 release defaults to `full:all`, but explicitly supplying `scopes` requires a
 non-empty array whose every entry has a non-empty `scope_type` and
-`scope_value`. To activate any non-full scoped draft, publish with
-`{"expected_scope":{"scope_type":"device_group","scope_value":"<group UUID>"}}`
-(or the exact `platform`, `user_cohort`, or `ip_range` scope). Hands rechecks
-that the draft still has exactly that one scope in the guarded activation
-operation and returns `409 RELEASE_SCOPE_PRECONDITION_FAILED` on missing,
-malformed, mixed, empty, or drifted scope state. Omitting the precondition can
-activate only an exact `full:all` release.
+`scope_value`; duplicate entries are rejected. `full:all` may be combined only
+with `device_group` entries. Publish with the complete canonical set, for
+example:
+
+```json
+{
+  "expected_scopes": [
+    { "scope_type": "full", "scope_value": "all" },
+    { "scope_type": "device_group", "scope_value": "<group UUID>" }
+  ]
+}
+```
+
+Hands rechecks the exact set inside the guarded activation operation and
+returns `409 RELEASE_SCOPE_PRECONDITION_FAILED` on missing, malformed,
+duplicate, unexpected, or drifted scope state. `expected_scope` remains a
+legacy single-scope compatibility field; new callers should always send
+`expected_scopes`.
+
+The admin release API permits only one lifecycle for each
+app/channel/product/release-type/version code. Duplicate creation returns
+`409 RELEASE_VERSION_ALREADY_EXISTS` with the existing release/build/status
+coordinates, including after cancellation. The rollback endpoint restores a
+superseded or cancelled release in place and returns the same release ID with a
+new activation time.
 
 ### Update Available
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -65,6 +65,7 @@ example:
 
 ```json
 {
+  "expected_revision": 4,
   "expected_scopes": [
     { "scope_type": "full", "scope_value": "all" },
     { "scope_type": "device_group", "scope_value": "<group UUID>" }
@@ -76,14 +77,21 @@ Hands rechecks the exact set inside the guarded activation operation and
 returns `409 RELEASE_SCOPE_PRECONDITION_FAILED` on missing, malformed,
 duplicate, unexpected, or drifted scope state. `expected_scope` remains a
 legacy single-scope compatibility field; new callers should always send
-`expected_scopes`.
+`expected_scopes`. Release detail also exposes an integer `revision`; send that
+value as `expected_revision` on PATCH, publish, cancel, restore, rollout-bump,
+and force-update writes. A stale revision returns
+`409 RELEASE_REVISION_CONFLICT` without changing the release, its scopes,
+fallback releases, or audit log.
 
 The admin release API permits only one lifecycle for each
 app/channel/product/release-type/version code. Duplicate creation returns
 `409 RELEASE_VERSION_ALREADY_EXISTS` with the existing release/build/status
 coordinates, including after cancellation. The rollback endpoint restores a
-superseded or cancelled release in place and returns the same release ID with a
-new activation time.
+superseded or cancelled release in place. A cancelled row whose
+`activated_at` is null was never published, so it returns to `draft` and must
+pass normal publish readiness, exact-scope, external-target, and revision
+gates. Only a previously active row returns to `active` with a new activation
+time.
 
 ### Update Available
 

--- a/docs/publish-architecture.md
+++ b/docs/publish-architecture.md
@@ -386,8 +386,9 @@ ToDesktop runs builds on actual Win/Mac/Linux VMs, captures screenshots + auto-u
       `409 RELEASE_VERSION_ALREADY_EXISTS` with the existing coordinates if
       the lane/version lifecycle already exists, including if it is cancelled
    b. Insert release_scopes row(s)
-   c. Publish only after an exact `expected_scopes` set matches atomically;
-      set status=`active` and refresh `activated_at`
+   c. Publish only after the fresh `expected_revision` and exact
+      `expected_scopes` set match atomically; set status=`active`, increment
+      `revision`, and refresh `activated_at`
    d. At full coverage, mark prior active releases on the same lane as
       `superseded`; during partial rollout, retain an eligible prior full
       release as fallback
@@ -397,11 +398,14 @@ ToDesktop runs builds on actual Win/Mac/Linux VMs, captures screenshots + auto-u
 
 ### 4.4 Rollback
 
-Admin picks a superseded or cancelled historical release on the same lane and
-chooses **Restore as active**. The server reactivates that exact release row,
-clears its supersession link, and refreshes `activated_at`; it never inserts a
-second release for the version. A full-coverage restore supersedes the current
-active release. A partial restore preserves or reactivates its fallback.
+Admin picks a superseded or cancelled historical release on the same lane. A
+cancelled row with `activated_at = null` was never published and uses
+**Restore draft**; the server returns that exact row to `draft`, so it must pass
+the normal publish gates. Previously active rows use **Restore as active**;
+the server clears the supersession link and refreshes `activated_at`. Neither
+path inserts a second release for the version. Every path requires the fresh
+revision. A full-coverage active restore supersedes the current active release;
+a partial active restore preserves or reactivates its fallback.
 
 ## 5. Public client API
 
@@ -604,9 +608,10 @@ LIMIT 1;
 3. **`full` is the only match**: `priority=1`; behaves like v1 (any active release on the channel).
 4. **No release matches**: 404 with body `{"error": "no active release for this client"}`. v1 clients that ignored scope will see this and should fall back to their bundled copy.
 5. **Release cancelled (`status='cancelled'`)** mid-request: never returned. Server filters by `status='active'` in Step 1.
-6. **Restore reuses the release ID**: a superseded or cancelled release moves
-   back to `active` and receives a new `activated_at`. The endpoint rejects
-   drafts and already-active rows and never clones a version lifecycle.
+6. **Restore reuses the release ID**: a never-published cancelled row moves
+   back to `draft`; a previously active row moves back to `active` and receives
+   a new `activated_at`. The endpoint rejects drafts and already-active rows
+   and never clones a version lifecycle.
 7. **`ip_range` matching** is server-trusted: we use `cf.clientIp` only, never the client `X-Forwarded-For`. v2 client must NOT send `X-Forwarded-For`; server strips it if present.
 8. **Cross-product-type scope**: scopes are per-release, but releases are per-`product_type`. A `platform` scope on an Android release cannot accidentally match an Electron client because the platform strings are disjoint.
 

--- a/docs/publish-architecture.md
+++ b/docs/publish-architecture.md
@@ -258,7 +258,8 @@ win32-arm64-NULL-msi
 
 ### 3.9 `releases` — promote build to "live" with scope
 
-A release is **a build that's been promoted**. It can have multiple scope records (full + partial overrides).
+A release is **a build that's been promoted**. It can have one full scope plus
+mandatory device-group overrides, all within the same lifecycle.
 
 ```
 releases
@@ -269,7 +270,8 @@ releases
   product_type            TEXT NOT NULL         -- denormalized from build for query speed
   release_type            TEXT NOT NULL         -- denormalized from build
   status                  TEXT NOT NULL         -- 'draft' | 'active' | 'superseded' | 'cancelled'
-  is_full                 INTEGER NOT NULL     -- 1 if this release covers all users; 0 if scoped
+  activated_at            INTEGER              -- latest successful publish/restore time; null for never-active drafts
+  is_full                 INTEGER NOT NULL     -- 1 iff scopes contain full:all; percentage may still be below 100
   superseded_by_release_id TEXT REFERENCES releases(id)
   rollout_cohort_count    INTEGER              -- null = 100%, otherwise staged %
   rollout_target_cohorts_json TEXT NOT NULL DEFAULT '[]'
@@ -279,16 +281,25 @@ releases
   provenance_json         TEXT NOT NULL DEFAULT '{}'
   created_by              TEXT NOT NULL         -- 'admin@...'
   created_at              INTEGER NOT NULL
-  INDEX (app_id, channel_id, product_type, release_type, status, created_at DESC)
+  INDEX (app_id, channel_id, product_type, release_type, status, activated_at DESC)
   INDEX (build_id)
   INDEX (status, created_at DESC)
 ```
 
 A release goes through status:
 - `draft` — editable release metadata and scopes; not returned by public update checks and does not supersede active releases.
-- `active` — currently live for this (channel, product_type, release_type).
+- `active` — currently eligible on this lane; a partial rollout may coexist
+  with an older active full fallback.
 - `superseded` — newer release was published on the same lane.
 - `cancelled` — soft-deleted / cancelled release; build rows and assets remain in storage.
+
+The lifecycle identity is
+`(app_id, channel_id, product_type, release_type, build.version_code)`. Exactly
+one release row may ever be created for that identity, regardless of status.
+Historical duplicate rows are retained for audit compatibility, so the current
+schema enforces new writes with an insert trigger rather than deleting history
+to add a unique index. Release identity and the identity fields of a referenced
+build are immutable after creation.
 
 ### 3.10 `release_scopes` — partial release overrides
 
@@ -298,11 +309,17 @@ A release can be partial (only some users get it). Each scope record defines one
 release_scopes
   id              TEXT PRIMARY KEY
   release_id      TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE
-  scope_type      TEXT NOT NULL         -- 'full' | 'platform' | 'ip_range' | 'user_cohort'
+  scope_type      TEXT NOT NULL         -- 'full' | 'platform' | 'ip_range' | 'user_cohort' | 'device_group'
   scope_value     TEXT NOT NULL         -- 'all' | 'darwin,linux' (CSV for platform) | '10.0.0.0/8' (CIDR) | 'cohort-uuid' (cohort ID)
   created_at      INTEGER NOT NULL
   INDEX (release_id)
 ```
+
+`full:all` may appear once and may be combined only with one or more
+`device_group` entries. This is one release: group members bypass the
+percentage gate, while non-members are evaluated against
+`rollout_cohort_count`. `is_full=1` records the presence of `full:all`; full
+coverage is reached only when the percentage is null/100.
 
 **Examples**:
 - Full release: `scope_type='full', scope_value='all'`
@@ -351,30 +368,40 @@ ToDesktop runs builds on actual Win/Mac/Linux VMs, captures screenshots + auto-u
    - Build status is 'succeeded' ✓
    - Version is higher/lower than previous release ✓
    - Signing credentials valid ✓
-   - No active release with same version_code ✓
+   - No release lifecycle with the same version_code in this lane ✓
 
-3. Admin picks release scope (radio buttons):
+3. Admin picks release scope:
    - [Full release] — all users on this (channel, product_type, release_type)
+     - rollout percentage (0-100)
+     - zero or more always-included device groups
    - [Platform release] — checkboxes: darwin-arm64, darwin-x64, ..., win32-x64
    - [IP range release] — text input CIDR list
 
-4. Optional: rollout_cohort_count slider (0-100)
-   Optional: availability_at datetime (schedule for later)
+4. Optional: availability_at datetime (schedule for later)
    Optional: should_force_update checkbox
 
 5. Click "Save draft" or "Publish now"
 6. Server:
-   a. Insert releases row (status='draft')
+   a. Insert the one releases row (status='draft'); return
+      `409 RELEASE_VERSION_ALREADY_EXISTS` with the existing coordinates if
+      the lane/version lifecycle already exists, including if it is cancelled
    b. Insert release_scopes row(s)
-   c. If publishing now, set the release to `active`
-   d. If publishing now, mark previous release(s) on same (channel, product_type, release_type) as 'superseded' (link via superseded_by_release_id)
+   c. Publish only after an exact `expected_scopes` set matches atomically;
+      set status=`active` and refresh `activated_at`
+   d. At full coverage, mark prior active releases on the same lane as
+      `superseded`; during partial rollout, retain an eligible prior full
+      release as fallback
    e. If publishing now, emit SSE event "release:new"
    f. If publishing now, fire webhook (if configured)
 ```
 
 ### 4.4 Rollback
 
-Admin picks any historical release on the same (channel, product_type, release_type) → "Roll back to this version" → inserts new release with `status='active'` pointing to the older build, marks current as `superseded`.
+Admin picks a superseded or cancelled historical release on the same lane and
+chooses **Restore as active**. The server reactivates that exact release row,
+clears its supersession link, and refreshes `activated_at`; it never inserts a
+second release for the version. A full-coverage restore supersedes the current
+active release. A partial restore preserves or reactivates its fallback.
 
 ## 5. Public client API
 
@@ -573,11 +600,13 @@ LIMIT 1;
 **Edge cases the contract locks in:**
 
 1. **Empty `cohort` header + cohort-scoped release**: no match (server treats `cohort IS NULL` as mismatch, never as `''`).
-2. **Multiple matches at the same priority**: `created_at DESC` wins. Ties broken by `release_id` (UUID lex order) for determinism.
+2. **Multiple matches at the same priority**: `activated_at DESC` wins. Ties broken by `release_id` (UUID lex order) for determinism.
 3. **`full` is the only match**: `priority=1`; behaves like v1 (any active release on the channel).
 4. **No release matches**: 404 with body `{"error": "no active release for this client"}`. v1 clients that ignored scope will see this and should fall back to their bundled copy.
 5. **Release cancelled (`status='cancelled'`)** mid-request: never returned. Server filters by `status='active'` in Step 1.
-6. **Rollback creates a new release**: original release moves to `superseded`; new release inherits the original's scopes (unless `POST /api/apps/:appId/releases/:id/rollback` overrides). Server returns the new one.
+6. **Restore reuses the release ID**: a superseded or cancelled release moves
+   back to `active` and receives a new `activated_at`. The endpoint rejects
+   drafts and already-active rows and never clones a version lifecycle.
 7. **`ip_range` matching** is server-trusted: we use `cf.clientIp` only, never the client `X-Forwarded-For`. v2 client must NOT send `X-Forwarded-For`; server strips it if present.
 8. **Cross-product-type scope**: scopes are per-release, but releases are per-`product_type`. A `platform` scope on an Android release cannot accidentally match an Electron client because the platform strings are disjoint.
 
@@ -811,7 +840,7 @@ After push, build sits in `succeeded` state in the Builds tab. User then opens i
 ✓ Build status: succeeded
 ✓ Version is higher than previous release (1.2.3 = 42)
 ✓ Code signing credentials valid for: darwin-arm64, darwin-x64, linux-x64, win32-x64, win32-arm64
-✓ No active release with same version_code
+✓ No existing release lifecycle with same version_code
 
 Release scope:
 ( ) Full release           — all users on this (channel, product_type, release_type)

--- a/docs/publish-tasks.md
+++ b/docs/publish-tasks.md
@@ -150,7 +150,7 @@ Goal: introduce `product_types`, `release_types`, `build_assets`, `releases`, `r
 | P2.5.2 Releases tab (table view, scope column, status, actions) | ✅ DONE | 3h | |
 | P2.5.3 Prepare release modal (validation checks + scope radio + cohort slider) | ✅ DONE | 3h | ToDesktop's validation checks inspiration |
 | P2.5.4 Backend: `POST /api/releases` (promote build → release with scope) | ✅ DONE | 3h | with scope resolution logic |
-| P2.5.5 Backend: `POST /api/releases/:id/rollback` | ✅ DONE | 2h | creates new release pointing to older build |
+| P2.5.5 Backend: `POST /api/releases/:id/rollback` | ✅ DONE | 2h | restores the same superseded/cancelled release row and refreshes activation time |
 | P2.5.6 Backend: `POST /api/releases/:id/bump-rollout` | ✅ DONE | 1h | increments `rollout_cohort_count` |
 | P2.5.7 Backend: `POST /api/releases/:id/force-update` toggle | ✅ DONE | 1h | flips `should_force_update` |
 | P2.5.8 Backend: webhook dispatch on release lifecycle events | ✅ DONE | 3h | commit `0a71ee2`. webhooks + webhook_deliveries tables (migration 0017); 6 org-scoped admin routes under `/api/orgs/:orgId/webhooks`; Worker Cron `*/5 * * * *` reaper (`handleReapDeliveries`) with HMAC SHA-256 signing, 3-attempt exponential backoff (5m / 30m / 2h); `emitWebhookEvent()` wired into handleCreateRelease / handleRollbackRelease / handleCreateBuild (terminal status) / handleUpdateBuild (terminal status). |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -184,6 +184,38 @@ hands releases publish raft-android <releaseId>
 hands releases share raft-android <releaseId> --password <pw>
 ```
 
-Publishing supersedes the previous active release on the same
-app/channel/product/release-type; staged rollout percentage can be set before
-or after publish (`rollout_cohort_count`, bump via admin or API).
+Hands keeps exactly one release lifecycle for each
+app/channel/product/release-type/version-code identity. Draft, active,
+superseded, and cancelled are states of that same release ID. A cancelled
+version remains reserved; publish corrected bytes under a higher version code
+instead of creating a second release for the old version.
+
+For a staged full rollout with mandatory acceptance devices, configure both
+behaviors on the same draft:
+
+```sh
+hands releases update raft-android <releaseId> \
+  --full \
+  --rollout-percent 25 \
+  --always-include-group <artin-group-id> \
+  --always-include-group <qa-group-id>
+
+# Optional repeated assertions make the operator intent visible. The CLI also
+# sends the complete stored scope set as the atomic publish precondition.
+hands releases publish raft-android <releaseId> \
+  --device-group <artin-group-id> \
+  --device-group <qa-group-id>
+```
+
+Members of the listed groups always receive the target release. Other clients
+with a stable device ID are gated by `rollout_cohort_count`; clients outside
+the percentage and anonymous clients fall back to the prior eligible full
+release. Raising the rollout to 100% supersedes that fallback. `--full` without
+`--always-include-group` resets the scope to only `full:all`. The legacy
+`--device-group <id>` update remains an exact group-only rollout.
+
+Restoring a superseded or cancelled release reactivates that same release ID
+and records a fresh activation time. It never clones the build into another
+release lifecycle. Use **Restore as active** in Admin or
+`POST /api/apps/:appId/releases/:releaseId/rollback`; an already-active or
+draft release cannot be restored.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -214,8 +214,10 @@ release. Raising the rollout to 100% supersedes that fallback. `--full` without
 `--always-include-group` resets the scope to only `full:all`. The legacy
 `--device-group <id>` update remains an exact group-only rollout.
 
-Restoring a superseded or cancelled release reactivates that same release ID
-and records a fresh activation time. It never clones the build into another
-release lifecycle. Use **Restore as active** in Admin or
-`POST /api/apps/:appId/releases/:releaseId/rollback`; an already-active or
-draft release cannot be restored.
+Restoring always reuses the same release ID and never clones the build into a
+second lifecycle. A cancelled release with `activated_at = null` was never
+published: Admin shows **Restore draft**, and rollback returns it to `draft` so
+normal publish gates still apply. A superseded release or a cancelled release
+with a prior activation uses **Restore as active** and records a fresh
+activation time. Send the revision from fresh release detail; stale restore
+requests return `409 RELEASE_REVISION_CONFLICT` with zero side effects.

--- a/migrations/sql/0053_release_identity_and_activation.sql
+++ b/migrations/sql/0053_release_identity_and_activation.sql
@@ -1,0 +1,30 @@
+-- One release lifecycle per app/channel/product/release-type/version.
+--
+-- Historical rows are retained, including legacy duplicates. The triggers
+-- reject every new duplicate by joining through builds.version_code and make
+-- both sides of the identity immutable after release creation, so the
+-- invariant covers API, admin, CI, and any future direct writer.
+-- activated_at lets rollback reactivate the original release row without
+-- cloning it merely to make it the newest resolver candidate.
+
+ALTER TABLE releases ADD COLUMN activated_at INTEGER;
+
+UPDATE releases
+SET activated_at = CASE
+  WHEN status = 'draft' THEN NULL
+  ELSE COALESCE(updated_at, created_at)
+END;
+
+CREATE INDEX IF NOT EXISTS idx_builds_release_identity
+  ON builds(app_id, channel_id, product_type, release_type, version_code);
+
+CREATE INDEX IF NOT EXISTS idx_releases_activation
+  ON releases(app_id, channel_id, product_type, release_type, status, activated_at DESC);
+
+-- Cloudflare's remote D1 migration parser requires trigger bodies on one
+-- physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact.
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_insert BEFORE INSERT ON releases WHEN EXISTS (SELECT 1 FROM builds incoming JOIN releases existing ON existing.app_id = NEW.app_id AND existing.channel_id = NEW.channel_id AND existing.product_type = NEW.product_type AND existing.release_type = NEW.release_type JOIN builds existing_build ON existing_build.id = existing.build_id WHERE incoming.id = NEW.build_id AND incoming.app_id = NEW.app_id AND existing_build.version_code = incoming.version_code) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_releases_identity_immutable_update BEFORE UPDATE OF app_id, build_id, channel_id, product_type, release_type ON releases WHEN NEW.app_id <> OLD.app_id OR NEW.build_id <> OLD.build_id OR NEW.channel_id <> OLD.channel_id OR NEW.product_type <> OLD.product_type OR NEW.release_type <> OLD.release_type BEGIN SELECT RAISE(ABORT, 'release identity is immutable'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_released_build_identity_immutable_update BEFORE UPDATE OF app_id, channel_id, product_type, release_type, version_code ON builds WHEN EXISTS (SELECT 1 FROM releases target WHERE target.build_id = OLD.id) AND (NEW.app_id <> OLD.app_id OR NEW.channel_id <> OLD.channel_id OR NEW.product_type <> OLD.product_type OR NEW.release_type <> OLD.release_type OR NEW.version_code <> OLD.version_code) BEGIN SELECT RAISE(ABORT, 'released build identity is immutable'); END;

--- a/migrations/sql/0053_release_identity_and_activation.sql
+++ b/migrations/sql/0053_release_identity_and_activation.sql
@@ -5,14 +5,16 @@
 -- both sides of the identity immutable after release creation, so the
 -- invariant covers API, admin, CI, and any future direct writer.
 -- activated_at lets rollback reactivate the original release row without
--- cloning it merely to make it the newest resolver candidate.
+-- cloning it merely to make it the newest resolver candidate. revision gives
+-- every lifecycle mutation one shared compare-and-set fence.
 
 ALTER TABLE releases ADD COLUMN activated_at INTEGER;
+ALTER TABLE releases ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
 
 UPDATE releases
 SET activated_at = CASE
-  WHEN status = 'draft' THEN NULL
-  ELSE COALESCE(updated_at, created_at)
+  WHEN status IN ('active', 'superseded') THEN COALESCE(updated_at, created_at)
+  ELSE NULL
 END;
 
 CREATE INDEX IF NOT EXISTS idx_builds_release_identity
@@ -25,6 +27,6 @@ CREATE INDEX IF NOT EXISTS idx_releases_activation
 -- physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact.
 CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_insert BEFORE INSERT ON releases WHEN EXISTS (SELECT 1 FROM builds incoming JOIN releases existing ON existing.app_id = NEW.app_id AND existing.channel_id = NEW.channel_id AND existing.product_type = NEW.product_type AND existing.release_type = NEW.release_type JOIN builds existing_build ON existing_build.id = existing.build_id WHERE incoming.id = NEW.build_id AND incoming.app_id = NEW.app_id AND existing_build.version_code = incoming.version_code) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
 
-CREATE TRIGGER IF NOT EXISTS trg_releases_identity_immutable_update BEFORE UPDATE OF app_id, build_id, channel_id, product_type, release_type ON releases WHEN NEW.app_id <> OLD.app_id OR NEW.build_id <> OLD.build_id OR NEW.channel_id <> OLD.channel_id OR NEW.product_type <> OLD.product_type OR NEW.release_type <> OLD.release_type BEGIN SELECT RAISE(ABORT, 'release identity is immutable'); END;
+CREATE TRIGGER IF NOT EXISTS trg_releases_identity_immutable_update BEFORE UPDATE OF app_id, build_id, channel_id, product_type, release_type ON releases WHEN NEW.app_id IS NOT OLD.app_id OR NEW.build_id IS NOT OLD.build_id OR NEW.channel_id IS NOT OLD.channel_id OR NEW.product_type IS NOT OLD.product_type OR NEW.release_type IS NOT OLD.release_type BEGIN SELECT RAISE(ABORT, 'release identity is immutable'); END;
 
-CREATE TRIGGER IF NOT EXISTS trg_released_build_identity_immutable_update BEFORE UPDATE OF app_id, channel_id, product_type, release_type, version_code ON builds WHEN EXISTS (SELECT 1 FROM releases target WHERE target.build_id = OLD.id) AND (NEW.app_id <> OLD.app_id OR NEW.channel_id <> OLD.channel_id OR NEW.product_type <> OLD.product_type OR NEW.release_type <> OLD.release_type OR NEW.version_code <> OLD.version_code) BEGIN SELECT RAISE(ABORT, 'released build identity is immutable'); END;
+CREATE TRIGGER IF NOT EXISTS trg_released_build_identity_immutable_update BEFORE UPDATE OF app_id, channel_id, product_type, release_type, version_code ON builds WHEN EXISTS (SELECT 1 FROM releases target WHERE target.build_id = OLD.id) AND (NEW.app_id IS NOT OLD.app_id OR NEW.channel_id IS NOT OLD.channel_id OR NEW.product_type IS NOT OLD.product_type OR NEW.release_type IS NOT OLD.release_type OR NEW.version_code IS NOT OLD.version_code) BEGIN SELECT RAISE(ABORT, 'released build identity is immutable'); END;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -328,8 +328,98 @@ describe("device-group rollout commands", () => {
       });
       expect(requests.find((request) => request.url.endsWith("/releases/release-1/publish"))).toMatchObject({
         method: "POST",
-        body: { expected_scope: { scope_type: "device_group", scope_value: "group-1" } },
+        body: {
+          expected_scopes: [{ scope_type: "device_group", scope_value: "group-1" }],
+        },
       });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("updates a full percentage rollout with mandatory groups and preserves full reset semantics", async () => {
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      if (req.url?.startsWith("/api/apps/app-1/releases/") && req.method === "PATCH") {
+        return res.end(JSON.stringify({ id: req.url.split("/").at(-1), status: "draft" }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    const runUpdate = async (releaseId: string, extra: string[]) => {
+      const program = new Command();
+      const { registerReleaseCommands } = await import("../src/commands/releases.js");
+      registerReleaseCommands(program);
+      return program.parseAsync([
+        "node", "hands", "releases", "update", "raft-android", releaseId, ...extra,
+      ]);
+    };
+
+    try {
+      await runUpdate("release-mixed", [
+        "--full",
+        "--always-include-group", "group-z",
+        "--always-include-group", "group-a",
+        "--rollout-percent", "25",
+      ]);
+      await runUpdate("release-full", ["--full", "--rollout-percent", "100"]);
+
+      const patches = Object.fromEntries(
+        requests
+          .filter((request) => request.method === "PATCH")
+          .map((request) => [request.url.split("/").at(-1), request.body]),
+      );
+      expect(patches).toEqual({
+        "release-mixed": {
+          scopes: [
+            { scope_type: "full", scope_value: "all" },
+            { scope_type: "device_group", scope_value: "group-a" },
+            { scope_type: "device_group", scope_value: "group-z" },
+          ],
+          rollout_cohort_count: 25,
+        },
+        "release-full": {
+          scopes: [{ scope_type: "full", scope_value: "all" }],
+          rollout_cohort_count: null,
+        },
+      });
+
+      const patchesBeforeInvalid = requests.filter((request) => request.method === "PATCH").length;
+      await expect(runUpdate("release-conflict", [
+        "--device-group", "group-a", "--full",
+      ])).rejects.toThrow("cannot be combined");
+      await expect(runUpdate("release-duplicate", [
+        "--always-include-group", "group-a",
+        "--always-include-group", "group-a",
+      ])).rejects.toThrow("may not repeat");
+      await expect(runUpdate("release-percent", [
+        "--rollout-percent", "101",
+      ])).rejects.toThrow("integer from 0 to 100");
+      expect(requests.filter((request) => request.method === "PATCH")).toHaveLength(patchesBeforeInvalid);
     } finally {
       if (originalApi === undefined) delete process.env.HANDS_API;
       else process.env.HANDS_API = originalApi;
@@ -350,6 +440,19 @@ describe("device-group rollout commands", () => {
       "release-mixed": [
         { scope_type: "platform", scope_value: "android" },
         { scope_type: "user_cohort", scope_value: "internal-qa" },
+      ],
+      "release-full-groups": [
+        { scope_type: "device_group", scope_value: "group-z" },
+        { scope_type: "full", scope_value: "all" },
+        { scope_type: "device_group", scope_value: "group-a" },
+      ],
+      "release-full-platform": [
+        { scope_type: "full", scope_value: "all" },
+        { scope_type: "platform", scope_value: "android" },
+      ],
+      "release-duplicate": [
+        { scope_type: "device_group", scope_value: "group-a" },
+        { scope_type: "device_group", scope_value: "group-a" },
       ],
       "release-unknown": [{ scope_type: "future_scope", scope_value: "value" }],
     };
@@ -399,29 +502,51 @@ describe("device-group rollout commands", () => {
     };
 
     try {
-      for (const releaseId of ["release-platform", "release-cohort", "release-ip", "release-full"]) {
+      for (const releaseId of ["release-platform", "release-cohort", "release-ip", "release-full", "release-mixed"]) {
         await runPublish(releaseId);
       }
+      await runPublish("release-full-groups", [
+        "--device-group", "group-z",
+        "--device-group", "group-a",
+      ]);
       const publishBodies = Object.fromEntries(
         requests
           .filter((request) => request.method === "POST" && request.url.endsWith("/publish"))
           .map((request) => [request.url.split("/").at(-2), request.body]),
       );
-      expect(publishBodies).toMatchObject({
-        "release-platform": { expected_scope: { scope_type: "platform", scope_value: "android" } },
-        "release-cohort": { expected_scope: { scope_type: "user_cohort", scope_value: "internal-qa" } },
-        "release-ip": { expected_scope: { scope_type: "ip_range", scope_value: "203.0.113.0/24" } },
-        "release-full": {},
+      expect(publishBodies).toEqual({
+        "release-platform": { expected_scopes: [{ scope_type: "platform", scope_value: "android" }] },
+        "release-cohort": { expected_scopes: [{ scope_type: "user_cohort", scope_value: "internal-qa" }] },
+        "release-ip": { expected_scopes: [{ scope_type: "ip_range", scope_value: "203.0.113.0/24" }] },
+        "release-full": { expected_scopes: [{ scope_type: "full", scope_value: "all" }] },
+        "release-mixed": {
+          expected_scopes: [
+            { scope_type: "platform", scope_value: "android" },
+            { scope_type: "user_cohort", scope_value: "internal-qa" },
+          ],
+        },
+        "release-full-groups": {
+          expected_scopes: [
+            { scope_type: "full", scope_value: "all" },
+            { scope_type: "device_group", scope_value: "group-a" },
+            { scope_type: "device_group", scope_value: "group-z" },
+          ],
+        },
       });
 
       const postsBeforeInvalid = requests.filter(
         (request) => request.method === "POST" && request.url.endsWith("/publish"),
       ).length;
-      for (const releaseId of ["release-zero", "release-mixed", "release-unknown"]) {
-        await expect(runPublish(releaseId)).rejects.toThrow(/refusing|exactly one/);
+      for (const releaseId of ["release-zero", "release-full-platform", "release-duplicate", "release-unknown"]) {
+        await expect(runPublish(releaseId)).rejects.toThrow(/refusing|duplicates/);
       }
       await expect(runPublish("release-platform", ["--device-group", "group-wrong"]))
-        .rejects.toThrow("does not match stored platform:android");
+        .rejects.toThrow("do not match stored []");
+      await expect(runPublish("release-full-groups", ["--device-group", "group-a"]))
+        .rejects.toThrow("do not match stored [group-a, group-z]");
+      await expect(runPublish("release-full-groups", [
+        "--device-group", "group-a", "--device-group", "group-a",
+      ])).rejects.toThrow("may not repeat");
       expect(requests.filter(
         (request) => request.method === "POST" && request.url.endsWith("/publish"),
       )).toHaveLength(postsBeforeInvalid);

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -261,7 +261,7 @@ describe("device-group rollout commands", () => {
       }
       if (req.url === "/api/apps/app-1/releases/release-1" && req.method === "GET") {
         return res.end(JSON.stringify({
-          release: { id: "release-1", status: "draft" },
+          release: { id: "release-1", status: "draft", revision: 7 },
           scopes: [{ scope_type: "device_group", scope_value: "group-1" }],
         }));
       }
@@ -322,14 +322,20 @@ describe("device-group rollout commands", () => {
           description: "Physical acceptance devices",
         },
       });
-      expect(requests.find((request) => request.url.endsWith("/releases/release-1"))).toMatchObject({
+      expect(requests.find((request) =>
+        request.url.endsWith("/releases/release-1") && request.method === "PATCH"
+      )).toMatchObject({
         method: "PATCH",
-        body: { scopes: [{ scope_type: "device_group", scope_value: "group-1" }] },
+        body: {
+          scopes: [{ scope_type: "device_group", scope_value: "group-1" }],
+          expected_revision: 7,
+        },
       });
       expect(requests.find((request) => request.url.endsWith("/releases/release-1/publish"))).toMatchObject({
         method: "POST",
         body: {
           expected_scopes: [{ scope_type: "device_group", scope_value: "group-1" }],
+          expected_revision: 7,
         },
       });
     } finally {
@@ -354,6 +360,11 @@ describe("device-group rollout commands", () => {
       res.setHeader("content-type", "application/json");
       if (req.url === "/api/apps") {
         return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      if (req.url?.startsWith("/api/apps/app-1/releases/") && req.method === "GET") {
+        return res.end(JSON.stringify({
+          release: { id: req.url.split("/").at(-1), status: "draft", revision: 11 },
+        }));
       }
       if (req.url?.startsWith("/api/apps/app-1/releases/") && req.method === "PATCH") {
         return res.end(JSON.stringify({ id: req.url.split("/").at(-1), status: "draft" }));
@@ -401,10 +412,12 @@ describe("device-group rollout commands", () => {
             { scope_type: "device_group", scope_value: "group-z" },
           ],
           rollout_cohort_count: 25,
+          expected_revision: 11,
         },
         "release-full": {
           scopes: [{ scope_type: "full", scope_value: "all" }],
           rollout_cohort_count: null,
+          expected_revision: 11,
         },
       });
 
@@ -472,7 +485,7 @@ describe("device-group rollout commands", () => {
       if (detailMatch && req.method === "GET") {
         const releaseId = detailMatch[1] ?? "";
         return res.end(JSON.stringify({
-          release: { id: releaseId, status: "draft" },
+          release: { id: releaseId, status: "draft", revision: 17 },
           scopes: details[releaseId],
         }));
       }
@@ -515,15 +528,16 @@ describe("device-group rollout commands", () => {
           .map((request) => [request.url.split("/").at(-2), request.body]),
       );
       expect(publishBodies).toEqual({
-        "release-platform": { expected_scopes: [{ scope_type: "platform", scope_value: "android" }] },
-        "release-cohort": { expected_scopes: [{ scope_type: "user_cohort", scope_value: "internal-qa" }] },
-        "release-ip": { expected_scopes: [{ scope_type: "ip_range", scope_value: "203.0.113.0/24" }] },
-        "release-full": { expected_scopes: [{ scope_type: "full", scope_value: "all" }] },
+        "release-platform": { expected_scopes: [{ scope_type: "platform", scope_value: "android" }], expected_revision: 17 },
+        "release-cohort": { expected_scopes: [{ scope_type: "user_cohort", scope_value: "internal-qa" }], expected_revision: 17 },
+        "release-ip": { expected_scopes: [{ scope_type: "ip_range", scope_value: "203.0.113.0/24" }], expected_revision: 17 },
+        "release-full": { expected_scopes: [{ scope_type: "full", scope_value: "all" }], expected_revision: 17 },
         "release-mixed": {
           expected_scopes: [
             { scope_type: "platform", scope_value: "android" },
             { scope_type: "user_cohort", scope_value: "internal-qa" },
           ],
+          expected_revision: 17,
         },
         "release-full-groups": {
           expected_scopes: [
@@ -531,6 +545,7 @@ describe("device-group rollout commands", () => {
             { scope_type: "device_group", scope_value: "group-a" },
             { scope_type: "device_group", scope_value: "group-z" },
           ],
+          expected_revision: 17,
         },
       });
 

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -85,6 +85,13 @@ function parseRolloutPercent(value: string): number {
   return parsed;
 }
 
+function releaseRevision(raw: unknown): number {
+  if (!Number.isInteger(raw) || Number(raw) < 0) {
+    throw new Error("release detail is missing a valid revision; refusing mutation");
+  }
+  return Number(raw);
+}
+
 export function registerReleaseCommands(program: Command): void {
   const releases = program
     .command("releases")
@@ -108,9 +115,11 @@ export function registerReleaseCommands(program: Command): void {
         status: string;
         changelog: string | null;
         rollout_cohort_count: number | null;
+        revision: number;
       };
       console.log(`Release ${r.id}`);
       console.log(`  status:  ${r.status}`);
+      console.log(`  revision: ${r.revision}`);
       console.log(`  rollout: ${r.rollout_cohort_count ?? 100}%`);
       console.log(`  changelog:`);
       console.log((r.changelog ?? "(none)").split("\n").map((l) => "    " + l).join("\n"));
@@ -217,6 +226,10 @@ export function registerReleaseCommands(program: Command): void {
           ];
         }
         if (rolloutPercent !== undefined) body.rollout_cohort_count = rolloutPercent === 100 ? null : rolloutPercent;
+        const detail = await apiRequest<{ release?: { revision?: unknown } }>(
+          `/api/apps/${appId}/releases/${releaseId}`,
+        );
+        body.expected_revision = releaseRevision(detail.release?.revision);
         const updated = await apiRequest<Record<string, unknown>>(
           `/api/apps/${appId}/releases/${releaseId}`,
           { method: "PATCH", body },
@@ -252,10 +265,14 @@ export function registerReleaseCommands(program: Command): void {
       opts: { deviceGroup?: string[]; json?: boolean },
     ) => {
       const appId = await resolveAppId(appIdOrSlug);
-      const detail = await apiRequest<{ scopes?: unknown }>(
+      const detail = await apiRequest<{
+        release?: { revision?: unknown };
+        scopes?: unknown;
+      }>(
         `/api/apps/${appId}/releases/${releaseId}`,
       );
       const scopes = normalizeStoredScopes(detail.scopes);
+      const expectedRevision = releaseRevision(detail.release?.revision);
       const assertedGroups = normalizeDeviceGroupIds(opts.deviceGroup, "--device-group");
       if (opts.deviceGroup !== undefined) {
         const storedGroups = scopes
@@ -273,7 +290,13 @@ export function registerReleaseCommands(program: Command): void {
       }
       const result = await apiRequest<Record<string, unknown>>(
         `/api/apps/${appId}/releases/${releaseId}/publish`,
-        { method: "POST", body: { expected_scopes: scopes } },
+        {
+          method: "POST",
+          body: {
+            expected_scopes: scopes,
+            expected_revision: expectedRevision,
+          },
+        },
       );
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -30,6 +30,61 @@ const RELEASE_SCOPE_TYPES = new Set(["full", "platform", "user_cohort", "ip_rang
 
 const DEFAULT_SHARE_TTL_SECONDS = "604800";
 
+function collectRepeated(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+function normalizeDeviceGroupIds(values: string[] | undefined, flag: string): string[] {
+  const normalized = (values ?? []).map((value) => value.trim());
+  if (normalized.some((value) => !value)) {
+    throw new Error(`${flag} requires a non-empty group id`);
+  }
+  const unique = [...new Set(normalized)];
+  if (unique.length !== normalized.length) {
+    throw new Error(`${flag} may not repeat the same group id`);
+  }
+  return unique.sort();
+}
+
+function normalizeStoredScopes(raw: unknown): ReleaseScope[] {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error("publish requires a non-empty stored release scope set; refusing publish");
+  }
+  const scopes = raw.map((entry, index) => {
+    const scope = entry as Partial<ReleaseScope> | null;
+    const scopeType = typeof scope?.scope_type === "string" ? scope.scope_type.trim() : "";
+    const scopeValue = typeof scope?.scope_value === "string" ? scope.scope_value.trim() : "";
+    if (!scopeType || !scopeValue || !RELEASE_SCOPE_TYPES.has(scopeType)) {
+      throw new Error(`stored release scope at index ${index} is empty or unsupported; refusing publish`);
+    }
+    if (scopeType === "full" && scopeValue !== "all") {
+      throw new Error("stored full release scope must be exactly full:all; refusing publish");
+    }
+    return { scope_type: scopeType, scope_value: scopeValue };
+  });
+  const keys = scopes.map((scope) => `${scope.scope_type}\u0000${scope.scope_value}`);
+  if (new Set(keys).size !== keys.length) {
+    throw new Error("stored release scope set contains duplicates; refusing publish");
+  }
+  const hasFull = scopes.some((scope) => scope.scope_type === "full");
+  if (hasFull && scopes.some((scope) => scope.scope_type !== "full" && scope.scope_type !== "device_group")) {
+    throw new Error("stored full release scope may be combined only with device groups; refusing publish");
+  }
+  return scopes.sort((left, right) => {
+    const leftRank = left.scope_type === "full" ? 0 : left.scope_type === "device_group" ? 1 : 2;
+    const rightRank = right.scope_type === "full" ? 0 : right.scope_type === "device_group" ? 1 : 2;
+    return leftRank - rightRank || left.scope_type.localeCompare(right.scope_type) || left.scope_value.localeCompare(right.scope_value);
+  });
+}
+
+function parseRolloutPercent(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 100) {
+    throw new Error("--rollout-percent must be an integer from 0 to 100");
+  }
+  return parsed;
+}
+
 export function registerReleaseCommands(program: Command): void {
   const releases = program
     .command("releases")
@@ -75,6 +130,13 @@ export function registerReleaseCommands(program: Command): void {
       (value: string, prev: string[] = []) => [...prev, value],
     )
     .option("--device-group <groupId>", "Replace release scope with one exact-rollout device group UUID.")
+    .option("--full", "Reset release scope to full:all.", false)
+    .option(
+      "--always-include-group <groupId>",
+      "Always include a device group alongside the full percentage rollout. Repeatable.",
+      collectRepeated,
+    )
+    .option("--rollout-percent <percent>", "Set the stable full-scope rollout percentage (0-100).")
     .option("--json", "Output JSON.", false)
     .action(
       async (
@@ -84,6 +146,9 @@ export function registerReleaseCommands(program: Command): void {
           changelog?: string[];
           changelogFile?: string[];
           deviceGroup?: string;
+          full?: boolean;
+          alwaysIncludeGroup?: string[];
+          rolloutPercent?: string;
           json?: boolean;
         },
       ) => {
@@ -117,16 +182,41 @@ export function registerReleaseCommands(program: Command): void {
         } else if (plain !== undefined) {
           changelog = plain;
         }
-        if (changelog === undefined && !opts.deviceGroup) {
+        const alwaysIncludeGroups = normalizeDeviceGroupIds(
+          opts.alwaysIncludeGroup,
+          "--always-include-group",
+        );
+        if (opts.deviceGroup && (opts.full || alwaysIncludeGroups.length > 0)) {
+          throw new Error("--device-group cannot be combined with --full or --always-include-group");
+        }
+        const rolloutPercent = opts.rolloutPercent === undefined
+          ? undefined
+          : parseRolloutPercent(opts.rolloutPercent);
+        if (
+          changelog === undefined &&
+          !opts.deviceGroup &&
+          !opts.full &&
+          alwaysIncludeGroups.length === 0 &&
+          rolloutPercent === undefined
+        ) {
           throw new Error(
-            "nothing to update: pass --changelog(-file) or --device-group",
+            "nothing to update: pass --changelog(-file), a scope option, or --rollout-percent",
           );
         }
         const body: Record<string, unknown> = {};
         if (changelog !== undefined) body.changelog = changelog;
         if (opts.deviceGroup) {
           body.scopes = [{ scope_type: "device_group", scope_value: opts.deviceGroup }];
+        } else if (opts.full || alwaysIncludeGroups.length > 0) {
+          body.scopes = [
+            { scope_type: "full", scope_value: "all" },
+            ...alwaysIncludeGroups.map((groupId) => ({
+              scope_type: "device_group",
+              scope_value: groupId,
+            })),
+          ];
         }
+        if (rolloutPercent !== undefined) body.rollout_cohort_count = rolloutPercent === 100 ? null : rolloutPercent;
         const updated = await apiRequest<Record<string, unknown>>(
           `/api/apps/${appId}/releases/${releaseId}`,
           { method: "PATCH", body },
@@ -135,9 +225,15 @@ export function registerReleaseCommands(program: Command): void {
           console.log(JSON.stringify(updated, null, 2));
           return;
         }
-        console.log(
-          `Updated release ${releaseId}${changelog !== undefined ? ` changelog${langs.length ? ` (${langs.join(", ")})` : ""}` : ""}${opts.deviceGroup ? ` scope=device_group:${opts.deviceGroup}` : ""}.`,
-        );
+        const updates = [
+          changelog !== undefined ? `changelog${langs.length ? ` (${langs.join(", ")})` : ""}` : "",
+          opts.deviceGroup ? `scope=device_group:${opts.deviceGroup}` : "",
+          opts.full || alwaysIncludeGroups.length > 0
+            ? `scope=full:all${alwaysIncludeGroups.map((groupId) => `+device_group:${groupId}`).join("")}`
+            : "",
+          rolloutPercent !== undefined ? `rollout=${rolloutPercent}%` : "",
+        ].filter(Boolean);
+        console.log(`Updated release ${releaseId} ${updates.join(" ")}.`);
       },
     );
 
@@ -146,50 +242,44 @@ export function registerReleaseCommands(program: Command): void {
     .description("Publish a draft release (the explicit human/agent step after changelog review).")
     .option(
       "--device-group <groupId>",
-      "Assert that the stored release scope is exactly this device group before activation.",
+      "Assert the exact stored device-group set before activation. Repeatable.",
+      collectRepeated,
     )
     .option("--json", "Output JSON.", false)
     .action(async (
       appIdOrSlug: string,
       releaseId: string,
-      opts: { deviceGroup?: string; json?: boolean },
+      opts: { deviceGroup?: string[]; json?: boolean },
     ) => {
       const appId = await resolveAppId(appIdOrSlug);
       const detail = await apiRequest<{ scopes?: unknown }>(
         `/api/apps/${appId}/releases/${releaseId}`,
       );
-      if (!Array.isArray(detail.scopes) || detail.scopes.length !== 1) {
-        throw new Error("publish requires exactly one stored release scope; refusing zero or mixed scopes");
-      }
-      const rawScope = detail.scopes[0] as Partial<ReleaseScope> | null;
-      const scopeType = typeof rawScope?.scope_type === "string" ? rawScope.scope_type.trim() : "";
-      const scopeValue = typeof rawScope?.scope_value === "string" ? rawScope.scope_value.trim() : "";
-      if (!scopeType || !scopeValue || !RELEASE_SCOPE_TYPES.has(scopeType)) {
-        throw new Error("stored release scope is empty or unsupported; refusing publish");
-      }
-      if (scopeType === "full" && scopeValue !== "all") {
-        throw new Error("stored full release scope must be exactly full:all; refusing publish");
-      }
-      if (opts.deviceGroup && (scopeType !== "device_group" || scopeValue !== opts.deviceGroup)) {
-        throw new Error(`--device-group ${opts.deviceGroup} does not match stored ${scopeType}:${scopeValue}`);
-      }
-
-      const body: Record<string, unknown> = {};
-      if (scopeType !== "full") {
-        body.expected_scope = {
-          scope_type: scopeType,
-          scope_value: scopeValue,
-        };
+      const scopes = normalizeStoredScopes(detail.scopes);
+      const assertedGroups = normalizeDeviceGroupIds(opts.deviceGroup, "--device-group");
+      if (opts.deviceGroup !== undefined) {
+        const storedGroups = scopes
+          .filter((scope) => scope.scope_type === "device_group")
+          .map((scope) => scope.scope_value)
+          .sort();
+        if (
+          assertedGroups.length !== storedGroups.length ||
+          assertedGroups.some((groupId, index) => groupId !== storedGroups[index])
+        ) {
+          throw new Error(
+            `--device-group assertions [${assertedGroups.join(", ")}] do not match stored [${storedGroups.join(", ")}]`,
+          );
+        }
       }
       const result = await apiRequest<Record<string, unknown>>(
         `/api/apps/${appId}/releases/${releaseId}/publish`,
-        { method: "POST", body },
+        { method: "POST", body: { expected_scopes: scopes } },
       );
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
         return;
       }
-      console.log(`Published release ${releaseId}${opts.deviceGroup ? ` to device_group:${opts.deviceGroup}` : ""}.`);
+      console.log(`Published release ${releaseId} with ${scopes.length} exact scope${scopes.length === 1 ? "" : "s"}.`);
     });
 
   releases

--- a/worker/src/openapi/releases.ts
+++ b/worker/src/openapi/releases.ts
@@ -31,9 +31,13 @@ const ReleaseInput = z
     status: z.enum(["draft", "active"]).optional(),
     changelog: z.string().nullable().optional(),
     release_notes: z.record(z.string(), z.string()).nullable().optional(),
-    rollout_cohort_count: z.number().int().nullable().optional(),
+    rollout_cohort_count: z.number().int().min(0).max(100).nullable().optional().openapi({
+      description: "Stable full-scope rollout percentage. Null or omitted means 100%.",
+    }),
     should_force_update: z.boolean().optional(),
-    scopes: z.array(GenericObject).optional(),
+    scopes: z.array(GenericObject).min(1).optional().openapi({
+      description: "Exact non-empty scope set. full:all may be combined only with device_group entries.",
+    }),
   })
   .catchall(z.unknown())
   .openapi("ReleaseInput");
@@ -210,7 +214,7 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
     method: "post",
     path: "/api/apps/{appId}/releases",
     tags: ["Releases"],
-    summary: "Create a draft or active release",
+    summary: "Create the single release lifecycle for a build version",
     security: auth,
     request: {
       params: AppIdParam,
@@ -220,15 +224,16 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
       201: success("Created release.", GenericObject),
       400: error("Invalid release payload."),
       403: error("Current principal cannot create releases."),
+      409: error("A release already exists for this app/channel/product/release-type/version."),
     },
   });
 
   for (const [method, path, summary, bodyRequired] of [
     ["get", "/api/apps/{appId}/releases/{releaseId}", "Get a release", false],
     ["patch", "/api/apps/{appId}/releases/{releaseId}", "Update release metadata and scopes", true],
-    ["post", "/api/apps/{appId}/releases/{releaseId}/publish", "Publish a draft release", false],
+    ["post", "/api/apps/{appId}/releases/{releaseId}/publish", "Publish a draft with an exact expected_scopes precondition", true],
     ["delete", "/api/apps/{appId}/releases/{releaseId}", "Cancel or delete a release", false],
-    ["post", "/api/apps/{appId}/releases/{releaseId}/rollback", "Roll back to a release", false],
+    ["post", "/api/apps/{appId}/releases/{releaseId}/rollback", "Restore a superseded or cancelled release", false],
     ["post", "/api/apps/{appId}/releases/{releaseId}/bump-rollout", "Update rollout percentage", true],
     ["post", "/api/apps/{appId}/releases/{releaseId}/force-update", "Toggle force update", true],
   ] as const) {
@@ -249,6 +254,7 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
         400: error("Invalid release operation."),
         403: error("Current principal cannot modify this release."),
         404: error("Release was not found."),
+        409: error("Release lifecycle or exact scope precondition conflict."),
       },
     });
   }

--- a/worker/src/openapi/releases.ts
+++ b/worker/src/openapi/releases.ts
@@ -42,6 +42,30 @@ const ReleaseInput = z
   .catchall(z.unknown())
   .openapi("ReleaseInput");
 
+const RevisionMutationInput = z
+  .object({
+    expected_revision: z.number().int().nonnegative().optional().openapi({
+      description: "Revision from fresh release detail. Stale values return RELEASE_REVISION_CONFLICT.",
+    }),
+  })
+  .catchall(z.unknown())
+  .openapi("RevisionMutationInput");
+
+const PublishReleaseInput = z
+  .object({
+    expected_revision: z.number().int().nonnegative().optional().openapi({
+      description: "Revision from the same fresh detail read as expected_scopes.",
+    }),
+    expected_scope: GenericObject.optional().openapi({
+      description: "Legacy single-scope precondition. Do not combine with expected_scopes.",
+    }),
+    expected_scopes: z.array(GenericObject).min(1).optional().openapi({
+      description: "Canonical exact release scope-set precondition.",
+    }),
+  })
+  .catchall(z.unknown())
+  .openapi("PublishReleaseInput");
+
 const ReleaseShare = z
   .object({
     id: z.string(),
@@ -230,13 +254,15 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
 
   for (const [method, path, summary, bodyRequired] of [
     ["get", "/api/apps/{appId}/releases/{releaseId}", "Get a release", false],
-    ["patch", "/api/apps/{appId}/releases/{releaseId}", "Update release metadata and scopes", true],
-    ["post", "/api/apps/{appId}/releases/{releaseId}/publish", "Publish a draft with an exact expected_scopes precondition", true],
-    ["delete", "/api/apps/{appId}/releases/{releaseId}", "Cancel or delete a release", false],
-    ["post", "/api/apps/{appId}/releases/{releaseId}/rollback", "Restore a superseded or cancelled release", false],
-    ["post", "/api/apps/{appId}/releases/{releaseId}/bump-rollout", "Update rollout percentage", true],
-    ["post", "/api/apps/{appId}/releases/{releaseId}/force-update", "Toggle force update", true],
+    ["patch", "/api/apps/{appId}/releases/{releaseId}", "Update release metadata and scopes with a revision precondition", true],
+    ["post", "/api/apps/{appId}/releases/{releaseId}/publish", "Publish a draft with exact revision and expected_scopes preconditions", true],
+    ["delete", "/api/apps/{appId}/releases/{releaseId}", "Cancel a release with a revision precondition", false],
+    ["post", "/api/apps/{appId}/releases/{releaseId}/rollback", "Restore a cancelled draft to draft or a previously active release to active", false],
+    ["post", "/api/apps/{appId}/releases/{releaseId}/bump-rollout", "Update rollout percentage with a revision precondition", true],
+    ["post", "/api/apps/{appId}/releases/{releaseId}/force-update", "Toggle force update with a revision precondition", true],
   ] as const) {
+    const isPublish = path.endsWith("/publish");
+    const isRollback = path.endsWith("/rollback");
     register(registry, {
       method,
       path,
@@ -245,8 +271,20 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
       security: auth,
       request: {
         params: AppReleaseParams,
-        ...(bodyRequired
-          ? { body: { content: json(GenericObject), required: true } }
+        ...(method === "delete"
+          ? {
+              query: z.object({
+                expected_revision: z.coerce.number().int().nonnegative().optional(),
+              }),
+            }
+          : {}),
+        ...(bodyRequired || isRollback
+          ? {
+              body: {
+                content: json(isPublish ? PublishReleaseInput : RevisionMutationInput),
+                required: bodyRequired,
+              },
+            }
           : {}),
       },
       responses: {
@@ -254,7 +292,7 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
         400: error("Invalid release operation."),
         403: error("Current principal cannot modify this release."),
         404: error("Release was not found."),
-        409: error("Release lifecycle or exact scope precondition conflict."),
+        409: error("Release revision, lifecycle, or exact scope precondition conflict."),
       },
     });
   }

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1045,7 +1045,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "create-release",
         description:
-          "Create a DRAFT release from an existing build. The server enforces draft — activation has exactly one path: the publish-release action. Requires app publisher.",
+          "Create the one DRAFT release lifecycle for a build version. A second release in the same app/channel/product/release-type/version lane fails with RELEASE_VERSION_ALREADY_EXISTS and returns the existing release id. Requires app publisher.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/draft" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
@@ -1053,7 +1053,8 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           channel_id: { type: "string", in: "body", required: false, description: "Channel UUID (defaults to the build's channel)." },
           changelog: { type: "string", in: "body", required: false, description: "Changelog text (single-language fallback)." },
           release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes, e.g. {\"en\": \"...\", \"zh-CN\": \"...\"}." },
-          scopes: { type: "array", in: "body", required: false, description: "Release scopes. Exact device targeting uses [{\"scope_type\":\"device_group\",\"scope_value\":\"<group UUID>\"}]." },
+          rollout_cohort_count: { type: "number", in: "body", required: false, description: "Stable full-scope rollout percentage, integer 0..100. Null/omitted means 100%." },
+          scopes: { type: "array", in: "body", required: false, description: "Exact scope set. full:all may be combined with device_group entries so listed devices are always included while everyone else is percentage-gated." },
         },
       },
       {
@@ -1067,7 +1068,8 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           changelog: { type: "string", in: "body", required: false, description: "Changelog text." },
           release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes object." },
           hidden: { type: "boolean", in: "body", required: false, description: "Hide/show on public history without deleting." },
-          scopes: { type: "array", in: "body", required: false, description: "Replace release scopes. Exact device targeting uses device_group with a same-app group UUID." },
+          rollout_cohort_count: { type: "number", in: "body", required: false, description: "Stable full-scope rollout percentage, integer 0..100. Null means 100%." },
+          scopes: { type: "array", in: "body", required: false, description: "Replace the exact scope set. full:all plus device_group entries expresses mandatory groups over a percentage rollout." },
         },
       },
       {
@@ -1078,7 +1080,26 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
-          expected_scope: { type: "object", in: "body", required: false, description: "Required for any non-full scoped activation, e.g. {\"scope_type\":\"device_group\",\"scope_value\":\"<group UUID>\"}. Publish fails with 409 unless the draft has exactly this one scope. Omit only for an exact full:all release." },
+          expected_scope: { type: "object", in: "body", required: false, description: "Legacy single-scope precondition. New callers should send expected_scopes. Do not combine both fields." },
+          expected_scopes: { type: "array", in: "body", required: false, description: "Canonical exact-set precondition. Every stored scope must match atomically, including full:all and mandatory device_group entries." },
+        },
+      },
+      {
+        name: "cancel-release",
+        description: "Cancel one draft or active release without deleting its build, assets, or audit history. Requires app publisher.",
+        endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+        },
+      },
+      {
+        name: "restore-release",
+        description: "Reactivate the same superseded or cancelled release row. This never creates a duplicate release for the version. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/{release_id}/rollback" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Existing release UUID to reactivate." },
         },
       },
       {

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -742,9 +742,9 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       create_share:
         "POST /api/apps/{app_id}/releases/{release_id}/shares — body: {ttl_seconds?, password?} — publisher; no expiry unless set",
       update_release:
-        "PATCH /api/apps/{app_id}/releases/{release_id} — body: {changelog?, release_notes?, hidden?} — publisher",
+        "PATCH /api/apps/{app_id}/releases/{release_id} — body: {expected_revision?, changelog?, release_notes?, hidden?} — publisher; stale revision returns 409 without side effects",
       publish_release:
-        "POST /api/apps/{app_id}/releases/{release_id}/publish — publisher; live-facing, needs explicit human authorization",
+        "POST /api/apps/{app_id}/releases/{release_id}/publish — body: {expected_revision?, expected_scopes} — publisher; live-facing, needs explicit human authorization",
       create_ios_simulator_artifact:
         "POST /api/apps/{app_id}/qa-artifacts/ios-simulator — publisher; declares filename/size/SHA/source/version/build/bundle/GitHub run and returns a presigned PUT URL",
       complete_ios_simulator_artifact:
@@ -1060,11 +1060,12 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "update-release",
         description:
-          "Update a release's changelog/bilingual release notes, rollout fields, or hidden flag. Requires app publisher.",
+          "Update a release's changelog/bilingual release notes, rollout fields, or hidden flag. Pass the revision from fresh release detail; stale revisions fail with RELEASE_REVISION_CONFLICT. Requires app publisher.",
         endpoint: { method: "PATCH", path: "/api/apps/{app_id}/releases/{release_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          expected_revision: { type: "number", in: "body", required: false, description: "Revision from fresh release detail. A stale value returns 409 with zero mutation side effects." },
           changelog: { type: "string", in: "body", required: false, description: "Changelog text." },
           release_notes: { type: "object", in: "body", required: false, description: "Bilingual notes object." },
           hidden: { type: "boolean", in: "body", required: false, description: "Hide/show on public history without deleting." },
@@ -1075,11 +1076,12 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "publish-release",
         description:
-          "Publish (activate) a draft release. Live-facing: only run with explicit human authorization. Requires app publisher.",
+          "Publish (activate) a draft release using exact scope and revision preconditions. Live-facing: only run with explicit human authorization. Requires app publisher.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/{release_id}/publish" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          expected_revision: { type: "number", in: "body", required: false, description: "Revision from the same fresh detail read used to derive expected_scopes." },
           expected_scope: { type: "object", in: "body", required: false, description: "Legacy single-scope precondition. New callers should send expected_scopes. Do not combine both fields." },
           expected_scopes: { type: "array", in: "body", required: false, description: "Canonical exact-set precondition. Every stored scope must match atomically, including full:all and mandatory device_group entries." },
         },
@@ -1091,15 +1093,17 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
           release_id: { type: "string", in: "path", required: true, description: "Release UUID." },
+          expected_revision: { type: "number", in: "query", required: false, description: "Revision from fresh release detail." },
         },
       },
       {
         name: "restore-release",
-        description: "Reactivate the same superseded or cancelled release row. This never creates a duplicate release for the version. Requires app publisher.",
+        description: "Restore the same release row. A never-published cancelled draft returns to draft and must pass normal publish gates; a previously active release returns to active. Requires app publisher.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/{release_id}/rollback" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
-          release_id: { type: "string", in: "path", required: true, description: "Existing release UUID to reactivate." },
+          release_id: { type: "string", in: "path", required: true, description: "Existing release UUID to restore." },
+          expected_revision: { type: "number", in: "body", required: false, description: "Revision from fresh release detail." },
         },
       },
       {

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -12,7 +12,7 @@
  *   4. platform     (priority 2) — CSV match on X-Quiver-Client-Platform
  *   5. full         (priority 1) — catch-all
  *
- * Within a priority level, ties broken by created_at DESC, then release_id.
+ * Within a priority level, ties break by latest activation, then release_id.
  *
  * `/public/apps/:slug/latest` is also wired to this resolver so Quiver has
  * a single release-backed public lookup path.
@@ -29,7 +29,7 @@ interface ScopedResolution {
   scope_type: "full" | "platform" | "user_cohort" | "ip_range" | "device_group";
   scope_value: string;
   priority: number;
-  release_created_at: number;
+  release_activated_at: number;
 }
 
 type PublicAssetResponse = {
@@ -114,20 +114,24 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   // Candidates: active releases on (channel, [product_type]). No time window:
   // an active release must stay resolvable no matter how old it is.
   const candidateSql = productType
-    ? `SELECT r.id, r.build_id, r.created_at, r.product_type, r.rollout_cohort_count, r.changelog
+    ? `SELECT r.id, r.build_id, r.created_at,
+              COALESCE(r.activated_at, r.created_at) AS activated_at,
+              r.product_type, r.rollout_cohort_count, r.changelog
        FROM releases r
        JOIN builds b ON b.id = r.build_id
        WHERE r.app_id = ?1 AND r.channel_id = ?2 AND r.product_type = ?3
          AND r.status = 'active'
          AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
-       ORDER BY r.created_at DESC`
-    : `SELECT r.id, r.build_id, r.created_at, r.product_type, r.rollout_cohort_count, r.changelog
+       ORDER BY COALESCE(r.activated_at, r.created_at) DESC`
+    : `SELECT r.id, r.build_id, r.created_at,
+              COALESCE(r.activated_at, r.created_at) AS activated_at,
+              r.product_type, r.rollout_cohort_count, r.changelog
        FROM releases r
        JOIN builds b ON b.id = r.build_id
        WHERE r.app_id = ?1 AND r.channel_id = ?2
          AND r.status = 'active'
          AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
-       ORDER BY r.created_at DESC`;
+       ORDER BY COALESCE(r.activated_at, r.created_at) DESC`;
   const candidateStmt = c.env.DB.prepare(candidateSql);
   const allCandidates = await (productType
     ? candidateStmt.bind(app.id, channelRow.id, productType)
@@ -136,21 +140,13 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
     id: string;
     build_id: string;
     created_at: number;
+    activated_at: number;
     product_type: string;
     rollout_cohort_count: number | null;
     changelog: string | null;
   }>();
 
-  // Rollout gate: a release with rollout_cohort_count < 100 is only served to
-  // clients whose stable per-release bucket falls below the percentage.
-  // Clients that do not send a device id only ever see fully rolled-out
-  // releases. Gated-out clients fall through to the previous active release.
-  const candidates = {
-    results: allCandidates.results.filter((release) =>
-      rolloutIncludes(release.id, release.rollout_cohort_count, deviceId),
-    ),
-  };
-  if (candidates.results.length === 0) {
+  if (allCandidates.results.length === 0) {
     return c.json(
       {
         error: `no active release for this client on channel '${channel}'`,
@@ -162,7 +158,7 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   }
 
   // Pull all scopes for those releases in one query.
-  const candidateIds = candidates.results.map((r) => r.id);
+  const candidateIds = allCandidates.results.map((r) => r.id);
   if (candidateIds.length === 0) {
     return c.json({ error: "no candidates" }, 404);
   }
@@ -188,7 +184,12 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
 
   // Build match list (release, scope, priority).
   const matched: ScopedResolution[] = [];
-  for (const release of candidates.results) {
+  const rolloutEligibleReleaseIds = new Set(
+    allCandidates.results
+      .filter((release) => rolloutIncludes(release.id, release.rollout_cohort_count, deviceId))
+      .map((release) => release.id),
+  );
+  for (const release of allCandidates.results) {
     for (const s of scopes) {
       if (s.release_id !== release.id) continue;
       const ok = matchesScope(
@@ -200,6 +201,10 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
         deviceGroupIds,
       );
       if (!ok) continue;
+      // Device groups are mandatory overrides on a staged release: a listed QA
+      // or customer device always receives the release, while its full:all
+      // scope remains percentage-gated for everybody else.
+      if (s.scope_type !== "device_group" && !rolloutEligibleReleaseIds.has(release.id)) continue;
       const prio =
         PRIORITY[s.scope_type as keyof typeof PRIORITY] ?? 0;
       matched.push({
@@ -207,7 +212,7 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
         scope_type: s.scope_type as ScopedResolution["scope_type"],
         scope_value: s.scope_value,
         priority: prio,
-        release_created_at: release.created_at,
+        release_activated_at: release.activated_at,
       });
     }
   }
@@ -224,11 +229,11 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
     );
   }
 
-  // Sort by priority DESC, created_at DESC, release_id ASC (deterministic tie-break).
+  // Sort by priority DESC, latest activation DESC, release_id ASC.
   matched.sort((a, b) => {
     if (a.priority !== b.priority) return b.priority - a.priority;
-    if (a.release_created_at !== b.release_created_at) {
-      return b.release_created_at - a.release_created_at;
+    if (a.release_activated_at !== b.release_activated_at) {
+      return b.release_activated_at - a.release_activated_at;
     }
     return a.release_id < b.release_id ? -1 : 1;
   });
@@ -243,7 +248,7 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
      WHERE id = ?1`,
   )
     .bind(
-      candidates.results.find((r) => r.id === winner.release_id)?.build_id ??
+      allCandidates.results.find((r) => r.id === winner.release_id)?.build_id ??
         null,
     )
     .first<{
@@ -314,14 +319,14 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
   if (winner.scope_type !== "full") {
     fallbackRelease = await buildFallbackRelease(
       c,
-      candidateIds,
+      candidateIds.filter((id) => rolloutEligibleReleaseIds.has(id)),
       winner,
       productType ?? null,
     );
   }
 
   const rawChangelog =
-    candidates.results.find((r) => r.id === winner.release_id)?.changelog ??
+    allCandidates.results.find((r) => r.id === winner.release_id)?.changelog ??
       build.changelog;
 
   return c.json({
@@ -346,7 +351,7 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
       scope_value: winner.scope_value,
       release_id: winner.release_id,
       rollout_cohort_count:
-        candidates.results.find((r) => r.id === winner.release_id)
+        allCandidates.results.find((r) => r.id === winner.release_id)
           ?.rollout_cohort_count ?? null,
     },
     fallback_release: fallbackRelease,
@@ -810,6 +815,7 @@ async function buildFallbackRelease(
   build: { version: string; version_code: number; platform: string };
   assets: Array<{ platform: string; download_url: string }>;
 } | null> {
+  if (candidateIds.length === 0) return null;
   // Look for a `full` match in the same candidate set, excluding the winner.
   const fallbackSql = productType
     ? `SELECT r.id AS release_id, r.build_id, r.product_type,
@@ -818,14 +824,18 @@ async function buildFallbackRelease(
        JOIN release_scopes s ON s.release_id = r.id
        WHERE r.id IN (${candidateIds.map(() => "?").join(",")})
          AND r.id != ?
-         AND s.scope_type = 'full' AND s.scope_value = 'all'`
+         AND s.scope_type = 'full' AND s.scope_value = 'all'
+       ORDER BY COALESCE(r.activated_at, r.created_at) DESC, r.id ASC
+       LIMIT 1`
     : `SELECT r.id AS release_id, r.build_id, r.product_type,
               s.scope_type, s.scope_value
        FROM releases r
        JOIN release_scopes s ON s.release_id = r.id
        WHERE r.id IN (${candidateIds.map(() => "?").join(",")})
          AND r.id != ?
-         AND s.scope_type = 'full' AND s.scope_value = 'all'`;
+         AND s.scope_type = 'full' AND s.scope_value = 'all'
+       ORDER BY COALESCE(r.activated_at, r.created_at) DESC, r.id ASC
+       LIMIT 1`;
   const stmt = c.env.DB.prepare(fallbackSql);
   const params = productType
     ? [...candidateIds, winner.release_id]

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -65,6 +65,7 @@ interface ReleaseUpdateInput {
   // without deleting it. Editable even on locked (superseded/cancelled)
   // releases so junk/duplicate old entries can be cleaned from the changelog.
   hidden?: boolean;
+  expected_revision?: number;
 }
 
 interface ReleaseRow {
@@ -76,6 +77,7 @@ interface ReleaseRow {
   release_type: string;
   status: string;
   activated_at: number | null;
+  revision: number;
   is_full: number;
   superseded_by_release_id: string | null;
   rollout_cohort_count: number | null;
@@ -87,6 +89,16 @@ interface ReleaseRow {
   created_by: string;
   created_at: number;
   updated_at: number;
+}
+
+interface ExternalTargetGatePlan {
+  buildId: string;
+  expectedFreezeToken: string | null;
+  expectedRequiredTargetsJson: string | null;
+  nextFreezeToken: string;
+  nextRequiredTargetsJson: string;
+  requiredTargets: string[];
+  freezesBuild: boolean;
 }
 
 function jsonString(value: unknown, fallback: Record<string, unknown> | unknown[] = {}): string {
@@ -229,22 +241,6 @@ function validateRolloutCohortCount(value: number | null | undefined): void {
   }
 }
 
-async function insertAuditLog(
-  db: D1Database,
-  appId: string,
-  action: string,
-  actor: string,
-  payload: unknown,
-  now = Date.now(),
-) {
-  await db
-    .prepare(
-      "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-    )
-    .bind(crypto.randomUUID(), appId, action, actor, JSON.stringify(payload), now)
-    .run();
-}
-
 function releaseStatus(inputStatus: ReleaseInput["status"] | undefined): "draft" | "active" {
   if (!inputStatus) return "active";
   if (inputStatus !== "draft" && inputStatus !== "active") {
@@ -268,6 +264,157 @@ function withReleaseNotes<T extends { changelog?: string | null }>(
     ...row,
     release_notes: parseReleaseNotes(row.changelog ?? null),
   };
+}
+
+class ReleaseRevisionConflictError extends Error {
+  readonly code = "RELEASE_REVISION_CONFLICT";
+
+  constructor(
+    readonly expectedRevision: number,
+    readonly currentRevision: number | null,
+  ) {
+    super(
+      currentRevision === null
+        ? "release disappeared during mutation"
+        : `release revision changed: expected ${expectedRevision}, current ${currentRevision}`,
+    );
+    this.name = "ReleaseRevisionConflictError";
+  }
+}
+
+function expectedReleaseRevision(raw: unknown, currentRevision: number): number {
+  if (raw === undefined) return currentRevision;
+  const parsed = typeof raw === "string" && raw.trim() !== "" ? Number(raw) : raw;
+  if (!Number.isInteger(parsed) || Number(parsed) < 0) {
+    throw new Error("expected_revision must be a non-negative integer");
+  }
+  return Number(parsed);
+}
+
+function releaseRevisionConflictResponse(
+  c: AdminContext,
+  expectedRevision: number,
+  currentRevision: number | null,
+) {
+  return c.json({
+    error: currentRevision === null
+      ? "release disappeared during mutation"
+      : "release changed before the operation completed",
+    code: "RELEASE_REVISION_CONFLICT",
+    expected_revision: expectedRevision,
+    current_revision: currentRevision,
+  }, 409);
+}
+
+async function currentReleaseRevision(
+  db: D1Database,
+  appId: string,
+  releaseId: string,
+): Promise<number | null> {
+  const row = await db.prepare(
+    "SELECT revision FROM releases WHERE app_id = ?1 AND id = ?2",
+  ).bind(appId, releaseId).first<{ revision: number }>();
+  return row?.revision ?? null;
+}
+
+async function releaseScopesForMutation(
+  db: D1Database,
+  releaseId: string,
+): Promise<ReleaseScopeInput[]> {
+  const { results } = await db.prepare(
+    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
+  ).bind(releaseId).all<ReleaseScopeInput>();
+  return results;
+}
+
+function conditionalReleaseAuditStatement(
+  db: D1Database,
+  options: {
+    auditId: string;
+    appId: string;
+    action: string;
+    actor: string;
+    payload: unknown;
+    now: number;
+    release: ReleaseRow;
+    expectedRevision: number;
+    expectedScopes: ReleaseScopeInput[];
+    externalTargetGate?: ExternalTargetGatePlan | null;
+  },
+): D1PreparedStatement {
+  const binds: (string | number | null)[] = [];
+  const bind = (value: string | number | null): string => {
+    binds.push(value);
+    return `?${binds.length}`;
+  };
+  const auditIdParam = bind(options.auditId);
+  const appIdParam = bind(options.appId);
+  const actionParam = bind(options.action);
+  const actorParam = bind(options.actor);
+  const payloadParam = bind(JSON.stringify(options.payload));
+  const nowParam = bind(options.now);
+  const releaseIdParam = bind(options.release.id);
+  const revisionParam = bind(options.expectedRevision);
+  const statusParam = bind(options.release.status);
+  const rolloutPredicate = options.release.rollout_cohort_count === null
+    ? "r.rollout_cohort_count IS NULL"
+    : `r.rollout_cohort_count = ${bind(options.release.rollout_cohort_count)}`;
+  const scopeCountParam = bind(options.expectedScopes.length);
+  const scopePredicates = options.expectedScopes.map((scope) => {
+    const typeParam = bind(scope.scope_type);
+    const valueParam = bind(scope.scope_value);
+    return `EXISTS (
+      SELECT 1 FROM release_scopes s
+      WHERE s.release_id = r.id AND s.scope_type = ${typeParam} AND s.scope_value = ${valueParam}
+    )`;
+  });
+  let externalTargetPredicate = "";
+  if (options.externalTargetGate) {
+    const gate = options.externalTargetGate;
+    const buildIdParam = bind(gate.buildId);
+    const freezePredicate = gate.expectedFreezeToken === null
+      ? "b.freeze_token IS NULL AND b.required_targets_json IS NULL AND b.targets_frozen_at IS NULL"
+      : `b.freeze_token = ${bind(gate.expectedFreezeToken)} AND b.required_targets_json = ${bind(gate.expectedRequiredTargetsJson)}`;
+    const targetCountParam = bind(gate.requiredTargets.length);
+    const targetPredicates = gate.requiredTargets.map((target) => {
+      const targetParam = bind(target);
+      return `EXISTS (
+        SELECT 1 FROM external_build_targets t
+        WHERE t.build_id = b.id AND t.target = ${targetParam}
+      )`;
+    });
+    externalTargetPredicate = `AND EXISTS (
+         SELECT 1 FROM builds b
+         WHERE b.id = r.build_id AND b.id = ${buildIdParam}
+           AND ${freezePredicate}
+           AND (SELECT COUNT(*) FROM external_build_targets t WHERE t.build_id = b.id) = ${targetCountParam}
+           ${targetPredicates.map((predicate) => `AND ${predicate}`).join("\n           ")}
+       )`;
+  }
+
+  return db.prepare(
+    `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+     SELECT ${auditIdParam}, ${appIdParam}, ${actionParam}, ${actorParam}, ${payloadParam}, ${nowParam}
+     FROM releases r
+     WHERE r.id = ${releaseIdParam} AND r.app_id = ${appIdParam}
+       AND r.revision = ${revisionParam} AND r.status = ${statusParam}
+       AND ${rolloutPredicate}
+       AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = ${scopeCountParam}
+       ${scopePredicates.map((predicate) => `AND ${predicate}`).join("\n       ")}
+       ${externalTargetPredicate}`,
+  ).bind(...binds);
+}
+
+async function throwReleaseMutationConflict(
+  db: D1Database,
+  appId: string,
+  releaseId: string,
+  expectedRevision: number,
+): Promise<never> {
+  throw new ReleaseRevisionConflictError(
+    expectedRevision,
+    await currentReleaseRevision(db, appId, releaseId),
+  );
 }
 
 export async function getReleaseForApp(
@@ -409,7 +556,8 @@ export async function createRelease(
       db
         .prepare(
           `UPDATE releases
-           SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+           SET status = 'superseded', superseded_by_release_id = ?1,
+               revision = revision + 1, updated_at = ?2
            WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
              AND release_type = ?6 AND status = 'active' AND id <> ?7`,
         )
@@ -461,6 +609,10 @@ async function updateReleaseFields(
       );
     }
   }
+  const expectedRevision = expectedReleaseRevision(input.expected_revision, release.revision);
+  if (expectedRevision !== release.revision) {
+    throw new ReleaseRevisionConflictError(expectedRevision, release.revision);
+  }
   const now = Date.now();
   const sets: string[] = [];
   const binds: (string | number | null)[] = [];
@@ -498,49 +650,96 @@ async function updateReleaseFields(
     binds.push(input.hidden ? 1 : 0);
   }
 
-  const statements: D1PreparedStatement[] = [];
-  if (sets.length > 0) {
-    sets.push(`updated_at = ?${binds.length + 1}`);
-    binds.push(now);
-    statements.push(
-      db
-        .prepare(`UPDATE releases SET ${sets.join(", ")} WHERE id = ?${binds.length + 1} AND app_id = ?${binds.length + 2}`)
-        .bind(...binds, release.id, appId),
-    );
-  }
-
   let scopes: ReleaseScopeInput[] | undefined;
   if (input.scopes !== undefined) {
     scopes = await validateScopes(db, appId, input.scopes);
+    sets.push(`is_full = ?${binds.length + 1}`);
+    binds.push(isFullRelease(scopes));
+  }
+
+  const existingScopes = await releaseScopesForMutation(db, release.id);
+  const nextScopes = scopes ?? existingScopes;
+  const nextRollout = input.rollout_cohort_count !== undefined
+    ? input.rollout_cohort_count
+    : release.rollout_cohort_count;
+  const auditId = crypto.randomUUID();
+  const auditPayload = {
+    release_id: release.id,
+    expected_revision: expectedRevision,
+    ...input,
+    scopes,
+  };
+  const statements: D1PreparedStatement[] = [
+    conditionalReleaseAuditStatement(db, {
+      auditId,
+      appId,
+      action: "release.update",
+      actor,
+      payload: auditPayload,
+      now,
+      release,
+      expectedRevision,
+      expectedScopes: existingScopes,
+    }),
+  ];
+
+  sets.push(`updated_at = ?${binds.length + 1}`);
+  binds.push(now);
+  sets.push("revision = revision + 1");
+  const releaseIdPosition = binds.length + 1;
+  const appIdPosition = releaseIdPosition + 1;
+  const revisionPosition = appIdPosition + 1;
+  const statusPosition = revisionPosition + 1;
+  const auditIdPosition = statusPosition + 1;
+  statements.push(
+    db.prepare(
+      `UPDATE releases SET ${sets.join(", ")}
+       WHERE id = ?${releaseIdPosition} AND app_id = ?${appIdPosition}
+         AND revision = ?${revisionPosition} AND status = ?${statusPosition}
+         AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?${auditIdPosition})`,
+    ).bind(
+      ...binds,
+      release.id,
+      appId,
+      expectedRevision,
+      release.status,
+      auditId,
+    ),
+  );
+
+  if (scopes !== undefined) {
     statements.push(
-      db.prepare("DELETE FROM release_scopes WHERE release_id = ?1").bind(release.id),
+      db.prepare(
+        `DELETE FROM release_scopes
+         WHERE release_id = ?1 AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?2)`,
+      ).bind(release.id, auditId),
       ...scopes.map((scope) =>
-        db
-          .prepare(
-            "INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-          )
-          .bind(crypto.randomUUID(), release.id, scope.scope_type, scope.scope_value, now),
+        db.prepare(
+          `INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+           SELECT ?1, ?2, ?3, ?4, ?5
+           WHERE EXISTS (SELECT 1 FROM audit_logs WHERE id = ?6)`,
+        ).bind(
+          crypto.randomUUID(),
+          release.id,
+          scope.scope_type,
+          scope.scope_value,
+          now,
+          auditId,
+        )
       ),
-      db
-        .prepare("UPDATE releases SET is_full = ?1, updated_at = ?2 WHERE id = ?3 AND app_id = ?4")
-      .bind(isFullRelease(scopes), now, release.id, appId),
     );
   }
 
   if (release.status === "active" && (input.scopes !== undefined || input.rollout_cohort_count !== undefined)) {
-    const nextScopes = scopes ?? (await db.prepare(
-      "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
-    ).bind(release.id).all<ReleaseScopeInput>()).results;
-    const nextRollout = input.rollout_cohort_count !== undefined
-      ? input.rollout_cohort_count
-      : release.rollout_cohort_count;
     if (isFullCoverage(nextScopes, nextRollout)) {
       statements.push(
         db.prepare(
           `UPDATE releases
-           SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+           SET status = 'superseded', superseded_by_release_id = ?1,
+               revision = revision + 1, updated_at = ?2
            WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
-             AND release_type = ?6 AND status = 'active' AND id <> ?7`,
+             AND release_type = ?6 AND status = 'active' AND id <> ?7
+             AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?8)`,
         ).bind(
           release.id,
           now,
@@ -549,6 +748,7 @@ async function updateReleaseFields(
           release.product_type,
           release.release_type,
           release.id,
+          auditId,
         ),
       );
     } else {
@@ -559,28 +759,20 @@ async function updateReleaseFields(
       statements.push(
         db.prepare(
           `UPDATE releases
-           SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
-           WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
-        ).bind(now, appId, release.id),
+           SET status = 'active', superseded_by_release_id = NULL,
+               revision = revision + 1, updated_at = ?1
+           WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'
+             AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
+        ).bind(now, appId, release.id, auditId),
       );
     }
   }
 
-  statements.push(
-    db
-      .prepare(
-        "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-      )
-      .bind(
-        crypto.randomUUID(),
-        appId,
-        "release.update",
-        actor,
-        JSON.stringify({ release_id: release.id, ...input, scopes }),
-        now,
-      ),
-  );
-  await db.batch(statements);
+  const batchResults = await db.batch(statements);
+  if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+      Number(batchResults[1]?.meta?.changes ?? 0) !== 1) {
+    await throwReleaseMutationConflict(db, appId, release.id, expectedRevision);
+  }
   const updated = await getReleaseForApp(db, appId, release.id);
   if (!updated) throw new Error("release not found after update");
   return updated;
@@ -993,6 +1185,8 @@ export async function handleCreateReleaseDraft(c: AdminContext) {
         id,
         app_id: appId,
         status: "draft",
+        activated_at: null,
+        revision: 0,
         ...draftBody,
         changelog,
         release_notes: parseReleaseNotes(changelog),
@@ -1033,6 +1227,8 @@ export async function handleCreateRelease(c: AdminContext) {
       id,
       app_id: appId,
       status,
+      activated_at: status === "active" ? Date.now() : null,
+      revision: 0,
       ...body,
       changelog,
       release_notes: parseReleaseNotes(changelog),
@@ -1055,6 +1251,9 @@ export async function handleUpdateRelease(c: AdminContext) {
     const release = await updateReleaseFields(c.env.DB, appId, existing, body, currentActor(c));
     return c.json(withReleaseNotes(release));
   } catch (e) {
+    if (e instanceof ReleaseRevisionConflictError) {
+      return releaseRevisionConflictResponse(c, e.expectedRevision, e.currentRevision);
+    }
     return c.json({ error: (e as Error).message }, 400);
   }
 }
@@ -1087,119 +1286,132 @@ function targetSetDiff(required: string[], declared: string[]): { missing: strin
 }
 
 /**
- * Freeze + assert the external-target contract inside the publish path.
- * Every external build's target set is frozen on its first publish attempt
- * (freeze_token = random ownership; declarations are conditionally rejected
- * once frozen). cli-binary requires a caller-supplied exact expected set; a
- * failed assertion clears ONLY a freeze this attempt created. Runs on every
- * publish attempt including already-active replays — no early no-op path.
- * Returns a Response on failure, null to proceed.
+ * Build a read-only external-target plan. The caller must commit a new freeze
+ * only inside the same D1 batch as the release revision/scope transition.
  */
-async function assertExternalTargetGate(
+async function prepareExternalTargetGate(
   c: AdminContext,
   release: { build_id: string },
   requiredRaw: unknown,
-): Promise<Response | null> {
+): Promise<{ plan: ExternalTargetGatePlan | null } | { response: Response }> {
   const build = await c.env.DB.prepare(
     `SELECT id, source, product_type, freeze_token, required_targets_json FROM builds WHERE id = ?1`,
   )
     .bind(release.build_id)
     .first<{ id: string; source: string; product_type: string; freeze_token: string | null; required_targets_json: string | null }>();
-  if (!build) return c.json({ error: "release build not found" }, 409);
+  if (!build) return { response: c.json({ error: "release build not found" }, 409) };
 
   if (build.source !== "external") {
     if (requiredRaw !== undefined) {
-      return c.json({ error: "required_external_targets only applies to external builds" }, 400);
+      return { response: c.json({ error: "required_external_targets only applies to external builds" }, 400) };
     }
-    return null;
+    return { plan: null };
   }
 
   let callerSet: string[] | undefined;
   if (requiredRaw !== undefined) {
     const canon = canonicalizeRequiredTargets(requiredRaw);
-    if ("error" in canon) return c.json({ error: canon.error }, 400);
+    if ("error" in canon) return { response: c.json({ error: canon.error }, 400) };
     callerSet = canon.set;
   }
   if (build.product_type === "cli-binary" && !callerSet && !build.freeze_token) {
-    return c.json(
-      { error: "required_external_targets is required when publishing a cli-binary external build" },
-      400,
-    );
+    return {
+      response: c.json(
+        { error: "required_external_targets is required when publishing a cli-binary external build" },
+        400,
+      ),
+    };
   }
 
-  const readDeclared = async (): Promise<string[]> => {
-    const { results } = await c.env.DB.prepare(
-      `SELECT target FROM external_build_targets WHERE build_id = ?1 ORDER BY target`,
-    )
-      .bind(build.id)
-      .all<{ target: string }>();
-    return (results || []).map((r) => r.target);
-  };
-
-  if (!build.freeze_token) {
-    const token = crypto.randomUUID();
-    const cas = await c.env.DB.prepare(
-      `UPDATE builds SET freeze_token = ?1, targets_frozen_at = ?2, required_targets_json = ?3
-       WHERE id = ?4 AND freeze_token IS NULL`,
-    )
-      .bind(token, Date.now(), JSON.stringify(callerSet ?? []), build.id)
-      .run();
-    if ((cas.meta?.changes ?? 0) === 1) {
-      // We own the freeze; declarations are now blocked, so this read is final.
-      const declared = await readDeclared();
-      const required = callerSet ?? declared;
-      await c.env.DB.prepare(
-        `UPDATE builds SET required_targets_json = ?1 WHERE id = ?2 AND freeze_token = ?3`,
-      )
-        .bind(JSON.stringify(required), build.id, token)
-        .run();
-      const diff = targetSetDiff(required, declared);
-      if (diff.missing.length > 0 || diff.unexpected.length > 0) {
-        // Roll back OUR freeze only, so the build isn't locked by a failed attempt.
-        await c.env.DB.prepare(
-          `UPDATE builds SET freeze_token = NULL, targets_frozen_at = NULL, required_targets_json = NULL
-           WHERE id = ?1 AND freeze_token = ?2`,
-        )
-          .bind(build.id, token)
-          .run();
-        return c.json(
-          { error: "external target set does not match the required set", code: "EXTERNAL_TARGETS_MISMATCH", missing: diff.missing, unexpected: diff.unexpected },
-          400,
-        );
-      }
-      return null;
-    }
-    // Lost the freeze race — fall through to the stored-contract path.
-  }
-
-  const frozen = await c.env.DB.prepare(
-    `SELECT required_targets_json FROM builds WHERE id = ?1`,
+  const { results } = await c.env.DB.prepare(
+    `SELECT target FROM external_build_targets WHERE build_id = ?1 ORDER BY target`,
   )
     .bind(build.id)
-    .first<{ required_targets_json: string | null }>();
-  let stored: string[] = [];
-  try {
-    stored = JSON.parse(frozen?.required_targets_json ?? "[]") as string[];
-  } catch {
-    stored = [];
+    .all<{ target: string }>();
+  const declared = (results || []).map((row) => row.target);
+
+  let required: string[];
+  if (build.freeze_token) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(build.required_targets_json ?? "null");
+    } catch {
+      parsed = null;
+    }
+    const canonical = canonicalizeRequiredTargets(parsed);
+    if ("error" in canonical) {
+      return {
+        response: c.json({
+          error: "frozen external target contract is invalid",
+          code: "EXTERNAL_TARGETS_CONTRACT_MISMATCH",
+        }, 409),
+      };
+    }
+    required = canonical.set;
+    if (callerSet && (callerSet.length !== required.length || callerSet.some((target, index) => target !== required[index]))) {
+      return {
+        response: c.json(
+          { error: "required_external_targets differs from the frozen contract", code: "EXTERNAL_TARGETS_CONTRACT_MISMATCH", frozen: required },
+          400,
+        ),
+      };
+    }
+  } else {
+    required = callerSet ?? declared;
   }
-  if (callerSet && (callerSet.length !== stored.length || callerSet.some((t, i) => t !== stored[i]))) {
-    return c.json(
-      { error: "required_external_targets differs from the frozen contract", code: "EXTERNAL_TARGETS_CONTRACT_MISMATCH", frozen: stored },
-      400,
-    );
-  }
-  const declared = await readDeclared();
-  const diff = targetSetDiff(stored, declared);
+
+  const diff = targetSetDiff(required, declared);
   if (diff.missing.length > 0 || diff.unexpected.length > 0) {
-    // Frozen contract violated after freeze — declarations are blocked, so
-    // this indicates out-of-band mutation; fail closed.
-    return c.json(
-      { error: "declared targets no longer match the frozen contract", code: "EXTERNAL_TARGETS_MISMATCH", missing: diff.missing, unexpected: diff.unexpected },
-      409,
-    );
+    return {
+      response: c.json(
+        {
+          error: build.freeze_token
+            ? "declared targets no longer match the frozen contract"
+            : "external target set does not match the required set",
+          code: "EXTERNAL_TARGETS_MISMATCH",
+          missing: diff.missing,
+          unexpected: diff.unexpected,
+        },
+        build.freeze_token ? 409 : 400,
+      ),
+    };
   }
-  return null;
+
+  const nextFreezeToken = build.freeze_token ?? crypto.randomUUID();
+  return {
+    plan: {
+      buildId: build.id,
+      expectedFreezeToken: build.freeze_token,
+      expectedRequiredTargetsJson: build.required_targets_json,
+      nextFreezeToken,
+      nextRequiredTargetsJson: build.freeze_token
+        ? build.required_targets_json ?? "[]"
+        : JSON.stringify(required),
+      requiredTargets: required,
+      freezesBuild: build.freeze_token === null,
+    },
+  };
+}
+
+function externalTargetFreezeStatement(
+  db: D1Database,
+  plan: ExternalTargetGatePlan,
+  auditId: string,
+  now: number,
+): D1PreparedStatement {
+  return db.prepare(
+    `UPDATE builds
+     SET freeze_token = ?1, targets_frozen_at = ?2, required_targets_json = ?3
+     WHERE id = ?4 AND freeze_token IS NULL
+       AND required_targets_json IS NULL AND targets_frozen_at IS NULL
+       AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?5)`,
+  ).bind(
+    plan.nextFreezeToken,
+    now,
+    plan.nextRequiredTargetsJson,
+    plan.buildId,
+    auditId,
+  );
 }
 
 export async function handlePublishRelease(c: AdminContext) {
@@ -1207,15 +1419,21 @@ export async function handlePublishRelease(c: AdminContext) {
   const releaseId = c.req.param("releaseId") ?? "";
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
-  // The external-target gate runs on EVERY publish attempt — including
-  // already-active replays — before any no-op shortcut.
   const publishBody = (await c.req.json().catch(() => ({}))) as {
     required_external_targets?: unknown;
     expected_scope?: unknown;
     expected_scopes?: unknown;
+    expected_revision?: unknown;
   };
-  const gateFail = await assertExternalTargetGate(c, existing, publishBody.required_external_targets);
-  if (gateFail) return gateFail;
+  let expectedRevision: number;
+  try {
+    expectedRevision = expectedReleaseRevision(publishBody.expected_revision, existing.revision);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
+  }
+  if (expectedRevision !== existing.revision) {
+    return releaseRevisionConflictResponse(c, expectedRevision, existing.revision);
+  }
 
   const hasExpectedScope = Object.prototype.hasOwnProperty.call(publishBody, "expected_scope");
   const hasExpectedScopes = Object.prototype.hasOwnProperty.call(publishBody, "expected_scopes");
@@ -1260,58 +1478,97 @@ export async function handlePublishRelease(c: AdminContext) {
       code: "RELEASE_SCOPE_PRECONDITION_FAILED",
     }, 409);
   }
-  if (existing.status === "active") return c.json(withReleaseNotes(existing));
-  if (existing.status !== "draft") {
+  if (existing.status !== "draft" && existing.status !== "active") {
     return c.json({ error: `cannot publish ${existing.status} release` }, 409);
+  }
+
+  const targetGateResult = await prepareExternalTargetGate(
+    c,
+    existing,
+    publishBody.required_external_targets,
+  );
+  if ("response" in targetGateResult) return targetGateResult.response;
+  const externalTargetGate = targetGateResult.plan;
+
+  if (existing.status === "active") {
+    if (externalTargetGate?.freezesBuild) {
+      const now = Date.now();
+      const auditId = crypto.randomUUID();
+      const batchResults = await c.env.DB.batch([
+        conditionalReleaseAuditStatement(c.env.DB, {
+          auditId,
+          appId,
+          action: "release.external_targets_freeze",
+          actor: currentActor(c),
+          payload: {
+            release_id: releaseId,
+            build_id: existing.build_id,
+            expected_revision: expectedRevision,
+            expected_scopes: expectedScopes,
+          },
+          now,
+          release: existing,
+          expectedRevision,
+          expectedScopes,
+          externalTargetGate,
+        }),
+        externalTargetFreezeStatement(c.env.DB, externalTargetGate, auditId, now),
+      ]);
+      if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+          Number(batchResults[1]?.meta?.changes ?? 0) !== 1) {
+        const currentRevision = await currentReleaseRevision(c.env.DB, appId, releaseId);
+        if (currentRevision !== expectedRevision) {
+          return releaseRevisionConflictResponse(c, expectedRevision, currentRevision);
+        }
+        return c.json({
+          error: "external target contract changed before freeze",
+          code: "EXTERNAL_TARGETS_CONTRACT_MISMATCH",
+        }, 409);
+      }
+    }
+    const active = await getReleaseForApp(c.env.DB, appId, releaseId);
+    return c.json(withReleaseNotes(active ?? existing));
   }
 
   const now = Date.now();
   const auditId = crypto.randomUUID();
-  const auditPayload = JSON.stringify({
+  const auditPayload = {
     release_id: releaseId,
     build_id: existing.build_id,
+    expected_revision: expectedRevision,
     expected_scopes: expectedScopes,
-  });
-
-  const scopeAssertionBinds: string[] = [];
-  const scopeAssertions = expectedScopes.map((scope, index) => {
-    const typePosition = 8 + index * 2;
-    const valuePosition = typePosition + 1;
-    scopeAssertionBinds.push(scope.scope_type, scope.scope_value);
-    return `EXISTS (
-      SELECT 1 FROM release_scopes s
-      WHERE s.release_id = r.id AND s.scope_type = ?${typePosition} AND s.scope_value = ?${valuePosition}
-    )`;
-  });
+    required_external_targets: externalTargetGate?.requiredTargets,
+  };
 
   // D1 batch is transactional. Every side effect is gated by the conditional
-  // audit insert, whose SELECT re-checks draft state and the exact stored scope
-  // inside the same batch. A stale preflight read therefore becomes a clean
-  // 409 with zero audit, fallback, activation, or webhook side effects.
-  const statements = [
-    c.env.DB
-      .prepare(
-        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
-         SELECT ?1, ?2, 'release.publish', ?3, ?4, ?5
-         FROM releases r
-         WHERE r.id = ?6 AND r.app_id = ?2 AND r.status = 'draft'
-           AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = ?7
-           AND ${scopeAssertions.join(" AND ")}`,
-      )
-      .bind(
-        auditId,
-        appId,
-        currentActor(c),
-        auditPayload,
-        now,
-        releaseId,
-        expectedScopes.length,
-        ...scopeAssertionBinds,
-      ),
+  // audit insert, whose SELECT re-checks draft state, exact stored scopes, and
+  // the external target/freeze precondition. A stale preflight read therefore
+  // becomes a clean 409 with zero freeze, audit, fallback, or activation.
+  const statements: D1PreparedStatement[] = [
+    conditionalReleaseAuditStatement(c.env.DB, {
+      auditId,
+      appId,
+      action: "release.publish",
+      actor: currentActor(c),
+      payload: auditPayload,
+      now,
+      release: existing,
+      expectedRevision,
+      expectedScopes,
+      externalTargetGate,
+    }),
+  ];
+  let freezeResultIndex: number | null = null;
+  if (externalTargetGate?.freezesBuild) {
+    freezeResultIndex = statements.length;
+    statements.push(externalTargetFreezeStatement(c.env.DB, externalTargetGate, auditId, now));
+  }
+  statements.push(
     c.env.DB
       .prepare(
         `UPDATE releases
-         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+         SET status = 'superseded', superseded_by_release_id = ?1,
+             revision = revision + 1, updated_at = ?2
          WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
            AND release_type = ?6 AND status = 'active' AND id <> ?1
            AND EXISTS (
@@ -1334,22 +1591,41 @@ export async function handlePublishRelease(c: AdminContext) {
         existing.release_type,
         auditId,
       ),
+  );
+  const activationResultIndex = statements.length;
+  statements.push(
     c.env.DB
       .prepare(
          `UPDATE releases
-         SET status = 'active', activated_at = ?1, updated_at = ?1
-         WHERE id = ?2 AND app_id = ?3 AND status = 'draft'
-           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
+         SET status = 'active', activated_at = ?1,
+             revision = revision + 1, updated_at = ?1
+         WHERE id = ?2 AND app_id = ?3 AND status = 'draft' AND revision = ?4
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?5)`,
       )
-      .bind(now, releaseId, appId, auditId),
-  ];
+      .bind(now, releaseId, appId, expectedRevision, auditId),
+  );
   const batchResults = await c.env.DB.batch(statements);
   if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
-      Number(batchResults[2]?.meta?.changes ?? 0) !== 1) {
-    return c.json({
-      error: "release status or scope changed before publish",
-      code: "RELEASE_SCOPE_PRECONDITION_FAILED",
-    }, 409);
+      Number(batchResults[activationResultIndex]?.meta?.changes ?? 0) !== 1 ||
+      (freezeResultIndex !== null && Number(batchResults[freezeResultIndex]?.meta?.changes ?? 0) !== 1)) {
+    const currentRevision = await currentReleaseRevision(c.env.DB, appId, releaseId);
+    if (currentRevision !== expectedRevision) {
+      return releaseRevisionConflictResponse(c, expectedRevision, currentRevision);
+    }
+    const currentScopes = await releaseScopesForMutation(c.env.DB, releaseId);
+    if (!matchesPublishScopeExpectation(currentScopes, expectedScopes)) {
+      return c.json({
+        error: "release status or scope changed before publish",
+        code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+      }, 409);
+    }
+    if (externalTargetGate) {
+      return c.json({
+        error: "external target contract changed before publish",
+        code: "EXTERNAL_TARGETS_CONTRACT_MISMATCH",
+      }, 409);
+    }
+    return releaseRevisionConflictResponse(c, expectedRevision, currentRevision);
   }
 
   const orgId = c.get("org_id");
@@ -1406,46 +1682,78 @@ export async function handleDeleteRelease(c: AdminContext) {
   const releaseId = c.req.param("releaseId") ?? "";
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  let expectedRevision: number;
+  try {
+    expectedRevision = expectedReleaseRevision(
+      c.req.query("expected_revision"),
+      existing.revision,
+    );
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
+  }
+  if (expectedRevision !== existing.revision) {
+    return releaseRevisionConflictResponse(c, expectedRevision, existing.revision);
+  }
   if (existing.status === "cancelled") {
-    return c.json({ ok: true, id: releaseId, status: "cancelled" });
+    return c.json({
+      ok: true,
+      id: releaseId,
+      status: "cancelled",
+      revision: existing.revision,
+    });
   }
   if (existing.status === "superseded") {
     return c.json({ error: "cannot cancel superseded release" }, 409);
   }
   const now = Date.now();
+  const auditId = crypto.randomUUID();
+  const existingScopes = await releaseScopesForMutation(c.env.DB, releaseId);
   const statements: D1PreparedStatement[] = [
+    conditionalReleaseAuditStatement(c.env.DB, {
+      auditId,
+      appId,
+      action: "release.cancel",
+      actor: currentActor(c),
+      payload: {
+        release_id: releaseId,
+        previous_status: existing.status,
+        expected_revision: expectedRevision,
+      },
+      now,
+      release: existing,
+      expectedRevision,
+      expectedScopes: existingScopes,
+    }),
     c.env.DB
       .prepare(
         `UPDATE releases
-         SET status = 'cancelled', superseded_by_release_id = NULL, updated_at = ?1
-         WHERE id = ?2 AND app_id = ?3`,
+         SET status = 'cancelled', superseded_by_release_id = NULL,
+             revision = revision + 1, updated_at = ?1
+         WHERE id = ?2 AND app_id = ?3 AND revision = ?4 AND status = ?5
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?6)`,
       )
-      .bind(now, releaseId, appId),
+      .bind(now, releaseId, appId, expectedRevision, existing.status, auditId),
   ];
   if (existing.status === "active") {
     statements.push(
       c.env.DB.prepare(
         `UPDATE releases
-         SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
-         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
-      ).bind(now, appId, releaseId),
+         SET status = 'active', superseded_by_release_id = NULL,
+             revision = revision + 1, updated_at = ?1
+         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
+      ).bind(now, appId, releaseId, auditId),
     );
   }
-  statements.push(
-    c.env.DB
-      .prepare(
-        "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-      )
-      .bind(
-        crypto.randomUUID(),
-        appId,
-        "release.cancel",
-        currentActor(c),
-        JSON.stringify({ release_id: releaseId, previous_status: existing.status }),
-        now,
-      ),
-  );
-  await c.env.DB.batch(statements);
+  const batchResults = await c.env.DB.batch(statements);
+  if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+      Number(batchResults[1]?.meta?.changes ?? 0) !== 1) {
+    return releaseRevisionConflictResponse(
+      c,
+      expectedRevision,
+      await currentReleaseRevision(c.env.DB, appId, releaseId),
+    );
+  }
   const orgId = c.get("org_id");
   if (orgId && existing.status === "active") {
     c.executionCtx?.waitUntil(
@@ -1457,15 +1765,31 @@ export async function handleDeleteRelease(c: AdminContext) {
       }),
     );
   }
-  return c.json({ ok: true, id: releaseId, status: "cancelled" });
+  return c.json({
+    ok: true,
+    id: releaseId,
+    status: "cancelled",
+    revision: expectedRevision + 1,
+  });
 }
 
 export async function handleRollbackRelease(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
   const releaseId = c.req.param("releaseId") ?? "";
-  const body = (await c.req.json().catch(() => ({}))) as Partial<ReleaseInput>;
+  const body = (await c.req.json().catch(() => ({}))) as Partial<ReleaseInput> & {
+    expected_revision?: unknown;
+  };
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  let expectedRevision: number;
+  try {
+    expectedRevision = expectedReleaseRevision(body.expected_revision, existing.revision);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
+  }
+  if (expectedRevision !== existing.revision) {
+    return releaseRevisionConflictResponse(c, expectedRevision, existing.revision);
+  }
   if (existing.status === "draft") {
     return c.json({ error: "cannot restore a draft; publish the existing release instead" }, 409);
   }
@@ -1473,11 +1797,7 @@ export async function handleRollbackRelease(c: AdminContext) {
     return c.json({ error: "release is already active" }, 409);
   }
 
-  const { results: existingScopes } = await c.env.DB.prepare(
-    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
-  )
-    .bind(releaseId)
-    .all<ReleaseScopeInput>();
+  const existingScopes = await releaseScopesForMutation(c.env.DB, releaseId);
   const requestedBuildId = body.build_id ?? c.req.query("build_id");
   if (requestedBuildId && requestedBuildId !== existing.build_id) {
     return c.json({
@@ -1507,14 +1827,62 @@ export async function handleRollbackRelease(c: AdminContext) {
     validateRolloutCohortCount(rollout);
     const changelog = inputChangelog(body);
     const now = Date.now();
-    const statements: D1PreparedStatement[] = [];
+    const restoresDraft = existing.status === "cancelled" && existing.activated_at === null;
+    const nextStatus = restoresDraft ? "draft" : "active";
+    const auditId = crypto.randomUUID();
+    const statements: D1PreparedStatement[] = [
+      conditionalReleaseAuditStatement(c.env.DB, {
+        auditId,
+        appId,
+        action: "release.rollback",
+        actor: currentActor(c),
+        payload: {
+          release_id: releaseId,
+          build_id: existing.build_id,
+          previous_status: existing.status,
+          next_status: nextStatus,
+          expected_revision: expectedRevision,
+          scopes,
+        },
+        now,
+        release: existing,
+        expectedRevision,
+        expectedScopes: existingScopes,
+      }),
+      c.env.DB.prepare(
+        `UPDATE releases
+         SET status = ?1, activated_at = ?2, is_full = ?3,
+             rollout_cohort_count = ?4, availability_at = ?5,
+             should_force_update = ?6, changelog = ?7, provenance_json = ?8,
+             superseded_by_release_id = NULL, revision = revision + 1, updated_at = ?9
+         WHERE id = ?10 AND app_id = ?11 AND revision = ?12 AND status = ?13
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?14)`,
+      ).bind(
+        nextStatus,
+        restoresDraft ? null : now,
+        isFullRelease(scopes),
+        rollout,
+        body.availability_at !== undefined ? body.availability_at : existing.availability_at,
+        body.should_force_update !== undefined ? (body.should_force_update ? 1 : 0) : existing.should_force_update,
+        changelog === undefined ? existing.changelog : changelog,
+        jsonString(body.provenance_json ?? existing.provenance_json),
+        now,
+        releaseId,
+        appId,
+        expectedRevision,
+        existing.status,
+        auditId,
+      ),
+    ];
 
-    if (isFullCoverage(scopes, rollout)) {
+    if (!restoresDraft && isFullCoverage(scopes, rollout)) {
       statements.push(c.env.DB.prepare(
         `UPDATE releases
-         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+         SET status = 'superseded', superseded_by_release_id = ?1,
+             revision = revision + 1, updated_at = ?2
          WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
-           AND release_type = ?6 AND status = 'active' AND id <> ?1`,
+           AND release_type = ?6 AND status = 'active' AND id <> ?1
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?7)`,
       ).bind(
         releaseId,
         now,
@@ -1522,57 +1890,43 @@ export async function handleRollbackRelease(c: AdminContext) {
         existing.channel_id,
         existing.product_type,
         existing.release_type,
+        auditId,
       ));
-    } else {
+    } else if (!restoresDraft) {
       statements.push(c.env.DB.prepare(
         `UPDATE releases
-         SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
-         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
-      ).bind(now, appId, releaseId));
+         SET status = 'active', superseded_by_release_id = NULL,
+             revision = revision + 1, updated_at = ?1
+         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
+      ).bind(now, appId, releaseId, auditId));
     }
-
-    statements.push(c.env.DB.prepare(
-      `UPDATE releases
-       SET status = 'active', activated_at = ?1, is_full = ?2,
-           rollout_cohort_count = ?3, availability_at = ?4,
-           should_force_update = ?5, changelog = ?6, provenance_json = ?7,
-           superseded_by_release_id = NULL, updated_at = ?1
-       WHERE id = ?8 AND app_id = ?9`,
-    ).bind(
-      now,
-      isFullRelease(scopes),
-      rollout,
-      body.availability_at !== undefined ? body.availability_at : existing.availability_at,
-      body.should_force_update !== undefined ? (body.should_force_update ? 1 : 0) : existing.should_force_update,
-      changelog === undefined ? existing.changelog : changelog,
-      jsonString(body.provenance_json ?? existing.provenance_json),
-      releaseId,
-      appId,
-    ));
 
     if (body.scopes !== undefined) {
       statements.push(
-        c.env.DB.prepare("DELETE FROM release_scopes WHERE release_id = ?1").bind(releaseId),
+        c.env.DB.prepare(
+          `DELETE FROM release_scopes
+           WHERE release_id = ?1 AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?2)`,
+        ).bind(releaseId, auditId),
         ...scopes.map((scope) => c.env.DB.prepare(
-          "INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-        ).bind(crypto.randomUUID(), releaseId, scope.scope_type, scope.scope_value, now)),
+          `INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+           SELECT ?1, ?2, ?3, ?4, ?5
+           WHERE EXISTS (SELECT 1 FROM audit_logs WHERE id = ?6)`,
+        ).bind(crypto.randomUUID(), releaseId, scope.scope_type, scope.scope_value, now, auditId)),
+      );
+    }
+    const batchResults = await c.env.DB.batch(statements);
+    if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+        Number(batchResults[1]?.meta?.changes ?? 0) !== 1) {
+      return releaseRevisionConflictResponse(
+        c,
+        expectedRevision,
+        await currentReleaseRevision(c.env.DB, appId, releaseId),
       );
     }
 
-    statements.push(c.env.DB.prepare(
-      "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-    ).bind(
-      crypto.randomUUID(),
-      appId,
-      "release.rollback",
-      currentActor(c),
-      JSON.stringify({ release_id: releaseId, build_id: existing.build_id, previous_status: existing.status, scopes }),
-      now,
-    ));
-    await c.env.DB.batch(statements);
-
     const orgId = c.get("org_id");
-    if (orgId) {
+    if (orgId && !restoresDraft) {
       c.executionCtx?.waitUntil(
         emitWebhookEvent(c.env.DB, {
           orgId,
@@ -1583,8 +1937,15 @@ export async function handleRollbackRelease(c: AdminContext) {
       );
     }
     const release = await getReleaseForApp(c.env.DB, appId, releaseId);
-    return c.json(release ? { ...withReleaseNotes(release), reactivated: true } : release);
+    return c.json(release ? {
+      ...withReleaseNotes(release),
+      restored_to_draft: restoresDraft,
+      reactivated: !restoresDraft,
+    } : release);
   } catch (e) {
+    if (e instanceof ReleaseRevisionConflictError) {
+      return releaseRevisionConflictResponse(c, e.expectedRevision, e.currentRevision);
+    }
     return c.json({ error: (e as Error).message }, 400);
   }
 }
@@ -1596,9 +1957,19 @@ export async function handleBumpRollout(c: AdminContext) {
     to?: number;
     by?: number;
     delta?: number;
+    expected_revision?: unknown;
   };
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  let expectedRevision: number;
+  try {
+    expectedRevision = expectedReleaseRevision(body.expected_revision, existing.revision);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
+  }
+  if (expectedRevision !== existing.revision) {
+    return releaseRevisionConflictResponse(c, expectedRevision, existing.revision);
+  }
   if (existing.status !== "draft" && existing.status !== "active") {
     return c.json({ error: `cannot change rollout on ${existing.status} release` }, 409);
   }
@@ -1612,21 +1983,41 @@ export async function handleBumpRollout(c: AdminContext) {
     return c.json({ error: (error as Error).message }, 400);
   }
   const now = Date.now();
-  const { results: scopes } = await c.env.DB.prepare(
-    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
-  ).bind(releaseId).all<ReleaseScopeInput>();
+  const scopes = await releaseScopesForMutation(c.env.DB, releaseId);
+  const auditId = crypto.randomUUID();
   const statements: D1PreparedStatement[] = [
+    conditionalReleaseAuditStatement(c.env.DB, {
+      auditId,
+      appId,
+      action: "release.bump_rollout",
+      actor: currentActor(c),
+      payload: {
+        release_id: releaseId,
+        previous: existing.rollout_cohort_count,
+        next,
+        expected_revision: expectedRevision,
+      },
+      now,
+      release: existing,
+      expectedRevision,
+      expectedScopes: scopes,
+    }),
     c.env.DB.prepare(
-      "UPDATE releases SET rollout_cohort_count = ?1, updated_at = ?2 WHERE id = ?3 AND app_id = ?4",
-    ).bind(next, now, releaseId, appId),
+      `UPDATE releases
+       SET rollout_cohort_count = ?1, revision = revision + 1, updated_at = ?2
+       WHERE id = ?3 AND app_id = ?4 AND revision = ?5 AND status = ?6
+         AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?7)`,
+    ).bind(next, now, releaseId, appId, expectedRevision, existing.status, auditId),
   ];
   if (existing.status === "active") {
     if (isFullCoverage(scopes, next)) {
       statements.push(c.env.DB.prepare(
         `UPDATE releases
-         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+         SET status = 'superseded', superseded_by_release_id = ?1,
+             revision = revision + 1, updated_at = ?2
          WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
-           AND release_type = ?6 AND status = 'active' AND id <> ?1`,
+           AND release_type = ?6 AND status = 'active' AND id <> ?1
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?7)`,
       ).bind(
         releaseId,
         now,
@@ -1634,27 +2025,32 @@ export async function handleBumpRollout(c: AdminContext) {
         existing.channel_id,
         existing.product_type,
         existing.release_type,
+        auditId,
       ));
     } else {
       statements.push(c.env.DB.prepare(
         `UPDATE releases
-         SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
-         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
-      ).bind(now, appId, releaseId));
+         SET status = 'active', superseded_by_release_id = NULL,
+             revision = revision + 1, updated_at = ?1
+         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
+      ).bind(now, appId, releaseId, auditId));
     }
   }
-  statements.push(c.env.DB.prepare(
-    "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-  ).bind(
-    crypto.randomUUID(),
-    appId,
-    "release.bump_rollout",
-    currentActor(c),
-    JSON.stringify({ release_id: releaseId, previous: existing.rollout_cohort_count, next }),
-    now,
-  ));
-  await c.env.DB.batch(statements);
-  return c.json({ ok: true, rollout_cohort_count: next });
+  const batchResults = await c.env.DB.batch(statements);
+  if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+      Number(batchResults[1]?.meta?.changes ?? 0) !== 1) {
+    return releaseRevisionConflictResponse(
+      c,
+      expectedRevision,
+      await currentReleaseRevision(c.env.DB, appId, releaseId),
+    );
+  }
+  return c.json({
+    ok: true,
+    rollout_cohort_count: next,
+    revision: expectedRevision + 1,
+  });
 }
 
 export async function handleForceUpdate(c: AdminContext) {
@@ -1663,9 +2059,19 @@ export async function handleForceUpdate(c: AdminContext) {
   const body = (await c.req.json().catch(() => ({}))) as {
     enabled?: boolean;
     should_force_update?: boolean;
+    expected_revision?: unknown;
   };
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  let expectedRevision: number;
+  try {
+    expectedRevision = expectedReleaseRevision(body.expected_revision, existing.revision);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
+  }
+  if (expectedRevision !== existing.revision) {
+    return releaseRevisionConflictResponse(c, expectedRevision, existing.revision);
+  }
   const next =
     body.should_force_update !== undefined
       ? body.should_force_update
@@ -1673,14 +2079,50 @@ export async function handleForceUpdate(c: AdminContext) {
         ? body.enabled
         : !Boolean(existing.should_force_update);
   const now = Date.now();
-  await c.env.DB.prepare(
-    "UPDATE releases SET should_force_update = ?1, updated_at = ?2 WHERE id = ?3 AND app_id = ?4",
-  )
-    .bind(next ? 1 : 0, now, releaseId, appId)
-    .run();
-  await insertAuditLog(c.env.DB, appId, "release.force_update", currentActor(c), {
-    release_id: releaseId,
+  const auditId = crypto.randomUUID();
+  const scopes = await releaseScopesForMutation(c.env.DB, releaseId);
+  const batchResults = await c.env.DB.batch([
+    conditionalReleaseAuditStatement(c.env.DB, {
+      auditId,
+      appId,
+      action: "release.force_update",
+      actor: currentActor(c),
+      payload: {
+        release_id: releaseId,
+        should_force_update: next,
+        expected_revision: expectedRevision,
+      },
+      now,
+      release: existing,
+      expectedRevision,
+      expectedScopes: scopes,
+    }),
+    c.env.DB.prepare(
+      `UPDATE releases
+       SET should_force_update = ?1, revision = revision + 1, updated_at = ?2
+       WHERE id = ?3 AND app_id = ?4 AND revision = ?5 AND status = ?6
+         AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?7)`,
+    ).bind(
+      next ? 1 : 0,
+      now,
+      releaseId,
+      appId,
+      expectedRevision,
+      existing.status,
+      auditId,
+    ),
+  ]);
+  if (Number(batchResults[0]?.meta?.changes ?? 0) !== 1 ||
+      Number(batchResults[1]?.meta?.changes ?? 0) !== 1) {
+    return releaseRevisionConflictResponse(
+      c,
+      expectedRevision,
+      await currentReleaseRevision(c.env.DB, appId, releaseId),
+    );
+  }
+  return c.json({
+    ok: true,
     should_force_update: next,
-  }, now);
-  return c.json({ ok: true, should_force_update: next });
+    revision: expectedRevision + 1,
+  });
 }

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -15,6 +15,25 @@ type ReleaseScopeInput = {
   scope_value: string;
 };
 
+type ReleaseVersionIdentity = {
+  id: string;
+  build_id: string;
+  status: string;
+  version_name: string;
+  version_code: number;
+};
+
+export class ReleaseVersionAlreadyExistsError extends Error {
+  readonly code = "RELEASE_VERSION_ALREADY_EXISTS";
+
+  constructor(readonly existing: ReleaseVersionIdentity) {
+    super(
+      `release version ${existing.version_name} (${existing.version_code}) already exists as ${existing.id}`,
+    );
+    this.name = "ReleaseVersionAlreadyExistsError";
+  }
+}
+
 const RELEASE_SCOPE_TYPES = new Set(["full", "platform", "user_cohort", "ip_range", "device_group"]);
 
 export interface ReleaseInput {
@@ -56,6 +75,7 @@ interface ReleaseRow {
   product_type: string;
   release_type: string;
   status: string;
+  activated_at: number | null;
   is_full: number;
   superseded_by_release_id: string | null;
   rollout_cohort_count: number | null;
@@ -82,7 +102,7 @@ function normalizeScopes(scopes: ReleaseScopeInput[] | undefined): ReleaseScopeI
   if (!Array.isArray(scopes) || scopes.length === 0) {
     throw new Error("release scopes must be a non-empty array when provided");
   }
-  return scopes.map((scope, index) => {
+  const normalized = scopes.map((scope, index) => {
     if (!scope || typeof scope !== "object") {
       throw new Error(`release scope at index ${index} must be an object`);
     }
@@ -93,18 +113,36 @@ function normalizeScopes(scopes: ReleaseScopeInput[] | undefined): ReleaseScopeI
     }
     return { scope_type: scopeType, scope_value: scopeValue };
   });
+
+  const seen = new Set<string>();
+  for (const scope of normalized) {
+    const key = `${scope.scope_type}\u0000${scope.scope_value}`;
+    if (seen.has(key)) {
+      throw new Error(`duplicate release scope: ${scope.scope_type}:${scope.scope_value}`);
+    }
+    seen.add(key);
+  }
+  return normalized.sort((left, right) => {
+    const leftRank = left.scope_type === "full" ? 0 : left.scope_type === "device_group" ? 1 : 2;
+    const rightRank = right.scope_type === "full" ? 0 : right.scope_type === "device_group" ? 1 : 2;
+    return leftRank - rightRank || left.scope_type.localeCompare(right.scope_type) || left.scope_value.localeCompare(right.scope_value);
+  });
 }
 
 function matchesPublishScopeExpectation(
   scopes: ReleaseScopeInput[],
-  expectedScope: ReleaseScopeInput | null,
+  expectedScopes: ReleaseScopeInput[],
 ): boolean {
-  if (scopes.length !== 1) return false;
-  const scope = scopes[0];
-  if (expectedScope !== null) {
-    return scope?.scope_type === expectedScope.scope_type && scope.scope_value === expectedScope.scope_value;
+  let actual: ReleaseScopeInput[];
+  try {
+    actual = normalizeScopes(scopes);
+  } catch {
+    return false;
   }
-  return scope?.scope_type === "full" && scope.scope_value === "all";
+  return actual.length === expectedScopes.length && actual.every((scope, index) =>
+    scope.scope_type === expectedScopes[index]?.scope_type &&
+    scope.scope_value === expectedScopes[index]?.scope_value
+  );
 }
 
 function parseExpectedPublishScope(raw: unknown): ReleaseScopeInput | null {
@@ -117,18 +155,45 @@ function parseExpectedPublishScope(raw: unknown): ReleaseScopeInput | null {
   return { scope_type: scopeType, scope_value: scopeValue };
 }
 
+function validateScopeCombination(scopes: ReleaseScopeInput[]): void {
+  const fullScopes = scopes.filter(
+    (scope) => scope.scope_type === "full" && scope.scope_value === "all",
+  );
+  if (fullScopes.length > 1) {
+    throw new Error("release scopes may contain full:all only once");
+  }
+  if (fullScopes.length === 1) {
+    const incompatible = scopes.find(
+      (scope) => scope.scope_type !== "full" && scope.scope_type !== "device_group",
+    );
+    if (incompatible) {
+      throw new Error("full:all may be combined only with device_group scopes");
+    }
+  }
+}
+
+function parseExpectedPublishScopes(raw: unknown): ReleaseScopeInput[] | null {
+  if (!Array.isArray(raw) || raw.length === 0) return null;
+  try {
+    const scopes = normalizeScopes(raw as ReleaseScopeInput[]);
+    for (const scope of scopes) {
+      if (!RELEASE_SCOPE_TYPES.has(scope.scope_type)) return null;
+      if (scope.scope_type === "full" && scope.scope_value !== "all") return null;
+    }
+    validateScopeCombination(scopes);
+    return scopes;
+  } catch {
+    return null;
+  }
+}
+
 async function validateScopes(
   db: D1Database,
   appId: string,
   scopes: ReleaseScopeInput[] | undefined,
 ): Promise<ReleaseScopeInput[]> {
   const normalized = normalizeScopes(scopes);
-  const fullScopes = normalized.filter(
-    (scope) => scope.scope_type === "full" && scope.scope_value === "all",
-  );
-  if (fullScopes.length > 0 && normalized.length > 1) {
-    throw new Error("full release scope cannot be combined with other scopes");
-  }
+  validateScopeCombination(normalized);
   for (const scope of normalized) {
     if (!RELEASE_SCOPE_TYPES.has(scope.scope_type)) {
       throw new Error(`unsupported release scope type: ${scope.scope_type}`);
@@ -147,20 +212,21 @@ async function validateScopes(
 }
 
 function isFullRelease(scopes: ReleaseScopeInput[]): number {
-  const onlyScope = scopes[0];
-  return scopes.length === 1 &&
-    onlyScope?.scope_type === "full" &&
-    onlyScope.scope_value === "all"
-    ? 1
-    : 0;
+  return scopes.some((scope) => scope.scope_type === "full" && scope.scope_value === "all") ? 1 : 0;
 }
 
 function isFullCoverage(scopes: ReleaseScopeInput[], rolloutCohortCount: number | null | undefined): boolean {
-  // Treat legacy/malformed mixed rows containing full:all as full coverage so
-  // publish never restores or preserves fallbacks for a release that already
-  // matches every client. validateScopes rejects creating new mixed sets.
+  // A full scope may carry mandatory device-group overrides. It becomes full
+  // coverage only when the percentage gate is also fully open.
   return scopes.some((scope) => scope.scope_type === "full" && scope.scope_value === "all") &&
     (rolloutCohortCount === null || rolloutCohortCount === undefined || rolloutCohortCount >= 100);
+}
+
+function validateRolloutCohortCount(value: number | null | undefined): void {
+  if (value === null || value === undefined) return;
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new Error("rollout_cohort_count must be an integer from 0 to 100");
+  }
 }
 
 async function insertAuditLog(
@@ -215,6 +281,39 @@ export async function getReleaseForApp(
     .first<ReleaseRow>();
 }
 
+async function findReleaseForVersionIdentity(
+  db: D1Database,
+  appId: string,
+  channelId: string,
+  productType: string,
+  releaseType: string,
+  versionCode: number,
+): Promise<ReleaseVersionIdentity | null> {
+  return await db.prepare(
+    `SELECT r.id, r.build_id, r.status, b.version_name, b.version_code
+     FROM releases r
+     JOIN builds b ON b.id = r.build_id
+     WHERE r.app_id = ?1 AND r.channel_id = ?2 AND r.product_type = ?3
+       AND r.release_type = ?4 AND b.version_code = ?5
+     ORDER BY CASE r.status
+       WHEN 'active' THEN 0 WHEN 'draft' THEN 1 WHEN 'superseded' THEN 2 ELSE 3
+     END, r.created_at ASC, r.id ASC
+     LIMIT 1`,
+  ).bind(appId, channelId, productType, releaseType, versionCode).first<ReleaseVersionIdentity>();
+}
+
+function releaseVersionConflictResponse(c: AdminContext, error: ReleaseVersionAlreadyExistsError) {
+  return c.json({
+    error: error.message,
+    code: error.code,
+    release_id: error.existing.id,
+    build_id: error.existing.build_id,
+    release_status: error.existing.status,
+    version_name: error.existing.version_name,
+    version_code: error.existing.version_code,
+  }, 409);
+}
+
 export async function createRelease(
   db: D1Database,
   appId: string,
@@ -241,6 +340,16 @@ export async function createRelease(
   const releaseType = input.release_type ?? build.release_type;
   const status = releaseStatus(input.status);
   const scopes = await validateScopes(db, appId, input.scopes);
+  validateRolloutCohortCount(input.rollout_cohort_count);
+  const existingVersion = await findReleaseForVersionIdentity(
+    db,
+    appId,
+    channelId,
+    productType,
+    releaseType,
+    build.version_code,
+  );
+  if (existingVersion) throw new ReleaseVersionAlreadyExistsError(existingVersion);
   const now = Date.now();
   const changelog = inputChangelog(input);
 
@@ -249,10 +358,10 @@ export async function createRelease(
       .prepare(
         `INSERT INTO releases
          (id, app_id, build_id, channel_id, product_type, release_type, status,
-          is_full, rollout_cohort_count, rollout_target_cohorts_json,
+          activated_at, is_full, rollout_cohort_count, rollout_target_cohorts_json,
           availability_at, should_force_update, changelog, provenance_json,
           created_by, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)`,
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)`,
       )
       .bind(
         id,
@@ -262,6 +371,7 @@ export async function createRelease(
         productType,
         releaseType,
         status,
+        status === "active" ? now : null,
         isFullRelease(scopes),
         input.rollout_cohort_count ?? null,
         jsonString(input.rollout_target_cohorts_json, []),
@@ -307,7 +417,22 @@ export async function createRelease(
     );
   }
 
-  await db.batch(statements);
+  try {
+    await db.batch(statements);
+  } catch (error) {
+    if ((error as Error).message.includes("release version already exists")) {
+      const conflict = await findReleaseForVersionIdentity(
+        db,
+        appId,
+        channelId,
+        productType,
+        releaseType,
+        build.version_code,
+      );
+      if (conflict) throw new ReleaseVersionAlreadyExistsError(conflict);
+    }
+    throw error;
+  }
   return id;
 }
 
@@ -352,9 +477,7 @@ async function updateReleaseFields(
   }
   if (input.rollout_cohort_count !== undefined) {
     const next = input.rollout_cohort_count;
-    if (next !== null && (!Number.isFinite(next) || next < 0)) {
-      throw new Error("rollout_cohort_count must be a non-negative number");
-    }
+    validateRolloutCohortCount(next);
     sets.push(`rollout_cohort_count = ?${binds.length + 1}`);
     binds.push(next);
   }
@@ -877,6 +1000,9 @@ export async function handleCreateReleaseDraft(c: AdminContext) {
       201,
     );
   } catch (e) {
+    if (e instanceof ReleaseVersionAlreadyExistsError) {
+      return releaseVersionConflictResponse(c, e);
+    }
     return c.json({ error: (e as Error).message }, 400);
   }
 }
@@ -912,6 +1038,9 @@ export async function handleCreateRelease(c: AdminContext) {
       release_notes: parseReleaseNotes(changelog),
     }, 201);
   } catch (e) {
+    if (e instanceof ReleaseVersionAlreadyExistsError) {
+      return releaseVersionConflictResponse(c, e);
+    }
     return c.json({ error: (e as Error).message }, 400);
   }
 }
@@ -1083,29 +1212,51 @@ export async function handlePublishRelease(c: AdminContext) {
   const publishBody = (await c.req.json().catch(() => ({}))) as {
     required_external_targets?: unknown;
     expected_scope?: unknown;
+    expected_scopes?: unknown;
   };
   const gateFail = await assertExternalTargetGate(c, existing, publishBody.required_external_targets);
   if (gateFail) return gateFail;
 
-  let expectedScope: ReleaseScopeInput | null = null;
-  if (Object.prototype.hasOwnProperty.call(publishBody, "expected_scope")) {
-    expectedScope = parseExpectedPublishScope(publishBody.expected_scope);
-    if (!expectedScope) {
+  const hasExpectedScope = Object.prototype.hasOwnProperty.call(publishBody, "expected_scope");
+  const hasExpectedScopes = Object.prototype.hasOwnProperty.call(publishBody, "expected_scopes");
+  if (hasExpectedScope && hasExpectedScopes) {
+    return c.json({
+      error: "provide expected_scope or expected_scopes, not both",
+      code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+    }, 409);
+  }
+
+  let expectedScopes: ReleaseScopeInput[];
+  if (hasExpectedScopes) {
+    const parsed = parseExpectedPublishScopes(publishBody.expected_scopes);
+    if (!parsed) {
+      return c.json({
+        error: "expected_scopes must be a valid non-empty exact release scope set",
+        code: "RELEASE_SCOPE_PRECONDITION_FAILED",
+      }, 409);
+    }
+    expectedScopes = parsed;
+  } else if (hasExpectedScope) {
+    const parsed = parseExpectedPublishScope(publishBody.expected_scope);
+    if (!parsed) {
       return c.json({
         error: "expected_scope must contain a supported non-empty scope_type and scope_value",
         code: "RELEASE_SCOPE_PRECONDITION_FAILED",
       }, 409);
     }
+    expectedScopes = [parsed];
+  } else {
+    expectedScopes = [{ scope_type: "full", scope_value: "all" }];
   }
 
   const { results: releaseScopes } = await c.env.DB.prepare(
     "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
   ).bind(releaseId).all<ReleaseScopeInput>();
-  if (!matchesPublishScopeExpectation(releaseScopes, expectedScope)) {
+  if (!matchesPublishScopeExpectation(releaseScopes, expectedScopes)) {
     return c.json({
-      error: expectedScope === null
-        ? "publish without an expected_scope precondition requires exactly one full:all scope"
-        : "release scope does not exactly match expected_scope",
+      error: hasExpectedScope || hasExpectedScopes
+        ? "release scope set does not exactly match the publish precondition"
+        : "publish without a scope precondition requires exactly one full:all scope",
       code: "RELEASE_SCOPE_PRECONDITION_FAILED",
     }, 409);
   }
@@ -1119,7 +1270,18 @@ export async function handlePublishRelease(c: AdminContext) {
   const auditPayload = JSON.stringify({
     release_id: releaseId,
     build_id: existing.build_id,
-    expected_scope: expectedScope,
+    expected_scopes: expectedScopes,
+  });
+
+  const scopeAssertionBinds: string[] = [];
+  const scopeAssertions = expectedScopes.map((scope, index) => {
+    const typePosition = 8 + index * 2;
+    const valuePosition = typePosition + 1;
+    scopeAssertionBinds.push(scope.scope_type, scope.scope_value);
+    return `EXISTS (
+      SELECT 1 FROM release_scopes s
+      WHERE s.release_id = r.id AND s.scope_type = ?${typePosition} AND s.scope_value = ?${valuePosition}
+    )`;
   });
 
   // D1 batch is transactional. Every side effect is gated by the conditional
@@ -1133,21 +1295,8 @@ export async function handlePublishRelease(c: AdminContext) {
          SELECT ?1, ?2, 'release.publish', ?3, ?4, ?5
          FROM releases r
          WHERE r.id = ?6 AND r.app_id = ?2 AND r.status = 'draft'
-           AND (
-             (?7 IS NULL AND ?8 IS NULL
-               AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = 1
-               AND EXISTS (
-                 SELECT 1 FROM release_scopes s
-                 WHERE s.release_id = r.id AND s.scope_type = 'full' AND s.scope_value = 'all'
-               ))
-             OR
-             (?7 IS NOT NULL AND ?8 IS NOT NULL
-               AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = 1
-               AND EXISTS (
-                 SELECT 1 FROM release_scopes s
-                 WHERE s.release_id = r.id AND s.scope_type = ?7 AND s.scope_value = ?8
-               ))
-           )`,
+           AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = r.id) = ?7
+           AND ${scopeAssertions.join(" AND ")}`,
       )
       .bind(
         auditId,
@@ -1156,8 +1305,8 @@ export async function handlePublishRelease(c: AdminContext) {
         auditPayload,
         now,
         releaseId,
-        expectedScope?.scope_type ?? null,
-        expectedScope?.scope_value ?? null,
+        expectedScopes.length,
+        ...scopeAssertionBinds,
       ),
     c.env.DB
       .prepare(
@@ -1169,7 +1318,6 @@ export async function handlePublishRelease(c: AdminContext) {
              SELECT 1 FROM releases next
              WHERE next.id = ?1 AND next.app_id = ?3 AND next.status = 'draft'
                AND (next.rollout_cohort_count IS NULL OR next.rollout_cohort_count >= 100)
-               AND (SELECT COUNT(*) FROM release_scopes s WHERE s.release_id = next.id) = 1
                AND EXISTS (
                  SELECT 1 FROM release_scopes s
                  WHERE s.release_id = next.id AND s.scope_type = 'full' AND s.scope_value = 'all'
@@ -1188,8 +1336,8 @@ export async function handlePublishRelease(c: AdminContext) {
       ),
     c.env.DB
       .prepare(
-        `UPDATE releases
-         SET status = 'active', updated_at = ?1
+         `UPDATE releases
+         SET status = 'active', activated_at = ?1, updated_at = ?1
          WHERE id = ?2 AND app_id = ?3 AND status = 'draft'
            AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?4)`,
       )
@@ -1265,7 +1413,7 @@ export async function handleDeleteRelease(c: AdminContext) {
     return c.json({ error: "cannot cancel superseded release" }, 409);
   }
   const now = Date.now();
-  await c.env.DB.batch([
+  const statements: D1PreparedStatement[] = [
     c.env.DB
       .prepare(
         `UPDATE releases
@@ -1273,6 +1421,17 @@ export async function handleDeleteRelease(c: AdminContext) {
          WHERE id = ?2 AND app_id = ?3`,
       )
       .bind(now, releaseId, appId),
+  ];
+  if (existing.status === "active") {
+    statements.push(
+      c.env.DB.prepare(
+        `UPDATE releases
+         SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
+         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
+      ).bind(now, appId, releaseId),
+    );
+  }
+  statements.push(
     c.env.DB
       .prepare(
         "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -1285,7 +1444,8 @@ export async function handleDeleteRelease(c: AdminContext) {
         JSON.stringify({ release_id: releaseId, previous_status: existing.status }),
         now,
       ),
-  ]);
+  );
+  await c.env.DB.batch(statements);
   const orgId = c.get("org_id");
   if (orgId && existing.status === "active") {
     c.executionCtx?.waitUntil(
@@ -1306,37 +1466,111 @@ export async function handleRollbackRelease(c: AdminContext) {
   const body = (await c.req.json().catch(() => ({}))) as Partial<ReleaseInput>;
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  if (existing.status === "draft") {
+    return c.json({ error: "cannot restore a draft; publish the existing release instead" }, 409);
+  }
+  if (existing.status === "active") {
+    return c.json({ error: "release is already active" }, 409);
+  }
 
   const { results: existingScopes } = await c.env.DB.prepare(
-    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at ASC",
+    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
   )
     .bind(releaseId)
     .all<ReleaseScopeInput>();
-  const buildId = body.build_id ?? c.req.query("build_id") ?? existing.build_id;
-  const rollbackChangelog = inputChangelog(body);
+  const requestedBuildId = body.build_id ?? c.req.query("build_id");
+  if (requestedBuildId && requestedBuildId !== existing.build_id) {
+    return c.json({
+      error: "rollback reactivates one existing release; address the release for the requested build instead",
+      code: "ROLLBACK_RELEASE_ID_REQUIRED",
+      release_id: releaseId,
+      build_id: existing.build_id,
+    }, 409);
+  }
+  for (const [field, requested, stored] of [
+    ["channel_id", body.channel_id, existing.channel_id],
+    ["product_type", body.product_type, existing.product_type],
+    ["release_type", body.release_type, existing.release_type],
+  ] as const) {
+    if (requested !== undefined && requested !== stored) {
+      return c.json({ error: `rollback cannot change ${field} on an existing release` }, 400);
+    }
+  }
+
   try {
-    const id = await createRelease(
-      c.env.DB,
+    const scopes = body.scopes !== undefined
+      ? await validateScopes(c.env.DB, appId, body.scopes)
+      : normalizeScopes(existingScopes);
+    const rollout = body.rollout_cohort_count !== undefined
+      ? body.rollout_cohort_count
+      : existing.rollout_cohort_count;
+    validateRolloutCohortCount(rollout);
+    const changelog = inputChangelog(body);
+    const now = Date.now();
+    const statements: D1PreparedStatement[] = [];
+
+    if (isFullCoverage(scopes, rollout)) {
+      statements.push(c.env.DB.prepare(
+        `UPDATE releases
+         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+         WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
+           AND release_type = ?6 AND status = 'active' AND id <> ?1`,
+      ).bind(
+        releaseId,
+        now,
+        appId,
+        existing.channel_id,
+        existing.product_type,
+        existing.release_type,
+      ));
+    } else {
+      statements.push(c.env.DB.prepare(
+        `UPDATE releases
+         SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
+         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
+      ).bind(now, appId, releaseId));
+    }
+
+    statements.push(c.env.DB.prepare(
+      `UPDATE releases
+       SET status = 'active', activated_at = ?1, is_full = ?2,
+           rollout_cohort_count = ?3, availability_at = ?4,
+           should_force_update = ?5, changelog = ?6, provenance_json = ?7,
+           superseded_by_release_id = NULL, updated_at = ?1
+       WHERE id = ?8 AND app_id = ?9`,
+    ).bind(
+      now,
+      isFullRelease(scopes),
+      rollout,
+      body.availability_at !== undefined ? body.availability_at : existing.availability_at,
+      body.should_force_update !== undefined ? (body.should_force_update ? 1 : 0) : existing.should_force_update,
+      changelog === undefined ? existing.changelog : changelog,
+      jsonString(body.provenance_json ?? existing.provenance_json),
+      releaseId,
       appId,
-      {
-        build_id: buildId,
-        channel_id: body.channel_id ?? existing.channel_id,
-        product_type: body.product_type ?? existing.product_type,
-        release_type: body.release_type ?? existing.release_type,
-        changelog: rollbackChangelog === undefined ? existing.changelog : rollbackChangelog,
-        should_force_update: body.should_force_update ?? Boolean(existing.should_force_update),
-        rollout_cohort_count: body.rollout_cohort_count ?? existing.rollout_cohort_count,
-        availability_at: body.availability_at ?? existing.availability_at,
-        provenance_json: body.provenance_json ?? existing.provenance_json,
-        scopes: body.scopes ?? existingScopes,
-      },
+    ));
+
+    if (body.scopes !== undefined) {
+      statements.push(
+        c.env.DB.prepare("DELETE FROM release_scopes WHERE release_id = ?1").bind(releaseId),
+        ...scopes.map((scope) => c.env.DB.prepare(
+          "INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        ).bind(crypto.randomUUID(), releaseId, scope.scope_type, scope.scope_value, now)),
+      );
+    }
+
+    statements.push(c.env.DB.prepare(
+      "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    ).bind(
+      crypto.randomUUID(),
+      appId,
+      "release.rollback",
       currentActor(c),
-    );
-    await insertAuditLog(c.env.DB, appId, "release.rollback", currentActor(c), {
-      from_release_id: releaseId,
-      new_release_id: id,
-      build_id: buildId,
-    });
+      JSON.stringify({ release_id: releaseId, build_id: existing.build_id, previous_status: existing.status, scopes }),
+      now,
+    ));
+    await c.env.DB.batch(statements);
+
     const orgId = c.get("org_id");
     if (orgId) {
       c.executionCtx?.waitUntil(
@@ -1344,18 +1578,12 @@ export async function handleRollbackRelease(c: AdminContext) {
           orgId,
           appId,
           event: "release:rolled_back",
-          body: { release_id: id, app_id: appId, rolled_back_from: releaseId, build_id: buildId },
+          body: { release_id: releaseId, app_id: appId, reactivated: true, build_id: existing.build_id },
         }),
       );
     }
-    const release = await getReleaseForApp(c.env.DB, appId, id);
-    return c.json({
-      id,
-      app_id: appId,
-      build_id: buildId,
-      rolled_back_from: releaseId,
-      release_notes: parseReleaseNotes(release?.changelog ?? null),
-    }, 201);
+    const release = await getReleaseForApp(c.env.DB, appId, releaseId);
+    return c.json(release ? { ...withReleaseNotes(release), reactivated: true } : release);
   } catch (e) {
     return c.json({ error: (e as Error).message }, 400);
   }
@@ -1371,24 +1599,61 @@ export async function handleBumpRollout(c: AdminContext) {
   };
   const existing = await getReleaseForApp(c.env.DB, appId, releaseId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  if (existing.status !== "draft" && existing.status !== "active") {
+    return c.json({ error: `cannot change rollout on ${existing.status} release` }, 409);
+  }
   const next =
     body.to !== undefined
       ? Number(body.to)
       : (existing.rollout_cohort_count ?? 0) + Number(body.by ?? body.delta ?? 0);
-  if (!Number.isFinite(next) || next < 0) {
-    return c.json({ error: "rollout_cohort_count must be a non-negative number" }, 400);
+  try {
+    validateRolloutCohortCount(next);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 400);
   }
   const now = Date.now();
-  await c.env.DB.prepare(
-    "UPDATE releases SET rollout_cohort_count = ?1, updated_at = ?2 WHERE id = ?3 AND app_id = ?4",
-  )
-    .bind(next, now, releaseId, appId)
-    .run();
-  await insertAuditLog(c.env.DB, appId, "release.bump_rollout", currentActor(c), {
-    release_id: releaseId,
-    previous: existing.rollout_cohort_count,
-    next,
-  }, now);
+  const { results: scopes } = await c.env.DB.prepare(
+    "SELECT scope_type, scope_value FROM release_scopes WHERE release_id = ?1 ORDER BY created_at, id",
+  ).bind(releaseId).all<ReleaseScopeInput>();
+  const statements: D1PreparedStatement[] = [
+    c.env.DB.prepare(
+      "UPDATE releases SET rollout_cohort_count = ?1, updated_at = ?2 WHERE id = ?3 AND app_id = ?4",
+    ).bind(next, now, releaseId, appId),
+  ];
+  if (existing.status === "active") {
+    if (isFullCoverage(scopes, next)) {
+      statements.push(c.env.DB.prepare(
+        `UPDATE releases
+         SET status = 'superseded', superseded_by_release_id = ?1, updated_at = ?2
+         WHERE app_id = ?3 AND channel_id = ?4 AND product_type = ?5
+           AND release_type = ?6 AND status = 'active' AND id <> ?1`,
+      ).bind(
+        releaseId,
+        now,
+        appId,
+        existing.channel_id,
+        existing.product_type,
+        existing.release_type,
+      ));
+    } else {
+      statements.push(c.env.DB.prepare(
+        `UPDATE releases
+         SET status = 'active', superseded_by_release_id = NULL, updated_at = ?1
+         WHERE app_id = ?2 AND superseded_by_release_id = ?3 AND status = 'superseded'`,
+      ).bind(now, appId, releaseId));
+    }
+  }
+  statements.push(c.env.DB.prepare(
+    "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+  ).bind(
+    crypto.randomUUID(),
+    appId,
+    "release.bump_rollout",
+    currentActor(c),
+    JSON.stringify({ release_id: releaseId, previous: existing.rollout_cohort_count, next }),
+    now,
+  ));
+  await c.env.DB.batch(statements);
   return c.json({ ok: true, rollout_cohort_count: next });
 }
 

--- a/worker/src/routes/tauri.ts
+++ b/worker/src/routes/tauri.ts
@@ -98,8 +98,9 @@ async function findActiveRelease(db: D1Database, slug: string, channel: string):
      JOIN builds b ON b.id = r.build_id
      WHERE a.slug = ?1 AND ch.slug = ?2 AND r.product_type = ?3
        AND r.status = 'active' AND r.is_full = 1
+       AND (r.rollout_cohort_count IS NULL OR r.rollout_cohort_count >= 100)
        AND (r.availability_at IS NULL OR r.availability_at <= ?4)
-     ORDER BY r.created_at DESC, r.id ASC LIMIT 1`,
+     ORDER BY COALESCE(r.activated_at, r.created_at) DESC, r.id ASC LIMIT 1`,
   ).bind(slug, channel, PRODUCT_TYPE, Date.now()).first<TauriRelease>();
 }
 

--- a/worker/test/release_identity_migration.test.ts
+++ b/worker/test/release_identity_migration.test.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0053_release_identity_and_activation.sql", import.meta.url),
+);
+
+describe("release identity migration", () => {
+  it("keeps remote-D1 trigger bodies on one physical line", () => {
+    const triggerLines = readFileSync(migrationPath, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("CREATE TRIGGER"));
+
+    expect(triggerLines).toHaveLength(3);
+    for (const line of triggerLines) {
+      expect(line).toContain(" BEGIN ");
+      expect(line).toMatch(/ END;$/);
+      expect(line.match(/\bEND;/g)).toHaveLength(1);
+    }
+  });
+
+  it("preserves legacy duplicates while rejecting every new duplicate lifecycle", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE builds (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        product_type TEXT NOT NULL,
+        release_type TEXT NOT NULL,
+        version_name TEXT NOT NULL,
+        version_code INTEGER NOT NULL
+      );
+      CREATE TABLE releases (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        build_id TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        product_type TEXT NOT NULL,
+        release_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE release_scopes (
+        id TEXT PRIMARY KEY,
+        release_id TEXT NOT NULL,
+        scope_type TEXT NOT NULL,
+        scope_value TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name, version_code)
+      VALUES
+        ('build-legacy-a', 'app-a', 'main', 'android-apk', 'stable', '1.0.0', 100),
+        ('build-legacy-b', 'app-a', 'main', 'android-apk', 'stable', '1.0.0', 100),
+        ('build-cancelled', 'app-a', 'main', 'android-apk', 'stable', '1.0.1', 101),
+        ('build-draft', 'app-a', 'main', 'android-apk', 'stable', '1.0.2', 102),
+        ('build-conflict', 'app-a', 'main', 'android-apk', 'stable', '1.0.0', 100),
+        ('build-cancel-conflict', 'app-a', 'main', 'android-apk', 'stable', '1.0.1', 101),
+        ('build-new', 'app-a', 'main', 'android-apk', 'stable', '1.0.3', 103),
+        ('build-other-channel', 'app-a', 'beta', 'android-apk', 'stable', '1.0.0', 100),
+        ('build-unreleased', 'app-a', 'main', 'android-apk', 'stable', '9.0.0', 900);
+
+      INSERT INTO releases
+        (id, app_id, build_id, channel_id, product_type, release_type, status, created_at, updated_at)
+      VALUES
+        ('release-legacy-a', 'app-a', 'build-legacy-a', 'main', 'android-apk', 'stable', 'active', 10, 20),
+        ('release-legacy-b', 'app-a', 'build-legacy-b', 'main', 'android-apk', 'stable', 'cancelled', 11, 21),
+        ('release-cancelled', 'app-a', 'build-cancelled', 'main', 'android-apk', 'stable', 'cancelled', 12, 22),
+        ('release-draft', 'app-a', 'build-draft', 'main', 'android-apk', 'stable', 'draft', 13, 23);
+
+      INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+      VALUES
+        ('scope-a', 'release-legacy-a', 'full', 'all', 10),
+        ('scope-b', 'release-legacy-b', 'device_group', 'legacy-group', 11),
+        ('scope-cancelled', 'release-cancelled', 'full', 'all', 12),
+        ('scope-draft', 'release-draft', 'full', 'all', 13);
+    `);
+
+    expect(() => db.exec(readFileSync(migrationPath, "utf8"))).not.toThrow();
+
+    expect(db.prepare(`
+      SELECT id, status, activated_at FROM releases ORDER BY id
+    `).all()).toEqual([
+      { id: "release-cancelled", status: "cancelled", activated_at: 22 },
+      { id: "release-draft", status: "draft", activated_at: null },
+      { id: "release-legacy-a", status: "active", activated_at: 20 },
+      { id: "release-legacy-b", status: "cancelled", activated_at: 21 },
+    ]);
+    expect(db.prepare(`
+      SELECT release_id, scope_type, scope_value FROM release_scopes ORDER BY id
+    `).all()).toEqual([
+      { release_id: "release-legacy-a", scope_type: "full", scope_value: "all" },
+      { release_id: "release-legacy-b", scope_type: "device_group", scope_value: "legacy-group" },
+      { release_id: "release-cancelled", scope_type: "full", scope_value: "all" },
+      { release_id: "release-draft", scope_type: "full", scope_value: "all" },
+    ]);
+
+    const insertRelease = db.prepare(`
+      INSERT INTO releases
+        (id, app_id, build_id, channel_id, product_type, release_type, status,
+         created_at, updated_at, activated_at)
+      VALUES (?, 'app-a', ?, ?, 'android-apk', 'stable', ?, 30, 30, NULL)
+    `);
+    expect(() => insertRelease.run(
+      "release-conflict",
+      "build-conflict",
+      "main",
+      "draft",
+    )).toThrow("release version already exists");
+    expect(() => insertRelease.run(
+      "release-cancel-conflict",
+      "build-cancel-conflict",
+      "main",
+      "draft",
+    )).toThrow("release version already exists");
+    expect(() => insertRelease.run(
+      "release-new",
+      "build-new",
+      "main",
+      "draft",
+    )).not.toThrow();
+    expect(() => insertRelease.run(
+      "release-other-channel",
+      "build-other-channel",
+      "beta",
+      "draft",
+    )).not.toThrow();
+
+    expect(() => db.prepare(`
+      UPDATE releases SET channel_id = 'beta' WHERE id = 'release-new'
+    `).run()).toThrow("release identity is immutable");
+    expect(() => db.prepare(`
+      UPDATE builds SET version_code = 104 WHERE id = 'build-new'
+    `).run()).toThrow("released build identity is immutable");
+    expect(() => db.prepare(`
+      UPDATE builds SET version_code = 901 WHERE id = 'build-unreleased'
+    `).run()).not.toThrow();
+    expect(() => db.prepare(`
+      UPDATE releases SET status = 'active' WHERE id = 'release-new'
+    `).run()).not.toThrow();
+  });
+});

--- a/worker/test/release_identity_migration.test.ts
+++ b/worker/test/release_identity_migration.test.ts
@@ -27,7 +27,7 @@ describe("release identity migration", () => {
       CREATE TABLE builds (
         id TEXT PRIMARY KEY,
         app_id TEXT NOT NULL,
-        channel_id TEXT NOT NULL,
+        channel_id TEXT,
         product_type TEXT NOT NULL,
         release_type TEXT NOT NULL,
         version_name TEXT NOT NULL,
@@ -62,8 +62,10 @@ describe("release identity migration", () => {
         ('build-conflict', 'app-a', 'main', 'android-apk', 'stable', '1.0.0', 100),
         ('build-cancel-conflict', 'app-a', 'main', 'android-apk', 'stable', '1.0.1', 101),
         ('build-new', 'app-a', 'main', 'android-apk', 'stable', '1.0.3', 103),
+        ('build-released-null', 'app-a', NULL, 'android-apk', 'stable', '1.0.4', 104),
         ('build-other-channel', 'app-a', 'beta', 'android-apk', 'stable', '1.0.0', 100),
-        ('build-unreleased', 'app-a', 'main', 'android-apk', 'stable', '9.0.0', 900);
+        ('build-unreleased', 'app-a', 'main', 'android-apk', 'stable', '9.0.0', 900),
+        ('build-unreleased-null', 'app-a', NULL, 'android-apk', 'stable', '9.0.1', 901);
 
       INSERT INTO releases
         (id, app_id, build_id, channel_id, product_type, release_type, status, created_at, updated_at)
@@ -71,7 +73,8 @@ describe("release identity migration", () => {
         ('release-legacy-a', 'app-a', 'build-legacy-a', 'main', 'android-apk', 'stable', 'active', 10, 20),
         ('release-legacy-b', 'app-a', 'build-legacy-b', 'main', 'android-apk', 'stable', 'cancelled', 11, 21),
         ('release-cancelled', 'app-a', 'build-cancelled', 'main', 'android-apk', 'stable', 'cancelled', 12, 22),
-        ('release-draft', 'app-a', 'build-draft', 'main', 'android-apk', 'stable', 'draft', 13, 23);
+        ('release-draft', 'app-a', 'build-draft', 'main', 'android-apk', 'stable', 'draft', 13, 23),
+        ('release-released-null', 'app-a', 'build-released-null', 'main', 'android-apk', 'stable', 'draft', 14, 24);
 
       INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
       VALUES
@@ -84,12 +87,13 @@ describe("release identity migration", () => {
     expect(() => db.exec(readFileSync(migrationPath, "utf8"))).not.toThrow();
 
     expect(db.prepare(`
-      SELECT id, status, activated_at FROM releases ORDER BY id
+      SELECT id, status, activated_at, revision FROM releases ORDER BY id
     `).all()).toEqual([
-      { id: "release-cancelled", status: "cancelled", activated_at: 22 },
-      { id: "release-draft", status: "draft", activated_at: null },
-      { id: "release-legacy-a", status: "active", activated_at: 20 },
-      { id: "release-legacy-b", status: "cancelled", activated_at: 21 },
+      { id: "release-cancelled", status: "cancelled", activated_at: null, revision: 0 },
+      { id: "release-draft", status: "draft", activated_at: null, revision: 0 },
+      { id: "release-legacy-a", status: "active", activated_at: 20, revision: 0 },
+      { id: "release-legacy-b", status: "cancelled", activated_at: null, revision: 0 },
+      { id: "release-released-null", status: "draft", activated_at: null, revision: 0 },
     ]);
     expect(db.prepare(`
       SELECT release_id, scope_type, scope_value FROM release_scopes ORDER BY id
@@ -138,7 +142,16 @@ describe("release identity migration", () => {
       UPDATE builds SET version_code = 104 WHERE id = 'build-new'
     `).run()).toThrow("released build identity is immutable");
     expect(() => db.prepare(`
+      UPDATE builds SET channel_id = 'main' WHERE id = 'build-released-null'
+    `).run()).toThrow("released build identity is immutable");
+    expect(() => db.prepare(`
+      UPDATE builds SET channel_id = NULL WHERE id = 'build-new'
+    `).run()).toThrow("released build identity is immutable");
+    expect(() => db.prepare(`
       UPDATE builds SET version_code = 901 WHERE id = 'build-unreleased'
+    `).run()).not.toThrow();
+    expect(() => db.prepare(`
+      UPDATE builds SET channel_id = 'main' WHERE id = 'build-unreleased-null'
     `).run()).not.toThrow();
     expect(() => db.prepare(`
       UPDATE releases SET status = 'active' WHERE id = 'release-new'

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -272,6 +272,7 @@ function makeMockDb() {
       release_type TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'active',
       activated_at INTEGER,
+      revision INTEGER NOT NULL DEFAULT 0,
       is_full INTEGER NOT NULL DEFAULT 1,
       superseded_by_release_id TEXT REFERENCES releases(id) ON DELETE SET NULL,
       rollout_cohort_count INTEGER,
@@ -3412,6 +3413,7 @@ describe("quiver releases — draft lifecycle", () => {
   function makeReleaseContext(
     releaseId: string,
     body: unknown = {},
+    query: Record<string, string | undefined> = {},
   ) {
     return {
       env,
@@ -3419,7 +3421,7 @@ describe("quiver releases — draft lifecycle", () => {
         param: (name: string) =>
           name === "appId" ? "app-release" : name === "releaseId" ? releaseId : "",
         json: async () => body,
-        query: () => undefined,
+        query: (name: string) => query[name],
       },
       get: (key: string) => (key === "admin_actor" ? "tester" : undefined),
       executionCtx: { waitUntil: () => undefined },
@@ -4076,6 +4078,569 @@ describe("quiver releases — draft lifecycle", () => {
     }, "tester", "rel-duplicate-scope")).rejects.toThrow("duplicate release scope");
   });
 
+  it("rejects a stale rollout bump after an actual scope PATCH and preserves the full fallback", async () => {
+    const {
+      createRelease,
+      handleBumpRollout,
+      handleUpdateRelease,
+    } = await import("../src/routes/releases");
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-bump-barrier", "app-release", "Bump barrier", null, now, now).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-bump-barrier-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+      rollout_cohort_count: 25,
+      scopes: [
+        { scope_type: "full", scope_value: "all" },
+        { scope_type: "device_group", scope_value: "group-bump-barrier" },
+      ],
+    }, "tester", "rel-bump-barrier-current");
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    let patchStatus: number | null = null;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        const patched = await handleUpdateRelease(makeReleaseContext(
+          "rel-bump-barrier-current",
+          {
+            expected_revision: 0,
+            scopes: [{ scope_type: "device_group", scope_value: "group-bump-barrier" }],
+          },
+        ));
+        patchStatus = patched.status;
+      }
+      return originalBatch(statements);
+    };
+
+    let bumped: Response;
+    try {
+      bumped = await handleBumpRollout(makeReleaseContext(
+        "rel-bump-barrier-current",
+        { to: 100, expected_revision: 0 },
+      ));
+    } finally {
+      db.batch = originalBatch;
+    }
+
+    expect(patchStatus).toBe(200);
+    expect(bumped.status).toBe(409);
+    await expect(responseJson<any>(bumped)).resolves.toMatchObject({
+      code: "RELEASE_REVISION_CONFLICT",
+      expected_revision: 0,
+      current_revision: 1,
+    });
+    await expect(env.DB.prepare(
+      `SELECT id, status, revision, rollout_cohort_count, superseded_by_release_id
+       FROM releases WHERE id IN ('rel-bump-barrier-current', 'rel-bump-barrier-fallback')
+       ORDER BY id`,
+    ).all()).resolves.toEqual({
+      results: [
+        {
+          id: "rel-bump-barrier-current",
+          status: "active",
+          revision: 1,
+          rollout_cohort_count: 25,
+          superseded_by_release_id: null,
+        },
+        {
+          id: "rel-bump-barrier-fallback",
+          status: "active",
+          revision: 0,
+          rollout_cohort_count: null,
+          superseded_by_release_id: null,
+        },
+      ],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      `SELECT scope_type, scope_value FROM release_scopes
+       WHERE release_id = 'rel-bump-barrier-current' ORDER BY scope_type, scope_value`,
+    ).all()).resolves.toMatchObject({
+      results: [{ scope_type: "device_group", scope_value: "group-bump-barrier" }],
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.bump_rollout'",
+    ).first()).resolves.toEqual({ count: 0 });
+
+    const publicContext = (deviceId?: string) => ({
+      env,
+      req: {
+        url: "https://hands.test/public/v2/apps/release-app/latest",
+        param: (name: string) => name === "slug" ? "release-app" : "",
+        query: (name: string) => ({
+          channel: "main",
+          product_type: "android-apk",
+          platform: "android",
+        } as Record<string, string>)[name],
+        header: (name: string) =>
+          name === "X-Hands-Device-Id" ? deviceId :
+          name === "CF-Connecting-IP" ? "203.0.113.7" : undefined,
+        raw: { cf: {} },
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    }) as any;
+    for (const deviceId of [undefined, "non-group-device"]) {
+      const resolved = await handlePublicV2Latest(publicContext(deviceId));
+      expect(resolved.status).toBe(200);
+      await expect(responseJson<any>(resolved)).resolves.toMatchObject({
+        build: { id: "build-active", version_code: 1 },
+        scoped: { release_id: "rel-bump-barrier-fallback", scope_type: "full" },
+      });
+    }
+  });
+
+  it("lets cancel win a rollout-bump race without stale audit or fallback damage", async () => {
+    const {
+      createRelease,
+      handleBumpRollout,
+      handleDeleteRelease,
+    } = await import("../src/routes/releases");
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-cancel-race-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+      rollout_cohort_count: 25,
+    }, "tester", "rel-cancel-race-current");
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    let cancelStatus: number | null = null;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        const cancelled = await handleDeleteRelease(makeReleaseContext(
+          "rel-cancel-race-current",
+          {},
+          { expected_revision: "0" },
+        ));
+        cancelStatus = cancelled.status;
+      }
+      return originalBatch(statements);
+    };
+
+    let bumped: Response;
+    try {
+      bumped = await handleBumpRollout(makeReleaseContext(
+        "rel-cancel-race-current",
+        { to: 100, expected_revision: 0 },
+      ));
+    } finally {
+      db.batch = originalBatch;
+    }
+
+    expect(cancelStatus).toBe(200);
+    expect(bumped.status).toBe(409);
+    await expect(responseJson<any>(bumped)).resolves.toMatchObject({
+      code: "RELEASE_REVISION_CONFLICT",
+      expected_revision: 0,
+      current_revision: 1,
+    });
+    await expect(env.DB.prepare(
+      `SELECT id, status, revision, rollout_cohort_count, superseded_by_release_id
+       FROM releases WHERE id IN ('rel-cancel-race-current', 'rel-cancel-race-fallback')
+       ORDER BY id`,
+    ).all()).resolves.toEqual({
+      results: [
+        {
+          id: "rel-cancel-race-current",
+          status: "cancelled",
+          revision: 1,
+          rollout_cohort_count: 25,
+          superseded_by_release_id: null,
+        },
+        {
+          id: "rel-cancel-race-fallback",
+          status: "active",
+          revision: 0,
+          rollout_cohort_count: null,
+          superseded_by_release_id: null,
+        },
+      ],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.bump_rollout'",
+    ).first()).resolves.toEqual({ count: 0 });
+
+    const resolved = await handlePublicV2Latest({
+      env,
+      req: {
+        url: "https://hands.test/public/v2/apps/release-app/latest",
+        param: (name: string) => name === "slug" ? "release-app" : "",
+        query: (name: string) => ({
+          channel: "main",
+          product_type: "android-apk",
+          platform: "android",
+        } as Record<string, string>)[name],
+        header: (name: string) => name === "CF-Connecting-IP" ? "203.0.113.9" : undefined,
+        raw: { cf: {} },
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    } as any);
+    expect(resolved.status).toBe(200);
+    await expect(responseJson<any>(resolved)).resolves.toMatchObject({
+      build: { id: "build-active", version_code: 1 },
+      scoped: { release_id: "rel-cancel-race-fallback", scope_type: "full" },
+    });
+  });
+
+  it("allows only one duplicate restore to reactivate a cancelled release", async () => {
+    const {
+      createRelease,
+      handleDeleteRelease,
+      handleRollbackRelease,
+    } = await import("../src/routes/releases");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-duplicate-restore-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+    }, "tester", "rel-duplicate-restore-current");
+    const cancelled = await handleDeleteRelease(makeReleaseContext(
+      "rel-duplicate-restore-current",
+      {},
+      { expected_revision: "0" },
+    ));
+    expect(cancelled.status).toBe(200);
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    let winnerStatus: number | null = null;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        const winner = await handleRollbackRelease(makeReleaseContext(
+          "rel-duplicate-restore-current",
+          { expected_revision: 1 },
+        ));
+        winnerStatus = winner.status;
+      }
+      return originalBatch(statements);
+    };
+
+    let loser: Response;
+    try {
+      loser = await handleRollbackRelease(makeReleaseContext(
+        "rel-duplicate-restore-current",
+        { expected_revision: 1 },
+      ));
+    } finally {
+      db.batch = originalBatch;
+    }
+
+    expect(winnerStatus).toBe(200);
+    expect(loser.status).toBe(409);
+    await expect(responseJson<any>(loser)).resolves.toMatchObject({
+      code: "RELEASE_REVISION_CONFLICT",
+      expected_revision: 1,
+      current_revision: 2,
+    });
+    await expect(env.DB.prepare(
+      `SELECT id, status, revision, superseded_by_release_id
+       FROM releases WHERE id IN ('rel-duplicate-restore-current', 'rel-duplicate-restore-fallback')
+       ORDER BY id`,
+    ).all()).resolves.toEqual({
+      results: [
+        {
+          id: "rel-duplicate-restore-current",
+          status: "active",
+          revision: 2,
+          superseded_by_release_id: null,
+        },
+        {
+          id: "rel-duplicate-restore-fallback",
+          status: "superseded",
+          revision: 3,
+          superseded_by_release_id: "rel-duplicate-restore-current",
+        },
+      ],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.rollback'",
+    ).first()).resolves.toEqual({ count: 1 });
+  });
+
+  it("returns stale revision conflicts with zero effects for every release mutation", async () => {
+    const {
+      createRelease,
+      handleBumpRollout,
+      handleDeleteRelease,
+      handleForceUpdate,
+      handlePublishRelease,
+      handleRollbackRelease,
+      handleUpdateRelease,
+    } = await import("../src/routes/releases");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-stale-active");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "draft",
+    }, "tester", "rel-stale-draft");
+    await seedReleaseBuild("build-stale-new", 33);
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-stale-new",
+      status: "active",
+    }, "tester", "rel-stale-new");
+
+    const readState = async () => ({
+      releases: (await env.DB.prepare(
+        `SELECT id, status, revision, rollout_cohort_count, should_force_update,
+                superseded_by_release_id, changelog
+         FROM releases ORDER BY id`,
+      ).all()).results,
+      scopes: (await env.DB.prepare(
+        `SELECT release_id, scope_type, scope_value
+         FROM release_scopes ORDER BY release_id, scope_type, scope_value`,
+      ).all()).results,
+      audits: (await env.DB.prepare(
+        "SELECT action, payload FROM audit_logs ORDER BY created_at, id",
+      ).all()).results,
+    });
+    const before = await readState();
+    const staleRevision = 999;
+    const responses = [
+      await handleUpdateRelease(makeReleaseContext("rel-stale-draft", {
+        changelog: "must not land",
+        expected_revision: staleRevision,
+      })),
+      await handlePublishRelease(makeReleaseContext("rel-stale-draft", {
+        expected_scopes: [{ scope_type: "full", scope_value: "all" }],
+        expected_revision: staleRevision,
+      })),
+      await handleDeleteRelease(makeReleaseContext(
+        "rel-stale-new",
+        {},
+        { expected_revision: String(staleRevision) },
+      )),
+      await handleRollbackRelease(makeReleaseContext("rel-stale-active", {
+        expected_revision: staleRevision,
+      })),
+      await handleBumpRollout(makeReleaseContext("rel-stale-new", {
+        to: 100,
+        expected_revision: staleRevision,
+      })),
+      await handleForceUpdate(makeReleaseContext("rel-stale-new", {
+        enabled: true,
+        expected_revision: staleRevision,
+      })),
+    ];
+    for (const response of responses) {
+      expect(response.status).toBe(409);
+      await expect(responseJson<any>(response)).resolves.toMatchObject({
+        code: "RELEASE_REVISION_CONFLICT",
+        expected_revision: staleRevision,
+      });
+    }
+    expect(await readState()).toEqual(before);
+
+    const invalid = await handleUpdateRelease(makeReleaseContext("rel-stale-draft", {
+      expected_revision: "not-a-revision",
+    }));
+    expect(invalid.status).toBe(400);
+    await expect(responseJson<any>(invalid)).resolves.toMatchObject({
+      error: "expected_revision must be a non-negative integer",
+    });
+    expect(await readState()).toEqual(before);
+  });
+
+  it("restores a never-published external release only to draft and reruns publish gates", async () => {
+    const {
+      createRelease,
+      handleDeleteRelease,
+      handlePublishRelease,
+      handleRollbackRelease,
+    } = await import("../src/routes/releases");
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+    const now = Date.now();
+    for (const [buildId, versionCode, source] of [
+      ["build-draft-restore-fallback", 34, "web"],
+      ["build-draft-restore-target", 35, "external"],
+    ] as const) {
+      await env.DB.prepare(
+        `INSERT INTO builds (id, app_id, channel_id, product_type, release_type, version_name, version_code,
+                             source, status, build_metadata_json, parsed_metadata_json,
+                             should_force_update, provenance_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        buildId,
+        "app-release",
+        "ch-main",
+        "cli-binary",
+        "stable",
+        `2.0.${versionCode}`,
+        versionCode,
+        source,
+        "succeeded",
+        "{}",
+        "{}",
+        0,
+        "{}",
+        now,
+        now,
+      ).run();
+    }
+    for (const target of ["darwin-arm64", "linux-x64"]) {
+      await env.DB.prepare(
+        `INSERT INTO external_build_targets
+         (id, app_id, build_id, version_name, target, source_url, raw_sha256, raw_size_bytes,
+          node_version, metadata_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        `target-draft-restore-${target}`,
+        "app-release",
+        "build-draft-restore-target",
+        "2.0.35",
+        target,
+        `https://cdn.test/2.0.35/${target}`,
+        target === "darwin-arm64" ? "a".repeat(64) : "b".repeat(64),
+        100,
+        "24.15.0",
+        "{}",
+        now,
+        now,
+      ).run();
+    }
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft-restore-fallback",
+      status: "active",
+    }, "tester", "rel-draft-restore-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft-restore-target",
+      status: "draft",
+    }, "tester", "rel-draft-restore-target");
+
+    const cancelled = await handleDeleteRelease(makeReleaseContext(
+      "rel-draft-restore-target",
+      {},
+      { expected_revision: "0" },
+    ));
+    expect(cancelled.status).toBe(200);
+    const restored = await handleRollbackRelease(makeReleaseContext(
+      "rel-draft-restore-target",
+      { expected_revision: 1 },
+    ));
+    expect(restored.status).toBe(200);
+    await expect(responseJson<any>(restored)).resolves.toMatchObject({
+      id: "rel-draft-restore-target",
+      status: "draft",
+      activated_at: null,
+      revision: 2,
+      restored_to_draft: true,
+      reactivated: false,
+    });
+    await expect(env.DB.prepare(
+      `SELECT id, status, revision, superseded_by_release_id FROM releases
+       WHERE id IN ('rel-draft-restore-fallback', 'rel-draft-restore-target') ORDER BY id`,
+    ).all()).resolves.toEqual({
+      results: [
+        {
+          id: "rel-draft-restore-fallback",
+          status: "active",
+          revision: 0,
+          superseded_by_release_id: null,
+        },
+        {
+          id: "rel-draft-restore-target",
+          status: "draft",
+          revision: 2,
+          superseded_by_release_id: null,
+        },
+      ],
+      success: true,
+    });
+
+    const wrongTargets = await handlePublishRelease(makeReleaseContext(
+      "rel-draft-restore-target",
+      {
+        expected_revision: 2,
+        expected_scopes: [{ scope_type: "full", scope_value: "all" }],
+        required_external_targets: ["darwin-arm64", "win32-x64"],
+      },
+    ));
+    expect(wrongTargets.status).toBe(400);
+    await expect(responseJson<any>(wrongTargets)).resolves.toMatchObject({
+      missing: ["win32-x64"],
+      unexpected: ["linux-x64"],
+    });
+    await expect(env.DB.prepare(
+      "SELECT status, revision FROM releases WHERE id = 'rel-draft-restore-target'",
+    ).first()).resolves.toEqual({ status: "draft", revision: 2 });
+    await expect(env.DB.prepare(
+      "SELECT freeze_token FROM builds WHERE id = 'build-draft-restore-target'",
+    ).first()).resolves.toEqual({ freeze_token: null });
+
+    const beforePublish = await handlePublicV2Latest({
+      env,
+      req: {
+        url: "https://hands.test/public/v2/apps/release-app/latest",
+        param: (name: string) => name === "slug" ? "release-app" : "",
+        query: (name: string) => ({
+          channel: "main",
+          product_type: "cli-binary",
+        } as Record<string, string>)[name],
+        header: (name: string) => name === "CF-Connecting-IP" ? "203.0.113.11" : undefined,
+        raw: { cf: {} },
+      },
+      json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    } as any);
+    expect(beforePublish.status).toBe(200);
+    await expect(responseJson<any>(beforePublish)).resolves.toMatchObject({
+      build: { id: "build-draft-restore-fallback", version_code: 34 },
+      scoped: { release_id: "rel-draft-restore-fallback", scope_type: "full" },
+    });
+
+    const published = await handlePublishRelease(makeReleaseContext(
+      "rel-draft-restore-target",
+      {
+        expected_revision: 2,
+        expected_scopes: [{ scope_type: "full", scope_value: "all" }],
+        required_external_targets: ["linux-x64", "darwin-arm64"],
+      },
+    ));
+    expect(published.status).toBe(200);
+    await expect(responseJson<any>(published)).resolves.toMatchObject({
+      status: "active",
+      revision: 3,
+    });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-draft-restore-fallback'",
+    ).first()).resolves.toEqual({
+      status: "superseded",
+      superseded_by_release_id: "rel-draft-restore-target",
+    });
+  });
+
   it("restores the same release id with a fresh activation and cancellation restores its fallback", async () => {
     const { createRelease, handleDeleteRelease, handleRollbackRelease } = await import("../src/routes/releases");
     await createRelease(env.DB as any, "app-release", {
@@ -4140,6 +4705,35 @@ describe("quiver releases — draft lifecycle", () => {
       results: [
         { id: "rel-restore-current", status: "active", superseded_by_release_id: null },
         { id: "rel-restore-fallback", status: "cancelled", superseded_by_release_id: null },
+      ],
+      success: true,
+    });
+
+    const restoredAfterCancel = await handleRollbackRelease(
+      makeReleaseContext("rel-restore-fallback", { expected_revision: 3 }),
+    );
+    expect(restoredAfterCancel.status).toBe(200);
+    await expect(responseJson<any>(restoredAfterCancel)).resolves.toMatchObject({
+      id: "rel-restore-fallback",
+      status: "active",
+      revision: 4,
+      restored_to_draft: false,
+      reactivated: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all()).resolves.toEqual({
+      results: [
+        {
+          id: "rel-restore-current",
+          status: "superseded",
+          superseded_by_release_id: "rel-restore-fallback",
+        },
+        {
+          id: "rel-restore-fallback",
+          status: "active",
+          superseded_by_release_id: null,
+        },
       ],
       success: true,
     });
@@ -4885,6 +5479,13 @@ describe("quiver public API v2 — scope resolution", () => {
        VALUES ('b-ext', 'app-scope', 'ch-scope-prod', 'cli-binary', 'stable', '2.0.0', 2000000,
                'external', 'succeeded', '{}', '{}', 0, '{"ci_provider":"gha","source_commit":"abc123"}', ?1, ?1)`,
     ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO builds (id, app_id, channel_id, product_type, release_type, version_name, version_code,
+                           source, status, build_metadata_json, parsed_metadata_json, should_force_update,
+                           provenance_json, created_at, updated_at)
+       VALUES ('b-ext-fallback', 'app-scope', 'ch-scope-prod', 'cli-binary', 'stable', '1.9.0', 1900000,
+               'web', 'succeeded', '{}', '{}', 0, '{}', ?1, ?1)`,
+    ).bind(now).run();
     for (const [t, gz] of [["darwin-arm64", "https://cdn.test/2.0.0/darwin-arm64.gz"], ["linux-x64", null]] as const) {
       await env.DB.prepare(
         `INSERT INTO external_build_targets
@@ -4905,8 +5506,22 @@ describe("quiver public API v2 — scope resolution", () => {
       `INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
        VALUES ('scope-rel-ext-full', 'rel-ext', 'full', 'all', ?1)`,
     ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO releases (id, app_id, build_id, channel_id, product_type, release_type, status,
+                             activated_at, is_full, changelog, created_by, created_at, updated_at)
+       VALUES ('rel-ext-fallback', 'app-scope', 'b-ext-fallback', 'ch-scope-prod', 'cli-binary',
+               'stable', 'active', ?1, 1, NULL, 'tester', ?1, ?1)`,
+    ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+       VALUES ('scope-rel-ext-fallback', 'rel-ext-fallback', 'full', 'all', ?1)`,
+    ).bind(now).run();
 
-    const { handlePublishRelease, handleGetRelease } = await import("../src/routes/releases");
+    const {
+      handleBumpRollout,
+      handleGetRelease,
+      handlePublishRelease,
+    } = await import("../src/routes/releases");
     const ctx = (params: Record<string, string>, body: unknown = {}) =>
       ({
         env,
@@ -4926,6 +5541,19 @@ describe("quiver public API v2 — scope resolution", () => {
     const noSet = await handlePublishRelease(ctx({ appId: "app-scope", releaseId: "rel-ext" }));
     expect(noSet.status).toBe(400);
 
+    // Scope validation happens before the external freeze plan is committed.
+    const wrongScope = await handlePublishRelease(ctx(
+      { appId: "app-scope", releaseId: "rel-ext" },
+      {
+        required_external_targets: ["darwin-arm64", "linux-x64"],
+        expected_scopes: [{ scope_type: "platform", scope_value: "android" }],
+      },
+    ));
+    expect(wrongScope.status).toBe(409);
+    await expect(env.DB.prepare(
+      "SELECT freeze_token, required_targets_json FROM builds WHERE id = 'b-ext'",
+    ).first()).resolves.toEqual({ freeze_token: null, required_targets_json: null });
+
     // Wrong set → 400 with named missing/unexpected; freeze rolled back.
     const wrong = await handlePublishRelease(
       ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["darwin-arm64", "win32-x64"] }),
@@ -4943,14 +5571,74 @@ describe("quiver public API v2 — scope resolution", () => {
     );
     expect(dup.status).toBe(400);
 
+    // A release mutation after target preflight but before the publish batch
+    // must win without allowing the stale publisher to freeze the build.
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    let bumpStatus: number | null = null;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        const bumped = await handleBumpRollout(ctx(
+          { appId: "app-scope", releaseId: "rel-ext" },
+          { to: 25, expected_revision: 0 },
+        ));
+        bumpStatus = bumped.status;
+      }
+      return originalBatch(statements);
+    };
+    let stalePublish: Response;
+    try {
+      stalePublish = await handlePublishRelease(ctx(
+        { appId: "app-scope", releaseId: "rel-ext" },
+        {
+          required_external_targets: ["darwin-arm64", "linux-x64"],
+          expected_scopes: [{ scope_type: "full", scope_value: "all" }],
+          expected_revision: 0,
+        },
+      ));
+    } finally {
+      db.batch = originalBatch;
+    }
+    expect(bumpStatus).toBe(200);
+    expect(stalePublish.status).toBe(409);
+    await expect(stalePublish.json()).resolves.toMatchObject({
+      code: "RELEASE_REVISION_CONFLICT",
+      expected_revision: 0,
+      current_revision: 1,
+    });
+    await expect(env.DB.prepare(
+      "SELECT freeze_token, required_targets_json FROM builds WHERE id = 'b-ext'",
+    ).first()).resolves.toEqual({ freeze_token: null, required_targets_json: null });
+    await expect(env.DB.prepare(
+      "SELECT status, revision, rollout_cohort_count FROM releases WHERE id = 'rel-ext'",
+    ).first()).resolves.toEqual({ status: "draft", revision: 1, rollout_cohort_count: 25 });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-ext-fallback'",
+    ).first()).resolves.toEqual({ status: "active", superseded_by_release_id: null });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+    ).first()).resolves.toEqual({ count: 0 });
+
     // Exact set → publish succeeds and freezes.
     const ok = await handlePublishRelease(
-      ctx({ appId: "app-scope", releaseId: "rel-ext" }, { required_external_targets: ["linux-x64", "darwin-arm64"] }),
+      ctx(
+        { appId: "app-scope", releaseId: "rel-ext" },
+        {
+          required_external_targets: ["linux-x64", "darwin-arm64"],
+          expected_scopes: [{ scope_type: "full", scope_value: "all" }],
+          expected_revision: 1,
+        },
+      ),
     );
     expect(ok.status).toBe(200);
     const frozen = (await env.DB.prepare("SELECT freeze_token, required_targets_json FROM builds WHERE id = 'b-ext'").first()) as any;
     expect(frozen.freeze_token).not.toBeNull();
     expect(JSON.parse(frozen.required_targets_json)).toEqual(["darwin-arm64", "linux-x64"]);
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.publish'",
+    ).first()).resolves.toEqual({ count: 1 });
 
     // Post-freeze: replay publish (already active) re-asserts and no-ops OK;
     // a different set on replay → contract mismatch.
@@ -9126,6 +9814,11 @@ describe("Hands iOS simulator QA artifacts", () => {
     });
     expect(byName["create-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
     expect(byName["update-release"].parameters.scopes).toMatchObject({ type: "array", in: "body" });
+    expect(byName["update-release"].parameters.expected_revision).toMatchObject({
+      type: "number",
+      in: "body",
+      required: false,
+    });
     expect(byName["get-release"].endpoint.method).toBe("GET");
     expect(byName["get-release"].parameters).not.toHaveProperty("expected_scope");
     expect(byName["publish-release"].endpoint.method).toBe("POST");
@@ -9139,6 +9832,11 @@ describe("Hands iOS simulator QA artifacts", () => {
     });
     expect(byName["publish-release"].parameters.expected_scope).toMatchObject({
       type: "object",
+      in: "body",
+      required: false,
+    });
+    expect(byName["publish-release"].parameters.expected_revision).toMatchObject({
+      type: "number",
       in: "body",
       required: false,
     });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -271,6 +271,7 @@ function makeMockDb() {
       product_type TEXT NOT NULL,
       release_type TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'active',
+      activated_at INTEGER,
       is_full INTEGER NOT NULL DEFAULT 1,
       superseded_by_release_id TEXT REFERENCES releases(id) ON DELETE SET NULL,
       rollout_cohort_count INTEGER,
@@ -3336,6 +3337,35 @@ describe("quiver apps — default_channel_id", () => {
 describe("quiver releases — draft lifecycle", () => {
   let env: MockEnv;
 
+  async function seedReleaseBuild(buildId: string, versionCode: number) {
+    const now = Date.now();
+    await env.DB
+      .prepare(
+        `INSERT INTO builds (id, app_id, channel_id, product_type, release_type, version_name, version_code,
+                             source, status, build_metadata_json, parsed_metadata_json,
+                             should_force_update, provenance_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        buildId,
+        "app-release",
+        "ch-main",
+        "android-apk",
+        "stable",
+        `1.0.${versionCode}`,
+        versionCode,
+        "web",
+        "succeeded",
+        "{}",
+        "{}",
+        0,
+        "{}",
+        now,
+        now,
+      )
+      .run();
+  }
+
   beforeEach(async () => {
     env = makeMockEnv();
     const now = Date.now();
@@ -3450,6 +3480,36 @@ describe("quiver releases — draft lifecycle", () => {
       { id: "rel-active", status: "active", superseded_by_release_id: null },
       { id: "rel-draft", status: "draft", superseded_by_release_id: null },
     ]);
+  });
+
+  it("returns the existing lifecycle in a structured 409 even when it is cancelled", async () => {
+    const { createRelease, handleCreateReleaseDraft } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-version-original", 30);
+    await seedReleaseBuild("build-version-race", 30);
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-version-original",
+      status: "draft",
+    }, "tester", "rel-version-reserved");
+    await env.DB.prepare(
+      "UPDATE releases SET status = 'cancelled' WHERE id = 'rel-version-reserved'",
+    ).run();
+
+    const response = await handleCreateReleaseDraft(makeReleaseContext("", {
+      build_id: "build-version-race",
+    }));
+
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "RELEASE_VERSION_ALREADY_EXISTS",
+      release_id: "rel-version-reserved",
+      build_id: "build-version-original",
+      release_status: "cancelled",
+      version_name: "1.0.30",
+      version_code: 30,
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM releases WHERE build_id = 'build-version-race'",
+    ).first()).resolves.toEqual({ count: 0 });
   });
 
   it("publishes a draft and supersedes the previous active release", async () => {
@@ -3695,8 +3755,9 @@ describe("quiver releases — draft lifecycle", () => {
       "SELECT COUNT(*) AS count FROM releases WHERE id LIKE 'rel-invalid-scope-%'",
     ).first()).resolves.toEqual({ count: 0 });
 
+    await seedReleaseBuild("build-scope-update", 3);
     await createRelease(env.DB as any, "app-release", {
-      build_id: "build-draft",
+      build_id: "build-scope-update",
       status: "draft",
       scopes: [{ scope_type: "device_group", scope_value: "group-scope-validation" }],
     }, "tester", "rel-scope-update-guard");
@@ -3793,8 +3854,10 @@ describe("quiver releases — draft lifecycle", () => {
     ];
     for (const [index, scope] of scopeCases.entries()) {
       const releaseId = `rel-generic-scope-${index}`;
+      const buildId = `build-generic-scope-${index}`;
+      await seedReleaseBuild(buildId, 10 + index);
       await createRelease(env.DB as any, "app-release", {
-        build_id: "build-draft",
+        build_id: buildId,
         status: "draft",
         scopes: [scope],
       }, "tester", releaseId);
@@ -3847,9 +3910,11 @@ describe("quiver releases — draft lifecycle", () => {
        VALUES (?, ?, ?, ?, ?, ?)`,
     ).bind("group-drift-guard", "app-release", "Drift guard", null, now, now).run();
 
-    for (const releaseId of ["rel-scope-drift-full", "rel-scope-drift-zero"]) {
+    for (const [index, releaseId] of ["rel-scope-drift-full", "rel-scope-drift-zero"].entries()) {
+      const buildId = `build-scope-drift-${index}`;
+      await seedReleaseBuild(buildId, 20 + index);
       await createRelease(env.DB as any, "app-release", {
-        build_id: "build-draft",
+        build_id: buildId,
         status: "draft",
         scopes: [{ scope_type: "device_group", scope_value: "group-drift-guard" }],
       }, "tester", releaseId);
@@ -3890,7 +3955,11 @@ describe("quiver releases — draft lifecycle", () => {
     await createRelease(env.DB as any, "app-release", {
       build_id: "build-draft",
       status: "draft",
-      scopes: [{ scope_type: "device_group", scope_value: "group-cas-race" }],
+      rollout_cohort_count: 25,
+      scopes: [
+        { scope_type: "full", scope_value: "all" },
+        { scope_type: "device_group", scope_value: "group-cas-race" },
+      ],
     }, "tester", "rel-cas-race-draft");
 
     const db = env.DB as any;
@@ -3900,15 +3969,18 @@ describe("quiver releases — draft lifecycle", () => {
       if (!injected) {
         injected = true;
         await env.DB.prepare(
-          `UPDATE release_scopes SET scope_type = 'full', scope_value = 'all'
-           WHERE release_id = 'rel-cas-race-draft'`,
+          `DELETE FROM release_scopes
+           WHERE release_id = 'rel-cas-race-draft' AND scope_type = 'device_group'`,
         ).run();
       }
       return originalBatch(statements);
     };
     const waitUntil = vi.fn();
     const context = makeReleaseContext("rel-cas-race-draft", {
-      expected_scope: { scope_type: "device_group", scope_value: "group-cas-race" },
+      expected_scopes: [
+        { scope_type: "full", scope_value: "all" },
+        { scope_type: "device_group", scope_value: "group-cas-race" },
+      ],
     });
     context.executionCtx.waitUntil = waitUntil;
 
@@ -3932,41 +4004,144 @@ describe("quiver releases — draft lifecycle", () => {
     ).first()).resolves.toEqual({ count: 0 });
   });
 
-  it("rejects mixing full:all with a device-group scope on create and active update", async () => {
-    const { createRelease, handleUpdateRelease } = await import("../src/routes/releases");
+  it("supports a full rollout with always-included device groups and rejects incompatible mixes", async () => {
+    const { createRelease, handleBumpRollout, handlePublishRelease } = await import("../src/routes/releases");
     const now = Date.now();
     await env.DB.prepare(
       `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?)`,
-    ).bind("group-no-mixed-full", "app-release", "No mixed full", null, now, now).run();
+    ).bind("group-no-mixed-full", "app-release", "Always included", null, now, now).run();
     const mixedScopes = [
       { scope_type: "full", scope_value: "all" },
       { scope_type: "device_group", scope_value: "group-no-mixed-full" },
     ];
-    await expect(createRelease(env.DB as any, "app-release", {
-      build_id: "build-draft",
-      status: "draft",
-      scopes: mixedScopes,
-    }, "tester", "rel-mixed-create")).rejects.toThrow("full release scope cannot be combined");
-
     await createRelease(env.DB as any, "app-release", {
       build_id: "build-active",
       status: "active",
     }, "tester", "rel-mixed-fallback");
     await createRelease(env.DB as any, "app-release", {
       build_id: "build-draft",
-      status: "active",
+      status: "draft",
+      rollout_cohort_count: 25,
+      scopes: mixedScopes,
     }, "tester", "rel-mixed-current");
-    const response = await handleUpdateRelease(makeReleaseContext("rel-mixed-current", { scopes: mixedScopes }));
-    expect(response.status).toBe(400);
-    await expect(responseJson<any>(response)).resolves.toMatchObject({
-      error: "full release scope cannot be combined with other scopes",
+
+    const legacyExpectation = await handlePublishRelease(makeReleaseContext("rel-mixed-current", {
+      expected_scope: { scope_type: "full", scope_value: "all" },
+    }));
+    expect(legacyExpectation.status).toBe(409);
+    const published = await handlePublishRelease(makeReleaseContext("rel-mixed-current", {
+      expected_scopes: [...mixedScopes].reverse(),
+    }));
+    expect(published.status).toBe(200);
+    await expect(env.DB.prepare(
+      "SELECT status, is_full, rollout_cohort_count FROM releases WHERE id = 'rel-mixed-current'",
+    ).first()).resolves.toEqual({
+      status: "active",
+      is_full: 1,
+      rollout_cohort_count: 25,
     });
+    await expect(env.DB.prepare(
+      "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-mixed-fallback'",
+    ).first()).resolves.toEqual({
+      status: "active",
+      superseded_by_release_id: null,
+    });
+
+    const bumped = await handleBumpRollout(makeReleaseContext("rel-mixed-current", { to: 100 }));
+    expect(bumped.status).toBe(200);
     await expect(env.DB.prepare(
       "SELECT status, superseded_by_release_id FROM releases WHERE id = 'rel-mixed-fallback'",
     ).first()).resolves.toEqual({
       status: "superseded",
       superseded_by_release_id: "rel-mixed-current",
+    });
+
+    await seedReleaseBuild("build-invalid-scope-mix", 31);
+    await expect(createRelease(env.DB as any, "app-release", {
+      build_id: "build-invalid-scope-mix",
+      status: "draft",
+      scopes: [
+        { scope_type: "full", scope_value: "all" },
+        { scope_type: "platform", scope_value: "android" },
+      ],
+    }, "tester", "rel-invalid-scope-mix")).rejects.toThrow(
+      "full:all may be combined only with device_group scopes",
+    );
+    await seedReleaseBuild("build-duplicate-scope", 32);
+    await expect(createRelease(env.DB as any, "app-release", {
+      build_id: "build-duplicate-scope",
+      status: "draft",
+      scopes: [mixedScopes[0]!, mixedScopes[0]!],
+    }, "tester", "rel-duplicate-scope")).rejects.toThrow("duplicate release scope");
+  });
+
+  it("restores the same release id with a fresh activation and cancellation restores its fallback", async () => {
+    const { createRelease, handleDeleteRelease, handleRollbackRelease } = await import("../src/routes/releases");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-active",
+      status: "active",
+    }, "tester", "rel-restore-fallback");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-draft",
+      status: "active",
+    }, "tester", "rel-restore-current");
+    await env.DB.prepare(
+      "UPDATE releases SET activated_at = 1 WHERE id = 'rel-restore-fallback'",
+    ).run();
+
+    const restoredResponse = await handleRollbackRelease(
+      makeReleaseContext("rel-restore-fallback"),
+    );
+    expect(restoredResponse.status).toBe(200);
+    await expect(responseJson<any>(restoredResponse)).resolves.toMatchObject({
+      id: "rel-restore-fallback",
+      status: "active",
+      reactivated: true,
+    });
+    await expect(env.DB.prepare(
+      `SELECT id, status, superseded_by_release_id, activated_at
+       FROM releases ORDER BY id`,
+    ).all()).resolves.toMatchObject({
+      results: [
+        {
+          id: "rel-restore-current",
+          status: "superseded",
+          superseded_by_release_id: "rel-restore-fallback",
+        },
+        {
+          id: "rel-restore-fallback",
+          status: "active",
+          superseded_by_release_id: null,
+          activated_at: expect.any(Number),
+        },
+      ],
+    });
+    const activated = await env.DB.prepare(
+      "SELECT activated_at FROM releases WHERE id = 'rel-restore-fallback'",
+    ).first() as { activated_at: number } | null;
+    expect(activated!.activated_at).toBeGreaterThan(1);
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM releases",
+    ).first()).resolves.toEqual({ count: 2 });
+
+    const duplicateRestore = await handleRollbackRelease(
+      makeReleaseContext("rel-restore-fallback"),
+    );
+    expect(duplicateRestore.status).toBe(409);
+
+    const cancelled = await handleDeleteRelease(
+      makeReleaseContext("rel-restore-fallback"),
+    );
+    expect(cancelled.status).toBe(200);
+    await expect(env.DB.prepare(
+      "SELECT id, status, superseded_by_release_id FROM releases ORDER BY id",
+    ).all()).resolves.toEqual({
+      results: [
+        { id: "rel-restore-current", status: "active", superseded_by_release_id: null },
+        { id: "rel-restore-fallback", status: "cancelled", superseded_by_release_id: null },
+      ],
+      success: true,
     });
   });
 
@@ -4169,6 +4344,7 @@ describe("quiver public API v2 — scope resolution", () => {
       versionName?: string;
       shouldForceUpdate?: number;
       rolloutCohortCount?: number | null;
+      activatedAt?: number | null;
     } = {},
   ) {
     const now = opts.createdAt ?? Date.now();
@@ -4198,8 +4374,9 @@ describe("quiver public API v2 — scope resolution", () => {
       .run();
     await env.DB.prepare(
       `INSERT INTO releases (id, app_id, build_id, channel_id, product_type, release_type, status,
-                             is_full, rollout_cohort_count, changelog, created_by, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                             activated_at, is_full, rollout_cohort_count, changelog,
+                             created_by, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
       .bind(
         releaseId,
@@ -4209,7 +4386,8 @@ describe("quiver public API v2 — scope resolution", () => {
         opts.productType ?? "android-apk",
         "stable",
         "active",
-        scopes.length === 1 && scopes[0]?.[0] === "full" && scopes[0]?.[1] === "all" ? 1 : 0,
+        opts.activatedAt === undefined ? now : opts.activatedAt,
+        scopes.some(([scopeType, scopeValue]) => scopeType === "full" && scopeValue === "all") ? 1 : 0,
         opts.rolloutCohortCount === undefined ? 100 : opts.rolloutCohortCount,
         null,
         "tester",
@@ -5360,6 +5538,46 @@ describe("quiver public API v2 — scope resolution", () => {
     });
   });
 
+  it("uses latest activation rather than creation time for same-priority scopes", async () => {
+    const env = makeEnv();
+    configureR2Presign(env);
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-reactivated", "app-scope", "Reactivated devices", null, now, now).run();
+    await env.DB.prepare(
+      `INSERT INTO device_group_members (group_id, device_id, label, created_at)
+       VALUES (?, ?, ?, ?)`,
+    ).bind("group-reactivated", "device-reactivated", null, now).run();
+    await seedRelease(env, "rel-created-old", "build-created-old", [["device_group", "group-reactivated"]], {
+      createdAt: now - 2_000,
+      activatedAt: now + 1_000,
+      versionCode: 11,
+    });
+    await seedAsset(env, "build-created-old", "asset-created-old", { arch: "arm64-v8a" });
+    await seedRelease(env, "rel-created-new", "build-created-new", [["device_group", "group-reactivated"]], {
+      createdAt: now,
+      activatedAt: now,
+      versionCode: 12,
+    });
+    await seedAsset(env, "build-created-new", "asset-created-new", { arch: "arm64-v8a" });
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+
+    const response = await handlePublicV2Latest(makePublicContext(env, {
+      channel: "production",
+      product_type: "android-apk",
+      platform: "android",
+      arch: "arm64-v8a",
+    }, { "X-Hands-Device-Id": "device-reactivated" }));
+
+    expect(response.status).toBe(200);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      build: { version_code: 11 },
+      scoped: { release_id: "rel-created-old", scope_type: "device_group" },
+    });
+  });
+
   it("resolves ip_range from Cloudflare's edge-owned client IP header, never X-Forwarded-For", async () => {
     const env = makeEnv();
     configureR2Presign(env);
@@ -5517,7 +5735,7 @@ describe("quiver public API v2 — scope resolution", () => {
     });
   });
 
-  it("updates/check gates a partial rollout by device bucket and falls back to the previous release", async () => {
+  it("combines percentage rollout with an always-included device group", async () => {
     const env = makeEnv();
     const { handlePublicV2UpdateCheck, rolloutBucket } = await import(
       "../src/routes/public_v2"
@@ -5528,7 +5746,15 @@ describe("quiver public API v2 — scope resolution", () => {
       createdAt: Date.now() - 1000,
     });
     await seedAsset(env, "build-stable", "asset-stable", { arch: "arm64-v8a" });
-    await seedRelease(env, "rel-gated", "build-gated", [["full", "all"]], {
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO device_groups (id, app_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind("group-always", "app-scope", "Always included", null, now, now).run();
+    await seedRelease(env, "rel-gated", "build-gated", [
+      ["full", "all"],
+      ["device_group", "group-always"],
+    ], {
       versionCode: 11,
       versionName: "1.0.11",
       rolloutCohortCount: 30,
@@ -5547,6 +5773,10 @@ describe("quiver public API v2 — scope resolution", () => {
     }
     expect(inDevice).not.toBe("");
     expect(outDevice).not.toBe("");
+    await env.DB.prepare(
+      `INSERT INTO device_group_members (group_id, device_id, label, created_at)
+       VALUES (?, ?, ?, ?)`,
+    ).bind("group-always", outDevice, "Outside percentage", now).run();
 
     const query = {
       channel: "production",
@@ -5565,12 +5795,32 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(inBody.latest.version_code).toBe(11);
     expect(inBody.scoped.rollout_cohort_count).toBe(30);
 
-    const outResponse = await handlePublicV2UpdateCheck(
-      makePublicContext(env, query, { "X-Quiver-Device-Id": outDevice }),
+    const memberResponse = await handlePublicV2UpdateCheck(
+      makePublicContext(env, query, { "X-Hands-Device-Id": outDevice }),
     );
-    expect(outResponse.status).toBe(200);
+    expect(memberResponse.status).toBe(200);
+    const memberBody = await responseJson<any>(memberResponse);
+    expect(memberBody.update_available).toBe(true);
+    expect(memberBody.latest.version_code).toBe(11);
+    expect(memberBody.scoped).toMatchObject({
+      scope_type: "device_group",
+      scope_value: "group-always",
+      rollout_cohort_count: 30,
+    });
+
+    let nonMemberOutDevice = "";
+    for (let i = 1000; i < 2000; i++) {
+      const candidate = `non-member-${i}`;
+      if (rolloutBucket("rel-gated", candidate) >= 30) {
+        nonMemberOutDevice = candidate;
+        break;
+      }
+    }
+    expect(nonMemberOutDevice).not.toBe("");
+    const outResponse = await handlePublicV2UpdateCheck(
+      makePublicContext(env, query, { "X-Hands-Device-Id": nonMemberOutDevice }),
+    );
     const outBody = await responseJson<any>(outResponse);
-    expect(outBody.update_available).toBe(true);
     expect(outBody.latest.version_code).toBe(10);
 
     const legacyResponse = await handlePublicV2UpdateCheck(
@@ -7936,6 +8186,7 @@ describe("quiver public API v2 — scope resolution", () => {
     const { handleCreateReleaseDraft } = await import("../src/routes/releases");
     // seed a build to release
     await seedRelease(env, "rel-seed", "build-draftonly", [["full", "all"]], { versionCode: 21 });
+    await env.DB.prepare("DELETE FROM releases WHERE id = 'rel-seed'").run();
     const ctx = (body: unknown) =>
       ({
         env,


### PR DESCRIPTION
## Summary

- enforce one durable release lifecycle for each app, channel, product type,
  release type, and version code while preserving legacy duplicate rows
- restore a cancelled never-published release to `draft`, while only a
  previously active lifecycle may restore to `active`
- fence PATCH, publish, cancel, restore, rollout bump, and force-update behind
  one revision + status + rollout + exact-scope CAS in the same D1 batch as all
  fallback and audit side effects
- commit an external build's target freeze only inside that same publish CAS
  batch, so every failed/stale publish leaves zero freeze side effects
- allow one release to combine `full:all`, percentage rollout, and mandatory
  device-group overrides while preserving fallback resolution
- align Worker routes, resolver, Tauri selection, CLI, Admin,
  Agent/OpenAPI contracts, tests, and documentation

## Review Successor

This successor closes all findings from the reviews of `ad68f1b6...` and
`78fb25c5...`; both old exacts are VOID for merge.

1. `activated_at` is populated only for known active/superseded legacy rows. A
   cancelled row with no activation history restores to draft and must pass the
   ordinary external-target and exact-scope publish gates.
2. Migration `0053` adds a monotonic release `revision`. Every lifecycle
   mutation conditionally inserts its audit token only when revision, status,
   rollout, and exact stored scopes still match; every release/scope/fallback
   write in that transaction requires the token.
3. External-target validation is now read-only preflight. For a draft publish,
   the conditional audit rechecks the release CAS, build freeze state, and exact
   target declarations; the freeze UPDATE, fallback changes, and activation all
   require that audit token in one D1 batch. Wrong scope or stale revision leaves
   `freeze_token`, audit, fallback, and release untouched by the publisher.
4. Release/build identity triggers use null-safe SQLite `IS NOT` comparisons.
   Released `channel_id NULL -> value` and `value -> NULL` are rejected, while
   the same transition remains allowed on an unreleased build.

## Regression Teeth

- external CLI build: draft -> cancel -> restore remains draft; wrong target set
  stays non-resolvable; exact target+scope publish succeeds
- correct target set + wrong scope precondition leaves the build unfrozen
- target preflight followed by a winning rollout mutation makes the stale
  publish return `RELEASE_REVISION_CONFLICT` with zero freeze/publish-audit/
  fallback side effects; a fresh publish freezes and activates exactly once
- deterministic scope PATCH vs bump, cancel vs bump, and duplicate restore races
- generic stale PATCH/publish/cancel/restore/bump/force mutations have zero
  side effects
- migration executable gate covers released NULL transitions in both directions
  and preserves mutability for an unreleased build

## Migration Safety

Migration `0053` does not delete, merge, or rewrite historical duplicate
releases. It adds `activated_at` and `revision`, backfills activation only for
`active`/`superseded` rows, and installs null-safe triggers that reject future
duplicate version lifecycles and identity changes while retaining existing
history.

## Validation

Fresh on head `e923d32f49389f9313e452ac539bd901cc66d52f` and
`main@b9a5b131889a5f590c0dd38fe318751cd88a426d`:

- `pnpm test` - PASS, 316 tests total; Worker 245 including route suite 164/164
- `pnpm build` - PASS for Worker, Admin, CLI, Node, Electron, and container
- isolated Wrangler 4.100 local-D1 execution of migration `0053` - PASS,
  all 8 SQL statements; activation/revision readback correct; released
  NULL->value and value->NULL both reject with `SQLITE_CONSTRAINT_TRIGGER`;
  unreleased NULL->value succeeds
- `git diff --check origin/main...HEAD` - PASS; worktree clean
- 2 commits, both author/committer/sign-off
  `林舟 <codex-android-devops@mail.build>`

Workspace lint still stops before source lint on the repository baseline:
ESLint 9 is installed but no `eslint.config.*` exists. The pre-existing full
migration-chain gate also stops at migration
`0003_operation_logs_nullable_app.sql` because that file contains multiple
transactions; migration `0053` itself passes Wrangler parser/execution in
isolation.

## Operational Boundary

This PR changes source and migration files only. It does not deploy the Worker,
apply migration `0053`, alter a live rollout, publish a release, or merge
itself. Those remain separate explicit approval gates.
