### PR TITLE
feat(testflight): add exact build expiration action

### DIFF
--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -173,7 +173,9 @@ production publishing. The integration exposes six actions:
   ids for the exact app.
 - `expire-testflight-build` (app admin): after explicit human authorization,
   expire one exact beta build using its ASC build id plus immutable
-  version/build confirmations; exact retries are no-ops.
+  version/build confirmations; a durable redacted operation receipt is written
+  before Apple mutation, PATCH/readback outcomes are terminalized, and exact
+  retries are no-ops linked to any prior PATCH-confirmed operation.
 - `publish-testflight-build` (publisher): assign a processed build to selected
   groups, upsert localized What to Test text, and submit external Beta App
   Review when requested.

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -163,7 +163,7 @@ presence.
 ### TestFlight upload and distribution
 
 TestFlight is a separate state machine from the Hands draft and from App Store
-production publishing. The integration exposes five actions:
+production publishing. The integration exposes six actions:
 
 - `upload-testflight-build` (app admin): stream the existing signed Hands IPA
   to Apple's Build Upload API.
@@ -171,6 +171,9 @@ production publishing. The integration exposes five actions:
   `state.state=COMPLETE|FAILED`, retaining Apple's errors/warnings/infos.
 - `list-testflight-groups` (viewer): get stable internal/external beta group
   ids for the exact app.
+- `expire-testflight-build` (app admin): after explicit human authorization,
+  expire one exact beta build using its ASC build id plus immutable
+  version/build confirmations; exact retries are no-ops.
 - `publish-testflight-build` (publisher): assign a processed build to selected
   groups, upsert localized What to Test text, and submit external Beta App
   Review when requested.
@@ -211,6 +214,18 @@ raft integration invoke --service <hands-service> \
     "group_ids":["<asc-beta-group-id>"],
     "what_to_test":{"en-US":"Verify login and Activity."},
     "notify_testers":false
