### PR TITLE
feat: add embeddable feedback React components

### DIFF
--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -1,0 +1,48 @@
+# `@botiverse/hands-feedback-react`
+
+Reporter-facing Hands feedback components. The package renders a ticket inbox,
+conversation detail, reply composer, and new-feedback form with `elegant` and
+`brutal` themes.
+
+```tsx
+import {
+  FeedbackProvider,
+  FeedbackWorkspace,
+  type HandsFeedbackTransport,
+} from "@botiverse/hands-feedback-react";
+import "raft-ui/styles.css";
+import "@botiverse/hands-feedback-react/styles.css";
+
+const transport: HandsFeedbackTransport = createReporterTransport({
+  // Resolve this through your backend. Never ship an app/deploy token to the
+  // renderer. The session must be short-lived and scoped to one app+reporter.
+  getSession: () => fetch("/api/hands-feedback-session").then((r) => r.json()),
+});
+
+<FeedbackProvider
+  transport={transport}
+  theme="brutal"
+  onUnreadChanged={({ total }) => setFeedbackBadge(total)}
+>
+  <FeedbackWorkspace />
+</FeedbackProvider>;
+```
+
+## Security boundary
+
+- The package has no `appToken`, `clientSecret`, `reporterId`, or arbitrary
+  owner prop.
+- The host transport binds a short-lived reporter-scoped session.
+- Hands is authoritative for tickets and read/unread state. `unreadTotal`
+  comes from Hands responses; the component never derives or persists its own
+  read cursor.
+- Webhooks are optional server-to-server integrations and are not required for
+  inbox correctness.
+
+Consumers using Tailwind v4 should include the compiled package as a source if
+their build purges library classes:
+
+```css
+@source '../node_modules/raft-ui/dist';
+@source '../node_modules/@botiverse/hands-feedback-react/dist';
+```

