### PR TITLE
fix(webhooks): guarantee reaper batch progress

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -194,7 +194,7 @@ import {
   handleDeleteWebhook,
   handleListDeliveries,
   handleListWebhooks,
-  handleReapDeliveries,
+  reapWebhookDeliveries,
   handleUpdateWebhook,
 } from "./routes/webhooks";
 import { handleHealth } from "./routes/health";
@@ -972,21 +972,31 @@ export interface ScheduledController {
 }
 
 export async function scheduled(
-  _controller: ScheduledController,
+  controller: ScheduledController,
   env: Env,
   ctx: ExecutionContext,
 ): Promise<void> {
-  // Build a minimal Hono context for the reaper handler.
-  const fakeC = {
-    env,
-    req: { param: () => ({}) },
-    json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
-      status,
-      headers: { "content-type": "application/json" },
-    }),
-  } as unknown as Parameters<typeof handleReapDeliveries>[0];
+  const reaperStartedAt = Date.now();
+  const reaper = reapWebhookDeliveries(env, {
+    scheduledTime: controller.scheduledTime,
+  }).then((summary) => {
+    // Deliberately metadata-only: never log a subscriber URL, request body,
+    // response body, signing secret, event id, or delivery id.
+    console.info("hands_webhook_reaper_summary", JSON.stringify(summary));
+  }).catch((error) => {
+    console.error("hands_webhook_reaper_summary", JSON.stringify({
+      scheduledTime: controller.scheduledTime,
+      selected: 0,
+      succeeded: 0,
+      retried: 0,
+      terminalized: 0,
+      durationMs: Math.max(0, Date.now() - reaperStartedAt),
+      errorCodes: { reaper_unhandled: 1 },
+    }));
+    throw error;
+  });
   ctx.waitUntil(Promise.all([
-    handleReapDeliveries(fakeC),
+    reaper,
     cleanupReporterFeedbackData(env),
   ]).then(() => undefined));
 }

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -119,8 +119,8 @@ export async function handleCreateWebhook(c: AdminContext) {
 export async function handleDeleteWebhook(c: AdminContext) {
   const orgId = c.req.param("orgId") ?? "";
   const webhookId = c.req.param("webhookId") ?? "";
-  // Soft-delete (set archived_at) so deliveries-in-flight still have a
-  // valid webhook row to reference.
+  // Soft-delete (set archived_at) so the scheduled reaper can identify and
+  // terminalize pending deliveries without attempting the retired endpoint.
   await c.env.DB.prepare(
     `UPDATE webhooks SET archived_at = ?1 WHERE id = ?2 AND org_id = ?3`,
   ).bind(Date.now(), webhookId, orgId).run();
@@ -275,98 +275,209 @@ export async function emitWebhookEvent(
 
 const BACKOFF_SCHEDULE_MS = [5 * 60_000, 30 * 60_000, 2 * 60 * 60_000]; // 5m, 30m, 2h
 
+const DELIVERY_ATTEMPT_TIMEOUT_MS = 10_000;
+const DELIVERY_REAPER_CONCURRENCY = 5;
+const DELIVERY_REAPER_BATCH_SIZE = 50;
+const DELIVERY_RESPONSE_BODY_LIMIT_BYTES = 500;
+
+interface ReapDeliveriesOptions {
+  now?: number;
+  scheduledTime?: number | null;
+  fetchImpl?: typeof fetch;
+  deliveryTimeoutMs?: number;
+  concurrency?: number;
+}
+
+export interface ReapDeliveriesSummary {
+  scheduledTime: number | null;
+  selected: number;
+  succeeded: number;
+  retried: number;
+  terminalized: number;
+  durationMs: number;
+  errorCodes: Record<string, number>;
+}
+
+interface DueDelivery {
+  id: string;
+  webhook_id: string;
+  event_id: string | null;
+  attempts: number;
+  max_attempts: number;
+  payload_json: string;
+  signing_secret: string | null;
+  resolved_webhook_id: string | null;
+  webhook_url: string | null;
+  webhook_secret: string | null;
+  webhook_enabled: number | null;
+  webhook_archived_at: number | null;
+}
+
 export async function handleReapDeliveries(c: Context<{ Bindings: Env }>) {
-  const now = Date.now();
-  // Find all deliveries ready to attempt
-  const { results: due } = await c.env.DB.prepare(
-    `SELECT id, webhook_id, COALESCE(event_id, feedback_submission_event_id) AS event_id,
-            attempts, max_attempts, payload_json, signing_secret
-     FROM webhook_deliveries
-     WHERE status = 'pending'
-       AND (next_attempt_at IS NULL OR next_attempt_at <= ?1)
-     ORDER BY created_at ASC
-     LIMIT 50`,
+  const summary = await reapWebhookDeliveries(c.env);
+  return c.json({
+    processed: summary.selected,
+    failed: summary.retried + summary.terminalized,
+    ...summary,
+  });
+}
+
+export async function reapWebhookDeliveries(
+  env: Pick<Env, "DB">,
+  options: ReapDeliveriesOptions = {},
+): Promise<ReapDeliveriesSummary> {
+  const startedAt = Date.now();
+  const now = options.now ?? startedAt;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const deliveryTimeoutMs = options.deliveryTimeoutMs ?? DELIVERY_ATTEMPT_TIMEOUT_MS;
+  const concurrency = Math.max(1, Math.min(
+    options.concurrency ?? DELIVERY_REAPER_CONCURRENCY,
+    DELIVERY_REAPER_BATCH_SIZE,
+  ));
+
+  // Resolve the webhook in the same bounded query. LEFT JOIN intentionally
+  // keeps orphaned deliveries visible so they can be terminalized instead of
+  // occupying the oldest slots forever.
+  const { results: due } = await env.DB.prepare(
+    `SELECT d.id, d.webhook_id,
+            COALESCE(d.event_id, d.feedback_submission_event_id) AS event_id,
+            d.attempts, d.max_attempts, d.payload_json, d.signing_secret,
+            w.id AS resolved_webhook_id, w.url AS webhook_url,
+            w.secret AS webhook_secret, w.enabled AS webhook_enabled,
+            w.archived_at AS webhook_archived_at
+     FROM webhook_deliveries d
+     LEFT JOIN webhooks w ON w.id = d.webhook_id
+     WHERE d.status = 'pending'
+       AND (d.next_attempt_at IS NULL OR d.next_attempt_at <= ?1)
+     ORDER BY d.created_at ASC, d.id ASC
+     LIMIT ${DELIVERY_REAPER_BATCH_SIZE}`,
   )
     .bind(now)
-    .all<{
-      id: string;
-      webhook_id: string;
-      event_id: string | null;
-      attempts: number;
-      max_attempts: number;
-      payload_json: string;
-      signing_secret: string | null;
-    }>();
+    .all<DueDelivery>();
 
-  let succeeded = 0;
-  let failed = 0;
-  for (const d of due) {
-    const wh = await c.env.DB.prepare(
-      `SELECT url, secret FROM webhooks WHERE id = ?1`,
-    )
-      .bind(d.webhook_id)
-      .first<{ url: string; secret: string }>();
-    if (!wh) continue;
+  const summary: ReapDeliveriesSummary = {
+    scheduledTime: options.scheduledTime ?? null,
+    selected: due.length,
+    succeeded: 0,
+    retried: 0,
+    terminalized: 0,
+    durationMs: 0,
+    errorCodes: {},
+  };
+  const recordError = (code: string) => {
+    summary.errorCodes[code] = (summary.errorCodes[code] ?? 0) + 1;
+  };
+
+  const processDelivery = async (d: DueDelivery) => {
+    const unavailableCode = !d.resolved_webhook_id
+      ? "webhook_missing"
+      : d.webhook_archived_at !== null
+        ? "webhook_archived"
+        : d.webhook_enabled !== 1
+          ? "webhook_disabled"
+          : null;
+    if (unavailableCode) {
+      await env.DB.prepare(
+        `UPDATE webhook_deliveries
+         SET status = 'failed', next_attempt_at = NULL, last_error = ?1,
+             completed_at = ?2, updated_at = ?2
+         WHERE id = ?3 AND status = 'pending'`,
+      ).bind(unavailableCode, now, d.id).run();
+      summary.terminalized++;
+      recordError(unavailableCode);
+      return;
+    }
 
     const result = await postOnce(
-      wh.url,
-      d.signing_secret ?? wh.secret,
+      d.webhook_url!,
+      d.signing_secret ?? d.webhook_secret!,
       d.payload_json,
       d.id,
       d.event_id,
+      fetchImpl,
+      deliveryTimeoutMs,
     );
     const nextAttempts = d.attempts + 1;
     if (result.ok) {
-      await c.env.DB.prepare(
+      await env.DB.prepare(
         `UPDATE webhook_deliveries
          SET status = 'succeeded', attempts = ?1, last_attempt_at = ?2,
-             last_response_status = ?3, last_response_body = ?4,
+             next_attempt_at = NULL, last_response_status = ?3,
+             last_response_body = ?4, last_error = NULL,
              completed_at = ?2, updated_at = ?2
-         WHERE id = ?5`,
-      ).bind(nextAttempts, now, result.status, result.body?.slice(0, 500), d.id).run();
-      succeeded++;
-    } else {
-      if (nextAttempts >= d.max_attempts) {
-        await c.env.DB.prepare(
-          `UPDATE webhook_deliveries
-           SET status = 'failed', attempts = ?1, last_attempt_at = ?2,
-               last_response_status = ?3, last_response_body = ?4,
-               last_error = ?5, completed_at = ?2, updated_at = ?2
-           WHERE id = ?6`,
-        ).bind(
-          nextAttempts,
-          now,
-          result.status,
-          result.body?.slice(0, 500),
-          result.error,
-          d.id,
-        ).run();
-      } else {
-        const backoff =
-          BACKOFF_SCHEDULE_MS[d.attempts] ??
-          BACKOFF_SCHEDULE_MS[BACKOFF_SCHEDULE_MS.length - 1] ??
-          60_000;
-        await c.env.DB.prepare(
-          `UPDATE webhook_deliveries
-           SET attempts = ?1, last_attempt_at = ?2, next_attempt_at = ?3,
-               last_response_status = ?4, last_response_body = ?5,
-               last_error = ?6, updated_at = ?2
-           WHERE id = ?7`,
-        ).bind(
-          nextAttempts,
-          now,
-          now + backoff,
-          result.status,
-          result.body?.slice(0, 500),
-          result.error,
-          d.id,
-        ).run();
-      }
-      failed++;
+         WHERE id = ?5 AND status = 'pending'`,
+      ).bind(nextAttempts, now, result.status, result.body ?? null, d.id).run();
+      summary.succeeded++;
+      return;
     }
-  }
 
-  return c.json({ processed: due.length, succeeded, failed });
+    const errorCode = result.errorCode ?? "webhook_http_error";
+    recordError(errorCode);
+    if (nextAttempts >= d.max_attempts) {
+      await env.DB.prepare(
+        `UPDATE webhook_deliveries
+         SET status = 'failed', attempts = ?1, last_attempt_at = ?2,
+             next_attempt_at = NULL, last_response_status = ?3,
+             last_response_body = ?4, last_error = ?5,
+             completed_at = ?2, updated_at = ?2
+         WHERE id = ?6 AND status = 'pending'`,
+      ).bind(
+        nextAttempts,
+        now,
+        result.status,
+        result.body ?? null,
+        errorCode,
+        d.id,
+      ).run();
+      summary.terminalized++;
+      return;
+    }
+
+    const backoff =
+      BACKOFF_SCHEDULE_MS[d.attempts] ??
+      BACKOFF_SCHEDULE_MS[BACKOFF_SCHEDULE_MS.length - 1] ??
+      60_000;
+    await env.DB.prepare(
+      `UPDATE webhook_deliveries
+       SET attempts = ?1, last_attempt_at = ?2, next_attempt_at = ?3,
+           last_response_status = ?4, last_response_body = ?5,
+           last_error = ?6, updated_at = ?2
+       WHERE id = ?7 AND status = 'pending'`,
+    ).bind(
+      nextAttempts,
+      now,
+      now + backoff,
+      result.status,
+      result.body ?? null,
+      errorCode,
+      d.id,
+    ).run();
+    summary.retried++;
+  };
+
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, due.length) },
+    async () => {
+      while (true) {
+        const index = nextIndex++;
+        const delivery = due[index];
+        if (!delivery) return;
+        try {
+          await processDelivery(delivery);
+        } catch {
+          // A single D1/fetch/runtime failure must not prevent later rows in
+          // the bounded batch from making progress. The untouched pending row
+          // remains eligible for a future cron invocation.
+          summary.retried++;
+          recordError("delivery_processing_error");
+        }
+      }
+    },
+  );
+  await Promise.all(workers);
+  summary.durationMs = Math.max(0, Date.now() - startedAt);
+  return summary;
 }
 
 async function postOnce(
@@ -375,41 +486,106 @@ async function postOnce(
   body: string,
   deliveryId: string,
   eventId: string | null,
-): Promise<{ ok: boolean; status: number; body?: string; error?: string }> {
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<{ ok: boolean; status: number; body?: string; errorCode?: string }> {
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
-    const sig = await hmacSha256Hex(secret, body);
-    const event = (() => {
-      try { return JSON.parse(body).event ?? ""; } catch { return ""; }
-    })();
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-      // New canonical headers; legacy X-Quiver-* sent too so existing
-      // webhook consumers keep verifying without a change.
-      "X-Hands-Signature": `sha256=${sig}`,
-      "X-Hands-Event": event,
-      "X-Hands-Delivery-Id": deliveryId,
-      "X-Quiver-Signature": `sha256=${sig}`,
-      "X-Quiver-Event": event,
-    };
-    if (eventId) headers["X-Hands-Event-Id"] = eventId;
-    const r = await fetch(url, {
-      method: "POST",
-      headers,
-      body,
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        reject(new Error("delivery_timeout"));
+      }, timeoutMs);
     });
-    const text = await r.text().catch(() => "");
-    return {
-      ok: r.ok,
-      status: r.status,
-      body: text,
-    };
-  } catch (e) {
+    return await Promise.race([
+      (async () => {
+        const sig = await hmacSha256Hex(secret, body);
+        const event = (() => {
+          try { return JSON.parse(body).event ?? ""; } catch { return ""; }
+        })();
+        const headers: Record<string, string> = {
+          "content-type": "application/json",
+          // New canonical headers; legacy X-Quiver-* sent too so existing
+          // webhook consumers keep verifying without a change.
+          "X-Hands-Signature": `sha256=${sig}`,
+          "X-Hands-Event": event,
+          "X-Hands-Delivery-Id": deliveryId,
+          "X-Quiver-Signature": `sha256=${sig}`,
+          "X-Quiver-Event": event,
+        };
+        if (eventId) headers["X-Hands-Event-Id"] = eventId;
+        const response = await fetchImpl(url, {
+          method: "POST",
+          headers,
+          body,
+          signal: controller.signal,
+        });
+        const responseBody = await readResponseBodyPrefix(
+          response,
+          DELIVERY_RESPONSE_BODY_LIMIT_BYTES,
+          controller.signal,
+        );
+        return {
+          ok: response.ok,
+          status: response.status,
+          body: responseBody,
+          ...(response.ok ? {} : { errorCode: "webhook_http_error" }),
+        };
+      })(),
+      deadline,
+    ]);
+  } catch {
     return {
       ok: false,
       status: 0,
-      error: (e as Error).message,
+      errorCode: timedOut ? "delivery_timeout" : "webhook_fetch_error",
     };
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }
+}
+
+async function readResponseBodyPrefix(
+  response: Response,
+  maxBytes: number,
+  signal: AbortSignal,
+): Promise<string> {
+  if (!response.body || maxBytes <= 0) return "";
+
+  const reader = response.body.getReader();
+  const prefix = new Uint8Array(maxBytes);
+  let length = 0;
+  const cancelForAbort = () => {
+    void reader.cancel("delivery_aborted").catch(() => undefined);
+  };
+  if (signal.aborted) cancelForAbort();
+  else signal.addEventListener("abort", cancelForAbort, { once: true });
+
+  try {
+    while (length < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      const take = Math.min(value.byteLength, maxBytes - length);
+      prefix.set(value.subarray(0, take), length);
+      length += take;
+      if (length === maxBytes) {
+        // Cancellation is advisory cleanup. A hostile stream may return a
+        // cancel promise that never settles, so it must not become another
+        // head-of-line wait after the bounded prefix is already complete.
+        void reader.cancel("response_body_prefix_complete").catch(() => undefined);
+        break;
+      }
+    }
+  } finally {
+    signal.removeEventListener("abort", cancelForAbort);
+    reader.releaseLock();
+  }
+
+  return new TextDecoder().decode(prefix.subarray(0, length));
 }
 
 async function hmacSha256Hex(secret: string, body: string): Promise<string> {

--- a/worker/test/webhook_reaper.test.ts
+++ b/worker/test/webhook_reaper.test.ts
@@ -1,0 +1,433 @@
+import Database from "better-sqlite3";
+import { describe, expect, it, vi } from "vitest";
+import { reapWebhookDeliveries } from "../src/routes/webhooks";
+
+function makeDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(`
+    CREATE TABLE webhooks (
+      id TEXT PRIMARY KEY,
+      url TEXT NOT NULL,
+      secret TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      archived_at INTEGER
+    );
+    CREATE TABLE webhook_deliveries (
+      id TEXT PRIMARY KEY,
+      webhook_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_id TEXT,
+      feedback_submission_event_id TEXT,
+      payload_json TEXT NOT NULL,
+      signing_secret TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      max_attempts INTEGER NOT NULL DEFAULT 3,
+      last_attempt_at INTEGER,
+      next_attempt_at INTEGER,
+      last_response_status INTEGER,
+      last_response_body TEXT,
+      last_error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER
+    );
+  `);
+
+  return {
+    prepare(sql: string) {
+      const indexes: number[] = [];
+      const normalized = sql.replace(/\?(\d+)/g, (_match, index) => {
+        indexes.push(Number(index));
+        return "?";
+      });
+      const statement = sqlite.prepare(normalized);
+      const bind = (...params: unknown[]) => {
+        const expanded = indexes.length > 0
+          ? indexes.map((index) => params[index - 1])
+          : params;
+        if (expanded.some((value) => value === undefined)) {
+          throw new TypeError("D1 bind rejects undefined; use explicit null");
+        }
+        return {
+          run: async () => {
+            const result = statement.run(...expanded);
+            return { success: true, meta: { changes: result.changes } };
+          },
+          all: async <T>() => ({
+            results: statement.all(...expanded) as T[],
+            success: true,
+          }),
+          first: async <T>() => (statement.get(...expanded) as T | undefined) ?? null,
+        };
+      };
+      return {
+        bind,
+        run: () => bind().run(),
+        all: <T>() => bind().all<T>(),
+        first: <T>() => bind().first<T>(),
+      };
+    },
+  };
+}
+
+async function insertWebhook(
+  db: ReturnType<typeof makeDb>,
+  id: string,
+  options: { enabled?: number; archivedAt?: number | null } = {},
+) {
+  await db.prepare(
+    `INSERT INTO webhooks (id, url, secret, enabled, archived_at)
+     VALUES (?1, ?2, ?3, ?4, ?5)`,
+  ).bind(
+    id,
+    `https://receiver.example/${id}`,
+    `secret-${id}`,
+    options.enabled ?? 1,
+    options.archivedAt ?? null,
+  ).run();
+}
+
+async function insertDelivery(
+  db: ReturnType<typeof makeDb>,
+  id: string,
+  webhookId: string,
+  createdAt: number,
+) {
+  await db.prepare(
+    `INSERT INTO webhook_deliveries
+     (id, webhook_id, event_type, event_id, payload_json, signing_secret,
+      status, attempts, max_attempts, next_attempt_at, created_at, updated_at)
+     VALUES (?1, ?2, 'feedback:status_changed', ?3, ?4, ?5,
+             'pending', 0, 3, 0, ?6, ?6)`,
+  ).bind(
+    id,
+    webhookId,
+    `event-${id}`,
+    JSON.stringify({ event: "feedback:status_changed", marker: `body-${id}` }),
+    `frozen-${webhookId}`,
+    createdAt,
+  ).run();
+}
+
+async function deliveryLedger(db: ReturnType<typeof makeDb>, id: string) {
+  return db.prepare(
+    `SELECT status, attempts, next_attempt_at, last_response_body,
+            last_error, completed_at
+     FROM webhook_deliveries WHERE id = ?1`,
+  ).bind(id).first<{
+    status: string;
+    attempts: number;
+    next_attempt_at: number | null;
+    last_response_body: string | null;
+    last_error: string | null;
+    completed_at: number | null;
+  }>();
+}
+
+describe("webhook delivery reaper progress guarantee", () => {
+  it("times out a hung oldest endpoint without blocking a healthy later row", async () => {
+    const db = makeDb();
+    await insertWebhook(db, "hung");
+    await insertWebhook(db, "healthy");
+    await insertDelivery(db, "delivery-hung", "hung", 1);
+    await insertDelivery(db, "delivery-healthy", "healthy", 2);
+
+    const fetchImpl = vi.fn((input: string | URL | Request) => {
+      if (String(input).endsWith("/hung")) {
+        return new Promise<Response>(() => {});
+      }
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as typeof fetch;
+
+    const summary = await reapWebhookDeliveries(
+      { DB: db as unknown as D1Database },
+      {
+        now: 1_000,
+        scheduledTime: 900,
+        fetchImpl,
+        deliveryTimeoutMs: 20,
+        concurrency: 2,
+      },
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(summary).toMatchObject({
+      scheduledTime: 900,
+      selected: 2,
+      succeeded: 1,
+      retried: 1,
+      terminalized: 0,
+      errorCodes: { delivery_timeout: 1 },
+    });
+    expect(await deliveryLedger(db, "delivery-hung")).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      next_attempt_at: 301_000,
+      last_error: "delivery_timeout",
+    });
+    expect(await deliveryLedger(db, "delivery-healthy")).toMatchObject({
+      status: "succeeded",
+      attempts: 1,
+      next_attempt_at: null,
+      last_error: null,
+      completed_at: 1_000,
+    });
+
+    const redactedSummary = JSON.stringify(summary);
+    expect(redactedSummary).not.toContain("receiver.example");
+    expect(redactedSummary).not.toContain("frozen-hung");
+    expect(redactedSummary).not.toContain("body-delivery-hung");
+    expect(redactedSummary).not.toContain("event-delivery-hung");
+    expect(redactedSummary).not.toContain("delivery-hung");
+  });
+
+  it("terminalizes 50 missing-webhook rows so the next cron reaches row 51", async () => {
+    const db = makeDb();
+    for (let index = 1; index <= 50; index++) {
+      await insertDelivery(db, `missing-${index.toString().padStart(2, "0")}`, `gone-${index}`, index);
+    }
+    await insertWebhook(db, "healthy-51");
+    await insertDelivery(db, "healthy-row-51", "healthy-51", 51);
+    const fetchMock = vi.fn(async (_input: string | URL | Request) =>
+      new Response(null, { status: 204 }));
+    const fetchImpl = fetchMock as unknown as typeof fetch;
+
+    const first = await reapWebhookDeliveries(
+      { DB: db as unknown as D1Database },
+      { now: 1_000, fetchImpl },
+    );
+    expect(first).toMatchObject({
+      selected: 50,
+      succeeded: 0,
+      retried: 0,
+      terminalized: 50,
+      errorCodes: { webhook_missing: 50 },
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(await db.prepare(
+      "SELECT COUNT(*) AS count FROM webhook_deliveries WHERE status = 'failed' AND last_error = 'webhook_missing'",
+    ).first<{ count: number }>()).toEqual({ count: 50 });
+
+    const second = await reapWebhookDeliveries(
+      { DB: db as unknown as D1Database },
+      { now: 2_000, fetchImpl },
+    );
+    expect(second).toMatchObject({
+      selected: 1,
+      succeeded: 1,
+      retried: 0,
+      terminalized: 0,
+      errorCodes: {},
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(await deliveryLedger(db, "healthy-row-51")).toMatchObject({
+      status: "succeeded",
+      attempts: 1,
+    });
+  });
+
+  it("terminalizes disabled and archived routes without posting to them", async () => {
+    const db = makeDb();
+    await insertWebhook(db, "disabled", { enabled: 0 });
+    await insertWebhook(db, "archived", { archivedAt: 500 });
+    await insertWebhook(db, "healthy");
+    await insertDelivery(db, "delivery-disabled", "disabled", 1);
+    await insertDelivery(db, "delivery-archived", "archived", 2);
+    await insertDelivery(db, "delivery-healthy", "healthy", 3);
+    const fetchMock = vi.fn(async (_input: string | URL | Request) =>
+      new Response(null, { status: 204 }));
+    const fetchImpl = fetchMock as unknown as typeof fetch;
+
+    const summary = await reapWebhookDeliveries(
+      { DB: db as unknown as D1Database },
+      { now: 1_000, fetchImpl },
+    );
+
+    expect(summary).toMatchObject({
+      selected: 3,
+      succeeded: 1,
+      retried: 0,
+      terminalized: 2,
+      errorCodes: { webhook_disabled: 1, webhook_archived: 1 },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("https://receiver.example/healthy");
+    expect(await deliveryLedger(db, "delivery-disabled")).toMatchObject({
+      status: "failed",
+      attempts: 0,
+      last_error: "webhook_disabled",
+      completed_at: 1_000,
+    });
+    expect(await deliveryLedger(db, "delivery-archived")).toMatchObject({
+      status: "failed",
+      attempts: 0,
+      last_error: "webhook_archived",
+      completed_at: 1_000,
+    });
+  });
+
+  it("caps the batch at five concurrent delivery attempts", async () => {
+    const db = makeDb();
+    for (let index = 1; index <= 12; index++) {
+      await insertWebhook(db, `bounded-${index}`);
+      await insertDelivery(db, `delivery-bounded-${index}`, `bounded-${index}`, index);
+    }
+    let active = 0;
+    let maxActive = 0;
+    const fetchImpl = vi.fn(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const summary = await reapWebhookDeliveries(
+      { DB: db as unknown as D1Database },
+      { now: 1_000, fetchImpl },
+    );
+
+    expect(summary).toMatchObject({
+      selected: 12,
+      succeeded: 12,
+      retried: 0,
+      terminalized: 0,
+      errorCodes: {},
+    });
+    expect(maxActive).toBe(5);
+  });
+
+  it("bounds oversized and continuous response bodies without blocking later rows", async () => {
+    const db = makeDb();
+    await insertWebhook(db, "oversized");
+    await insertWebhook(db, "continuous");
+    await insertWebhook(db, "healthy-after-bodies");
+    await insertDelivery(db, "delivery-oversized", "oversized", 1);
+    await insertDelivery(db, "delivery-continuous", "continuous", 2);
+    await insertDelivery(db, "delivery-healthy-after-bodies", "healthy-after-bodies", 3);
+
+    let continuousPulls = 0;
+    let continuousCancelled = false;
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/oversized")) {
+        return new Response(new Uint8Array(100_000).fill(65), { status: 500 });
+      }
+      if (url.endsWith("/continuous")) {
+        return new Response(new ReadableStream<Uint8Array>({
+          pull(controller) {
+            continuousPulls++;
+            controller.enqueue(new Uint8Array(256).fill(66));
+          },
+          cancel() {
+            continuousCancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }), { status: 500 });
+      }
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const startedAt = performance.now();
+    const summary = await reapWebhookDeliveries(
+      { DB: db as unknown as D1Database },
+      { now: 1_000, fetchImpl, concurrency: 3, deliveryTimeoutMs: 1_000 },
+    );
+    const durationMs = performance.now() - startedAt;
+
+    expect(summary).toMatchObject({
+      selected: 3,
+      succeeded: 1,
+      retried: 2,
+      terminalized: 0,
+      errorCodes: { webhook_http_error: 2 },
+    });
+    expect(await deliveryLedger(db, "delivery-oversized")).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      last_response_body: "A".repeat(500),
+      last_error: "webhook_http_error",
+    });
+    expect(await deliveryLedger(db, "delivery-continuous")).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      last_response_body: "B".repeat(500),
+      last_error: "webhook_http_error",
+    });
+    expect(await deliveryLedger(db, "delivery-healthy-after-bodies")).toMatchObject({
+      status: "succeeded",
+      attempts: 1,
+    });
+    expect(continuousCancelled).toBe(true);
+    expect(continuousPulls).toBeLessThanOrEqual(3);
+    expect(durationMs).toBeLessThan(500);
+  });
+
+  it("isolates per-row fetch and D1 failures so a healthy row still completes", async () => {
+    const db = makeDb();
+    await insertWebhook(db, "fetch-error");
+    await insertWebhook(db, "d1-error");
+    await insertWebhook(db, "healthy");
+    await insertDelivery(db, "delivery-fetch-error", "fetch-error", 1);
+    await insertDelivery(db, "delivery-d1-error", "d1-error", 2);
+    await insertDelivery(db, "delivery-healthy", "healthy", 3);
+
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      if (String(input).endsWith("/fetch-error")) throw new Error("synthetic network failure");
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+    const faultingDb = {
+      prepare(sql: string) {
+        const prepared = db.prepare(sql);
+        if (!sql.includes("SET status = 'succeeded'")) return prepared;
+        return {
+          ...prepared,
+          bind(...params: unknown[]) {
+            const bound = prepared.bind(...params);
+            return {
+              ...bound,
+              run: async () => {
+                if (params[4] === "delivery-d1-error") {
+                  throw new Error("synthetic D1 failure");
+                }
+                return bound.run();
+              },
+            };
+          },
+        };
+      },
+    };
+
+    const summary = await reapWebhookDeliveries(
+      { DB: faultingDb as unknown as D1Database },
+      { now: 1_000, fetchImpl, concurrency: 3 },
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(summary).toMatchObject({
+      selected: 3,
+      succeeded: 1,
+      retried: 2,
+      terminalized: 0,
+      errorCodes: {
+        webhook_fetch_error: 1,
+        delivery_processing_error: 1,
+      },
+    });
+    expect(await deliveryLedger(db, "delivery-fetch-error")).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      last_error: "webhook_fetch_error",
+    });
+    expect(await deliveryLedger(db, "delivery-d1-error")).toMatchObject({
+      status: "pending",
+      attempts: 0,
+      last_error: null,
+    });
+    expect(await deliveryLedger(db, "delivery-healthy")).toMatchObject({
+      status: "succeeded",
+      attempts: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- bound each webhook POST and response-body read to a 10-second hard deadline and process at most five deliveries concurrently
- retain at most a 500-byte response prefix, cancelling oversized or continuous response streams instead of buffering them in full
- terminalize pending deliveries for missing, disabled, or archived webhook rows instead of reselecting them forever
- isolate per-row failures and emit only redacted scheduled-run counts/duration/error codes
- preserve the frozen payload, signing secret/signature, event-id, delivery-id, and retry ledger contract

## Regression coverage

- a hung oldest endpoint times out while a later healthy row succeeds, with a D1-shaped test rejecting every `undefined` bind and proving attempt 1 + 5-minute backoff
- 50 missing-webhook rows terminalize; the next invocation reaches row 51
- disabled/archived rows terminalize without network delivery
- fetch and D1 failures remain row-local
- default concurrency never exceeds five
- fast oversized and never-ending response streams retain only 500 bytes, cancel the remainder, and do not block a healthy later row
- existing retry-stability test keeps body/signature/event-id/delivery-id identical across attempts

## Validation

- focused reaper + frozen retry contract: 7/7
- `pnpm --filter @botiverse/hands-worker test`: 251/251
- `pnpm --filter @botiverse/hands-worker build`: PASS
- `pnpm --filter @botiverse/hands-worker build:shim`: PASS
- `pnpm -w build`: PASS
- `pnpm -w test`: PASS (Worker 251, CLI 27, Node 13, Admin 25, Electron 3, Container 3)
- Wrangler deploy dry-run: PASS
- `git diff --check`: PASS
- `pnpm -w lint`: repository-pre-existing ESLint 9 configuration blocker (`eslint.config.*` absent), before source linting

Task: #195