+  }' --json
+
+# Live-facing and irreversible for TestFlight availability: run only after an
+# explicit human selects the exact build. All three confirmations are required.
+raft integration invoke --service <hands-service> \
+  --action expire-testflight-build \
+  --param app_id=<app-uuid> \
+  --param build_id=<hands-build-uuid> \
+  --data-json '{
+    "asc_build_id":"<exact-asc-build-id>",
+    "confirm_version":"1.0.0",
+    "confirm_build_number":"1000006"
   }' --json
 ```
 

--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -82,6 +82,24 @@ build + sign IPA  ──────────▶ build + assets in R2
    Beta App Review, auto-notify, assigned-group, and localization state. It
    distinguishes `waiting_for_review`, `in_review`, `approved_not_notified`,
    `testing`, `rejected`, `expired`, and processing failures.
+7. **Expire an exact beta build when it must leave testing** — after explicit
+   human authorization, an app admin supplies all three independent
+   confirmations from the status response:
+
+   ```
+   POST /api/apps/{app_id}/builds/{build_id}/testflight-expire
+   {
+     "asc_build_id": "<exact-asc-build-id>",
+     "confirm_version": "1.0.0",
+     "confirm_build_number": "1000006"
+   }
+   ```
+
+   Hands resolves the immutable build tuple again, refuses any ASC id or
+   version/build mismatch, sets only the ASC Build resource's `expired` flag,
+   and immediately reads the same build back. Retrying an already-expired exact
+   build is a `200` no-op with `changed=false`. Expiration removes TestFlight
+   availability; Apple keeps the build record for audit/history.
 
 These endpoints and the matching CLI/integration actions are TestFlight-only.
 They never activate a Hands release and never create, submit, or release an
@@ -100,8 +118,8 @@ Hands is the credential's only home — CI never needs a copy, so rotation
 stays single-source.
 
 Hands roles are intentionally split: uploading to Apple requires app admin,
-distribution requires app publisher, and status/group reads require app
-viewer. Apple's own role boundary still applies to the stored key: external
+expiring an exact beta build requires app admin, distribution requires app
+publisher, and status/group reads require app viewer. Apple's own role boundary still applies to the stored key: external
 testing requires Account Holder, Admin, or App Manager; internal testing also
 permits Developer or Marketing.
 
@@ -142,6 +160,7 @@ Raft integration actions:
 - `upload-testflight-build`
 - `get-testflight-upload-status`
 - `list-testflight-groups`
+- `expire-testflight-build`
 - `publish-testflight-build`
 - `get-testflight-publish-status`
 

--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -97,9 +97,14 @@ build + sign IPA  ──────────▶ build + assets in R2
 
    Hands resolves the immutable build tuple again, refuses any ASC id or
    version/build mismatch, sets only the ASC Build resource's `expired` flag,
-   and immediately reads the same build back. Retrying an already-expired exact
-   build is a `200` no-op with `changed=false`. Expiration removes TestFlight
-   availability; Apple keeps the build record for audit/history.
+   and immediately reads the same build back. Before the Apple mutation it
+   stores a redacted operation intent containing the actor and exact build
+   coordinate; PATCH/readback success or failure terminalizes that receipt.
+   Retrying an already-expired exact build is a `200` no-op with
+   `changed=false` and links to any prior PATCH-confirmed operation, so a lost
+   readback or audit response cannot erase who triggered the mutation.
+   Expiration removes TestFlight availability; Apple keeps the build record for
+   audit/history. Responses include `operation_id` for supported inspection.
 
 These endpoints and the matching CLI/integration actions are TestFlight-only.
 They never activate a Hands release and never create, submit, or release an

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -120,6 +120,7 @@ import {
 } from "./routes/asc_credentials";
 import {
   handleListTestflightGroups,
+  handleTestflightExpire,
   handleTestflightPublish,
   handleTestflightPublishStatus,
   handleTestflightUpload,
@@ -923,6 +924,7 @@ admin.post("/api/apps/:appId/asc-credentials/verify", requireAppRole("admin"), h
 admin.post("/api/apps/:appId/builds/:buildId/testflight-upload", requireAppRole("admin"), handleTestflightUpload);
 admin.get("/api/apps/:appId/testflight-uploads/:buildUploadId", requireAppRole("viewer"), handleTestflightUploadStatus);
 admin.get("/api/apps/:appId/builds/:buildId/testflight-groups", requireAppRole("viewer"), handleListTestflightGroups);
+admin.post("/api/apps/:appId/builds/:buildId/testflight-expire", requireAppRole("admin"), handleTestflightExpire);
 admin.post("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("publisher"), handleTestflightPublish);
 admin.get("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("viewer"), handleTestflightPublishStatus);
 admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);

--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -379,6 +379,32 @@ export async function resolveAscBuild(
   return res.data?.[0] ?? null;
 }
 
+/**
+ * Mark one exact processed build as expired in TestFlight.
+ *
+ * App Store Connect keeps the build record for audit/history; setting
+ * `expired=true` only removes its TestFlight availability. This endpoint does
+ * not mutate an App Store production version.
+ */
+export async function expireAscBuild(
+  creds: AscApiCredentials,
+  ascBuildId: string,
+): Promise<AscBuildResource> {
+  const res = await ascRequest<{ data: AscBuildResource }>(
+    creds,
+    "PATCH",
+    `/v1/builds/${encodeURIComponent(ascBuildId)}`,
+    {
+      data: {
+        type: "builds",
+        id: ascBuildId,
+        attributes: { expired: true },
+      },
+    },
+  );
+  return res.data;
+}
+
 export async function listBetaGroups(
   creds: AscApiCredentials,
   ascAppId: string,

--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -117,6 +117,12 @@ const TestflightPublishInput = TestflightBundleAssertion.extend({
   }),
 }).openapi("TestflightPublishInput");
 
+const TestflightExpireInput = TestflightBundleAssertion.extend({
+  asc_build_id: z.string().min(1),
+  confirm_version: z.string().min(1),
+  confirm_build_number: z.string().regex(/^\d+$/),
+}).strict().openapi("TestflightExpireInput");
+
 export function registerBuildRoutes(registry: OpenApiRegistry) {
   register(registry, {
     method: "get",
@@ -275,6 +281,28 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
       403: error("App viewer role is required."),
       404: error("Hands build or App Store Connect app was not found."),
       502: error("Apple group lookup failed."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/builds/{buildId}/testflight-expire",
+    tags: ["TestFlight"],
+    summary: "Expire one exact TestFlight build",
+    description:
+      "Requires the resolved App Store Connect build id plus the immutable Hands version/build tuple as confirmation. Idempotently marks only that Build resource expired, immediately reads it back, and never mutates an App Store production version or a Hands release.",
+    security: auth,
+    request: {
+      params: AppBuildParams,
+      body: { content: json(TestflightExpireInput), required: true },
+    },
+    responses: {
+      200: success("Exact build expired, or an already-expired exact build confirmed unchanged.", GenericObject),
+      400: error("ASC credentials, bundle assertion, or confirmation body is invalid."),
+      403: error("App admin role is required."),
+      404: error("Hands build or App Store Connect app was not found."),
+      409: error("The exact build coordinate or post-expire readback did not match."),
+      502: error("Apple rejected the expire request."),
     },
   });
 

--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -290,7 +290,7 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
     tags: ["TestFlight"],
     summary: "Expire one exact TestFlight build",
     description:
-      "Requires the resolved App Store Connect build id plus the immutable Hands version/build tuple as confirmation. Idempotently marks only that Build resource expired, immediately reads it back, and never mutates an App Store production version or a Hands release.",
+      "Requires the resolved App Store Connect build id plus the immutable Hands version/build tuple as confirmation. Persists a redacted actor/coordinate operation intent before Apple mutation, terminalizes PATCH/readback outcome, idempotently marks only that Build resource expired, and never mutates an App Store production version or a Hands release.",
     security: auth,
     request: {
       params: AppBuildParams,

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -720,7 +720,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
       "4. Release management (app publisher): create-release from an existing build (DRAFT by default) → update-release with bilingual release_notes → after explicit human authorization, publish-release. See docs.release_guide.",
       "5. iOS simulator QA fixtures: create-ios-simulator-artifact → PUT the .app.zip to upload.url with the returned headers → complete-ios-simulator-artifact → get/presign the durable exact-byte artifact. QA artifacts can never become releases or update offers.",
-      "6. TestFlight: an app admin runs upload-testflight-build and polls get-testflight-upload-status to COMPLETE; an app viewer lists stable beta-group ids, then an app publisher runs publish-testflight-build and polls distribution status. These actions never activate a Hands release or submit an App Store production release.",
+      "6. TestFlight: an app admin runs upload-testflight-build and polls get-testflight-upload-status to COMPLETE; an app viewer lists stable beta-group ids, then an app publisher runs publish-testflight-build and polls distribution status. If an exact beta build must be removed from testing, an app admin uses expire-testflight-build with the ASC build id plus version/build confirmations. These actions never activate a Hands release or submit an App Store production release.",
     ],
     auth: {
       raft_agents:
@@ -753,6 +753,8 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
         "POST /api/apps/{app_id}/builds/{build_id}/testflight-upload — admin; streams the stored signed IPA to Apple's Build Upload API without distributing it",
       publish_testflight_build:
         "POST /api/apps/{app_id}/builds/{build_id}/testflight-publish — publisher; assigns processed builds to beta groups and optionally submits external Beta App Review",
+      expire_testflight_build:
+        "POST /api/apps/{app_id}/builds/{build_id}/testflight-expire — admin; exact ASC build id + immutable version/build confirmation; expires TestFlight availability only",
     },
     docs: {
       agent_guide: `${origin}/docs/agent-cli-feedback`,
@@ -1239,6 +1241,23 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
           build_id: { type: "string", in: "path", required: true, description: "Hands build UUID used to resolve the bundle id." },
           bundle_id: { type: "string", in: "query", required: false, description: "Optional bundle-id assertion; it must match immutable build metadata, and is only a fallback when metadata is absent." },
+        },
+      },
+      {
+        name: "expire-testflight-build",
+        description:
+          "Expire one exact App Store Connect Build from TestFlight availability. Requires the resolved ASC build id plus exact immutable version/build confirmations, is idempotent with immediate readback, and never mutates App Store production or a Hands release. Requires app admin and explicit human authorization for the live-facing mutation.",
+        endpoint: {
+          method: "POST",
+          path: "/api/apps/{app_id}/builds/{build_id}/testflight-expire",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands app UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Hands iOS build UUID whose exact ASC build should be expired." },
+          asc_build_id: { type: "string", in: "body", required: true, description: "Exact App Store Connect Build id returned by get-testflight-publish-status." },
+          confirm_version: { type: "string", in: "body", required: true, description: "Exact immutable Hands marketing version confirmation." },
+          confirm_build_number: { type: "string", in: "body", required: true, description: "Exact immutable Hands numeric build-number confirmation." },
+          bundle_id: { type: "string", in: "body", required: false, description: "Optional bundle-id assertion; it must match immutable build metadata, and is only a fallback when metadata is absent." },
         },
       },
       {

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1246,7 +1246,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "expire-testflight-build",
         description:
-          "Expire one exact App Store Connect Build from TestFlight availability. Requires the resolved ASC build id plus exact immutable version/build confirmations, is idempotent with immediate readback, and never mutates App Store production or a Hands release. Requires app admin and explicit human authorization for the live-facing mutation.",
+          "Expire one exact App Store Connect Build from TestFlight availability. Requires the resolved ASC build id plus exact immutable version/build confirmations, persists a redacted operation intent before Apple mutation, terminalizes PATCH/readback outcome, is idempotent with immediate readback, and never mutates App Store production or a Hands release. Requires app admin and explicit human authorization for the live-facing mutation.",
         endpoint: {
           method: "POST",
           path: "/api/apps/{app_id}/builds/{build_id}/testflight-expire",

--- a/worker/src/routes/operations.ts
+++ b/worker/src/routes/operations.ts
@@ -26,6 +26,7 @@ export interface OperationLog {
     | "signed_url"
     | "testflight-upload"
     | "testflight-publish"
+    | "testflight-expire"
     | "delta-generate";
   status: "pending" | "in_progress" | "success" | "failed" | "cancelled";
   parent_op_id: string | null;
@@ -184,6 +185,15 @@ export async function handleRetryOperation(c: Context<{ Bindings: Env }>) {
   const id = c.req.param("opId") ?? "";
   const existing = await getOperation(c.env.DB, id);
   if (!existing) return c.json({ error: "not found" }, 404);
+  if (existing.kind === "testflight-expire") {
+    return c.json(
+      {
+        error: "retry cannot rewrite a durable TestFlight expire receipt; invoke the exact expire action again",
+        operation: existing,
+      },
+      400,
+    );
+  }
   if (existing.status === "in_progress") {
     return c.json(
       { error: "operation already in_progress; wait or cancel first" },
@@ -231,6 +241,12 @@ export async function handleDeleteOperation(c: Context<{ Bindings: Env }>) {
   const id = c.req.param("opId") ?? "";
   const existing = await getOperation(c.env.DB, id);
   if (!existing) return c.json({ error: "not found" }, 404);
+  if (existing.kind === "testflight-expire") {
+    return c.json(
+      { error: "durable TestFlight expire receipts cannot be deleted" },
+      409,
+    );
+  }
   await c.env.DB.prepare("DELETE FROM operation_logs WHERE id = ?").bind(id).run();
   return c.json({ ok: true, id });
 }

--- a/worker/src/routes/testflight.ts
+++ b/worker/src/routes/testflight.ts
@@ -36,6 +36,7 @@ import {
   createBetaAppReviewSubmission,
   createBuildUpload,
   createBuildUploadFile,
+  expireAscBuild,
   getAssignedBetaGroupIds,
   getBetaAppReviewSubmission,
   getBetaBuildLocalizations,
@@ -74,6 +75,13 @@ interface TestflightPublishInput {
   group_ids: string[];
   what_to_test: Record<string, string>;
   notify_testers: boolean;
+  bundle_id?: string;
+}
+
+interface TestflightExpireInput {
+  asc_build_id: string;
+  confirm_version: string;
+  confirm_build_number: string;
   bundle_id?: string;
 }
 
@@ -309,6 +317,80 @@ export function parsePublishInput(raw: unknown): TestflightPublishInput {
     notify_testers: body.notify_testers ?? false,
     ...(bundleId ? { bundle_id: bundleId } : {}),
   };
+}
+
+export function parseExpireInput(raw: unknown): TestflightExpireInput {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_EXPIRE_INPUT",
+      "an exact TestFlight expire confirmation body is required",
+    );
+  }
+  const body = raw as Record<string, unknown>;
+  const allowed = new Set([
+    "asc_build_id",
+    "confirm_version",
+    "confirm_build_number",
+    "bundle_id",
+  ]);
+  if (Object.keys(body).some((key) => !allowed.has(key))) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_EXPIRE_INPUT",
+      "unexpected TestFlight expire input field",
+    );
+  }
+  const ascBuildId =
+    typeof body.asc_build_id === "string" ? body.asc_build_id.trim() : "";
+  const confirmVersion =
+    typeof body.confirm_version === "string" ? body.confirm_version.trim() : "";
+  const confirmBuildNumber =
+    typeof body.confirm_build_number === "string"
+      ? body.confirm_build_number.trim()
+      : "";
+  const bundleId =
+    typeof body.bundle_id === "string" ? body.bundle_id.trim() : undefined;
+  if (!ascBuildId || !confirmVersion || !/^\d+$/.test(confirmBuildNumber)) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_EXPIRE_INPUT",
+      "asc_build_id, confirm_version, and numeric confirm_build_number are required",
+    );
+  }
+  if (body.bundle_id !== undefined && !bundleId) {
+    throw new TestflightPublishError(
+      400,
+      "INVALID_BUNDLE_ID",
+      "bundle_id must be a non-empty string when provided",
+    );
+  }
+  return {
+    asc_build_id: ascBuildId,
+    confirm_version: confirmVersion,
+    confirm_build_number: confirmBuildNumber,
+    ...(bundleId ? { bundle_id: bundleId } : {}),
+  };
+}
+
+export function assertExpireConfirmation(
+  build: Pick<HandsTestflightBuild, "version_name" | "version_code">,
+  input: Pick<TestflightExpireInput, "confirm_version" | "confirm_build_number">,
+): void {
+  if (
+    input.confirm_version !== build.version_name ||
+    input.confirm_build_number !== String(build.version_code)
+  ) {
+    throw new TestflightPublishError(
+      409,
+      "EXPIRE_CONFIRMATION_MISMATCH",
+      "the version/build confirmation does not match the immutable Hands build",
+      {
+        expected_version: build.version_name,
+        expected_build_number: String(build.version_code),
+      },
+    );
+  }
 }
 
 function publicGroup(group: BetaGroupResource) {
@@ -841,6 +923,151 @@ export async function handleTestflightPublishStatus(c: AdminContext) {
         ...(distribution ? { distribution } : {}),
       }),
     );
+  } catch (error) {
+    return testflightErrorResponse(c, error);
+  }
+}
+
+function expireStatusPayload(args: {
+  handsBuild: HandsTestflightBuild;
+  bundleId: string;
+  ascAppId: string;
+  ascBuild: AscBuildResource;
+  changed: boolean;
+}) {
+  return {
+    ok: true,
+    changed: args.changed,
+    hands_build_id: args.handsBuild.id,
+    bundle_id: args.bundleId,
+    asc_app_id: args.ascAppId,
+    asc_build_id: args.ascBuild.id,
+    version: args.handsBuild.version_name,
+    build_number: String(args.handsBuild.version_code),
+    processing_state: args.ascBuild.attributes.processingState,
+    expired: args.ascBuild.attributes.expired === true,
+    expiration_date: args.ascBuild.attributes.expirationDate,
+  };
+}
+
+export async function expireResolvedAscBuild(
+  creds: AscApiCredentials,
+  args: {
+    ascAppId: string;
+    handsBuild: HandsTestflightBuild;
+    ascBuild: AscBuildResource;
+    expectedAscBuildId: string;
+  },
+): Promise<{ changed: boolean; ascBuild: AscBuildResource }> {
+  if (args.ascBuild.id !== args.expectedAscBuildId) {
+    throw new TestflightPublishError(
+      409,
+      "ASC_BUILD_ID_MISMATCH",
+      "asc_build_id does not match the App Store Connect build resolved from the immutable Hands version tuple",
+      { resolved_asc_build_id: args.ascBuild.id },
+    );
+  }
+  if (args.ascBuild.attributes.expired === true) {
+    return { changed: false, ascBuild: args.ascBuild };
+  }
+  if (args.ascBuild.attributes.processingState !== "VALID") {
+    throw new TestflightPublishError(
+      409,
+      "ASC_BUILD_NOT_READY",
+      "only a VALID App Store Connect build can be expired",
+      { processing_state: args.ascBuild.attributes.processingState },
+    );
+  }
+
+  const patched = await expireAscBuild(creds, args.ascBuild.id);
+  if (patched.id !== args.ascBuild.id || patched.attributes.expired !== true) {
+    throw new TestflightPublishError(
+      409,
+      "ASC_EXPIRE_NOT_CONFIRMED",
+      "App Store Connect did not confirm the exact build as expired",
+    );
+  }
+  const readback = await resolveAscBuild(creds, {
+    ascAppId: args.ascAppId,
+    version: args.handsBuild.version_name,
+    buildNumber: String(args.handsBuild.version_code),
+  });
+  if (
+    !readback ||
+    readback.id !== args.ascBuild.id ||
+    readback.attributes.expired !== true
+  ) {
+    throw new TestflightPublishError(
+      409,
+      "ASC_EXPIRE_READBACK_FAILED",
+      "the exact App Store Connect build did not read back as expired",
+    );
+  }
+  return { changed: true, ascBuild: readback };
+}
+
+/**
+ * Expire one exact TestFlight build. This only toggles the ASC Build resource's
+ * TestFlight availability; it never submits, publishes, or edits an App Store
+ * production version and never mutates a Hands release.
+ */
+export async function handleTestflightExpire(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  try {
+    const input = parseExpireInput(await c.req.json().catch(() => null));
+    const build = await loadHandsTestflightBuild(
+      c,
+      appId,
+      c.req.param("buildId") ?? "",
+    );
+    assertExpireConfirmation(build, input);
+
+    const bundleId = await resolveBuildBundleId(c, build, input.bundle_id);
+    const creds = await loadAscCredentials(c, appId);
+    const ascAppId = await resolveAscAppId(creds, bundleId);
+    if (!ascAppId) {
+      throw new TestflightPublishError(
+        404,
+        "ASC_APP_NOT_FOUND",
+        `no App Store Connect app record for bundle id ${bundleId}`,
+      );
+    }
+    const ascBuild = await resolveAscBuild(creds, {
+      ascAppId,
+      version: build.version_name,
+      buildNumber: String(build.version_code),
+    });
+    if (!ascBuild) {
+      throw new TestflightPublishError(
+        409,
+        "ASC_BUILD_NOT_AVAILABLE",
+        "the exact App Store Connect build is not available",
+      );
+    }
+    const expired = await expireResolvedAscBuild(creds, {
+      ascAppId,
+      handsBuild: build,
+      ascBuild,
+      expectedAscBuildId: input.asc_build_id,
+    });
+    await insertAuditLog(c.env.DB, c, {
+      app_id: appId,
+      action: "testflight.expire",
+      payload: {
+        build_id: build.id,
+        asc_build_id: ascBuild.id,
+        version: build.version_name,
+        build_number: String(build.version_code),
+        changed: expired.changed,
+      },
+    });
+    return c.json(expireStatusPayload({
+      handsBuild: build,
+      bundleId,
+      ascAppId,
+      ascBuild: expired.ascBuild,
+      changed: expired.changed,
+    }));
   } catch (error) {
     return testflightErrorResponse(c, error);
   }

--- a/worker/src/routes/testflight.ts
+++ b/worker/src/routes/testflight.ts
@@ -86,12 +86,12 @@ interface TestflightExpireInput {
 }
 
 export class TestflightPublishError extends Error {
-  status: 400 | 404 | 409;
+  status: 400 | 404 | 409 | 500 | 502;
   code: string;
   details: Record<string, unknown>;
 
   constructor(
-    status: 400 | 404 | 409,
+    status: 400 | 404 | 409 | 500 | 502,
     code: string,
     message: string,
     details: Record<string, unknown> = {},
@@ -957,6 +957,7 @@ export async function expireResolvedAscBuild(
     handsBuild: HandsTestflightBuild;
     ascBuild: AscBuildResource;
     expectedAscBuildId: string;
+    onPatchConfirmed?: (patched: AscBuildResource) => Promise<void>;
   },
 ): Promise<{ changed: boolean; ascBuild: AscBuildResource }> {
   if (args.ascBuild.id !== args.expectedAscBuildId) {
@@ -987,6 +988,7 @@ export async function expireResolvedAscBuild(
       "App Store Connect did not confirm the exact build as expired",
     );
   }
+  await args.onPatchConfirmed?.(patched);
   const readback = await resolveAscBuild(creds, {
     ascAppId: args.ascAppId,
     version: args.handsBuild.version_name,
@@ -1006,6 +1008,159 @@ export async function expireResolvedAscBuild(
   return { changed: true, ascBuild: readback };
 }
 
+type TestflightExpireOperationCoordinate = {
+  appId: string;
+  actor: string;
+  handsBuildId: string;
+  bundleId: string;
+  ascAppId: string;
+  ascBuildId: string;
+  version: string;
+  buildNumber: string;
+};
+
+type TestflightExpireExecution = {
+  changed: boolean;
+  ascBuild: AscBuildResource;
+};
+
+/**
+ * Persist an exact redacted intent before the irreversible Apple PATCH, then
+ * preserve the PATCH/readback outcome in the same operation row. Even if a
+ * later audit write fails, the actor + exact coordinate + effect phase remain
+ * durable and an already-expired retry can link back to the original mutation.
+ */
+export async function runTestflightExpireOperation(
+  db: D1Database,
+  coordinate: TestflightExpireOperationCoordinate,
+  callbacks: {
+    beforeExecute?: (operationId: string) => Promise<void>;
+    execute: (hooks: {
+      onPatchConfirmed: (patched: AscBuildResource) => Promise<void>;
+    }) => Promise<TestflightExpireExecution>;
+  },
+) {
+  const operation = await createOperation(db, {
+    app_id: coordinate.appId,
+    kind: "testflight-expire",
+    actor: coordinate.actor,
+    input: JSON.stringify({
+      build_id: coordinate.handsBuildId,
+      bundle_id: coordinate.bundleId,
+      asc_app_id: coordinate.ascAppId,
+      asc_build_id: coordinate.ascBuildId,
+      version: coordinate.version,
+      build_number: coordinate.buildNumber,
+    }),
+  });
+  let patchConfirmed = false;
+  try {
+    await updateOperation(db, operation.id, {
+      status: "in_progress",
+      progress: 10,
+      output: JSON.stringify({
+        phase: "intent_recorded",
+        patch_confirmed: false,
+        readback_confirmed: false,
+      }),
+    });
+    await callbacks.beforeExecute?.(operation.id);
+    const result = await callbacks.execute({
+      onPatchConfirmed: async (patched) => {
+        patchConfirmed = true;
+        // The intent row already exists, so failure to add this intermediate
+        // breadcrumb must not skip the exact Apple readback or erase intent.
+        await updateOperation(db, operation.id, {
+          status: "in_progress",
+          progress: 70,
+          output: JSON.stringify({
+            phase: "apple_patch_confirmed",
+            patch_confirmed: true,
+            readback_confirmed: false,
+            asc_build_id: patched.id,
+          }),
+        }).catch(() => null);
+      },
+    });
+    const priorMutation = result.changed
+      ? null
+      : await db.prepare(
+          `SELECT id FROM operation_logs
+           WHERE app_id = ?1 AND kind = 'testflight-expire' AND id != ?2
+             AND json_extract(input, '$.build_id') = ?3
+             AND json_extract(input, '$.asc_build_id') = ?4
+             AND json_extract(output, '$.patch_confirmed') = 1
+           ORDER BY created_at ASC LIMIT 1`,
+        ).bind(
+          coordinate.appId,
+          operation.id,
+          coordinate.handsBuildId,
+          coordinate.ascBuildId,
+        ).first<{ id: string }>();
+    const output = {
+      phase: result.changed ? "readback_confirmed" : "already_expired",
+      changed: result.changed,
+      patch_confirmed: patchConfirmed,
+      readback_confirmed: true,
+      asc_build_id: result.ascBuild.id,
+      prior_mutation_operation_id: priorMutation?.id ?? null,
+    };
+    await updateOperation(db, operation.id, {
+      status: "success",
+      progress: 100,
+      output: JSON.stringify(output),
+      completed_at: Date.now(),
+    });
+    return {
+      operationId: operation.id,
+      priorMutationOperationId: priorMutation?.id ?? null,
+      ...result,
+    };
+  } catch (error) {
+    const phase = patchConfirmed ? "readback_failed" : "pre_patch_failed";
+    await updateOperation(db, operation.id, {
+      status: "failed",
+      output: JSON.stringify({
+        phase,
+        patch_confirmed: patchConfirmed,
+        readback_confirmed: false,
+        asc_build_id: coordinate.ascBuildId,
+      }),
+      error: JSON.stringify({
+        code: error instanceof TestflightPublishError
+          ? error.code
+          : error instanceof AscApiError
+            ? "ASC_API_ERROR"
+            : "TESTFLIGHT_EXPIRE_OPERATION_FAILED",
+      }),
+      completed_at: Date.now(),
+    }).catch(() => null);
+    const details = {
+      operation_id: operation.id,
+      patch_confirmed: patchConfirmed,
+      phase,
+    };
+    if (error instanceof TestflightPublishError) {
+      error.details = { ...error.details, ...details };
+      throw error;
+    }
+    if (error instanceof AscApiError) {
+      throw new TestflightPublishError(
+        502,
+        "ASC_EXPIRE_OPERATION_FAILED",
+        "App Store Connect expire operation failed; inspect the durable operation receipt",
+        { ...details, upstream_status: error.status },
+      );
+    }
+    throw new TestflightPublishError(
+      500,
+      "TESTFLIGHT_EXPIRE_OPERATION_FAILED",
+      "TestFlight expire operation failed; inspect the durable operation receipt",
+      details,
+    );
+  }
+}
+
 /**
  * Expire one exact TestFlight build. This only toggles the ASC Build resource's
  * TestFlight availability; it never submits, publishes, or edits an App Store
@@ -1013,6 +1168,12 @@ export async function expireResolvedAscBuild(
  */
 export async function handleTestflightExpire(c: AdminContext) {
   const appId = c.req.param("appId") ?? "";
+  let failureAudit: {
+    buildId: string;
+    ascBuildId: string;
+    version: string;
+    buildNumber: string;
+  } | null = null;
   try {
     const input = parseExpireInput(await c.req.json().catch(() => null));
     const build = await loadHandsTestflightBuild(
@@ -1044,31 +1205,108 @@ export async function handleTestflightExpire(c: AdminContext) {
         "the exact App Store Connect build is not available",
       );
     }
-    const expired = await expireResolvedAscBuild(creds, {
-      ascAppId,
-      handsBuild: build,
-      ascBuild,
-      expectedAscBuildId: input.asc_build_id,
-    });
-    await insertAuditLog(c.env.DB, c, {
-      app_id: appId,
-      action: "testflight.expire",
-      payload: {
-        build_id: build.id,
-        asc_build_id: ascBuild.id,
-        version: build.version_name,
-        build_number: String(build.version_code),
-        changed: expired.changed,
-      },
-    });
-    return c.json(expireStatusPayload({
-      handsBuild: build,
+    // Freeze the caller assertion before creating the intent receipt; no
+    // operation or audit row is created for a mismatched ASC id.
+    if (ascBuild.id !== input.asc_build_id) {
+      throw new TestflightPublishError(
+        409,
+        "ASC_BUILD_ID_MISMATCH",
+        "asc_build_id does not match the App Store Connect build resolved from the immutable Hands version tuple",
+        { resolved_asc_build_id: ascBuild.id },
+      );
+    }
+    failureAudit = {
+      buildId: build.id,
+      ascBuildId: ascBuild.id,
+      version: build.version_name,
+      buildNumber: String(build.version_code),
+    };
+    const expired = await runTestflightExpireOperation(c.env.DB, {
+      appId,
+      actor: currentActor(c),
+      handsBuildId: build.id,
       bundleId,
       ascAppId,
-      ascBuild: expired.ascBuild,
-      changed: expired.changed,
-    }));
+      ascBuildId: ascBuild.id,
+      version: build.version_name,
+      buildNumber: String(build.version_code),
+    }, {
+      beforeExecute: async (operationId) => {
+        await insertAuditLog(c.env.DB, c, {
+          app_id: appId,
+          action: "testflight.expire_intent",
+          payload: {
+            operation_id: operationId,
+            build_id: build.id,
+            asc_build_id: ascBuild.id,
+            version: build.version_name,
+            build_number: String(build.version_code),
+          },
+        });
+      },
+      execute: ({ onPatchConfirmed }) => expireResolvedAscBuild(creds, {
+        ascAppId,
+        handsBuild: build,
+        ascBuild,
+        expectedAscBuildId: input.asc_build_id,
+        onPatchConfirmed,
+      }),
+    });
+    try {
+      await insertAuditLog(c.env.DB, c, {
+        app_id: appId,
+        action: "testflight.expire",
+        payload: {
+          operation_id: expired.operationId,
+          prior_mutation_operation_id: expired.priorMutationOperationId,
+          build_id: build.id,
+          asc_build_id: ascBuild.id,
+          version: build.version_name,
+          build_number: String(build.version_code),
+          changed: expired.changed,
+        },
+      });
+    } catch {
+      return c.json({
+        error: "TestFlight build state changed but final audit write failed; inspect the durable operation receipt",
+        code: "TESTFLIGHT_EXPIRE_AUDIT_FAILED",
+        operation_id: expired.operationId,
+        prior_mutation_operation_id: expired.priorMutationOperationId,
+        changed: expired.changed,
+        expired: expired.ascBuild.attributes.expired === true,
+      }, 500);
+    }
+    return c.json({
+      operation_id: expired.operationId,
+      prior_mutation_operation_id: expired.priorMutationOperationId,
+      ...expireStatusPayload({
+        handsBuild: build,
+        bundleId,
+        ascAppId,
+        ascBuild: expired.ascBuild,
+        changed: expired.changed,
+      }),
+    });
   } catch (error) {
+    if (
+      failureAudit
+      && error instanceof TestflightPublishError
+      && typeof error.details.operation_id === "string"
+    ) {
+      await insertAuditLog(c.env.DB, c, {
+        app_id: appId,
+        action: "testflight.expire_failed",
+        payload: {
+          operation_id: error.details.operation_id,
+          build_id: failureAudit.buildId,
+          asc_build_id: failureAudit.ascBuildId,
+          version: failureAudit.version,
+          build_number: failureAudit.buildNumber,
+          patch_confirmed: error.details.patch_confirmed === true,
+          phase: error.details.phase,
+        },
+      }).catch(() => null);
+    }
     return testflightErrorResponse(c, error);
   }
 }

--- a/worker/test/asc_api.test.ts
+++ b/worker/test/asc_api.test.ts
@@ -12,6 +12,7 @@ import {
   createBuildUpload,
   createBuildUploadFile,
   commitBuildUploadFile,
+  expireAscBuild,
   resolveAscBuild,
   resolveAscAppId,
   AscApiError,
@@ -264,5 +265,36 @@ describe("TestFlight build resolution", () => {
       buildNumber: "1000005",
     });
     expect(build?.id).toBe("build-1");
+  });
+
+  it("expires only the exact ASC Build resource with the documented PATCH shape", async () => {
+    const { creds } = await generateTestCreds();
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      expect(new URL(String(url)).pathname).toBe("/v1/builds/build-1");
+      expect(init?.method).toBe("PATCH");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        data: {
+          type: "builds",
+          id: "build-1",
+          attributes: { expired: true },
+        },
+      });
+      return Response.json({
+        data: {
+          id: "build-1",
+          attributes: {
+            version: "1000005",
+            processingState: "VALID",
+            expired: true,
+          },
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const build = await expireAscBuild(creds, "build-1");
+    expect(build.id).toBe("build-1");
+    expect(build.attributes.expired).toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2200,6 +2200,61 @@ describe("quiver operation retry — legacy publish is not replayed", () => {
       .all();
     expect(releases.results).toHaveLength(0);
   });
+
+  it("keeps TestFlight expire receipts terminal and undeletable", async () => {
+    const now = Date.now();
+    const output = JSON.stringify({
+      phase: "readback_failed",
+      patch_confirmed: true,
+      readback_confirmed: false,
+      asc_build_id: "asc-build-1",
+    });
+    await env.DB
+      .prepare(
+        `INSERT INTO operation_logs
+         (id, app_id, kind, status, actor, input, output, error, progress,
+          retry_count, created_at, updated_at, completed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "op-expire",
+        "a1",
+        "testflight-expire",
+        "failed",
+        "tester",
+        JSON.stringify({ build_id: "hands-build-1", asc_build_id: "asc-build-1" }),
+        output,
+        JSON.stringify({ code: "ASC_EXPIRE_READBACK_FAILED" }),
+        70,
+        0,
+        now,
+        now,
+        now,
+      )
+      .run();
+
+    const { handleDeleteOperation, handleRetryOperation } = await import("../src/routes/operations");
+    const context = {
+      env,
+      req: { param: (name: string) => (name === "opId" ? "op-expire" : "") },
+      json: (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), { status }),
+    } as any;
+    expect((await handleRetryOperation(context)).status).toBe(400);
+    expect((await handleDeleteOperation(context)).status).toBe(409);
+
+    const preserved = await env.DB.prepare(
+      `SELECT status, output, progress, retry_count, completed_at
+       FROM operation_logs WHERE id = ?`,
+    ).bind("op-expire").first() as any;
+    expect(preserved).toMatchObject({
+      status: "failed",
+      output,
+      progress: 70,
+      retry_count: 0,
+      completed_at: now,
+    });
+  });
 });
 
 describe("quiver Hono app — auth + dispatch", () => {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -95,6 +95,7 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/builds/{buildId}/testflight-upload",
       "/api/apps/{appId}/testflight-uploads/{buildUploadId}",
       "/api/apps/{appId}/builds/{buildId}/testflight-groups",
+      "/api/apps/{appId}/builds/{buildId}/testflight-expire",
       "/api/apps/{appId}/builds/{buildId}/testflight-publish",
       "/api/apps/{appId}/qa-artifacts/ios-simulator",
       "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}",
@@ -8535,6 +8536,10 @@ describe("Hands iOS simulator QA artifacts", () => {
         method: "GET",
         path: "/api/apps/{app_id}/builds/{build_id}/testflight-groups",
       },
+      "expire-testflight-build": {
+        method: "POST",
+        path: "/api/apps/{app_id}/builds/{build_id}/testflight-expire",
+      },
       "publish-testflight-build": {
         method: "POST",
         path: "/api/apps/{app_id}/builds/{build_id}/testflight-publish",
@@ -8574,6 +8579,14 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect(byName["get-release"].endpoint.method).toBe("GET");
     expect(byName["get-release"].parameters).not.toHaveProperty("expected_scope");
     expect(byName["publish-release"].endpoint.method).toBe("POST");
+    expect(byName["expire-testflight-build"].parameters).toMatchObject({
+      app_id: { type: "string", in: "path", required: true },
+      build_id: { type: "string", in: "path", required: true },
+      asc_build_id: { type: "string", in: "body", required: true },
+      confirm_version: { type: "string", in: "body", required: true },
+      confirm_build_number: { type: "string", in: "body", required: true },
+      bundle_id: { type: "string", in: "body", required: false },
+    });
     expect(byName["publish-release"].parameters.expected_scope).toMatchObject({
       type: "object",
       in: "body",

--- a/worker/test/testflight_publish.test.ts
+++ b/worker/test/testflight_publish.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { AscApiCredentials } from "../src/lib/asc_api";
 import {
+  assertExpireConfirmation,
+  expireResolvedAscBuild,
   handleTestflightPublish,
+  parseExpireInput,
   parsePublishInput,
   publishProcessedAscBuild,
   TestflightPublishError,
@@ -248,6 +251,119 @@ afterEach(() => {
 });
 
 describe("publishProcessedAscBuild", () => {
+  it("requires an exact closed expire confirmation body", () => {
+    expect(parseExpireInput({
+      asc_build_id: "build-1",
+      confirm_version: "1.0.0",
+      confirm_build_number: "1000005",
+    })).toEqual({
+      asc_build_id: "build-1",
+      confirm_version: "1.0.0",
+      confirm_build_number: "1000005",
+    });
+    expect(() => parseExpireInput({
+      asc_build_id: "build-1",
+      confirm_version: "1.0.0",
+      confirm_build_number: 1000005,
+    })).toThrowError(expect.objectContaining({ code: "INVALID_EXPIRE_INPUT" }));
+    expect(() => parseExpireInput({
+      asc_build_id: "build-1",
+      confirm_version: "1.0.0",
+      confirm_build_number: "1000005",
+      force: true,
+    })).toThrowError(expect.objectContaining({ code: "INVALID_EXPIRE_INPUT" }));
+    expect(() => assertExpireConfirmation(
+      baseArgs().handsBuild,
+      { confirm_version: "1.0.0", confirm_build_number: "1000006" },
+    )).toThrowError(expect.objectContaining({
+      code: "EXPIRE_CONFIRMATION_MISMATCH",
+      details: {
+        expected_version: "1.0.0",
+        expected_build_number: "1000005",
+      },
+    }));
+  });
+
+  it("expires one resolved exact build, reads it back, and makes an exact retry a no-op", async () => {
+    const creds = await generateTestCreds();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (init?.method === "PATCH" && url.pathname === "/v1/builds/build-1") {
+        expect(JSON.parse(String(init.body))).toEqual({
+          data: {
+            type: "builds",
+            id: "build-1",
+            attributes: { expired: true },
+          },
+        });
+        return Response.json({
+          data: {
+            ...baseArgs().ascBuild,
+            attributes: { ...baseArgs().ascBuild.attributes, expired: true },
+          },
+        });
+      }
+      if (init?.method === "GET" && url.pathname === "/v1/builds") {
+        expect(url.searchParams.get("filter[app]")).toBe("app-1");
+        expect(url.searchParams.get("filter[version]")).toBe("1000005");
+        expect(url.searchParams.get("filter[preReleaseVersion.version]")).toBe("1.0.0");
+        return Response.json({
+          data: [{
+            ...baseArgs().ascBuild,
+            attributes: { ...baseArgs().ascBuild.attributes, expired: true },
+          }],
+        });
+      }
+      return Response.json({ errors: [{ title: "UNEXPECTED_REQUEST" }] }, { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const args = baseArgs();
+
+    const first = await expireResolvedAscBuild(creds, {
+      ascAppId: args.ascAppId,
+      handsBuild: args.handsBuild,
+      ascBuild: args.ascBuild,
+      expectedAscBuildId: "build-1",
+    });
+    expect(first.changed).toBe(true);
+    expect(first.ascBuild.attributes.expired).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    fetchMock.mockClear();
+    const replay = await expireResolvedAscBuild(creds, {
+      ascAppId: args.ascAppId,
+      handsBuild: args.handsBuild,
+      ascBuild: first.ascBuild,
+      expectedAscBuildId: "build-1",
+    });
+    expect(replay.changed).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mismatched ASC id or non-VALID build before Apple mutation", async () => {
+    const creds = await generateTestCreds();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const args = baseArgs();
+
+    await expect(expireResolvedAscBuild(creds, {
+      ascAppId: args.ascAppId,
+      handsBuild: args.handsBuild,
+      ascBuild: args.ascBuild,
+      expectedAscBuildId: "other-build",
+    })).rejects.toMatchObject({ code: "ASC_BUILD_ID_MISMATCH" });
+    await expect(expireResolvedAscBuild(creds, {
+      ascAppId: args.ascAppId,
+      handsBuild: args.handsBuild,
+      ascBuild: {
+        ...args.ascBuild,
+        attributes: { ...args.ascBuild.attributes, processingState: "PROCESSING" },
+      },
+      expectedAscBuildId: "build-1",
+    })).rejects.toMatchObject({ code: "ASC_BUILD_NOT_READY" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects a bundle assertion mismatch before operation or Apple access", async () => {
     let operationWrites = 0;
     const db = {

--- a/worker/test/testflight_publish.test.ts
+++ b/worker/test/testflight_publish.test.ts
@@ -8,6 +8,7 @@ import {
   parseExpireInput,
   parsePublishInput,
   publishProcessedAscBuild,
+  runTestflightExpireOperation,
   TestflightPublishError,
 } from "../src/routes/testflight";
 
@@ -246,6 +247,74 @@ function baseArgs() {
   } as const;
 }
 
+function operationReceiptDb() {
+  const rows: Array<Record<string, any>> = [];
+  const db = {
+    prepare(sql: string) {
+      let params: any[] = [];
+      const statement = {
+        bind(...values: any[]) {
+          params = values;
+          return statement;
+        },
+        async run() {
+          if (sql.includes("INSERT INTO operation_logs")) {
+            rows.push({
+              id: params[0],
+              app_id: params[1],
+              kind: params[2],
+              status: params[3],
+              parent_op_id: params[4],
+              step_number: params[5],
+              actor: params[6],
+              input: params[7],
+              output: params[8],
+              error: params[9],
+              progress: params[10],
+              retry_count: params[11],
+              created_at: params[12],
+              updated_at: params[13],
+              completed_at: params[14],
+            });
+            return { success: true };
+          }
+          if (sql.includes("UPDATE operation_logs SET")) {
+            const id = params.at(-1);
+            const row = rows.find((candidate) => candidate.id === id);
+            const setClause = sql.match(/SET ([\s\S]+?) WHERE/)?.[1] ?? "";
+            const fields = setClause.split(",").map((entry) => entry.trim().split(" ")[0]);
+            fields.forEach((field, index) => {
+              if (row && field) row[field] = params[index];
+            });
+            return { success: true };
+          }
+          throw new Error(`unexpected run SQL: ${sql}`);
+        },
+        async first() {
+          if (sql.includes("SELECT * FROM operation_logs WHERE id")) {
+            return rows.find((row) => row.id === params[0]) ?? null;
+          }
+          if (sql.includes("SELECT id FROM operation_logs")) {
+            const [appId, excludedId, buildId, ascBuildId] = params;
+            return rows
+              .filter((row) => row.app_id === appId && row.kind === "testflight-expire" && row.id !== excludedId)
+              .find((row) => {
+                const input = JSON.parse(row.input);
+                const output = JSON.parse(row.output);
+                return input.build_id === buildId
+                  && input.asc_build_id === ascBuildId
+                  && output.patch_confirmed === true;
+              }) ?? null;
+          }
+          throw new Error(`unexpected first SQL: ${sql}`);
+        },
+      };
+      return statement;
+    },
+  };
+  return { db: db as unknown as D1Database, rows };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -362,6 +431,89 @@ describe("publishProcessedAscBuild", () => {
       expectedAscBuildId: "build-1",
     })).rejects.toMatchObject({ code: "ASC_BUILD_NOT_READY" });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves PATCH-confirmed intent when readback fails and links the no-op retry", async () => {
+    const { db, rows } = operationReceiptDb();
+    const args = baseArgs();
+    const coordinate = {
+      appId: "app-hands",
+      actor: "reviewer@example.test",
+      handsBuildId: args.handsBuild.id,
+      bundleId: args.bundleId,
+      ascAppId: args.ascAppId,
+      ascBuildId: args.ascBuild.id,
+      version: args.handsBuild.version_name,
+      buildNumber: String(args.handsBuild.version_code),
+    };
+
+    let firstOperationId = "";
+    await expect(runTestflightExpireOperation(db, coordinate, {
+      beforeExecute: async (operationId) => {
+        firstOperationId = operationId;
+      },
+      execute: async ({ onPatchConfirmed }) => {
+        await onPatchConfirmed({
+          ...args.ascBuild,
+          attributes: { ...args.ascBuild.attributes, expired: true },
+        });
+        throw new TestflightPublishError(
+          409,
+          "ASC_EXPIRE_READBACK_FAILED",
+          "readback failed after patch",
+        );
+      },
+    })).rejects.toMatchObject({
+      code: "ASC_EXPIRE_READBACK_FAILED",
+      details: {
+        operation_id: expect.any(String),
+        patch_confirmed: true,
+        phase: "readback_failed",
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: firstOperationId,
+      actor: "reviewer@example.test",
+      kind: "testflight-expire",
+      status: "failed",
+    });
+    expect(JSON.parse(rows[0]!.input)).toEqual({
+      build_id: "hands-build-1",
+      bundle_id: "build.raft.app",
+      asc_app_id: "app-1",
+      asc_build_id: "build-1",
+      version: "1.0.0",
+      build_number: "1000005",
+    });
+    expect(JSON.parse(rows[0]!.output)).toMatchObject({
+      phase: "readback_failed",
+      patch_confirmed: true,
+      readback_confirmed: false,
+      asc_build_id: "build-1",
+    });
+    expect(rows[0]!.input).not.toContain("PRIVATE KEY");
+
+    const retry = await runTestflightExpireOperation(db, coordinate, {
+      execute: async () => ({
+        changed: false,
+        ascBuild: {
+          ...args.ascBuild,
+          attributes: { ...args.ascBuild.attributes, expired: true },
+        },
+      }),
+    });
+    expect(retry).toMatchObject({
+      changed: false,
+      priorMutationOperationId: firstOperationId,
+    });
+    expect(rows).toHaveLength(2);
+    expect(JSON.parse(rows[1]!.output)).toMatchObject({
+      phase: "already_expired",
+      changed: false,
+      prior_mutation_operation_id: firstOperationId,
+    });
   });
 
   it("rejects a bundle assertion mismatch before operation or Apple access", async () => {


### PR DESCRIPTION
## Summary

- add an app-admin `expire-testflight-build` action and REST/OpenAPI route
- require the exact ASC build id plus immutable Hands version/build confirmations
- patch only the App Store Connect Build resource's `expired` flag, then immediately resolve/read back the same tuple
- make exact retries no-ops, audit every accepted request, and expose no ASC credential material
- document the TestFlight-only boundary and Agent Login usage

This never mutates an App Store production version, a Hands release/share, or any other build.

## Safety gates

- mismatched Hands version/build confirmation rejects before Apple access
- resolved ASC build id must exactly equal the caller confirmation
- non-`VALID` unexpired builds reject before PATCH
- PATCH response and immediate tuple readback must both confirm the same build as expired
- app admin role required; manifest warns that explicit human authorization is required

## Validation

- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-worker test` — 16 files / 231 tests
- focused ASC/TestFlight/routes — 3 files / 177 tests
- `pnpm --filter @botiverse/hands-admin build`
- `git diff --check`

`pnpm --filter @botiverse/hands-worker lint` is currently blocked before source lint because this repository uses ESLint 9 without an `eslint.config.*` file.

Task: #proj-hands task #194