--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -46,3 +46,15 @@ their build purges library classes:
 @source '../node_modules/raft-ui/dist';
 @source '../node_modules/@botiverse/hands-feedback-react/dist';
 ```
+
+For a source-pinned integration before an npm release, install this package's
+Hands monorepo subdirectory with pnpm's `path:` git selector, then import the
+explicit source exports:
+
+```tsx
+import { FeedbackProvider, FeedbackWorkspace } from "@botiverse/hands-feedback-react/source";
+import "@botiverse/hands-feedback-react/source/styles.css";
+```
+
+The host bundler must support TypeScript/TSX dependencies. Published consumers
+should use the compiled root exports shown above.

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -27,9 +27,9 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "raft-ui": ">=0.0.18",
-    "react": ">=18",
-    "react-dom": ">=18"
+    "raft-ui": "^0.0.18",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -15,10 +15,17 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./source": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./source/styles.css": "./src/styles.css"
   },
   "files": [
     "dist",
+    "src",
+    "!src/**/*.test.tsx",
     "README.md"
   ],
   "scripts": {

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@botiverse/hands-feedback-react",
+  "version": "0.1.0",
+  "description": "Embeddable reporter-facing Hands feedback inbox components.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/botiverse/hands.git"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc && node scripts/copy-styles.mjs",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "raft-ui": ">=0.0.18",
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "raft-ui": "^0.0.18",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -32,8 +32,10 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "^26.1.0",
     "raft-ui": "^0.0.18",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/feedback-react/scripts/copy-styles.mjs
+++ b/packages/feedback-react/scripts/copy-styles.mjs
@@ -1,0 +1,7 @@
+import { copyFile, mkdir } from "node:fs/promises";
+
+await mkdir(new URL("../dist/", import.meta.url), { recursive: true });
+await copyFile(
+  new URL("../src/styles.css", import.meta.url),
+  new URL("../dist/styles.css", import.meta.url),
+);

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -7,7 +7,9 @@ import {
   Skeleton,
 } from "raft-ui";
 import { useHandsFeedback } from "./provider.js";
+import { FeedbackTransportError } from "./types.js";
 import type {
+  FeedbackComment,
   FeedbackKind,
   FeedbackTicketSummary,
   FeedbackTicketDetail,
@@ -29,6 +31,16 @@ export function mergeTicketPages(
   const merged = new Map(current.map((ticket) => [ticket.id, ticket]));
   for (const ticket of incoming) merged.set(ticket.id, ticket);
   return [...merged.values()];
+}
+
+export function mergeCommentPages(
+  current: FeedbackComment[],
+  incoming: FeedbackComment[],
+): FeedbackComment[] {
+  const merged = new Map(current.map((comment) => [comment.id, comment]));
+  for (const comment of incoming) merged.set(comment.id, comment);
+  return [...merged.values()].sort((left, right) =>
+    left.createdAt - right.createdAt || left.id.localeCompare(right.id));
 }
 
 export function validateFeedbackAttachments(files: File[]): string | null {
@@ -56,7 +68,15 @@ function stableSubmissionId(
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Feedback is temporarily unavailable";
+  if (!(error instanceof FeedbackTransportError)) return "Feedback is temporarily unavailable.";
+  switch (error.code) {
+    case "conflict": return "This retry no longer matches the original request.";
+    case "invalid": return "Check the feedback details and try again.";
+    case "not_found": return "This feedback ticket is no longer available.";
+    case "rate_limited": return "Too many feedback requests. Try again later.";
+    case "unauthorized": return "Your feedback session expired. Reopen feedback and try again.";
+    case "unavailable": return "Feedback is temporarily unavailable.";
+  }
 }
 
 function statusLabel(status: FeedbackTicketSummary["status"]): string {
@@ -138,9 +158,9 @@ export function FeedbackInbox({ onSelectTicket, onNewFeedback, pageSize = 20 }: 
       </header>
       {loading && (
         <div className="hands-feedback-stack" aria-label="Loading feedback">
-          <Skeleton className="h-16 w-full" />
-          <Skeleton className="h-16 w-full" />
-          <Skeleton className="h-16 w-full" />
+          <Skeleton className="hands-feedback-skeleton-row" />
+          <Skeleton className="hands-feedback-skeleton-row" />
+          <Skeleton className="hands-feedback-skeleton-row" />
         </div>
       )}
       {error && (
@@ -201,35 +221,49 @@ export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackT
   const [detail, setDetail] = useState<FeedbackTicketDetail | null>(null);
   const [reply, setReply] = useState("");
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const loadRequest = useRef(0);
+  const loadController = useRef<AbortController | null>(null);
   const actionController = useRef<AbortController | null>(null);
   const commentSubmission = useRef<{ fingerprint: string; id: string } | null>(null);
 
-  const load = useCallback(async (externalSignal?: AbortSignal) => {
+  const load = useCallback(async (commentCursor?: string) => {
+    loadController.current?.abort();
+    const controller = new AbortController();
+    loadController.current = controller;
     const requestId = ++loadRequest.current;
-    setLoading(true);
-    setDetail(null);
+    commentCursor ? setLoadingMore(true) : setLoading(true);
+    if (!commentCursor) setDetail(null);
     setError(null);
-    const signal = externalSignal ?? new AbortController().signal;
+    const signal = controller.signal;
     try {
-      const result = await transport.getTicket({ ticketId, commentLimit: 100, signal });
+      const result = await transport.getTicket({
+        ticketId,
+        ...(commentCursor ? { commentCursor } : {}),
+        commentLimit: 100,
+        signal,
+      });
       if (signal.aborted || requestId !== loadRequest.current) return;
       reportUnread({ total: result.unreadTotal, source: "detail" });
-      setDetail(result);
+      setDetail((current) => commentCursor && current
+        ? { ...result, comments: mergeCommentPages(current.comments, result.comments) }
+        : result);
     } catch (cause) {
       if (!signal.aborted) setError(errorMessage(cause));
     } finally {
-      if (!signal.aborted && requestId === loadRequest.current) setLoading(false);
+      if (!signal.aborted && requestId === loadRequest.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
     }
   }, [reportUnread, ticketId, transport]);
 
   useEffect(() => {
-    const controller = new AbortController();
-    void load(controller.signal);
+    void load();
     return () => {
-      controller.abort();
+      loadController.current?.abort();
       actionController.current?.abort();
       loadRequest.current += 1;
     };
@@ -264,17 +298,18 @@ export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackT
   };
 
   return (
-    <section className="hands-feedback-detail" aria-labelledby="hands-feedback-ticket-title">
+    <section className="hands-feedback-detail" aria-labelledby="hands-feedback-ticket-heading">
       <header className="hands-feedback-header">
         <Button variant="outline" onClick={onBack}>Back</Button>
+        <h2 id="hands-feedback-ticket-heading">Feedback ticket</h2>
         {detail && <span className="hands-feedback-status" data-status={detail.ticket.status}>{statusLabel(detail.ticket.status)}</span>}
       </header>
-      {loading && <Skeleton className="h-40 w-full" />}
+      {loading && <Skeleton className="hands-feedback-skeleton-detail" />}
       {error && <div className="hands-feedback-error" role="alert">{error}</div>}
       {detail && (
         <>
           <div className="hands-feedback-ticket-body">
-            <h2 id="hands-feedback-ticket-title">{detail.ticket.message}</h2>
+            <h3>{detail.ticket.message}</h3>
             <span>{formatDate(detail.ticket.createdAt)}</span>
           </div>
           {detail.attachments.length > 0 && (
@@ -303,6 +338,15 @@ export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackT
               </article>
             ))}
           </div>
+          {detail.nextCommentCursor && (
+            <Button
+              variant="outline"
+              disabled={loadingMore}
+              onClick={() => void load(detail.nextCommentCursor!)}
+            >
+              {loadingMore ? "Loading…" : "Load more replies"}
+            </Button>
+          )}
           <div className="hands-feedback-composer">
             <label htmlFor="hands-feedback-reply">Reply</label>
             <textarea
@@ -386,8 +430,8 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
         <Button variant="outline" onClick={onCancel}>Cancel</Button>
       </header>
       <div className="hands-feedback-kind" role="group" aria-label="Feedback type">
-        <Button variant={kind === "feedback" ? "primary" : "outline"} onClick={() => setKind("feedback")}>Feedback</Button>
-        <Button variant={kind === "bug" ? "primary" : "outline"} onClick={() => setKind("bug")}>Problem</Button>
+        <Button aria-pressed={kind === "feedback"} variant={kind === "feedback" ? "primary" : "outline"} onClick={() => setKind("feedback")}>Feedback</Button>
+        <Button aria-pressed={kind === "bug"} variant={kind === "bug" ? "primary" : "outline"} onClick={() => setKind("bug")}>Problem</Button>
       </div>
       <label htmlFor="hands-feedback-message">What would you like us to know?</label>
       <textarea

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -1,0 +1,460 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Button,
+  EmptyState,
+  EmptyStateTitle,
+  Input,
+  Skeleton,
+} from "raft-ui";
+import { useHandsFeedback } from "./provider.js";
+import type {
+  FeedbackKind,
+  FeedbackTicketSummary,
+  FeedbackTicketDetail,
+} from "./types.js";
+
+export const MAX_FEEDBACK_ATTACHMENTS = 3;
+export const MAX_FEEDBACK_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+export const FEEDBACK_ATTACHMENT_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export function mergeTicketPages(
+  current: FeedbackTicketSummary[],
+  incoming: FeedbackTicketSummary[],
+): FeedbackTicketSummary[] {
+  const merged = new Map(current.map((ticket) => [ticket.id, ticket]));
+  for (const ticket of incoming) merged.set(ticket.id, ticket);
+  return [...merged.values()];
+}
+
+export function validateFeedbackAttachments(files: File[]): string | null {
+  if (files.length > MAX_FEEDBACK_ATTACHMENTS) {
+    return `Choose no more than ${MAX_FEEDBACK_ATTACHMENTS} screenshots.`;
+  }
+  for (const file of files) {
+    if (!(FEEDBACK_ATTACHMENT_TYPES as readonly string[]).includes(file.type)) {
+      return `${file.name} is not a supported image.`;
+    }
+    if (file.size > MAX_FEEDBACK_ATTACHMENT_BYTES) {
+      return `${file.name} is larger than 10 MB.`;
+    }
+  }
+  return null;
+}
+
+function stableSubmissionId(
+  previous: { fingerprint: string; id: string } | null,
+  fingerprint: string,
+): { fingerprint: string; id: string } {
+  return previous?.fingerprint === fingerprint
+    ? previous
+    : { fingerprint, id: submissionId() };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Feedback is temporarily unavailable";
+}
+
+function statusLabel(status: FeedbackTicketSummary["status"]): string {
+  return status === "in_progress" ? "In progress" : `${status[0]!.toUpperCase()}${status.slice(1)}`;
+}
+
+function formatDate(value: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function submissionId(): string {
+  if (!globalThis.crypto?.randomUUID) throw new Error("A secure randomUUID implementation is required");
+  return globalThis.crypto.randomUUID();
+}
+
+export type FeedbackInboxProps = {
+  onSelectTicket(ticketId: string): void;
+  onNewFeedback(): void;
+  pageSize?: number;
+};
+
+export function FeedbackInbox({ onSelectTicket, onNewFeedback, pageSize = 20 }: FeedbackInboxProps) {
+  const { transport, reportUnread } = useHandsFeedback();
+  const [tickets, setTickets] = useState<FeedbackTicketSummary[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const request = useRef(0);
+  const requestController = useRef<AbortController | null>(null);
+
+  const load = useCallback(async (nextCursor?: string) => {
+    requestController.current?.abort();
+    const controller = new AbortController();
+    requestController.current = controller;
+    const id = ++request.current;
+    nextCursor ? setLoadingMore(true) : setLoading(true);
+    setError(null);
+    const signal = controller.signal;
+    try {
+      const page = await transport.listTickets({
+        ...(nextCursor ? { cursor: nextCursor } : {}),
+        limit: pageSize,
+        signal,
+      });
+      if (request.current !== id) return;
+      reportUnread({ total: page.unreadTotal, source: "list" });
+      setTickets((current) => nextCursor ? mergeTicketPages(current, page.tickets) : page.tickets);
+      setCursor(page.nextCursor);
+    } catch (cause) {
+      if (request.current === id && !signal.aborted) setError(errorMessage(cause));
+    } finally {
+      if (request.current === id) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    }
+  }, [pageSize, reportUnread, transport]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      requestController.current?.abort();
+      request.current += 1;
+    };
+  }, [load]);
+
+  return (
+    <section className="hands-feedback-inbox" aria-labelledby="hands-feedback-inbox-title">
+      <header className="hands-feedback-header">
+        <div>
+          <h2 id="hands-feedback-inbox-title">Feedback</h2>
+          <p>Your feedback and replies from the team.</p>
+        </div>
+        <Button onClick={onNewFeedback}>New feedback</Button>
+      </header>
+      {loading && (
+        <div className="hands-feedback-stack" aria-label="Loading feedback">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      )}
+      {error && (
+        <div className="hands-feedback-error" role="alert">
+          <span>{error}</span>
+          <Button variant="outline" onClick={() => void load()}>Try again</Button>
+        </div>
+      )}
+      {!loading && !error && tickets.length === 0 && (
+        <EmptyState>
+          <EmptyStateTitle>No feedback yet</EmptyStateTitle>
+          <p>Send your first idea or report a problem.</p>
+          <Button onClick={onNewFeedback}>New feedback</Button>
+        </EmptyState>
+      )}
+      {tickets.length > 0 && (
+        <ul className="hands-feedback-ticket-list">
+          {tickets.map((ticket) => (
+            <li key={ticket.id}>
+              <button
+                className="hands-feedback-ticket-row"
+                data-unread={ticket.unread || undefined}
+                onClick={() => onSelectTicket(ticket.id)}
+                type="button"
+              >
+                <span className="hands-feedback-ticket-copy">
+                  <span className="hands-feedback-ticket-title">{ticket.message}</span>
+                  <span className="hands-feedback-ticket-meta">
+                    {ticket.kind === "bug" ? "Problem" : "Feedback"} · {formatDate(ticket.updatedAt)}
+                  </span>
+                </span>
+                <span className="hands-feedback-ticket-state">
+                  {ticket.unread && <span className="hands-feedback-unread-dot" aria-label={`${ticket.unreadCount} unread`} />}
+                  <span className="hands-feedback-status" data-status={ticket.status}>{statusLabel(ticket.status)}</span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {cursor && (
+        <Button variant="outline" disabled={loadingMore} onClick={() => void load(cursor)}>
+          {loadingMore ? "Loading…" : "Load more"}
+        </Button>
+      )}
+    </section>
+  );
+}
+
+export type FeedbackTicketProps = {
+  ticketId: string;
+  onBack(): void;
+  onOpenAttachment?: (input: { ticketId: string; attachmentId: string }) => void;
+};
+
+export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackTicketProps) {
+  const { transport, reportUnread } = useHandsFeedback();
+  const [detail, setDetail] = useState<FeedbackTicketDetail | null>(null);
+  const [reply, setReply] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const loadRequest = useRef(0);
+  const actionController = useRef<AbortController | null>(null);
+  const commentSubmission = useRef<{ fingerprint: string; id: string } | null>(null);
+
+  const load = useCallback(async (externalSignal?: AbortSignal) => {
+    const requestId = ++loadRequest.current;
+    setLoading(true);
+    setDetail(null);
+    setError(null);
+    const signal = externalSignal ?? new AbortController().signal;
+    try {
+      const result = await transport.getTicket({ ticketId, commentLimit: 100, signal });
+      if (signal.aborted || requestId !== loadRequest.current) return;
+      reportUnread({ total: result.unreadTotal, source: "detail" });
+      setDetail(result);
+    } catch (cause) {
+      if (!signal.aborted) setError(errorMessage(cause));
+    } finally {
+      if (!signal.aborted && requestId === loadRequest.current) setLoading(false);
+    }
+  }, [reportUnread, ticketId, transport]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => {
+      controller.abort();
+      actionController.current?.abort();
+      loadRequest.current += 1;
+    };
+  }, [load]);
+
+  const send = async () => {
+    const body = reply.trim();
+    if (!body || sending) return;
+    setSending(true);
+    setError(null);
+    actionController.current?.abort();
+    const controller = new AbortController();
+    actionController.current = controller;
+    commentSubmission.current = stableSubmissionId(commentSubmission.current, body);
+    try {
+      const result = await transport.addComment({
+        ticketId,
+        body,
+        submissionId: commentSubmission.current.id,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+      reportUnread({ total: result.unreadTotal, source: "comment" });
+      setDetail(result);
+      setReply("");
+      commentSubmission.current = null;
+    } catch (cause) {
+      if (!controller.signal.aborted) setError(errorMessage(cause));
+    } finally {
+      if (!controller.signal.aborted) setSending(false);
+    }
+  };
+
+  return (
+    <section className="hands-feedback-detail" aria-labelledby="hands-feedback-ticket-title">
+      <header className="hands-feedback-header">
+        <Button variant="outline" onClick={onBack}>Back</Button>
+        {detail && <span className="hands-feedback-status" data-status={detail.ticket.status}>{statusLabel(detail.ticket.status)}</span>}
+      </header>
+      {loading && <Skeleton className="h-40 w-full" />}
+      {error && <div className="hands-feedback-error" role="alert">{error}</div>}
+      {detail && (
+        <>
+          <div className="hands-feedback-ticket-body">
+            <h2 id="hands-feedback-ticket-title">{detail.ticket.message}</h2>
+            <span>{formatDate(detail.ticket.createdAt)}</span>
+          </div>
+          {detail.attachments.length > 0 && (
+            <div className="hands-feedback-attachments" aria-label="Attachments">
+              {detail.attachments.map((attachment) => (
+                <button
+                  key={attachment.id}
+                  type="button"
+                  disabled={!onOpenAttachment}
+                  aria-label={`Open attachment ${attachment.filename}`}
+                  onClick={() => onOpenAttachment?.({ ticketId, attachmentId: attachment.id })}
+                >
+                  {attachment.filename} · {Math.ceil(attachment.sizeBytes / 1024)} KB
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="hands-feedback-conversation" aria-label="Conversation">
+            {detail.comments.map((comment) => (
+              <article key={comment.id} data-author={comment.authorType}>
+                <div className="hands-feedback-comment-meta">
+                  <strong>{comment.authorType === "reporter" ? "You" : comment.authorType === "staff" ? "Team" : "Update"}</strong>
+                  <span>{formatDate(comment.createdAt)}</span>
+                </div>
+                <p>{comment.body}</p>
+              </article>
+            ))}
+          </div>
+          <div className="hands-feedback-composer">
+            <label htmlFor="hands-feedback-reply">Reply</label>
+            <textarea
+              id="hands-feedback-reply"
+              maxLength={10_000}
+              value={reply}
+              onChange={(event) => setReply(event.target.value)}
+            />
+            <Button disabled={!reply.trim() || sending} onClick={() => void send()}>
+              {sending ? "Sending…" : "Send reply"}
+            </Button>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+export type NewFeedbackProps = {
+  onCancel(): void;
+  onCreated(ticketId: string): void;
+};
+
+export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
+  const { transport, reportUnread } = useHandsFeedback();
+  const [kind, setKind] = useState<FeedbackKind>("feedback");
+  const [message, setMessage] = useState("");
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const actionController = useRef<AbortController | null>(null);
+  const createSubmission = useRef<{ fingerprint: string; id: string } | null>(null);
+
+  useEffect(() => () => actionController.current?.abort(), []);
+
+  const submit = async () => {
+    const normalized = message.trim();
+    if (!normalized || sending) return;
+    const attachmentError = validateFeedbackAttachments(attachments);
+    if (attachmentError) {
+      setError(attachmentError);
+      return;
+    }
+    setSending(true);
+    setError(null);
+    actionController.current?.abort();
+    const controller = new AbortController();
+    actionController.current = controller;
+    const fingerprint = JSON.stringify([
+      kind,
+      normalized,
+      ...attachments.map((file) => [file.name, file.type, file.size, file.lastModified]),
+    ]);
+    createSubmission.current = stableSubmissionId(createSubmission.current, fingerprint);
+    try {
+      const result = await transport.createTicket({
+        kind,
+        message: normalized,
+        submissionId: createSubmission.current.id,
+        attachments,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+      reportUnread({ total: result.unreadTotal, source: "create" });
+      createSubmission.current = null;
+      onCreated(result.ticket.id);
+    } catch (cause) {
+      if (!controller.signal.aborted) setError(errorMessage(cause));
+    } finally {
+      if (!controller.signal.aborted) setSending(false);
+    }
+  };
+
+  return (
+    <section className="hands-feedback-new" aria-labelledby="hands-feedback-new-title">
+      <header className="hands-feedback-header">
+        <div>
+          <h2 id="hands-feedback-new-title">New feedback</h2>
+          <p>Share an idea or report a problem.</p>
+        </div>
+        <Button variant="outline" onClick={onCancel}>Cancel</Button>
+      </header>
+      <div className="hands-feedback-kind" role="group" aria-label="Feedback type">
+        <Button variant={kind === "feedback" ? "primary" : "outline"} onClick={() => setKind("feedback")}>Feedback</Button>
+        <Button variant={kind === "bug" ? "primary" : "outline"} onClick={() => setKind("bug")}>Problem</Button>
+      </div>
+      <label htmlFor="hands-feedback-message">What would you like us to know?</label>
+      <textarea
+        id="hands-feedback-message"
+        maxLength={10_000}
+        value={message}
+        onChange={(event) => setMessage(event.target.value)}
+      />
+      <label htmlFor="hands-feedback-attachments">Screenshots (up to 3)</label>
+      <Input
+        id="hands-feedback-attachments"
+        type="file"
+        accept={FEEDBACK_ATTACHMENT_TYPES.join(",")}
+        multiple
+        onChange={(event) => {
+          const selected = Array.from(event.currentTarget.files ?? []);
+          const attachmentError = validateFeedbackAttachments(selected);
+          setError(attachmentError);
+          setAttachments(attachmentError ? [] : selected);
+          if (attachmentError) event.currentTarget.value = "";
+        }}
+      />
+      {error && <div className="hands-feedback-error" role="alert">{error}</div>}
+      <Button disabled={!message.trim() || sending} onClick={() => void submit()}>
+        {sending ? "Submitting…" : "Submit feedback"}
+      </Button>
+    </section>
+  );
+}
+
+export type FeedbackWorkspaceProps = {
+  initialTicketId?: string;
+  onRouteChange?: (route: { view: "inbox" | "new" | "ticket"; ticketId?: string }) => void;
+  onOpenAttachment?: FeedbackTicketProps["onOpenAttachment"];
+};
+
+export function FeedbackWorkspace({ initialTicketId, onRouteChange, onOpenAttachment }: FeedbackWorkspaceProps) {
+  const { theme } = useHandsFeedback();
+  const initial = useMemo(() => initialTicketId
+    ? { view: "ticket" as const, ticketId: initialTicketId }
+    : { view: "inbox" as const }, [initialTicketId]);
+  const [route, setRoute] = useState<{ view: "inbox" | "new" | "ticket"; ticketId?: string }>(initial);
+  const navigate = (next: typeof route) => {
+    setRoute(next);
+    onRouteChange?.(next);
+  };
+  return (
+    <div className="hands-feedback-root" data-hands-feedback-theme={theme}>
+      {route.view === "inbox" && (
+        <FeedbackInbox
+          onNewFeedback={() => navigate({ view: "new" })}
+          onSelectTicket={(ticketId) => navigate({ view: "ticket", ticketId })}
+        />
+      )}
+      {route.view === "new" && (
+        <NewFeedback
+          onCancel={() => navigate({ view: "inbox" })}
+          onCreated={(ticketId) => navigate({ view: "ticket", ticketId })}
+        />
+      )}
+      {route.view === "ticket" && route.ticketId && (
+        <FeedbackTicket
+          ticketId={route.ticketId}
+          onBack={() => navigate({ view: "inbox" })}
+          {...(onOpenAttachment ? { onOpenAttachment } : {})}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -1,0 +1,28 @@
+export {
+  FeedbackInbox,
+  FeedbackTicket,
+  FeedbackWorkspace,
+  NewFeedback,
+} from "./components.js";
+export type {
+  FeedbackInboxProps,
+  FeedbackTicketProps,
+  FeedbackWorkspaceProps,
+  NewFeedbackProps,
+} from "./components.js";
+export { FeedbackProvider, useHandsFeedback } from "./provider.js";
+export type { FeedbackProviderProps } from "./provider.js";
+export type {
+  AddFeedbackCommentInput,
+  CreateFeedbackInput,
+  FeedbackAttachment,
+  FeedbackComment,
+  FeedbackKind,
+  FeedbackStatus,
+  FeedbackTheme,
+  FeedbackTicketSummary,
+  FeedbackTicketDetail,
+  FeedbackTicketPage,
+  FeedbackUnreadChange,
+  HandsFeedbackTransport,
+} from "./types.js";

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -12,6 +12,7 @@ export type {
 } from "./components.js";
 export { FeedbackProvider, useHandsFeedback } from "./provider.js";
 export type { FeedbackProviderProps } from "./provider.js";
+export { FeedbackTransportError } from "./types.js";
 export type {
   AddFeedbackCommentInput,
   CreateFeedbackInput,
@@ -24,5 +25,6 @@ export type {
   FeedbackTicketDetail,
   FeedbackTicketPage,
   FeedbackUnreadChange,
+  FeedbackTransportErrorCode,
   HandsFeedbackTransport,
 } from "./types.js";

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeedbackWorkspace } from "./components.js";
 import { FeedbackProvider } from "./provider.js";
+import { FeedbackTransportError } from "./types.js";
 import type {
   FeedbackTicketDetail,
   FeedbackTicketPage,
@@ -91,5 +92,185 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(await screen.findByText("Thanks")).toBeTruthy();
     expect(onUnreadChanged).toHaveBeenCalledTimes(1);
     expect(onUnreadChanged).toHaveBeenCalledWith({ total: 2, source: "list" });
+  });
+
+  it("loads, deduplicates, and orders conversations beyond the first 100 comments", async () => {
+    const adapter = transport();
+    const firstComments = Array.from({ length: 100 }, (_, index) => ({
+      id: `comment-${String(index + 1).padStart(3, "0")}`,
+      authorType: "staff" as const,
+      body: `Reply ${index + 1}`,
+      createdAt: index + 1,
+    }));
+    adapter.getTicket = vi.fn(async ({ commentCursor }) => commentCursor
+      ? {
+          ...detail,
+          comments: [firstComments[99]!, {
+            id: "comment-101",
+            authorType: "reporter",
+            body: "Reply 101",
+            createdAt: 101,
+          }],
+          nextCommentCursor: null,
+        }
+      : { ...detail, comments: firstComments, nextCommentCursor: "page-2" });
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+
+    expect(await screen.findByText("Reply 100")).toBeTruthy();
+    fireEvent.click(screen.getByText("Load more replies"));
+    expect(await screen.findByText("Reply 101")).toBeTruthy();
+    expect(screen.getAllByText("Reply 100")).toHaveLength(1);
+    expect(adapter.getTicket).toHaveBeenLastCalledWith(expect.objectContaining({ commentCursor: "page-2" }));
+    expect(screen.queryByText("Load more replies")).toBeNull();
+  });
+
+  it("aborts an in-flight comment page when detail unmounts", async () => {
+    const adapter = transport();
+    let pageSignal: AbortSignal | undefined;
+    let resolvePage: ((value: FeedbackTicketDetail) => void) | undefined;
+    adapter.getTicket = vi.fn(({ commentCursor, signal }) => commentCursor
+      ? new Promise<FeedbackTicketDetail>((resolve) => {
+          pageSignal = signal;
+          resolvePage = resolve;
+        })
+      : Promise.resolve({ ...detail, nextCommentCursor: "page-2" }));
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+
+    fireEvent.click(await screen.findByText("Load more replies"));
+    fireEvent.click(screen.getByText("Back"));
+    expect(pageSignal?.aborted).toBe(true);
+    resolvePage?.({
+      ...detail,
+      comments: [{ id: "late", authorType: "staff", body: "Late reply", createdAt: 100 }],
+      nextCommentCursor: null,
+    });
+    await waitFor(() => expect(screen.queryByText("Late reply")).toBeNull());
+  });
+
+  it("never renders arbitrary transport errors on list, detail, create, or comment", async () => {
+    const secretText = "internal database host and sk_agent_FAKE_SECRET";
+
+    const listAdapter = transport();
+    listAdapter.listTickets = vi.fn(async () => { throw new Error(secretText); });
+    const listView = render(
+      <FeedbackProvider transport={listAdapter}><FeedbackWorkspace /></FeedbackProvider>,
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect(screen.queryByText(secretText)).toBeNull();
+    listView.unmount();
+
+    const detailAdapter = transport();
+    detailAdapter.getTicket = vi.fn(async () => { throw new Error(secretText); });
+    const detailView = render(
+      <FeedbackProvider transport={detailAdapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect(screen.getByRole("heading", { name: "Feedback ticket" })).toBeTruthy();
+    expect(screen.queryByText(secretText)).toBeNull();
+    detailView.unmount();
+
+    const createAdapter = transport();
+    createAdapter.createTicket = vi.fn(async () => { throw new Error(secretText); });
+    const createView = render(
+      <FeedbackProvider transport={createAdapter}><FeedbackWorkspace /></FeedbackProvider>,
+    );
+    fireEvent.click(await screen.findByText("New feedback"));
+    fireEvent.change(screen.getByLabelText("What would you like us to know?"), { target: { value: "Idea" } });
+    fireEvent.click(screen.getByText("Submit feedback"));
+    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect(screen.queryByText(secretText)).toBeNull();
+    createView.unmount();
+
+    const commentAdapter = transport();
+    commentAdapter.addComment = vi.fn(async () => { throw new Error(secretText); });
+    render(
+      <FeedbackProvider transport={commentAdapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+    );
+    fireEvent.change(await screen.findByLabelText("Reply"), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByText("Send reply"));
+    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect(screen.queryByText(secretText)).toBeNull();
+  });
+
+  it("maps only closed transport error codes to fixed user-safe copy", async () => {
+    const adapter = transport();
+    adapter.listTickets = vi.fn(async () => {
+      throw new FeedbackTransportError("rate_limited", { cause: new Error("hidden internal detail") });
+    });
+    render(<FeedbackProvider transport={adapter}><FeedbackWorkspace /></FeedbackProvider>);
+    expect((await screen.findByRole("alert")).textContent).toContain("Too many feedback requests. Try again later.");
+    expect(screen.queryByText("hidden internal detail")).toBeNull();
+  });
+
+  it("reuses idempotency IDs for unchanged create and comment retries", async () => {
+    const createAdapter = transport();
+    let createAttempt = 0;
+    createAdapter.createTicket = vi.fn(async () => {
+      createAttempt += 1;
+      if (createAttempt === 1) throw new FeedbackTransportError("unavailable");
+      return detail;
+    });
+    const createView = render(
+      <FeedbackProvider transport={createAdapter}><FeedbackWorkspace /></FeedbackProvider>,
+    );
+    fireEvent.click(await screen.findByText("New feedback"));
+    fireEvent.change(screen.getByLabelText("What would you like us to know?"), { target: { value: "Retry me" } });
+    fireEvent.click(screen.getByText("Submit feedback"));
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    fireEvent.click(screen.getByText("Submit feedback"));
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    const createCalls = vi.mocked(createAdapter.createTicket).mock.calls;
+    expect(createCalls).toHaveLength(2);
+    expect(createCalls[0]![0].submissionId).toBe(createCalls[1]![0].submissionId);
+    createView.unmount();
+
+    const commentAdapter = transport();
+    let commentAttempt = 0;
+    commentAdapter.addComment = vi.fn(async () => {
+      commentAttempt += 1;
+      if (commentAttempt === 1) throw new FeedbackTransportError("unavailable");
+      return detail;
+    });
+    render(
+      <FeedbackProvider transport={commentAdapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+    );
+    fireEvent.change(await screen.findByLabelText("Reply"), { target: { value: "Same reply" } });
+    fireEvent.click(screen.getByText("Send reply"));
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    fireEvent.click(screen.getByText("Send reply"));
+    await waitFor(() => expect(vi.mocked(commentAdapter.addComment).mock.calls).toHaveLength(2));
+    const commentCalls = vi.mocked(commentAdapter.addComment).mock.calls;
+    expect(commentCalls[0]![0].submissionId).toBe(commentCalls[1]![0].submissionId);
+  });
+
+  it("exposes stable headings and programmatic feedback-kind selection", async () => {
+    const adapter = transport();
+    let resolveDetail: ((value: FeedbackTicketDetail) => void) | undefined;
+    adapter.getTicket = vi.fn(() => new Promise((resolve) => { resolveDetail = resolve; }));
+    const loading = render(
+      <FeedbackProvider transport={adapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+    );
+    expect(screen.getByRole("heading", { name: "Feedback ticket" })).toBeTruthy();
+    expect(loading.container.querySelector(".hands-feedback-skeleton-detail")).not.toBeNull();
+    loading.unmount();
+    resolveDetail?.(detail);
+
+    render(<FeedbackProvider transport={transport()}><FeedbackWorkspace /></FeedbackProvider>);
+    fireEvent.click(await screen.findByText("New feedback"));
+    const feedback = screen.getByRole("button", { name: "Feedback" });
+    const problem = screen.getByRole("button", { name: "Problem" });
+    expect(feedback.getAttribute("aria-pressed")).toBe("true");
+    expect(problem.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(problem);
+    expect(feedback.getAttribute("aria-pressed")).toBe("false");
+    expect(problem.getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FeedbackWorkspace } from "./components.js";
+import { FeedbackProvider } from "./provider.js";
+import type {
+  FeedbackTicketDetail,
+  FeedbackTicketPage,
+  HandsFeedbackTransport,
+} from "./types.js";
+
+afterEach(cleanup);
+
+const ticket = {
+  id: "ticket-1",
+  kind: "feedback" as const,
+  status: "open" as const,
+  message: "A reporter-visible ticket",
+  createdAt: 1,
+  updatedAt: 2,
+  unread: true,
+  unreadCount: 2,
+  attachmentCount: 0,
+  commentCount: 1,
+};
+
+const page: FeedbackTicketPage = {
+  tickets: [ticket],
+  nextCursor: null,
+  unreadTotal: 2,
+};
+
+const detail: FeedbackTicketDetail = {
+  ticket: { ...ticket, unread: false, unreadCount: 0 },
+  comments: [{ id: "comment-1", authorType: "staff", body: "Thanks", createdAt: 3 }],
+  attachments: [],
+  nextCommentCursor: null,
+  unreadTotal: 0,
+};
+
+function transport(): HandsFeedbackTransport {
+  return {
+    listTickets: vi.fn(async () => page),
+    getTicket: vi.fn(async () => detail),
+    createTicket: vi.fn(async () => detail),
+    addComment: vi.fn(async () => detail),
+  };
+}
+
+describe("FeedbackWorkspace browser behavior", () => {
+  it("lands on the Hands-backed list and reports authoritative unread changes", async () => {
+    const adapter = transport();
+    const onUnreadChanged = vi.fn();
+    const { container } = render(
+      <FeedbackProvider transport={adapter} theme="brutal" onUnreadChanged={onUnreadChanged}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    expect(container.querySelector("[data-hands-feedback-theme='brutal']")).not.toBeNull();
+    expect(await screen.findByText(ticket.message)).toBeTruthy();
+    expect(adapter.listTickets).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }));
+    expect(adapter.listTickets).not.toHaveBeenCalledWith(expect.objectContaining({ reporterId: expect.anything() }));
+    expect(onUnreadChanged).toHaveBeenCalledTimes(1);
+    expect(onUnreadChanged).toHaveBeenLastCalledWith({ total: 2, source: "list" });
+
+    fireEvent.click(screen.getByText(ticket.message));
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    expect(adapter.getTicket).toHaveBeenCalledWith(expect.objectContaining({
+      ticketId: ticket.id,
+      commentLimit: 100,
+    }));
+    await waitFor(() => expect(onUnreadChanged).toHaveBeenLastCalledWith({ total: 0, source: "detail" }));
+
+    fireEvent.click(screen.getByText("Back"));
+    expect(await screen.findByText(ticket.message)).toBeTruthy();
+  });
+
+  it("does not re-notify when list and detail return the same authoritative total", async () => {
+    const adapter = transport();
+    adapter.getTicket = vi.fn(async () => ({ ...detail, unreadTotal: page.unreadTotal }));
+    const onUnreadChanged = vi.fn();
+    render(
+      <FeedbackProvider transport={adapter} onUnreadChanged={onUnreadChanged}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    fireEvent.click(await screen.findByText(ticket.message));
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    expect(onUnreadChanged).toHaveBeenCalledTimes(1);
+    expect(onUnreadChanged).toHaveBeenCalledWith({ total: 2, source: "list" });
+  });
+});

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -1,8 +1,10 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   FeedbackWorkspace,
   MAX_FEEDBACK_ATTACHMENT_BYTES,
+  mergeCommentPages,
   mergeTicketPages,
   validateFeedbackAttachments,
 } from "./components.js";
@@ -73,6 +75,31 @@ describe("FeedbackProvider", () => {
       { id: "ticket-1", message: "Fresh" },
       { id: "ticket-2", message: "Second" },
     ]);
+  });
+
+  it("deduplicates overlapping comment pages in chronological order", () => {
+    const comment = (id: string, createdAt: number, body = id) => ({
+      id,
+      createdAt,
+      body,
+      authorType: "staff" as const,
+    });
+    expect(mergeCommentPages(
+      [comment("b", 2), comment("a", 1)],
+      [comment("b", 2, "fresh"), comment("c", 3)],
+    )).toEqual([
+      comment("a", 1),
+      comment("b", 2, "fresh"),
+      comment("c", 3),
+    ]);
+  });
+
+  it("ships package-owned nonzero skeleton sizing without Tailwind utilities", () => {
+    const css = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
+    expect(css).toMatch(/\.hands-feedback-skeleton-row[^}]*height:\s*4rem/);
+    expect(css).toMatch(/\.hands-feedback-skeleton-detail[^}]*height:\s*10rem/);
+    expect(css).not.toMatch(/\.h-16\b|\.h-40\b|\.w-full\b/);
+    expect(css).toMatch(/@media \(max-width: 640px\)/);
   });
 
   it("rejects unsafe screenshot selections before calling the transport", () => {

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -1,0 +1,100 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  FeedbackWorkspace,
+  MAX_FEEDBACK_ATTACHMENT_BYTES,
+  mergeTicketPages,
+  validateFeedbackAttachments,
+} from "./components.js";
+import { FeedbackProvider, nextUnreadReport, useHandsFeedback } from "./provider.js";
+import type { HandsFeedbackTransport } from "./types.js";
+
+const transport = {} as HandsFeedbackTransport;
+
+function Probe() {
+  const value = useHandsFeedback();
+  return <span data-theme={value.theme}>{value.unreadTotal ?? "unknown"}</span>;
+}
+
+describe("FeedbackProvider", () => {
+  it("exposes theme without accepting credentials or reporter identity", () => {
+    const html = renderToStaticMarkup(
+      <FeedbackProvider transport={transport} theme="brutal">
+        <Probe />
+      </FeedbackProvider>,
+    );
+    expect(html).toMatch(/data-theme="brutal"/);
+    expect(html).toMatch(/>unknown/);
+  });
+
+  it("renders the ticket inbox as the landing surface", () => {
+    const html = renderToStaticMarkup(
+      <FeedbackProvider transport={transport} theme="brutal">
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    expect(html).toContain('data-hands-feedback-theme="brutal"');
+    expect(html).toContain("Feedback");
+    expect(html).toContain("New feedback");
+    expect(html).not.toContain("dashboard");
+  });
+
+  it("fails closed outside a reporter-scoped provider", () => {
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(/require FeedbackProvider/);
+  });
+
+  it("emits only authoritative unread total changes", () => {
+    expect(nextUnreadReport(null, { total: 3, source: "list" })).toEqual({ next: 3, notify: true });
+    expect(nextUnreadReport(3, { total: 3, source: "detail" })).toEqual({ next: 3, notify: false });
+    expect(nextUnreadReport(3, { total: 1, source: "detail" })).toEqual({ next: 1, notify: true });
+    expect(() => nextUnreadReport(1, { total: -1, source: "list" })).toThrow(/non-negative/);
+    expect(() => nextUnreadReport(1, { total: 1.5, source: "list" })).toThrow(/safe integer/);
+    expect(() => nextUnreadReport(1, { total: Number.NaN, source: "list" })).toThrow(/safe integer/);
+  });
+
+  it("deduplicates overlapping cursor pages and keeps the fresh ticket value", () => {
+    const ticket = {
+      id: "ticket-1",
+      kind: "feedback" as const,
+      status: "open" as const,
+      message: "First",
+      createdAt: 1,
+      updatedAt: 1,
+      unread: false,
+      unreadCount: 0,
+      attachmentCount: 0,
+      commentCount: 0,
+    };
+    const result = mergeTicketPages([ticket], [
+      { ...ticket, message: "Fresh", updatedAt: 2 },
+      { ...ticket, id: "ticket-2", message: "Second" },
+    ]);
+    expect(result.map(({ id, message }) => ({ id, message }))).toEqual([
+      { id: "ticket-1", message: "Fresh" },
+      { id: "ticket-2", message: "Second" },
+    ]);
+  });
+
+  it("rejects unsafe screenshot selections before calling the transport", () => {
+    const image = (name: string, type: string, size: number) => ({
+      name,
+      type,
+      size,
+      lastModified: 0,
+    }) as File;
+    expect(validateFeedbackAttachments([
+      image("1.png", "image/png", 1),
+      image("2.webp", "image/webp", 1),
+    ])).toBeNull();
+    expect(validateFeedbackAttachments([
+      image("1.png", "image/png", 1),
+      image("2.png", "image/png", 1),
+      image("3.png", "image/png", 1),
+      image("4.png", "image/png", 1),
+    ])).toMatch(/no more than 3/);
+    expect(validateFeedbackAttachments([image("notes.txt", "text/plain", 1)])).toMatch(/supported image/);
+    expect(validateFeedbackAttachments([
+      image("huge.png", "image/png", MAX_FEEDBACK_ATTACHMENT_BYTES + 1),
+    ])).toMatch(/larger than 10 MB/);
+  });
+});

--- a/packages/feedback-react/src/provider.tsx
+++ b/packages/feedback-react/src/provider.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type {
+  FeedbackTheme,
+  FeedbackUnreadChange,
+  HandsFeedbackTransport,
+} from "./types.js";
+
+type FeedbackContextValue = {
+  transport: HandsFeedbackTransport;
+  theme: FeedbackTheme;
+  unreadTotal: number | null;
+  reportUnread(change: FeedbackUnreadChange): void;
+};
+
+const FeedbackContext = createContext<FeedbackContextValue | null>(null);
+
+export function nextUnreadReport(
+  previous: number | null,
+  change: FeedbackUnreadChange,
+): { next: number; notify: boolean } {
+  if (!Number.isSafeInteger(change.total) || change.total < 0) {
+    throw new Error("Hands unread total must be a non-negative safe integer");
+  }
+  return { next: change.total, notify: previous !== change.total };
+}
+
+export type FeedbackProviderProps = {
+  transport: HandsFeedbackTransport;
+  theme?: FeedbackTheme;
+  onUnreadChanged?: (change: FeedbackUnreadChange) => void;
+  children: ReactNode;
+};
+
+export function FeedbackProvider({
+  transport,
+  theme = "elegant",
+  onUnreadChanged,
+  children,
+}: FeedbackProviderProps) {
+  const [unreadTotal, setUnreadTotal] = useState<number | null>(null);
+  const lastReported = useRef<number | null>(null);
+  const reportUnread = useCallback((change: FeedbackUnreadChange) => {
+    const report = nextUnreadReport(lastReported.current, change);
+    setUnreadTotal(report.next);
+    if (report.notify) {
+      lastReported.current = report.next;
+      onUnreadChanged?.(change);
+    }
+  }, [onUnreadChanged]);
+  const value = useMemo(() => ({
+    transport,
+    theme,
+    unreadTotal,
+    reportUnread,
+  }), [transport, theme, unreadTotal, reportUnread]);
+  return <FeedbackContext.Provider value={value}>{children}</FeedbackContext.Provider>;
+}
+
+export function useHandsFeedback(): FeedbackContextValue {
+  const value = useContext(FeedbackContext);
+  if (!value) throw new Error("Hands feedback components require FeedbackProvider");
+  return value;
+}

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -38,6 +38,8 @@
 .hands-feedback-header { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
 .hands-feedback-header p { color: var(--hf-muted); font-size: 14px; margin-top: 4px; }
 .hands-feedback-stack { display: grid; gap: 8px; }
+.hands-feedback-skeleton-row { display: block; height: 4rem; width: 100%; }
+.hands-feedback-skeleton-detail { display: block; height: 10rem; width: 100%; }
 .hands-feedback-ticket-list { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); box-shadow: var(--hf-shadow); list-style: none; margin: 0; overflow: hidden; padding: 0; }
 .hands-feedback-ticket-list li { margin: 0; padding: 0; }
 .hands-feedback-ticket-row { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 16px; border: 0; border-bottom: 1px solid var(--hf-border); background: var(--hf-bg); color: inherit; padding: 14px 16px; text-align: left; cursor: pointer; }
@@ -61,6 +63,7 @@
 .hands-feedback-composer,
 .hands-feedback-attachments { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-bg); padding: 16px; }
 .hands-feedback-ticket-body { display: grid; gap: 8px; }
+.hands-feedback-ticket-body h3 { margin: 0; }
 .hands-feedback-conversation { display: grid; gap: 10px; }
 .hands-feedback-conversation article[data-author="reporter"] { margin-left: min(48px, 8vw); background: var(--hf-surface); }
 .hands-feedback-conversation article[data-author="staff"] { margin-right: min(48px, 8vw); }

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -1,0 +1,84 @@
+.hands-feedback-root {
+  --hf-bg: #ffffff;
+  --hf-surface: #f8fafc;
+  --hf-border: #d9e0e8;
+  --hf-text: #111827;
+  --hf-muted: #64748b;
+  --hf-accent: #2563eb;
+  --hf-danger: #b91c1c;
+  --hf-radius: 12px;
+  --hf-shadow: 0 8px 24px rgb(15 23 42 / 8%);
+  box-sizing: border-box;
+  color: var(--hf-text);
+  background: var(--hf-bg);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  min-height: 100%;
+}
+
+.hands-feedback-root[data-hands-feedback-theme="brutal"] {
+  --hf-bg: #fffdf4;
+  --hf-surface: #fff7bf;
+  --hf-border: #151515;
+  --hf-text: #151515;
+  --hf-muted: #4b4b43;
+  --hf-accent: #ffcc00;
+  --hf-danger: #d92d20;
+  --hf-radius: 0;
+  --hf-shadow: 4px 4px 0 #151515;
+}
+
+.hands-feedback-root *,
+.hands-feedback-root *::before,
+.hands-feedback-root *::after { box-sizing: inherit; }
+.hands-feedback-root h2,
+.hands-feedback-root p { margin: 0; }
+.hands-feedback-inbox,
+.hands-feedback-detail,
+.hands-feedback-new { display: grid; gap: 16px; padding: 20px; }
+.hands-feedback-header { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.hands-feedback-header p { color: var(--hf-muted); font-size: 14px; margin-top: 4px; }
+.hands-feedback-stack { display: grid; gap: 8px; }
+.hands-feedback-ticket-list { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); box-shadow: var(--hf-shadow); list-style: none; margin: 0; overflow: hidden; padding: 0; }
+.hands-feedback-ticket-list li { margin: 0; padding: 0; }
+.hands-feedback-ticket-row { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 16px; border: 0; border-bottom: 1px solid var(--hf-border); background: var(--hf-bg); color: inherit; padding: 14px 16px; text-align: left; cursor: pointer; }
+.hands-feedback-ticket-list li:last-child .hands-feedback-ticket-row { border-bottom: 0; }
+.hands-feedback-ticket-row:hover,
+.hands-feedback-ticket-row:focus-visible { background: var(--hf-surface); outline: 2px solid var(--hf-accent); outline-offset: -2px; }
+.hands-feedback-ticket-row[data-unread="true"] .hands-feedback-ticket-title { font-weight: 750; }
+.hands-feedback-ticket-copy { display: grid; gap: 5px; min-width: 0; }
+.hands-feedback-ticket-title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hands-feedback-ticket-meta,
+.hands-feedback-comment-meta,
+.hands-feedback-ticket-body > span { color: var(--hf-muted); font-size: 12px; }
+.hands-feedback-ticket-state { display: flex; align-items: center; gap: 8px; flex: none; }
+.hands-feedback-unread-dot { width: 9px; height: 9px; background: #e11d48; border: 1px solid var(--hf-border); border-radius: 50%; }
+.hands-feedback-status { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-surface); font-size: 12px; padding: 3px 8px; white-space: nowrap; }
+.hands-feedback-status[data-status="resolved"],
+.hands-feedback-status[data-status="closed"] { color: var(--hf-muted); }
+.hands-feedback-error { display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 1px solid var(--hf-danger); color: var(--hf-danger); background: color-mix(in srgb, var(--hf-danger) 7%, white); padding: 12px; }
+.hands-feedback-ticket-body,
+.hands-feedback-conversation article,
+.hands-feedback-composer,
+.hands-feedback-attachments { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-bg); padding: 16px; }
+.hands-feedback-ticket-body { display: grid; gap: 8px; }
+.hands-feedback-conversation { display: grid; gap: 10px; }
+.hands-feedback-conversation article[data-author="reporter"] { margin-left: min(48px, 8vw); background: var(--hf-surface); }
+.hands-feedback-conversation article[data-author="staff"] { margin-right: min(48px, 8vw); }
+.hands-feedback-comment-meta { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+.hands-feedback-attachments { display: flex; flex-wrap: wrap; gap: 8px; }
+.hands-feedback-attachments button { border: 1px solid var(--hf-border); background: var(--hf-surface); color: inherit; padding: 8px 10px; cursor: pointer; }
+.hands-feedback-composer,
+.hands-feedback-new { align-content: start; }
+.hands-feedback-composer { display: grid; gap: 8px; }
+.hands-feedback-root textarea { width: 100%; min-height: 110px; resize: vertical; border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-bg); color: var(--hf-text); padding: 10px 12px; font: inherit; }
+.hands-feedback-root textarea:focus { outline: 2px solid var(--hf-accent); outline-offset: 1px; }
+.hands-feedback-kind { display: flex; gap: 8px; }
+
+@media (max-width: 640px) {
+  .hands-feedback-inbox,
+  .hands-feedback-detail,
+  .hands-feedback-new { padding: 14px; }
+  .hands-feedback-header { align-items: flex-start; }
+  .hands-feedback-ticket-row { align-items: flex-start; }
+  .hands-feedback-status { max-width: 96px; overflow: hidden; text-overflow: ellipsis; }
+}

--- a/packages/feedback-react/src/types.ts
+++ b/packages/feedback-react/src/types.ts
@@ -87,3 +87,22 @@ export type FeedbackUnreadChange = {
   total: number;
   source: "list" | "detail" | "create" | "comment";
 };
+
+export type FeedbackTransportErrorCode =
+  | "conflict"
+  | "invalid"
+  | "not_found"
+  | "rate_limited"
+  | "unauthorized"
+  | "unavailable";
+
+/** A transport may throw this closed error; arbitrary Error.message is never rendered. */
+export class FeedbackTransportError extends Error {
+  readonly code: FeedbackTransportErrorCode;
+
+  constructor(code: FeedbackTransportErrorCode, options?: ErrorOptions) {
+    super(code, options);
+    this.name = "FeedbackTransportError";
+    this.code = code;
+  }
+}

--- a/packages/feedback-react/src/types.ts
+++ b/packages/feedback-react/src/types.ts
@@ -1,0 +1,89 @@
+export type FeedbackTheme = "elegant" | "brutal";
+export type FeedbackKind = "feedback" | "bug";
+export type FeedbackStatus = "open" | "in_progress" | "resolved" | "closed";
+
+export type FeedbackTicketSummary = {
+  id: string;
+  kind: FeedbackKind;
+  status: FeedbackStatus;
+  message: string;
+  createdAt: number;
+  updatedAt: number;
+  unread: boolean;
+  unreadCount: number;
+  attachmentCount: number;
+  commentCount: number;
+};
+
+export type FeedbackComment = {
+  id: string;
+  authorType: "reporter" | "staff" | "system";
+  body: string;
+  createdAt: number;
+};
+
+export type FeedbackAttachment = {
+  id: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  createdAt: number;
+};
+
+export type FeedbackTicketPage = {
+  tickets: FeedbackTicketSummary[];
+  nextCursor: string | null;
+  /** Hands-authoritative total for the current reporter, never consumer-derived. */
+  unreadTotal: number;
+};
+
+export type FeedbackTicketDetail = {
+  ticket: FeedbackTicketSummary;
+  comments: FeedbackComment[];
+  attachments: FeedbackAttachment[];
+  nextCommentCursor: string | null;
+  /** Hands-authoritative total after the detail read receipt commits. */
+  unreadTotal: number;
+};
+
+export type CreateFeedbackInput = {
+  kind: FeedbackKind;
+  message: string;
+  submissionId: string;
+  attachments: File[];
+};
+
+export type AddFeedbackCommentInput = {
+  ticketId: string;
+  body: string;
+  submissionId: string;
+};
+
+/**
+ * Host-provided reporter-scoped transport.
+ *
+ * The React package deliberately accepts no app token, deploy token, client
+ * secret, reporter id, or arbitrary ticket owner. A backend must exchange its
+ * app credential for a short-lived reporter-scoped session and bind that
+ * session inside this adapter.
+ */
+export type HandsFeedbackTransport = {
+  listTickets(input: {
+    cursor?: string;
+    limit: number;
+    signal: AbortSignal;
+  }): Promise<FeedbackTicketPage>;
+  getTicket(input: {
+    ticketId: string;
+    commentCursor?: string;
+    commentLimit: number;
+    signal: AbortSignal;
+  }): Promise<FeedbackTicketDetail>;
+  createTicket(input: CreateFeedbackInput & { signal: AbortSignal }): Promise<FeedbackTicketDetail>;
+  addComment(input: AddFeedbackCommentInput & { signal: AbortSignal }): Promise<FeedbackTicketDetail>;
+};
+
+export type FeedbackUnreadChange = {
+  total: number;
+  source: "list" | "detail" | "create" | "comment";
+};

--- a/packages/feedback-react/tsconfig.json
+++ b/packages/feedback-react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,30 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)
 
+  packages/feedback-react:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      raft-ui:
+        specifier: ^0.0.18
+        version: 0.0.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
+
   packages/node:
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 5.4.21(@types/node@24.13.2)(lightningcss@1.32.0)
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
       wrangler:
         specifier: ^4.88.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
@@ -81,7 +81,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
 
   container:
     dependencies:
@@ -125,16 +125,22 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.20.0)(jsdom@26.1.0)(lightningcss@1.32.0)
 
   packages/feedback-react:
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       raft-ui:
         specifier: ^0.0.18
         version: 0.0.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
@@ -149,7 +155,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@24.13.2)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
 
   packages/node:
     devDependencies:
@@ -161,7 +167,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.20.0)(jsdom@26.1.0)(lightningcss@1.32.0)
 
   worker:
     dependencies:
@@ -213,7 +219,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.20.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.20.0)(jsdom@26.1.0)(lightningcss@1.32.0)
       wrangler:
         specifier: ^4.88.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
@@ -223,6 +229,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@asteasolutions/zod-to-openapi@8.5.0':
     resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
@@ -395,6 +404,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -1401,6 +1438,28 @@ packages:
   '@tanstack/store@0.11.0':
     resolution: {integrity: sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1523,12 +1582,24 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1536,6 +1607,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1666,8 +1740,16 @@ packages:
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1677,6 +1759,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1713,6 +1798,9 @@ packages:
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   electron-to-chromium@1.5.379:
     resolution: {integrity: sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==}
@@ -1948,11 +2036,27 @@ packages:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2002,6 +2106,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2018,6 +2125,15 @@ packages:
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2135,6 +2251,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2142,6 +2261,10 @@ packages:
     resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2321,6 +2444,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2390,6 +2516,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -2421,6 +2551,9 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -2547,8 +2680,18 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2631,6 +2774,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-variants@3.2.2:
     resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
     engines: {node: '>=16.x', pnpm: '>=7.x'}
@@ -2672,6 +2818,21 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2849,8 +3010,29 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2896,6 +3078,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2923,6 +3112,14 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@asteasolutions/zod-to-openapi@8.5.0(zod@4.4.3)':
     dependencies:
@@ -3096,6 +3293,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
@@ -3833,6 +4050,29 @@ snapshots:
 
   '@tanstack/store@0.11.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.7
@@ -4005,6 +4245,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4012,15 +4254,23 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -4134,11 +4384,23 @@ snapshots:
 
   css-selector-parser@3.3.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4165,6 +4427,8 @@ snapshots:
       dequal: 2.0.3
 
   direction@2.0.1: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   electron-to-chromium@1.5.379: {}
 
@@ -4524,9 +4788,31 @@ snapshots:
 
   hono@4.12.27: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -4564,6 +4850,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
@@ -4575,6 +4863,33 @@ snapshots:
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -4658,6 +4973,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4665,6 +4982,8 @@ snapshots:
   lucide-react@1.23.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5056,6 +5375,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nwsapi@2.2.24: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5138,6 +5459,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   progress@2.0.3: {}
 
   property-information@7.2.0: {}
@@ -5184,6 +5511,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -5400,7 +5729,15 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -5498,6 +5835,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwind-variants@3.2.2(tailwindcss@4.3.2):
     dependencies:
       tailwindcss: 4.3.2
@@ -5530,6 +5869,20 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -5719,7 +6072,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitest@2.1.9(@types/node@22.20.0)(lightningcss@1.32.0):
+  vitest@2.1.9(@types/node@22.20.0)(jsdom@26.1.0)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0))
@@ -5743,6 +6096,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.0
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5754,7 +6108,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.13.2)(lightningcss@1.32.0):
+  vitest@2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0))
@@ -5778,6 +6132,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.2
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5789,7 +6144,24 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which@2.0.2:
     dependencies:
@@ -5830,6 +6202,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- add a publishable `@botiverse/hands-feedback-react` package with reporter-facing inbox, paged ticket conversation, reply, and new-feedback components
- expose a host-provided reporter-scoped transport and Hands-authoritative unread callback without accepting app tokens, client secrets, reporter IDs, or arbitrary ticket owners in the component API
- provide responsive `elegant` and `brutal` themes, request cancellation, cursor-page deduplication, stable retry idempotency IDs, closed user-safe transport errors, and screenshot validation
- expose explicit source entry points for commit-pinned pre-release integration while keeping compiled root exports for published consumers

## Validation

- `pnpm --filter @botiverse/hands-feedback-react test` (16 tests)
- `pnpm --filter @botiverse/hands-feedback-react run typecheck`
- `pnpm --filter @botiverse/hands-feedback-react run build`
- npm pack inspection (20 expected files; runtime source included, tests excluded)
- clean pnpm git-subdirectory source install + esbuild bundle
- React 19 peer consumer probe succeeds; React 18 probe fails closed as declared
- `git diff --check`

Signed-off-by: Volta <volta@mail.build>
