### PR TITLE
feat(feedback): own reporter interaction state

### DIFF
--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -22,11 +22,25 @@ const transport: HandsFeedbackTransport = createReporterTransport({
 <FeedbackProvider
   transport={transport}
   theme="brutal"
+  // Optional. Without this override the SDK maps browser `zh*` to `zh-CN`
+  // and falls back to English. Pass the host app's selected locale when set.
+  locale="en"
   onUnreadChanged={({ total }) => setFeedbackBadge(total)}
 >
   <FeedbackWorkspace />
 </FeedbackProvider>;
 ```
+
+The workspace owns the reporter interaction state: list filter/scroll/focus
+restoration, per-ticket reply drafts, IME-safe Enter handling, attachment
+progress/retry/cancel, recoverable cursor pages, and near-bottom conversation
+following. Hosts should not duplicate that state machine. They provide only
+the reporter-scoped transport, route notifications, and (optionally) an
+attachment opener.
+
+All visible copy, closed error copy, dates, and accessibility labels share the
+SDK locale. Supported locales are `en` and `zh-CN`; an explicit provider
+`locale` takes precedence over browser language detection.
 
 ## Security boundary
 
@@ -36,6 +50,8 @@ const transport: HandsFeedbackTransport = createReporterTransport({
 - Hands is authoritative for tickets and read/unread state. `unreadTotal`
   comes from Hands responses; the component never derives or persists its own
   read cursor.
+- A detail request reports and clears unread only after its successful Hands
+  response. Failed, aborted, stale, and unmounted reads do not mutate unread.
 - Webhooks are optional server-to-server integrations and are not required for
   inbox correctness.
 
@@ -52,7 +68,10 @@ Hands monorepo subdirectory with pnpm's `path:` git selector, then import the
 explicit source exports:
 
 ```tsx
-import { FeedbackProvider, FeedbackWorkspace } from "@botiverse/hands-feedback-react/source";
+import {
+  FeedbackProvider,
+  FeedbackWorkspace,
+} from "@botiverse/hands-feedback-react/source";
 import "@botiverse/hands-feedback-react/source/styles.css";
 ```
 

--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -42,6 +42,25 @@ All visible copy, closed error copy, dates, and accessibility labels share the
 SDK locale. Supported locales are `en` and `zh-CN`; an explicit provider
 `locale` takes precedence over browser language detection.
 
+Localization is provider-driven rather than limited to the built-in bundles.
+`messages` accepts a typed partial override (missing keys fall back to the
+resolved locale), including parameterized validation strings. `formatDate`
+lets the host apply its own date/time conventions without rebuilding SDK UI:
+
+```tsx
+<FeedbackProvider
+  transport={transport}
+  locale={appLocale}
+  messages={{
+    newFeedback: t("feedback.new"),
+    attachmentUnsupported: t("feedback.attachmentUnsupported"), // `{name}`
+  }}
+  formatDate={(date, { locale }) => appDateFormatter(date, locale)}
+>
+  <FeedbackWorkspace />
+</FeedbackProvider>
+```
+
 ## Security boundary
 
 - The package has no `appToken`, `clientSecret`, `reporterId`, or arbitrary

--- a/packages/feedback-react/README.md
+++ b/packages/feedback-react/README.md
@@ -45,7 +45,9 @@ SDK locale. Supported locales are `en` and `zh-CN`; an explicit provider
 Localization is provider-driven rather than limited to the built-in bundles.
 `messages` accepts a typed partial override (missing keys fall back to the
 resolved locale), including parameterized validation strings. `formatDate`
-lets the host apply its own date/time conventions without rebuilding SDK UI:
+and `formatFileSize` let the host apply its own formatting conventions without
+rebuilding SDK UI. Browser negotiation selects the first supported entry in
+`navigator.languages` order, then falls back to English.
 
 ```tsx
 <FeedbackProvider
@@ -56,6 +58,7 @@ lets the host apply its own date/time conventions without rebuilding SDK UI:
     attachmentUnsupported: t("feedback.attachmentUnsupported"), // `{name}`
   }}
   formatDate={(date, { locale }) => appDateFormatter(date, locale)}
+  formatFileSize={(bytes, { locale }) => appFileSizeFormatter(bytes, locale)}
 >
   <FeedbackWorkspace />
 </FeedbackProvider>

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -346,7 +346,9 @@ export function FeedbackInbox({
                     {ticket.unread && (
                       <span
                         className="hands-feedback-unread-dot"
-                        aria-label={`${ticket.unreadCount} ${message("unread")}`}
+                        aria-label={message("unreadCount", {
+                          count: ticket.unreadCount,
+                        })}
                       />
                     )}
                     <StatusBadge status={ticket.status} />
@@ -393,7 +395,8 @@ export function FeedbackTicket({
   onDraftChange,
   onReadSuccess,
 }: FeedbackTicketProps) {
-  const { formatDate, message, reportUnread, transport } = useHandsFeedback();
+  const { formatDate, formatFileSize, message, reportUnread, transport } =
+    useHandsFeedback();
   const safeError = useSafeError();
   const [detail, setDetail] = useState<FeedbackTicketDetail | null>(null);
   const [internalDraft, setInternalDraft] = useState("");
@@ -591,7 +594,9 @@ export function FeedbackTicket({
                     key={attachment.id}
                     type="button"
                     disabled={!onOpenAttachment}
-                    aria-label={`${message("openAttachment")} ${attachment.filename}`}
+                    aria-label={message("openAttachment", {
+                      name: attachment.filename,
+                    })}
                     onClick={() =>
                       onOpenAttachment?.({
                         ticketId,
@@ -599,8 +604,10 @@ export function FeedbackTicket({
                       })
                     }
                   >
-                    {attachment.filename} ·{" "}
-                    {Math.ceil(attachment.sizeBytes / 1024)} KB
+                    {message("attachmentSummary", {
+                      name: attachment.filename,
+                      size: formatFileSize(attachment.sizeBytes),
+                    })}
                   </button>
                 ))}
               </div>
@@ -736,7 +743,16 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
     null,
   );
   const textareaRef = useAutosize(message);
-  useEffect(() => () => actionController.current?.abort(), []);
+  useEffect(() => {
+    actionController.current?.abort();
+    actionController.current = null;
+    createSubmission.current = null;
+    setSending(false);
+    setAttachments((current) =>
+      current.map((item) => ({ ...item, state: "ready", progress: 0 })),
+    );
+    return () => actionController.current?.abort();
+  }, [transport]);
 
   const submit = async () => {
     const normalized = message.trim();
@@ -886,7 +902,7 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
           rows={2}
         />
         <label htmlFor="hands-feedback-attachments">
-          {copy("screenshots")}
+          {copy("screenshots", { count: MAX_FEEDBACK_ATTACHMENTS })}
         </label>
         <Input
           id="hands-feedback-attachments"
@@ -905,7 +921,9 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
                   <progress
                     max={1}
                     value={item.progress || undefined}
-                    aria-label={`${item.file.name} ${copy("uploadProgress")}`}
+                    aria-label={copy("uploadProgress", {
+                      name: item.file.name,
+                    })}
                   />
                 )}
                 {item.state === "failed" && (
@@ -994,25 +1012,30 @@ export function FeedbackWorkspace({
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [readTicketId, setReadTicketId] = useState<string | null>(null);
   const originTicket = useRef<string | null>(initialTicketId ?? null);
+  const pendingInboxFocus = useRef<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const navigate = (next: FeedbackWorkspaceRoute) => {
     if (!controlledRoute) setInternalRoute(next);
     onRouteChange?.(next);
   };
   const back = () => {
-    const focusId = originTicket.current;
+    pendingInboxFocus.current = originTicket.current ?? "";
     navigate({ view: "inbox" });
-    requestAnimationFrame(() =>
-      Array.from(
-        rootRef.current?.querySelectorAll<HTMLElement>("[data-ticket-id]") ??
-          [],
-      )
-        .find((element) => element.dataset.ticketId === focusId)
-        ?.focus(),
-    );
   };
   useEffect(() => {
-    if (route.view !== "inbox")
+    if (route.view === "inbox" && pendingInboxFocus.current !== null) {
+      const focusId = pendingInboxFocus.current;
+      pendingInboxFocus.current = null;
+      requestAnimationFrame(() => {
+        const root = rootRef.current;
+        const row = Array.from(
+          root?.querySelectorAll<HTMLElement>("[data-ticket-id]") ?? [],
+        ).find((element) => element.dataset.ticketId === focusId);
+        (
+          row ?? root?.querySelector<HTMLElement>("[data-feedback-list-scroll]")
+        )?.focus();
+      });
+    } else if (route.view !== "inbox")
       requestAnimationFrame(() =>
         rootRef.current
           ?.querySelector<HTMLElement>("section:not([hidden]) h2")

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -1,18 +1,29 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Badge,
   Button,
   EmptyState,
   EmptyStateTitle,
   Input,
   Skeleton,
 } from "raft-ui";
+import { feedbackErrorMessage, feedbackStatusLabel } from "./locale.js";
 import { useHandsFeedback } from "./provider.js";
 import { FeedbackTransportError } from "./types.js";
 import type {
   FeedbackComment,
   FeedbackKind,
-  FeedbackTicketSummary,
   FeedbackTicketDetail,
+  FeedbackTicketSummary,
 } from "./types.js";
 
 export const MAX_FEEDBACK_ATTACHMENTS = 3;
@@ -27,7 +38,7 @@ export const FEEDBACK_ATTACHMENT_TYPES = [
 export function mergeTicketPages(
   current: FeedbackTicketSummary[],
   incoming: FeedbackTicketSummary[],
-): FeedbackTicketSummary[] {
+) {
   const merged = new Map(current.map((ticket) => [ticket.id, ticket]));
   for (const ticket of incoming) merged.set(ticket.id, ticket);
   return [...merged.values()];
@@ -36,176 +47,310 @@ export function mergeTicketPages(
 export function mergeCommentPages(
   current: FeedbackComment[],
   incoming: FeedbackComment[],
-): FeedbackComment[] {
+) {
   const merged = new Map(current.map((comment) => [comment.id, comment]));
   for (const comment of incoming) merged.set(comment.id, comment);
-  return [...merged.values()].sort((left, right) =>
-    left.createdAt - right.createdAt || left.id.localeCompare(right.id));
+  return [...merged.values()].sort(
+    (left, right) =>
+      left.createdAt - right.createdAt || left.id.localeCompare(right.id),
+  );
 }
 
 export function validateFeedbackAttachments(files: File[]): string | null {
-  if (files.length > MAX_FEEDBACK_ATTACHMENTS) {
+  if (files.length > MAX_FEEDBACK_ATTACHMENTS)
     return `Choose no more than ${MAX_FEEDBACK_ATTACHMENTS} screenshots.`;
-  }
   for (const file of files) {
-    if (!(FEEDBACK_ATTACHMENT_TYPES as readonly string[]).includes(file.type)) {
+    if (!(FEEDBACK_ATTACHMENT_TYPES as readonly string[]).includes(file.type))
       return `${file.name} is not a supported image.`;
-    }
-    if (file.size > MAX_FEEDBACK_ATTACHMENT_BYTES) {
+    if (file.size > MAX_FEEDBACK_ATTACHMENT_BYTES)
       return `${file.name} is larger than 10 MB.`;
-    }
   }
   return null;
 }
 
-function stableSubmissionId(
+function localizedAttachmentError(files: File[], locale: "en" | "zh-CN") {
+  const error = validateFeedbackAttachments(files);
+  if (!error || locale === "en") return error;
+  if (files.length > MAX_FEEDBACK_ATTACHMENTS)
+    return `最多选择 ${MAX_FEEDBACK_ATTACHMENTS} 张截图。`;
+  const invalid = files.find(
+    (file) =>
+      !(FEEDBACK_ATTACHMENT_TYPES as readonly string[]).includes(file.type),
+  );
+  if (invalid) return `${invalid.name} 不是支持的图片格式。`;
+  const large = files.find((file) => file.size > MAX_FEEDBACK_ATTACHMENT_BYTES);
+  return large ? `${large.name} 超过 10 MB。` : error;
+}
+
+function submissionId() {
+  if (!globalThis.crypto?.randomUUID)
+    throw new Error("A secure randomUUID implementation is required");
+  return globalThis.crypto.randomUUID();
+}
+
+export function stableFeedbackSubmission(
   previous: { fingerprint: string; id: string } | null,
   fingerprint: string,
-): { fingerprint: string; id: string } {
+) {
   return previous?.fingerprint === fingerprint
     ? previous
     : { fingerprint, id: submissionId() };
 }
 
-function errorMessage(error: unknown): string {
-  if (!(error instanceof FeedbackTransportError)) return "Feedback is temporarily unavailable.";
-  switch (error.code) {
-    case "conflict": return "This retry no longer matches the original request.";
-    case "invalid": return "Check the feedback details and try again.";
-    case "not_found": return "This feedback ticket is no longer available.";
-    case "rate_limited": return "Too many feedback requests. Try again later.";
-    case "unauthorized": return "Your feedback session expired. Reopen feedback and try again.";
-    case "unavailable": return "Feedback is temporarily unavailable.";
-  }
+export function isNearConversationBottom(
+  input: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+  threshold = 64,
+) {
+  return input.scrollHeight - input.scrollTop - input.clientHeight <= threshold;
 }
 
-function statusLabel(status: FeedbackTicketSummary["status"]): string {
-  return status === "in_progress" ? "In progress" : `${status[0]!.toUpperCase()}${status.slice(1)}`;
+function useSafeError() {
+  const { locale } = useHandsFeedback();
+  return useCallback(
+    (error: unknown) =>
+      feedbackErrorMessage(
+        locale,
+        error instanceof FeedbackTransportError ? error.code : undefined,
+      ),
+    [locale],
+  );
 }
 
-function formatDate(value: number): string {
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
+function useAutosize(value: string) {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+  useLayoutEffect(() => {
+    const textarea = ref.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 240)}px`;
+  }, [value]);
+  return ref;
 }
 
-function submissionId(): string {
-  if (!globalThis.crypto?.randomUUID) throw new Error("A secure randomUUID implementation is required");
-  return globalThis.crypto.randomUUID();
+function StatusBadge({ status }: { status: FeedbackTicketSummary["status"] }) {
+  const { locale } = useHandsFeedback();
+  if (status === "in_progress")
+    return (
+      <Badge variant="information" uppercase={false}>
+        {feedbackStatusLabel(locale, status)}
+      </Badge>
+    );
+  if (status === "resolved")
+    return (
+      <Badge variant="success" uppercase={false}>
+        {feedbackStatusLabel(locale, status)}
+      </Badge>
+    );
+  return (
+    <Badge appearance="outline" uppercase={false}>
+      {feedbackStatusLabel(locale, status)}
+    </Badge>
+  );
 }
 
 export type FeedbackInboxProps = {
   onSelectTicket(ticketId: string): void;
   onNewFeedback(): void;
   pageSize?: number;
+  hidden?: boolean;
+  readTicketId?: string | null;
 };
 
-export function FeedbackInbox({ onSelectTicket, onNewFeedback, pageSize = 20 }: FeedbackInboxProps) {
-  const { transport, reportUnread } = useHandsFeedback();
+export function FeedbackInbox({
+  onSelectTicket,
+  onNewFeedback,
+  pageSize = 20,
+  hidden = false,
+  readTicketId,
+}: FeedbackInboxProps) {
+  const { locale, message, reportUnread, transport } = useHandsFeedback();
+  const safeError = useSafeError();
   const [tickets, setTickets] = useState<FeedbackTicketSummary[]>([]);
+  const [filter, setFilter] = useState<"all" | "open" | "resolved">("all");
   const [cursor, setCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryCursor, setRetryCursor] = useState<string | undefined>(undefined);
   const request = useRef(0);
-  const requestController = useRef<AbortController | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
 
-  const load = useCallback(async (nextCursor?: string) => {
-    requestController.current?.abort();
-    const controller = new AbortController();
-    requestController.current = controller;
-    const id = ++request.current;
-    nextCursor ? setLoadingMore(true) : setLoading(true);
-    setError(null);
-    const signal = controller.signal;
-    try {
-      const page = await transport.listTickets({
-        ...(nextCursor ? { cursor: nextCursor } : {}),
-        limit: pageSize,
-        signal,
-      });
-      if (request.current !== id) return;
-      reportUnread({ total: page.unreadTotal, source: "list" });
-      setTickets((current) => nextCursor ? mergeTicketPages(current, page.tickets) : page.tickets);
-      setCursor(page.nextCursor);
-    } catch (cause) {
-      if (request.current === id && !signal.aborted) setError(errorMessage(cause));
-    } finally {
-      if (request.current === id) {
-        setLoading(false);
-        setLoadingMore(false);
+  const load = useCallback(
+    async (nextCursor?: string) => {
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      const id = ++request.current;
+      nextCursor ? setLoadingMore(true) : setLoading(true);
+      setError(null);
+      setRetryCursor(undefined);
+      try {
+        const page = await transport.listTickets({
+          ...(nextCursor ? { cursor: nextCursor } : {}),
+          limit: pageSize,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted || request.current !== id) return;
+        reportUnread({ total: page.unreadTotal, source: "list" });
+        setTickets((current) =>
+          nextCursor ? mergeTicketPages(current, page.tickets) : page.tickets,
+        );
+        setCursor(page.nextCursor);
+      } catch (cause) {
+        if (!controller.signal.aborted && request.current === id) {
+          setError(safeError(cause));
+          setRetryCursor(nextCursor);
+        }
+      } finally {
+        if (!controller.signal.aborted && request.current === id) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
       }
-    }
-  }, [pageSize, reportUnread, transport]);
+    },
+    [pageSize, reportUnread, safeError, transport],
+  );
 
   useEffect(() => {
     void load();
     return () => {
-      requestController.current?.abort();
+      controllerRef.current?.abort();
       request.current += 1;
     };
   }, [load]);
 
+  useEffect(() => {
+    if (!readTicketId) return;
+    setTickets((current) =>
+      current.map((ticket) =>
+        ticket.id === readTicketId
+          ? { ...ticket, unread: false, unreadCount: 0 }
+          : ticket,
+      ),
+    );
+  }, [readTicketId]);
+
+  const visibleTickets = tickets.filter(
+    (ticket) =>
+      filter === "all" ||
+      (filter === "open"
+        ? ticket.status === "open" || ticket.status === "in_progress"
+        : ticket.status === "resolved" || ticket.status === "closed"),
+  );
+
   return (
-    <section className="hands-feedback-inbox" aria-labelledby="hands-feedback-inbox-title">
+    <section
+      className="hands-feedback-inbox"
+      aria-labelledby="hands-feedback-inbox-title"
+      hidden={hidden}
+    >
       <header className="hands-feedback-header">
         <div>
-          <h2 id="hands-feedback-inbox-title">Feedback</h2>
-          <p>Your feedback and replies from the team.</p>
+          <h2 id="hands-feedback-inbox-title">{message("feedback")}</h2>
+          <p>{message("inboxDescription")}</p>
         </div>
-        <Button onClick={onNewFeedback}>New feedback</Button>
+        <Button onClick={onNewFeedback}>{message("newFeedback")}</Button>
       </header>
-      {loading && (
-        <div className="hands-feedback-stack" aria-label="Loading feedback">
-          <Skeleton className="hands-feedback-skeleton-row" />
-          <Skeleton className="hands-feedback-skeleton-row" />
-          <Skeleton className="hands-feedback-skeleton-row" />
-        </div>
-      )}
-      {error && (
-        <div className="hands-feedback-error" role="alert">
-          <span>{error}</span>
-          <Button variant="outline" onClick={() => void load()}>Try again</Button>
-        </div>
-      )}
-      {!loading && !error && tickets.length === 0 && (
-        <EmptyState>
-          <EmptyStateTitle>No feedback yet</EmptyStateTitle>
-          <p>Send your first idea or report a problem.</p>
-          <Button onClick={onNewFeedback}>New feedback</Button>
-        </EmptyState>
-      )}
-      {tickets.length > 0 && (
-        <ul className="hands-feedback-ticket-list">
-          {tickets.map((ticket) => (
-            <li key={ticket.id}>
-              <button
-                className="hands-feedback-ticket-row"
-                data-unread={ticket.unread || undefined}
-                onClick={() => onSelectTicket(ticket.id)}
-                type="button"
-              >
-                <span className="hands-feedback-ticket-copy">
-                  <span className="hands-feedback-ticket-title">{ticket.message}</span>
-                  <span className="hands-feedback-ticket-meta">
-                    {ticket.kind === "bug" ? "Problem" : "Feedback"} · {formatDate(ticket.updatedAt)}
+      <div
+        className="hands-feedback-filter"
+        role="group"
+        aria-label={message("statusFilter")}
+      >
+        {(["all", "open", "resolved"] as const).map((value) => (
+          <Button
+            key={value}
+            variant={filter === value ? "primary" : "outline"}
+            aria-pressed={filter === value}
+            onClick={() => setFilter(value)}
+          >
+            {value === "all"
+              ? locale === "zh-CN"
+                ? "全部"
+                : "All"
+              : feedbackStatusLabel(locale, value)}
+          </Button>
+        ))}
+      </div>
+      <div
+        className="hands-feedback-middle hands-feedback-list-scroll"
+        data-feedback-list-scroll
+        tabIndex={-1}
+      >
+        {loading && (
+          <div className="hands-feedback-stack" aria-label={message("loading")}>
+            <Skeleton className="hands-feedback-skeleton-row" />
+            <Skeleton className="hands-feedback-skeleton-row" />
+            <Skeleton className="hands-feedback-skeleton-row" />
+          </div>
+        )}
+        {error && (
+          <div className="hands-feedback-error" role="alert">
+            <span>{error}</span>
+            <Button variant="outline" onClick={() => void load(retryCursor)}>
+              {message("retry")}
+            </Button>
+          </div>
+        )}
+        {!loading && !error && visibleTickets.length === 0 && (
+          <EmptyState>
+            <EmptyStateTitle>{message("emptyTitle")}</EmptyStateTitle>
+            <p>{message("emptyBody")}</p>
+            <Button onClick={onNewFeedback}>{message("newFeedback")}</Button>
+          </EmptyState>
+        )}
+        {visibleTickets.length > 0 && (
+          <ul className="hands-feedback-ticket-list">
+            {visibleTickets.map((ticket) => (
+              <li key={ticket.id}>
+                <button
+                  className="hands-feedback-ticket-row"
+                  data-ticket-id={ticket.id}
+                  data-unread={ticket.unread || undefined}
+                  onClick={() => onSelectTicket(ticket.id)}
+                  type="button"
+                >
+                  <span className="hands-feedback-ticket-copy">
+                    <span className="hands-feedback-ticket-title">
+                      {ticket.message}
+                    </span>
+                    <span className="hands-feedback-ticket-meta">
+                      {ticket.kind === "bug"
+                        ? message("problem")
+                        : message("feedback")}{" "}
+                      ·{" "}
+                      {new Intl.DateTimeFormat(locale, {
+                        dateStyle: "medium",
+                        timeStyle: "short",
+                      }).format(new Date(ticket.updatedAt))}
+                    </span>
                   </span>
-                </span>
-                <span className="hands-feedback-ticket-state">
-                  {ticket.unread && <span className="hands-feedback-unread-dot" aria-label={`${ticket.unreadCount} unread`} />}
-                  <span className="hands-feedback-status" data-status={ticket.status}>{statusLabel(ticket.status)}</span>
-                </span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-      {cursor && (
-        <Button variant="outline" disabled={loadingMore} onClick={() => void load(cursor)}>
-          {loadingMore ? "Loading…" : "Load more"}
-        </Button>
-      )}
+                  <span className="hands-feedback-ticket-state">
+                    {ticket.unread && (
+                      <span
+                        className="hands-feedback-unread-dot"
+                        aria-label={`${ticket.unreadCount} ${message("unread")}`}
+                      />
+                    )}
+                    <StatusBadge status={ticket.status} />
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {cursor && (
+          <Button
+            variant="outline"
+            disabled={loadingMore}
+            onClick={() => void load(cursor)}
+          >
+            {loadingMore ? message("loadingMore") : message("loadMore")}
+          </Button>
+        )}
+      </div>
+      <div className="hands-feedback-live" aria-live="polite">
+        {loadingMore ? message("loadingMore") : (error ?? "")}
+      </div>
     </section>
   );
 }
@@ -213,52 +358,118 @@ export function FeedbackInbox({ onSelectTicket, onNewFeedback, pageSize = 20 }: 
 export type FeedbackTicketProps = {
   ticketId: string;
   onBack(): void;
-  onOpenAttachment?: (input: { ticketId: string; attachmentId: string }) => void;
+  onOpenAttachment?: (input: {
+    ticketId: string;
+    attachmentId: string;
+  }) => void;
+  draft?: string;
+  onDraftChange?: (value: string) => void;
+  onReadSuccess?: (ticketId: string) => void;
 };
 
-export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackTicketProps) {
-  const { transport, reportUnread } = useHandsFeedback();
+export function FeedbackTicket({
+  ticketId,
+  onBack,
+  onOpenAttachment,
+  draft,
+  onDraftChange,
+  onReadSuccess,
+}: FeedbackTicketProps) {
+  const { locale, message, reportUnread, transport } = useHandsFeedback();
+  const safeError = useSafeError();
   const [detail, setDetail] = useState<FeedbackTicketDetail | null>(null);
-  const [reply, setReply] = useState("");
+  const [internalDraft, setInternalDraft] = useState("");
+  const reply = draft ?? internalDraft;
+  const setReply = onDraftChange ?? setInternalDraft;
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [sending, setSending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryLoad, setRetryLoad] = useState<{
+    cursor: string | undefined;
+    refresh: boolean;
+  }>({ cursor: undefined, refresh: false });
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [newReplies, setNewReplies] = useState(false);
   const loadRequest = useRef(0);
   const loadController = useRef<AbortController | null>(null);
   const actionController = useRef<AbortController | null>(null);
-  const commentSubmission = useRef<{ fingerprint: string; id: string } | null>(null);
+  const commentSubmission = useRef<{ fingerprint: string; id: string } | null>(
+    null,
+  );
+  const conversationRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useAutosize(reply);
+  const scrollIntent = useRef<"bottom" | "preserve" | null>(null);
 
-  const load = useCallback(async (commentCursor?: string) => {
-    loadController.current?.abort();
-    const controller = new AbortController();
-    loadController.current = controller;
-    const requestId = ++loadRequest.current;
-    commentCursor ? setLoadingMore(true) : setLoading(true);
-    if (!commentCursor) setDetail(null);
-    setError(null);
-    const signal = controller.signal;
-    try {
-      const result = await transport.getTicket({
-        ticketId,
-        ...(commentCursor ? { commentCursor } : {}),
-        commentLimit: 100,
-        signal,
-      });
-      if (signal.aborted || requestId !== loadRequest.current) return;
-      reportUnread({ total: result.unreadTotal, source: "detail" });
-      setDetail((current) => commentCursor && current
-        ? { ...result, comments: mergeCommentPages(current.comments, result.comments) }
-        : result);
-    } catch (cause) {
-      if (!signal.aborted) setError(errorMessage(cause));
-    } finally {
-      if (!signal.aborted && requestId === loadRequest.current) {
-        setLoading(false);
-        setLoadingMore(false);
+  const load = useCallback(
+    async (commentCursor?: string, refresh = false) => {
+      loadController.current?.abort();
+      const controller = new AbortController();
+      loadController.current = controller;
+      const requestId = ++loadRequest.current;
+      commentCursor ? setLoadingMore(true) : setLoading(!refresh);
+      if (!commentCursor && !refresh) setDetail(null);
+      setLoadError(null);
+      setRetryLoad({ cursor: undefined, refresh: false });
+      const nearBottom = conversationRef.current
+        ? isNearConversationBottom(conversationRef.current)
+        : true;
+      try {
+        const result = await transport.getTicket({
+          ticketId,
+          ...(commentCursor ? { commentCursor } : {}),
+          commentLimit: 100,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted || requestId !== loadRequest.current)
+          return;
+        reportUnread({ total: result.unreadTotal, source: "detail" });
+        if (!commentCursor) onReadSuccess?.(ticketId);
+        setDetail((current) => {
+          const next =
+            commentCursor && current
+              ? {
+                  ...result,
+                  comments: mergeCommentPages(
+                    current.comments,
+                    result.comments,
+                  ),
+                }
+              : result;
+          if (
+            refresh &&
+            current &&
+            next.comments.length > current.comments.length &&
+            !nearBottom
+          )
+            setNewReplies(true);
+          return next;
+        });
+        scrollIntent.current = nearBottom ? "bottom" : "preserve";
+        setAnnouncement(message("ticketUpdated"));
+      } catch (cause) {
+        if (!controller.signal.aborted && requestId === loadRequest.current) {
+          setLoadError(safeError(cause));
+          setRetryLoad({ cursor: commentCursor, refresh });
+        }
+      } finally {
+        if (!controller.signal.aborted && requestId === loadRequest.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
       }
-    }
-  }, [reportUnread, ticketId, transport]);
+    },
+    [
+      locale,
+      message,
+      onReadSuccess,
+      reportUnread,
+      safeError,
+      ticketId,
+      transport,
+    ],
+  );
 
   useEffect(() => {
     void load();
@@ -269,15 +480,24 @@ export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackT
     };
   }, [load]);
 
+  useLayoutEffect(() => {
+    if (scrollIntent.current === "bottom" && conversationRef.current)
+      conversationRef.current.scrollTop = conversationRef.current.scrollHeight;
+    scrollIntent.current = null;
+  }, [detail]);
+
   const send = async () => {
     const body = reply.trim();
     if (!body || sending) return;
     setSending(true);
-    setError(null);
+    setActionError(null);
     actionController.current?.abort();
     const controller = new AbortController();
     actionController.current = controller;
-    commentSubmission.current = stableSubmissionId(commentSubmission.current, body);
+    commentSubmission.current = stableFeedbackSubmission(
+      commentSubmission.current,
+      body,
+    );
     try {
       const result = await transport.addComment({
         ticketId,
@@ -287,83 +507,213 @@ export function FeedbackTicket({ ticketId, onBack, onOpenAttachment }: FeedbackT
       });
       if (controller.signal.aborted) return;
       reportUnread({ total: result.unreadTotal, source: "comment" });
+      scrollIntent.current = "bottom";
       setDetail(result);
       setReply("");
+      setNewReplies(false);
       commentSubmission.current = null;
+      setAnnouncement(message("replySent"));
+      requestAnimationFrame(() => textareaRef.current?.focus());
     } catch (cause) {
-      if (!controller.signal.aborted) setError(errorMessage(cause));
+      if (!controller.signal.aborted) {
+        setActionError(safeError(cause));
+        setAnnouncement(safeError(cause));
+      }
     } finally {
       if (!controller.signal.aborted) setSending(false);
     }
   };
 
+  const onReplyKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key !== "Enter" ||
+      event.shiftKey ||
+      event.nativeEvent.isComposing ||
+      event.keyCode === 229
+    )
+      return;
+    event.preventDefault();
+    void send();
+  };
+
   return (
-    <section className="hands-feedback-detail" aria-labelledby="hands-feedback-ticket-heading">
+    <section
+      className="hands-feedback-detail"
+      aria-labelledby="hands-feedback-ticket-heading"
+    >
       <header className="hands-feedback-header">
-        <Button variant="outline" onClick={onBack}>Back</Button>
-        <h2 id="hands-feedback-ticket-heading">Feedback ticket</h2>
-        {detail && <span className="hands-feedback-status" data-status={detail.ticket.status}>{statusLabel(detail.ticket.status)}</span>}
+        <Button variant="outline" onClick={onBack}>
+          {message("back")}
+        </Button>
+        <h2 id="hands-feedback-ticket-heading" tabIndex={-1}>
+          {message("ticketHeading")}
+        </h2>
+        {detail ? <StatusBadge status={detail.ticket.status} /> : <span />}
       </header>
-      {loading && <Skeleton className="hands-feedback-skeleton-detail" />}
-      {error && <div className="hands-feedback-error" role="alert">{error}</div>}
-      {detail && (
-        <>
-          <div className="hands-feedback-ticket-body">
-            <h3>{detail.ticket.message}</h3>
-            <span>{formatDate(detail.ticket.createdAt)}</span>
-          </div>
-          {detail.attachments.length > 0 && (
-            <div className="hands-feedback-attachments" aria-label="Attachments">
-              {detail.attachments.map((attachment) => (
-                <button
-                  key={attachment.id}
-                  type="button"
-                  disabled={!onOpenAttachment}
-                  aria-label={`Open attachment ${attachment.filename}`}
-                  onClick={() => onOpenAttachment?.({ ticketId, attachmentId: attachment.id })}
-                >
-                  {attachment.filename} · {Math.ceil(attachment.sizeBytes / 1024)} KB
-                </button>
-              ))}
-            </div>
-          )}
-          <div className="hands-feedback-conversation" aria-label="Conversation">
-            {detail.comments.map((comment) => (
-              <article key={comment.id} data-author={comment.authorType}>
-                <div className="hands-feedback-comment-meta">
-                  <strong>{comment.authorType === "reporter" ? "You" : comment.authorType === "staff" ? "Team" : "Update"}</strong>
-                  <span>{formatDate(comment.createdAt)}</span>
-                </div>
-                <p>{comment.body}</p>
-              </article>
-            ))}
-          </div>
-          {detail.nextCommentCursor && (
+      <div className="hands-feedback-middle">
+        {loading && <Skeleton className="hands-feedback-skeleton-detail" />}
+        {loadError && (
+          <div className="hands-feedback-error" role="alert">
+            <span>{loadError}</span>
             <Button
               variant="outline"
-              disabled={loadingMore}
-              onClick={() => void load(detail.nextCommentCursor!)}
+              onClick={() => void load(retryLoad.cursor, retryLoad.refresh)}
             >
-              {loadingMore ? "Loading…" : "Load more replies"}
-            </Button>
-          )}
-          <div className="hands-feedback-composer">
-            <label htmlFor="hands-feedback-reply">Reply</label>
-            <textarea
-              id="hands-feedback-reply"
-              maxLength={10_000}
-              value={reply}
-              onChange={(event) => setReply(event.target.value)}
-            />
-            <Button disabled={!reply.trim() || sending} onClick={() => void send()}>
-              {sending ? "Sending…" : "Send reply"}
+              {message("retry")}
             </Button>
           </div>
-        </>
+        )}
+        {detail && (
+          <>
+            <div className="hands-feedback-ticket-body">
+              <h3>{detail.ticket.message}</h3>
+              <span>
+                {new Intl.DateTimeFormat(locale, {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                }).format(new Date(detail.ticket.createdAt))}
+              </span>
+            </div>
+            {detail.attachments.length > 0 && (
+              <div
+                className="hands-feedback-attachments"
+                aria-label={message("attachments")}
+              >
+                {detail.attachments.map((attachment) => (
+                  <button
+                    key={attachment.id}
+                    type="button"
+                    disabled={!onOpenAttachment}
+                    aria-label={`${message("openAttachment")} ${attachment.filename}`}
+                    onClick={() =>
+                      onOpenAttachment?.({
+                        ticketId,
+                        attachmentId: attachment.id,
+                      })
+                    }
+                  >
+                    {attachment.filename} ·{" "}
+                    {Math.ceil(attachment.sizeBytes / 1024)} KB
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="hands-feedback-conversation-toolbar">
+              <strong>{message("conversation")}</strong>
+              <Button
+                variant="outline"
+                onClick={() => void load(undefined, true)}
+              >
+                {message("refresh")}
+              </Button>
+            </div>
+            <div
+              className="hands-feedback-conversation"
+              aria-label={message("conversation")}
+              ref={conversationRef}
+              onScroll={() => {
+                if (
+                  conversationRef.current &&
+                  isNearConversationBottom(conversationRef.current)
+                )
+                  setNewReplies(false);
+              }}
+            >
+              {detail.comments.length === 0 && (
+                <p className="hands-feedback-muted">{message("noReplies")}</p>
+              )}
+              {detail.comments.map((comment) => (
+                <article key={comment.id} data-author={comment.authorType}>
+                  <div className="hands-feedback-comment-meta">
+                    <strong>
+                      {comment.authorType === "reporter"
+                        ? message("you")
+                        : comment.authorType === "staff"
+                          ? message("team")
+                          : message("update")}
+                    </strong>
+                    <span>
+                      {new Intl.DateTimeFormat(locale, {
+                        dateStyle: "medium",
+                        timeStyle: "short",
+                      }).format(new Date(comment.createdAt))}
+                    </span>
+                  </div>
+                  <p>{comment.body}</p>
+                </article>
+              ))}
+            </div>
+            {newReplies && (
+              <Button
+                className="hands-feedback-new-replies"
+                onClick={() => {
+                  if (conversationRef.current)
+                    conversationRef.current.scrollTop =
+                      conversationRef.current.scrollHeight;
+                  setNewReplies(false);
+                }}
+              >
+                {message("newReplies")}
+              </Button>
+            )}
+            {detail.nextCommentCursor && (
+              <Button
+                variant="outline"
+                disabled={loadingMore}
+                onClick={() => void load(detail.nextCommentCursor!)}
+              >
+                {loadingMore
+                  ? message("loadingMore")
+                  : message("loadMoreReplies")}
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+      {detail && (
+        <div className="hands-feedback-composer">
+          <label htmlFor={`hands-feedback-reply-${ticketId}`}>
+            {message("reply")}
+          </label>
+          <textarea
+            ref={textareaRef}
+            id={`hands-feedback-reply-${ticketId}`}
+            maxLength={10_000}
+            value={reply}
+            onChange={(event) => setReply(event.target.value)}
+            onKeyDown={onReplyKeyDown}
+            rows={1}
+          />
+          {actionError && (
+            <div className="hands-feedback-error" role="alert">
+              {actionError}
+            </div>
+          )}
+          <Button
+            disabled={!reply.trim() || sending}
+            onClick={() => void send()}
+          >
+            {sending ? message("sending") : message("sendReply")}
+          </Button>
+        </div>
       )}
+      <div
+        className="hands-feedback-live"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {announcement}
+      </div>
     </section>
   );
 }
+
+type PendingAttachment = {
+  id: string;
+  file: File;
+  progress: number;
+  state: "ready" | "uploading" | "failed";
+};
 
 export type NewFeedbackProps = {
   onCancel(): void;
@@ -371,131 +721,352 @@ export type NewFeedbackProps = {
 };
 
 export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
-  const { transport, reportUnread } = useHandsFeedback();
+  const { locale, message: copy, reportUnread, transport } = useHandsFeedback();
+  const safeError = useSafeError();
   const [kind, setKind] = useState<FeedbackKind>("feedback");
   const [message, setMessage] = useState("");
-  const [attachments, setAttachments] = useState<File[]>([]);
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
   const actionController = useRef<AbortController | null>(null);
-  const createSubmission = useRef<{ fingerprint: string; id: string } | null>(null);
-
+  const createSubmission = useRef<{ fingerprint: string; id: string } | null>(
+    null,
+  );
+  const textareaRef = useAutosize(message);
   useEffect(() => () => actionController.current?.abort(), []);
 
   const submit = async () => {
     const normalized = message.trim();
     if (!normalized || sending) return;
-    const attachmentError = validateFeedbackAttachments(attachments);
+    const files = attachments.map(({ file }) => file);
+    const attachmentError = localizedAttachmentError(files, locale);
     if (attachmentError) {
       setError(attachmentError);
       return;
     }
     setSending(true);
     setError(null);
+    setAttachments((current) =>
+      current.map((item) => ({ ...item, state: "uploading", progress: 0 })),
+    );
     actionController.current?.abort();
     const controller = new AbortController();
     actionController.current = controller;
     const fingerprint = JSON.stringify([
       kind,
       normalized,
-      ...attachments.map((file) => [file.name, file.type, file.size, file.lastModified]),
+      ...files.map((file) => [
+        file.name,
+        file.type,
+        file.size,
+        file.lastModified,
+      ]),
     ]);
-    createSubmission.current = stableSubmissionId(createSubmission.current, fingerprint);
+    createSubmission.current = stableFeedbackSubmission(
+      createSubmission.current,
+      fingerprint,
+    );
     try {
       const result = await transport.createTicket({
         kind,
         message: normalized,
         submissionId: createSubmission.current.id,
-        attachments,
+        attachments: files,
         signal: controller.signal,
+        onAttachmentProgress: ({ index, progress }) => {
+          if (controller.signal.aborted) return;
+          setAttachments((current) =>
+            current.map((item, itemIndex) =>
+              itemIndex === index
+                ? { ...item, progress: Math.max(0, Math.min(1, progress)) }
+                : item,
+            ),
+          );
+        },
       });
       if (controller.signal.aborted) return;
       reportUnread({ total: result.unreadTotal, source: "create" });
       createSubmission.current = null;
+      setAnnouncement(copy("feedbackCreated"));
       onCreated(result.ticket.id);
     } catch (cause) {
-      if (!controller.signal.aborted) setError(errorMessage(cause));
+      if (!controller.signal.aborted) {
+        const safe = safeError(cause);
+        setError(safe);
+        setAnnouncement(safe);
+        setAttachments((current) =>
+          current.map((item) =>
+            item.state === "uploading" ? { ...item, state: "failed" } : item,
+          ),
+        );
+      }
     } finally {
       if (!controller.signal.aborted) setSending(false);
     }
   };
 
+  const choose = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(event.currentTarget.files ?? []);
+    const combined = [...attachments.map(({ file }) => file), ...selected];
+    const attachmentError = localizedAttachmentError(combined, locale);
+    if (attachmentError) {
+      setError(attachmentError);
+      event.currentTarget.value = "";
+      return;
+    }
+    setError(null);
+    setAttachments((current) => [
+      ...current,
+      ...selected.map((file) => ({
+        id: submissionId(),
+        file,
+        progress: 0,
+        state: "ready" as const,
+      })),
+    ]);
+    event.currentTarget.value = "";
+  };
+
+  const cancelUpload = () => {
+    actionController.current?.abort();
+    setSending(false);
+    setAttachments((current) =>
+      current.map((item) => ({ ...item, state: "ready", progress: 0 })),
+    );
+    setAnnouncement(copy("uploadCanceled"));
+  };
+
   return (
-    <section className="hands-feedback-new" aria-labelledby="hands-feedback-new-title">
+    <section
+      className="hands-feedback-new"
+      aria-labelledby="hands-feedback-new-title"
+    >
       <header className="hands-feedback-header">
         <div>
-          <h2 id="hands-feedback-new-title">New feedback</h2>
-          <p>Share an idea or report a problem.</p>
+          <h2 id="hands-feedback-new-title" tabIndex={-1}>
+            {copy("newFeedback")}
+          </h2>
+          <p>{copy("newDescription")}</p>
         </div>
-        <Button variant="outline" onClick={onCancel}>Cancel</Button>
+        <Button variant="outline" onClick={onCancel}>
+          {copy("cancel")}
+        </Button>
       </header>
-      <div className="hands-feedback-kind" role="group" aria-label="Feedback type">
-        <Button aria-pressed={kind === "feedback"} variant={kind === "feedback" ? "primary" : "outline"} onClick={() => setKind("feedback")}>Feedback</Button>
-        <Button aria-pressed={kind === "bug"} variant={kind === "bug" ? "primary" : "outline"} onClick={() => setKind("bug")}>Problem</Button>
+      <div className="hands-feedback-middle hands-feedback-new-fields">
+        <div
+          className="hands-feedback-kind"
+          role="group"
+          aria-label={copy("feedbackType")}
+        >
+          <Button
+            aria-pressed={kind === "feedback"}
+            variant={kind === "feedback" ? "primary" : "outline"}
+            onClick={() => setKind("feedback")}
+          >
+            {copy("feedback")}
+          </Button>
+          <Button
+            aria-pressed={kind === "bug"}
+            variant={kind === "bug" ? "primary" : "outline"}
+            onClick={() => setKind("bug")}
+          >
+            {copy("problem")}
+          </Button>
+        </div>
+        <label htmlFor="hands-feedback-message">{copy("question")}</label>
+        <textarea
+          ref={textareaRef}
+          id="hands-feedback-message"
+          maxLength={10_000}
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          rows={2}
+        />
+        <label htmlFor="hands-feedback-attachments">
+          {copy("screenshots")}
+        </label>
+        <Input
+          id="hands-feedback-attachments"
+          type="file"
+          accept={FEEDBACK_ATTACHMENT_TYPES.join(",")}
+          multiple
+          disabled={sending || attachments.length >= MAX_FEEDBACK_ATTACHMENTS}
+          onChange={choose}
+        />
+        {attachments.length > 0 && (
+          <ul className="hands-feedback-pending-attachments">
+            {attachments.map((item) => (
+              <li key={item.id}>
+                <span>{item.file.name}</span>
+                {item.state === "uploading" && (
+                  <progress
+                    max={1}
+                    value={item.progress || undefined}
+                    aria-label={`${item.file.name} ${copy("uploadProgress")}`}
+                  />
+                )}
+                {item.state === "failed" && (
+                  <span role="status">{copy("uploadFailed")}</span>
+                )}
+                <Button
+                  variant="outline"
+                  disabled={sending}
+                  onClick={() =>
+                    setAttachments((current) =>
+                      current.filter(({ id }) => id !== item.id),
+                    )
+                  }
+                >
+                  {copy("remove")}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {error && (
+          <div className="hands-feedback-error" role="alert">
+            {error}
+          </div>
+        )}
       </div>
-      <label htmlFor="hands-feedback-message">What would you like us to know?</label>
-      <textarea
-        id="hands-feedback-message"
-        maxLength={10_000}
-        value={message}
-        onChange={(event) => setMessage(event.target.value)}
-      />
-      <label htmlFor="hands-feedback-attachments">Screenshots (up to 3)</label>
-      <Input
-        id="hands-feedback-attachments"
-        type="file"
-        accept={FEEDBACK_ATTACHMENT_TYPES.join(",")}
-        multiple
-        onChange={(event) => {
-          const selected = Array.from(event.currentTarget.files ?? []);
-          const attachmentError = validateFeedbackAttachments(selected);
-          setError(attachmentError);
-          setAttachments(attachmentError ? [] : selected);
-          if (attachmentError) event.currentTarget.value = "";
-        }}
-      />
-      {error && <div className="hands-feedback-error" role="alert">{error}</div>}
-      <Button disabled={!message.trim() || sending} onClick={() => void submit()}>
-        {sending ? "Submitting…" : "Submit feedback"}
-      </Button>
+      <footer className="hands-feedback-submit-bar">
+        {sending ? (
+          <Button variant="outline" onClick={cancelUpload}>
+            {copy("cancel")}
+          </Button>
+        ) : attachments.some(({ state }) => state === "failed") ? (
+          <Button
+            variant="outline"
+            disabled={!message.trim()}
+            onClick={() => void submit()}
+          >
+            {copy("retryUpload")}
+          </Button>
+        ) : null}
+        <Button
+          disabled={!message.trim() || sending}
+          onClick={() => void submit()}
+        >
+          {sending ? copy("submitting") : copy("submit")}
+        </Button>
+      </footer>
+      <div
+        className="hands-feedback-live"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {announcement}
+      </div>
     </section>
   );
 }
 
+export type FeedbackWorkspaceRoute = {
+  view: "inbox" | "new" | "ticket";
+  ticketId?: string;
+};
 export type FeedbackWorkspaceProps = {
   initialTicketId?: string;
-  onRouteChange?: (route: { view: "inbox" | "new" | "ticket"; ticketId?: string }) => void;
+  route?: FeedbackWorkspaceRoute;
+  onRouteChange?: (route: FeedbackWorkspaceRoute) => void;
   onOpenAttachment?: FeedbackTicketProps["onOpenAttachment"];
 };
 
-export function FeedbackWorkspace({ initialTicketId, onRouteChange, onOpenAttachment }: FeedbackWorkspaceProps) {
+export function FeedbackWorkspace({
+  initialTicketId,
+  route: controlledRoute,
+  onRouteChange,
+  onOpenAttachment,
+}: FeedbackWorkspaceProps) {
   const { theme } = useHandsFeedback();
-  const initial = useMemo(() => initialTicketId
-    ? { view: "ticket" as const, ticketId: initialTicketId }
-    : { view: "inbox" as const }, [initialTicketId]);
-  const [route, setRoute] = useState<{ view: "inbox" | "new" | "ticket"; ticketId?: string }>(initial);
-  const navigate = (next: typeof route) => {
-    setRoute(next);
+  const initial = useMemo<FeedbackWorkspaceRoute>(
+    () =>
+      initialTicketId
+        ? { view: "ticket", ticketId: initialTicketId }
+        : { view: "inbox" },
+    [initialTicketId],
+  );
+  const [internalRoute, setInternalRoute] = useState(initial);
+  const route = controlledRoute ?? internalRoute;
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [readTicketId, setReadTicketId] = useState<string | null>(null);
+  const originTicket = useRef<string | null>(initialTicketId ?? null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const navigate = (next: FeedbackWorkspaceRoute) => {
+    if (!controlledRoute) setInternalRoute(next);
     onRouteChange?.(next);
   };
+  const back = () => {
+    const focusId = originTicket.current;
+    navigate({ view: "inbox" });
+    requestAnimationFrame(() =>
+      Array.from(
+        rootRef.current?.querySelectorAll<HTMLElement>("[data-ticket-id]") ??
+          [],
+      )
+        .find((element) => element.dataset.ticketId === focusId)
+        ?.focus(),
+    );
+  };
+  useEffect(() => {
+    if (route.view !== "inbox")
+      requestAnimationFrame(() =>
+        rootRef.current
+          ?.querySelector<HTMLElement>("section:not([hidden]) h2")
+          ?.focus(),
+      );
+  }, [route]);
+  useEffect(() => {
+    const viewport = globalThis.window?.visualViewport;
+    const root = rootRef.current;
+    if (!viewport || !root) return;
+    const sync = () =>
+      root.style.setProperty(
+        "--hf-visual-viewport-height",
+        `${viewport.height}px`,
+      );
+    sync();
+    viewport.addEventListener("resize", sync);
+    viewport.addEventListener("scroll", sync);
+    return () => {
+      viewport.removeEventListener("resize", sync);
+      viewport.removeEventListener("scroll", sync);
+    };
+  }, []);
   return (
-    <div className="hands-feedback-root" data-hands-feedback-theme={theme}>
-      {route.view === "inbox" && (
-        <FeedbackInbox
-          onNewFeedback={() => navigate({ view: "new" })}
-          onSelectTicket={(ticketId) => navigate({ view: "ticket", ticketId })}
-        />
-      )}
+    <div
+      className="hands-feedback-root"
+      data-hands-feedback-theme={theme}
+      ref={rootRef}
+    >
+      <FeedbackInbox
+        hidden={route.view !== "inbox"}
+        readTicketId={readTicketId}
+        onNewFeedback={() => navigate({ view: "new" })}
+        onSelectTicket={(ticketId) => {
+          originTicket.current = ticketId;
+          navigate({ view: "ticket", ticketId });
+        }}
+      />
       {route.view === "new" && (
         <NewFeedback
           onCancel={() => navigate({ view: "inbox" })}
-          onCreated={(ticketId) => navigate({ view: "ticket", ticketId })}
+          onCreated={(ticketId) => {
+            originTicket.current = ticketId;
+            navigate({ view: "ticket", ticketId });
+          }}
         />
       )}
       {route.view === "ticket" && route.ticketId && (
         <FeedbackTicket
           ticketId={route.ticketId}
-          onBack={() => navigate({ view: "inbox" })}
+          draft={drafts[route.ticketId] ?? ""}
+          onDraftChange={(value) =>
+            setDrafts((current) => ({ ...current, [route.ticketId!]: value }))
+          }
+          onReadSuccess={setReadTicketId}
+          onBack={back}
           {...(onOpenAttachment ? { onOpenAttachment } : {})}
         />
       )}

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -16,7 +16,7 @@ import {
   Input,
   Skeleton,
 } from "raft-ui";
-import { feedbackErrorMessage, feedbackStatusLabel } from "./locale.js";
+import type { FeedbackMessageKey, FeedbackMessageValues } from "./locale.js";
 import { useHandsFeedback } from "./provider.js";
 import { FeedbackTransportError } from "./types.js";
 import type {
@@ -68,18 +68,21 @@ export function validateFeedbackAttachments(files: File[]): string | null {
   return null;
 }
 
-function localizedAttachmentError(files: File[], locale: "en" | "zh-CN") {
+function localizedAttachmentError(
+  files: File[],
+  message: (key: FeedbackMessageKey, values?: FeedbackMessageValues) => string,
+) {
   const error = validateFeedbackAttachments(files);
-  if (!error || locale === "en") return error;
+  if (!error) return null;
   if (files.length > MAX_FEEDBACK_ATTACHMENTS)
-    return `最多选择 ${MAX_FEEDBACK_ATTACHMENTS} 张截图。`;
+    return message("attachmentTooMany", { count: MAX_FEEDBACK_ATTACHMENTS });
   const invalid = files.find(
     (file) =>
       !(FEEDBACK_ATTACHMENT_TYPES as readonly string[]).includes(file.type),
   );
-  if (invalid) return `${invalid.name} 不是支持的图片格式。`;
+  if (invalid) return message("attachmentUnsupported", { name: invalid.name });
   const large = files.find((file) => file.size > MAX_FEEDBACK_ATTACHMENT_BYTES);
-  return large ? `${large.name} 超过 10 MB。` : error;
+  return large ? message("attachmentTooLarge", { name: large.name }) : error;
 }
 
 function submissionId() {
@@ -105,14 +108,24 @@ export function isNearConversationBottom(
 }
 
 function useSafeError() {
-  const { locale } = useHandsFeedback();
+  const { message } = useHandsFeedback();
   return useCallback(
-    (error: unknown) =>
-      feedbackErrorMessage(
-        locale,
-        error instanceof FeedbackTransportError ? error.code : undefined,
-      ),
-    [locale],
+    (error: unknown) => {
+      const keys = {
+        conflict: "errorConflict",
+        invalid: "errorInvalid",
+        not_found: "errorNotFound",
+        rate_limited: "errorRateLimited",
+        unauthorized: "errorUnauthorized",
+        unavailable: "errorUnavailable",
+      } as const;
+      return message(
+        error instanceof FeedbackTransportError
+          ? keys[error.code]
+          : "errorUnavailable",
+      );
+    },
+    [message],
   );
 }
 
@@ -128,22 +141,31 @@ function useAutosize(value: string) {
 }
 
 function StatusBadge({ status }: { status: FeedbackTicketSummary["status"] }) {
-  const { locale } = useHandsFeedback();
+  const { message } = useHandsFeedback();
+  const label = message(
+    status === "in_progress"
+      ? "statusInProgress"
+      : status === "resolved"
+        ? "statusResolved"
+        : status === "closed"
+          ? "statusClosed"
+          : "statusOpen",
+  );
   if (status === "in_progress")
     return (
       <Badge variant="information" uppercase={false}>
-        {feedbackStatusLabel(locale, status)}
+        {label}
       </Badge>
     );
   if (status === "resolved")
     return (
       <Badge variant="success" uppercase={false}>
-        {feedbackStatusLabel(locale, status)}
+        {label}
       </Badge>
     );
   return (
     <Badge appearance="outline" uppercase={false}>
-      {feedbackStatusLabel(locale, status)}
+      {label}
     </Badge>
   );
 }
@@ -163,7 +185,7 @@ export function FeedbackInbox({
   hidden = false,
   readTicketId,
 }: FeedbackInboxProps) {
-  const { locale, message, reportUnread, transport } = useHandsFeedback();
+  const { formatDate, message, reportUnread, transport } = useHandsFeedback();
   const safeError = useSafeError();
   const [tickets, setTickets] = useState<FeedbackTicketSummary[]>([]);
   const [filter, setFilter] = useState<"all" | "open" | "resolved">("all");
@@ -210,14 +232,16 @@ export function FeedbackInbox({
     },
     [pageSize, reportUnread, safeError, transport],
   );
+  const initialLoad = useRef(load);
+  initialLoad.current = load;
 
   useEffect(() => {
-    void load();
+    void initialLoad.current();
     return () => {
       controllerRef.current?.abort();
       request.current += 1;
     };
-  }, [load]);
+  }, [pageSize, transport]);
 
   useEffect(() => {
     if (!readTicketId) return;
@@ -264,10 +288,8 @@ export function FeedbackInbox({
             onClick={() => setFilter(value)}
           >
             {value === "all"
-              ? locale === "zh-CN"
-                ? "全部"
-                : "All"
-              : feedbackStatusLabel(locale, value)}
+              ? message("all")
+              : message(value === "open" ? "statusOpen" : "statusResolved")}
           </Button>
         ))}
       </div>
@@ -317,11 +339,7 @@ export function FeedbackInbox({
                       {ticket.kind === "bug"
                         ? message("problem")
                         : message("feedback")}{" "}
-                      ·{" "}
-                      {new Intl.DateTimeFormat(locale, {
-                        dateStyle: "medium",
-                        timeStyle: "short",
-                      }).format(new Date(ticket.updatedAt))}
+                      · {formatDate(ticket.updatedAt)}
                     </span>
                   </span>
                   <span className="hands-feedback-ticket-state">
@@ -375,7 +393,7 @@ export function FeedbackTicket({
   onDraftChange,
   onReadSuccess,
 }: FeedbackTicketProps) {
-  const { locale, message, reportUnread, transport } = useHandsFeedback();
+  const { formatDate, message, reportUnread, transport } = useHandsFeedback();
   const safeError = useSafeError();
   const [detail, setDetail] = useState<FeedbackTicketDetail | null>(null);
   const [internalDraft, setInternalDraft] = useState("");
@@ -460,25 +478,19 @@ export function FeedbackTicket({
         }
       }
     },
-    [
-      locale,
-      message,
-      onReadSuccess,
-      reportUnread,
-      safeError,
-      ticketId,
-      transport,
-    ],
+    [message, onReadSuccess, reportUnread, safeError, ticketId, transport],
   );
+  const initialLoad = useRef(load);
+  initialLoad.current = load;
 
   useEffect(() => {
-    void load();
+    void initialLoad.current();
     return () => {
       loadController.current?.abort();
       actionController.current?.abort();
       loadRequest.current += 1;
     };
-  }, [load]);
+  }, [ticketId, transport]);
 
   useLayoutEffect(() => {
     if (scrollIntent.current === "bottom" && conversationRef.current)
@@ -567,12 +579,7 @@ export function FeedbackTicket({
           <>
             <div className="hands-feedback-ticket-body">
               <h3>{detail.ticket.message}</h3>
-              <span>
-                {new Intl.DateTimeFormat(locale, {
-                  dateStyle: "medium",
-                  timeStyle: "short",
-                }).format(new Date(detail.ticket.createdAt))}
-              </span>
+              <span>{formatDate(detail.ticket.createdAt)}</span>
             </div>
             {detail.attachments.length > 0 && (
               <div
@@ -632,12 +639,7 @@ export function FeedbackTicket({
                           ? message("team")
                           : message("update")}
                     </strong>
-                    <span>
-                      {new Intl.DateTimeFormat(locale, {
-                        dateStyle: "medium",
-                        timeStyle: "short",
-                      }).format(new Date(comment.createdAt))}
-                    </span>
+                    <span>{formatDate(comment.createdAt)}</span>
                   </div>
                   <p>{comment.body}</p>
                 </article>
@@ -721,7 +723,7 @@ export type NewFeedbackProps = {
 };
 
 export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
-  const { locale, message: copy, reportUnread, transport } = useHandsFeedback();
+  const { message: copy, reportUnread, transport } = useHandsFeedback();
   const safeError = useSafeError();
   const [kind, setKind] = useState<FeedbackKind>("feedback");
   const [message, setMessage] = useState("");
@@ -740,7 +742,7 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
     const normalized = message.trim();
     if (!normalized || sending) return;
     const files = attachments.map(({ file }) => file);
-    const attachmentError = localizedAttachmentError(files, locale);
+    const attachmentError = localizedAttachmentError(files, copy);
     if (attachmentError) {
       setError(attachmentError);
       return;
@@ -809,7 +811,7 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
   const choose = (event: ChangeEvent<HTMLInputElement>) => {
     const selected = Array.from(event.currentTarget.files ?? []);
     const combined = [...attachments.map(({ file }) => file), ...selected];
-    const attachmentError = localizedAttachmentError(combined, locale);
+    const attachmentError = localizedAttachmentError(combined, copy);
     if (attachmentError) {
       setError(attachmentError);
       event.currentTarget.value = "";

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -8,10 +8,12 @@ export type {
   FeedbackInboxProps,
   FeedbackTicketProps,
   FeedbackWorkspaceProps,
+  FeedbackWorkspaceRoute,
   NewFeedbackProps,
 } from "./components.js";
 export { FeedbackProvider, useHandsFeedback } from "./provider.js";
 export type { FeedbackProviderProps } from "./provider.js";
+export { resolveFeedbackLocale } from "./locale.js";
 export { FeedbackTransportError } from "./types.js";
 export type {
   AddFeedbackCommentInput,
@@ -19,6 +21,7 @@ export type {
   FeedbackAttachment,
   FeedbackComment,
   FeedbackKind,
+  FeedbackLocale,
   FeedbackStatus,
   FeedbackTheme,
   FeedbackTicketSummary,

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -13,7 +13,11 @@ export type {
 } from "./components.js";
 export { FeedbackProvider, useHandsFeedback } from "./provider.js";
 export type { FeedbackProviderProps } from "./provider.js";
-export { feedbackMessage, resolveFeedbackLocale } from "./locale.js";
+export {
+  feedbackMessage,
+  resolveFeedbackLocale,
+  resolveFeedbackLocaleFromPreferences,
+} from "./locale.js";
 export type {
   FeedbackMessageKey,
   FeedbackMessages,

--- a/packages/feedback-react/src/index.ts
+++ b/packages/feedback-react/src/index.ts
@@ -13,7 +13,12 @@ export type {
 } from "./components.js";
 export { FeedbackProvider, useHandsFeedback } from "./provider.js";
 export type { FeedbackProviderProps } from "./provider.js";
-export { resolveFeedbackLocale } from "./locale.js";
+export { feedbackMessage, resolveFeedbackLocale } from "./locale.js";
+export type {
+  FeedbackMessageKey,
+  FeedbackMessages,
+  FeedbackMessageValues,
+} from "./locale.js";
 export { FeedbackTransportError } from "./types.js";
 export type {
   AddFeedbackCommentInput,

--- a/packages/feedback-react/src/locale.ts
+++ b/packages/feedback-react/src/locale.ts
@@ -5,12 +5,22 @@ import type {
 } from "./types.js";
 
 export type FeedbackMessageKey =
+  | "all"
+  | "attachmentTooLarge"
+  | "attachmentTooMany"
+  | "attachmentUnsupported"
   | "attachments"
   | "back"
   | "cancel"
   | "conversation"
   | "emptyBody"
   | "emptyTitle"
+  | "errorConflict"
+  | "errorInvalid"
+  | "errorNotFound"
+  | "errorRateLimited"
+  | "errorUnauthorized"
+  | "errorUnavailable"
   | "feedback"
   | "feedbackType"
   | "inboxDescription"
@@ -36,6 +46,10 @@ export type FeedbackMessageKey =
   | "submit"
   | "submitting"
   | "statusFilter"
+  | "statusClosed"
+  | "statusInProgress"
+  | "statusOpen"
+  | "statusResolved"
   | "team"
   | "feedbackCreated"
   | "replySent"
@@ -48,14 +62,28 @@ export type FeedbackMessageKey =
   | "uploadProgress"
   | "you";
 
-const messages: Record<FeedbackLocale, Record<FeedbackMessageKey, string>> = {
+export type FeedbackMessages = Record<FeedbackMessageKey, string>;
+export type FeedbackMessageValues = Record<string, string | number>;
+
+const messages: Record<FeedbackLocale, FeedbackMessages> = {
   en: {
+    all: "All",
+    attachmentTooLarge: "{name} is larger than 10 MB.",
+    attachmentTooMany: "Choose no more than {count} screenshots.",
+    attachmentUnsupported: "{name} is not a supported image.",
     attachments: "Attachments",
     back: "Back",
     cancel: "Cancel",
     conversation: "Conversation",
     emptyBody: "Send your first idea or report a problem.",
     emptyTitle: "No feedback yet",
+    errorConflict: "This retry no longer matches the original request.",
+    errorInvalid: "Check the feedback details and try again.",
+    errorNotFound: "This feedback ticket is no longer available.",
+    errorRateLimited: "Too many feedback requests. Try again later.",
+    errorUnauthorized:
+      "Your feedback session expired. Reopen feedback and try again.",
+    errorUnavailable: "Feedback is temporarily unavailable.",
     feedback: "Feedback",
     feedbackType: "Feedback type",
     inboxDescription: "Your feedback and replies from the team.",
@@ -81,6 +109,10 @@ const messages: Record<FeedbackLocale, Record<FeedbackMessageKey, string>> = {
     submit: "Submit feedback",
     submitting: "Submitting…",
     statusFilter: "Status filter",
+    statusClosed: "Closed",
+    statusInProgress: "In progress",
+    statusOpen: "Open",
+    statusResolved: "Resolved",
     team: "Team",
     feedbackCreated: "Feedback created",
     replySent: "Reply sent",
@@ -94,12 +126,22 @@ const messages: Record<FeedbackLocale, Record<FeedbackMessageKey, string>> = {
     you: "You",
   },
   "zh-CN": {
+    all: "全部",
+    attachmentTooLarge: "{name} 超过 10 MB。",
+    attachmentTooMany: "最多选择 {count} 张截图。",
+    attachmentUnsupported: "{name} 不是支持的图片格式。",
     attachments: "附件",
     back: "返回",
     cancel: "取消",
     conversation: "对话",
     emptyBody: "提交第一个想法或问题。",
     emptyTitle: "暂无反馈",
+    errorConflict: "本次重试与原请求不一致。",
+    errorInvalid: "请检查反馈内容后重试。",
+    errorNotFound: "该反馈工单已不可用。",
+    errorRateLimited: "请求过于频繁，请稍后重试。",
+    errorUnauthorized: "反馈会话已过期，请重新打开后重试。",
+    errorUnavailable: "反馈服务暂时不可用。",
     feedback: "反馈",
     feedbackType: "反馈类型",
     inboxDescription: "你的反馈和团队回复。",
@@ -125,6 +167,10 @@ const messages: Record<FeedbackLocale, Record<FeedbackMessageKey, string>> = {
     submit: "提交反馈",
     submitting: "提交中…",
     statusFilter: "状态筛选",
+    statusClosed: "已关闭",
+    statusInProgress: "处理中",
+    statusOpen: "待处理",
+    statusResolved: "已解决",
     team: "团队",
     feedbackCreated: "反馈已创建",
     replySent: "回复已发送",
@@ -157,8 +203,14 @@ export function resolveFeedbackLocale(
 export function feedbackMessage(
   locale: FeedbackLocale,
   key: FeedbackMessageKey,
+  overrides?: Partial<FeedbackMessages>,
+  values?: FeedbackMessageValues,
 ): string {
-  return messages[locale][key];
+  const template = overrides?.[key] ?? messages[locale][key];
+  if (!values) return template;
+  return template.replace(/\{([^}]+)\}/g, (match, name: string) =>
+    Object.hasOwn(values, name) ? String(values[name]) : match,
+  );
 }
 
 export function feedbackStatusLabel(
@@ -186,32 +238,13 @@ export function feedbackErrorMessage(
   locale: FeedbackLocale,
   code?: FeedbackTransportErrorCode,
 ): string {
-  const fallback =
-    locale === "zh-CN"
-      ? "反馈服务暂时不可用。"
-      : "Feedback is temporarily unavailable.";
-  if (!code) return fallback;
-  const copy: Record<
-    FeedbackLocale,
-    Record<FeedbackTransportErrorCode, string>
-  > = {
-    en: {
-      conflict: "This retry no longer matches the original request.",
-      invalid: "Check the feedback details and try again.",
-      not_found: "This feedback ticket is no longer available.",
-      rate_limited: "Too many feedback requests. Try again later.",
-      unauthorized:
-        "Your feedback session expired. Reopen feedback and try again.",
-      unavailable: fallback,
-    },
-    "zh-CN": {
-      conflict: "本次重试与原请求不一致。",
-      invalid: "请检查反馈内容后重试。",
-      not_found: "该反馈工单已不可用。",
-      rate_limited: "请求过于频繁，请稍后重试。",
-      unauthorized: "反馈会话已过期，请重新打开后重试。",
-      unavailable: fallback,
-    },
+  const keys: Record<FeedbackTransportErrorCode, FeedbackMessageKey> = {
+    conflict: "errorConflict",
+    invalid: "errorInvalid",
+    not_found: "errorNotFound",
+    rate_limited: "errorRateLimited",
+    unauthorized: "errorUnauthorized",
+    unavailable: "errorUnavailable",
   };
-  return copy[locale][code];
+  return feedbackMessage(locale, code ? keys[code] : "errorUnavailable");
 }

--- a/packages/feedback-react/src/locale.ts
+++ b/packages/feedback-react/src/locale.ts
@@ -1,0 +1,217 @@
+import type {
+  FeedbackLocale,
+  FeedbackStatus,
+  FeedbackTransportErrorCode,
+} from "./types.js";
+
+export type FeedbackMessageKey =
+  | "attachments"
+  | "back"
+  | "cancel"
+  | "conversation"
+  | "emptyBody"
+  | "emptyTitle"
+  | "feedback"
+  | "feedbackType"
+  | "inboxDescription"
+  | "loadMore"
+  | "loadMoreReplies"
+  | "loading"
+  | "loadingMore"
+  | "newDescription"
+  | "newFeedback"
+  | "newReplies"
+  | "noReplies"
+  | "openAttachment"
+  | "problem"
+  | "question"
+  | "refresh"
+  | "remove"
+  | "reply"
+  | "retry"
+  | "retryUpload"
+  | "screenshots"
+  | "sendReply"
+  | "sending"
+  | "submit"
+  | "submitting"
+  | "statusFilter"
+  | "team"
+  | "feedbackCreated"
+  | "replySent"
+  | "ticketUpdated"
+  | "ticketHeading"
+  | "unread"
+  | "update"
+  | "uploadCanceled"
+  | "uploadFailed"
+  | "uploadProgress"
+  | "you";
+
+const messages: Record<FeedbackLocale, Record<FeedbackMessageKey, string>> = {
+  en: {
+    attachments: "Attachments",
+    back: "Back",
+    cancel: "Cancel",
+    conversation: "Conversation",
+    emptyBody: "Send your first idea or report a problem.",
+    emptyTitle: "No feedback yet",
+    feedback: "Feedback",
+    feedbackType: "Feedback type",
+    inboxDescription: "Your feedback and replies from the team.",
+    loadMore: "Load more",
+    loadMoreReplies: "Load more replies",
+    loading: "Loading feedback",
+    loadingMore: "Loading…",
+    newDescription: "Share an idea or report a problem.",
+    newFeedback: "New feedback",
+    newReplies: "New replies",
+    noReplies: "No replies yet",
+    openAttachment: "Open attachment",
+    problem: "Problem",
+    question: "What would you like us to know?",
+    refresh: "Refresh",
+    remove: "Remove",
+    reply: "Reply",
+    retry: "Try again",
+    retryUpload: "Retry upload",
+    screenshots: "Screenshots (up to 3)",
+    sendReply: "Send reply",
+    sending: "Sending…",
+    submit: "Submit feedback",
+    submitting: "Submitting…",
+    statusFilter: "Status filter",
+    team: "Team",
+    feedbackCreated: "Feedback created",
+    replySent: "Reply sent",
+    ticketUpdated: "Ticket updated",
+    ticketHeading: "Feedback ticket",
+    unread: "unread",
+    update: "Update",
+    uploadCanceled: "Upload canceled",
+    uploadFailed: "Upload failed",
+    uploadProgress: "upload progress",
+    you: "You",
+  },
+  "zh-CN": {
+    attachments: "附件",
+    back: "返回",
+    cancel: "取消",
+    conversation: "对话",
+    emptyBody: "提交第一个想法或问题。",
+    emptyTitle: "暂无反馈",
+    feedback: "反馈",
+    feedbackType: "反馈类型",
+    inboxDescription: "你的反馈和团队回复。",
+    loadMore: "加载更多",
+    loadMoreReplies: "加载更多回复",
+    loading: "正在加载反馈",
+    loadingMore: "加载中…",
+    newDescription: "分享想法或报告问题。",
+    newFeedback: "新建反馈",
+    newReplies: "有新回复",
+    noReplies: "暂无回复",
+    openAttachment: "打开附件",
+    problem: "问题",
+    question: "你想告诉我们什么？",
+    refresh: "刷新",
+    remove: "移除",
+    reply: "回复",
+    retry: "重试",
+    retryUpload: "重试上传",
+    screenshots: "截图（最多 3 张）",
+    sendReply: "发送回复",
+    sending: "发送中…",
+    submit: "提交反馈",
+    submitting: "提交中…",
+    statusFilter: "状态筛选",
+    team: "团队",
+    feedbackCreated: "反馈已创建",
+    replySent: "回复已发送",
+    ticketUpdated: "工单已更新",
+    ticketHeading: "反馈工单",
+    unread: "条未读",
+    update: "更新",
+    uploadCanceled: "上传已取消",
+    uploadFailed: "上传失败",
+    uploadProgress: "上传进度",
+    you: "你",
+  },
+};
+
+export function resolveFeedbackLocale(
+  explicit?: FeedbackLocale,
+): FeedbackLocale {
+  if (explicit) return explicit;
+  if (typeof navigator !== "undefined") {
+    const requested = [
+      ...(navigator.languages ?? []),
+      navigator.language,
+    ].filter(Boolean);
+    if (requested.some((value) => value.toLowerCase().startsWith("zh")))
+      return "zh-CN";
+  }
+  return "en";
+}
+
+export function feedbackMessage(
+  locale: FeedbackLocale,
+  key: FeedbackMessageKey,
+): string {
+  return messages[locale][key];
+}
+
+export function feedbackStatusLabel(
+  locale: FeedbackLocale,
+  status: FeedbackStatus,
+): string {
+  const labels: Record<FeedbackLocale, Record<FeedbackStatus, string>> = {
+    en: {
+      open: "Open",
+      in_progress: "In progress",
+      resolved: "Resolved",
+      closed: "Closed",
+    },
+    "zh-CN": {
+      open: "待处理",
+      in_progress: "处理中",
+      resolved: "已解决",
+      closed: "已关闭",
+    },
+  };
+  return labels[locale][status];
+}
+
+export function feedbackErrorMessage(
+  locale: FeedbackLocale,
+  code?: FeedbackTransportErrorCode,
+): string {
+  const fallback =
+    locale === "zh-CN"
+      ? "反馈服务暂时不可用。"
+      : "Feedback is temporarily unavailable.";
+  if (!code) return fallback;
+  const copy: Record<
+    FeedbackLocale,
+    Record<FeedbackTransportErrorCode, string>
+  > = {
+    en: {
+      conflict: "This retry no longer matches the original request.",
+      invalid: "Check the feedback details and try again.",
+      not_found: "This feedback ticket is no longer available.",
+      rate_limited: "Too many feedback requests. Try again later.",
+      unauthorized:
+        "Your feedback session expired. Reopen feedback and try again.",
+      unavailable: fallback,
+    },
+    "zh-CN": {
+      conflict: "本次重试与原请求不一致。",
+      invalid: "请检查反馈内容后重试。",
+      not_found: "该反馈工单已不可用。",
+      rate_limited: "请求过于频繁，请稍后重试。",
+      unauthorized: "反馈会话已过期，请重新打开后重试。",
+      unavailable: fallback,
+    },
+  };
+  return copy[locale][code];
+}

--- a/packages/feedback-react/src/locale.ts
+++ b/packages/feedback-react/src/locale.ts
@@ -9,6 +9,7 @@ export type FeedbackMessageKey =
   | "attachmentTooLarge"
   | "attachmentTooMany"
   | "attachmentUnsupported"
+  | "attachmentSummary"
   | "attachments"
   | "back"
   | "cancel"
@@ -55,7 +56,7 @@ export type FeedbackMessageKey =
   | "replySent"
   | "ticketUpdated"
   | "ticketHeading"
-  | "unread"
+  | "unreadCount"
   | "update"
   | "uploadCanceled"
   | "uploadFailed"
@@ -71,6 +72,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     attachmentTooLarge: "{name} is larger than 10 MB.",
     attachmentTooMany: "Choose no more than {count} screenshots.",
     attachmentUnsupported: "{name} is not a supported image.",
+    attachmentSummary: "{name} · {size}",
     attachments: "Attachments",
     back: "Back",
     cancel: "Cancel",
@@ -95,7 +97,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     newFeedback: "New feedback",
     newReplies: "New replies",
     noReplies: "No replies yet",
-    openAttachment: "Open attachment",
+    openAttachment: "Open attachment {name}",
     problem: "Problem",
     question: "What would you like us to know?",
     refresh: "Refresh",
@@ -103,7 +105,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     reply: "Reply",
     retry: "Try again",
     retryUpload: "Retry upload",
-    screenshots: "Screenshots (up to 3)",
+    screenshots: "Screenshots (up to {count})",
     sendReply: "Send reply",
     sending: "Sending…",
     submit: "Submit feedback",
@@ -118,11 +120,11 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     replySent: "Reply sent",
     ticketUpdated: "Ticket updated",
     ticketHeading: "Feedback ticket",
-    unread: "unread",
+    unreadCount: "{count} unread",
     update: "Update",
     uploadCanceled: "Upload canceled",
     uploadFailed: "Upload failed",
-    uploadProgress: "upload progress",
+    uploadProgress: "Upload progress for {name}",
     you: "You",
   },
   "zh-CN": {
@@ -130,6 +132,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     attachmentTooLarge: "{name} 超过 10 MB。",
     attachmentTooMany: "最多选择 {count} 张截图。",
     attachmentUnsupported: "{name} 不是支持的图片格式。",
+    attachmentSummary: "{name} · {size}",
     attachments: "附件",
     back: "返回",
     cancel: "取消",
@@ -153,7 +156,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     newFeedback: "新建反馈",
     newReplies: "有新回复",
     noReplies: "暂无回复",
-    openAttachment: "打开附件",
+    openAttachment: "打开附件 {name}",
     problem: "问题",
     question: "你想告诉我们什么？",
     refresh: "刷新",
@@ -161,7 +164,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     reply: "回复",
     retry: "重试",
     retryUpload: "重试上传",
-    screenshots: "截图（最多 3 张）",
+    screenshots: "截图（最多 {count} 张）",
     sendReply: "发送回复",
     sending: "发送中…",
     submit: "提交反馈",
@@ -176,11 +179,11 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     replySent: "回复已发送",
     ticketUpdated: "工单已更新",
     ticketHeading: "反馈工单",
-    unread: "条未读",
+    unreadCount: "{count} 条未读",
     update: "更新",
     uploadCanceled: "上传已取消",
     uploadFailed: "上传失败",
-    uploadProgress: "上传进度",
+    uploadProgress: "{name} 的上传进度",
     you: "你",
   },
 };
@@ -194,8 +197,18 @@ export function resolveFeedbackLocale(
       ...(navigator.languages ?? []),
       navigator.language,
     ].filter(Boolean);
-    if (requested.some((value) => value.toLowerCase().startsWith("zh")))
-      return "zh-CN";
+    return resolveFeedbackLocaleFromPreferences(requested);
+  }
+  return "en";
+}
+
+export function resolveFeedbackLocaleFromPreferences(
+  preferences: readonly string[],
+): FeedbackLocale {
+  for (const value of preferences) {
+    const normalized = value.toLowerCase();
+    if (normalized.startsWith("en")) return "en";
+    if (normalized.startsWith("zh")) return "zh-CN";
   }
   return "en";
 }

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeedbackWorkspace } from "./components.js";
 import { FeedbackProvider } from "./provider.js";
@@ -60,15 +61,30 @@ function transport(): HandsFeedbackTransport {
 describe("FeedbackWorkspace browser behavior", () => {
   it("supports host copy and date localization overrides through one provider contract", async () => {
     const adapter = transport();
+    adapter.getTicket = vi.fn(async () => ({
+      ...detail,
+      attachments: [
+        {
+          id: "attachment-1",
+          filename: "proof.png",
+          contentType: "image/png",
+          sizeBytes: 2048,
+          createdAt: 4,
+        },
+      ],
+    }));
     render(
       <FeedbackProvider
         transport={adapter}
         messages={{
           newFeedback: "Create report",
           statusFilter: "Ticket state",
-          unread: "new items",
+          unreadCount: "{count} new items",
+          attachmentSummary: "FILE {name} SIZE {size}",
+          openAttachment: "OPEN {name}",
         }}
         formatDate={(value, { locale }) => `DATE:${locale}:${value.getTime()}`}
+        formatFileSize={(bytes, { locale }) => `SIZE:${locale}:${bytes}`}
       >
         <FeedbackWorkspace />
       </FeedbackProvider>,
@@ -78,6 +94,11 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(screen.getByRole("group", { name: "Ticket state" })).toBeTruthy();
     expect(screen.getByLabelText("2 new items")).toBeTruthy();
     expect(screen.getByText("DATE:en:2", { exact: false })).toBeTruthy();
+    fireEvent.click(screen.getByText(ticket.message));
+    expect(
+      await screen.findByText("FILE proof.png SIZE SIZE:en:2048"),
+    ).toBeTruthy();
+    expect(screen.getByLabelText("OPEN proof.png")).toBeTruthy();
   });
 
   it("localizes closed errors and parameterized attachment validation through message overrides", async () => {
@@ -356,6 +377,75 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(uploadSignal?.aborted).toBe(true);
     expect(editor.value).toBe("Only once");
     expect(screen.getByText("Submit feedback")).toBeTruthy();
+  });
+
+  it("aborts and resets an in-flight create when the reporter transport changes", async () => {
+    const first = transport();
+    const second = transport();
+    let firstSignal: AbortSignal | undefined;
+    let resolveFirst: ((value: FeedbackTicketDetail) => void) | undefined;
+    first.createTicket = vi.fn(
+      ({ signal }) =>
+        new Promise<FeedbackTicketDetail>((resolve) => {
+          firstSignal = signal;
+          resolveFirst = resolve;
+        }),
+    );
+    const view = render(
+      <FeedbackProvider transport={first}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    fireEvent.click(await screen.findByText("New feedback"));
+    const editor = screen.getByLabelText(
+      "What would you like us to know?",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Preserve across session" } });
+    fireEvent.click(screen.getByText("Submit feedback"));
+    expect(await screen.findByText("Submitting…")).toBeTruthy();
+
+    view.rerender(
+      <FeedbackProvider transport={second}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    await waitFor(() => expect(firstSignal?.aborted).toBe(true));
+    expect(editor.value).toBe("Preserve across session");
+    expect(screen.getByText("Submit feedback")).toBeTruthy();
+    resolveFirst?.(detail);
+    await Promise.resolve();
+    expect(
+      screen.getByRole("heading", { name: "New feedback" }),
+    ).toBeTruthy();
+    expect(second.createTicket).not.toHaveBeenCalled();
+  });
+
+  it("restores row focus after a delayed controlled host commits the inbox route", async () => {
+    const adapter = transport();
+    function DelayedHost() {
+      const [route, setRoute] = useState<{
+        view: "inbox" | "new" | "ticket";
+        ticketId?: string;
+      }>({ view: "inbox" });
+      return (
+        <FeedbackProvider transport={adapter}>
+          <FeedbackWorkspace
+            route={route}
+            onRouteChange={(next) => setTimeout(() => setRoute(next), 40)}
+          />
+        </FeedbackProvider>
+      );
+    }
+    render(<DelayedHost />);
+    const row = await screen.findByRole("button", {
+      name: /A reporter-visible ticket/,
+    });
+    fireEvent.click(row);
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => expect(document.activeElement).toBe(row), {
+      timeout: 1000,
+    });
   });
 
   it("loads, deduplicates, and orders conversations beyond the first 100 comments", async () => {

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -58,6 +58,64 @@ function transport(): HandsFeedbackTransport {
 }
 
 describe("FeedbackWorkspace browser behavior", () => {
+  it("supports host copy and date localization overrides through one provider contract", async () => {
+    const adapter = transport();
+    render(
+      <FeedbackProvider
+        transport={adapter}
+        messages={{
+          newFeedback: "Create report",
+          statusFilter: "Ticket state",
+          unread: "new items",
+        }}
+        formatDate={(value, { locale }) => `DATE:${locale}:${value.getTime()}`}
+      >
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    expect(await screen.findByText(ticket.message)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create report" })).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Ticket state" })).toBeTruthy();
+    expect(screen.getByLabelText("2 new items")).toBeTruthy();
+    expect(screen.getByText("DATE:en:2", { exact: false })).toBeTruthy();
+  });
+
+  it("localizes closed errors and parameterized attachment validation through message overrides", async () => {
+    const adapter = transport();
+    adapter.listTickets = vi.fn(async () => {
+      throw new Error("hidden");
+    });
+    const list = render(
+      <FeedbackProvider
+        transport={adapter}
+        messages={{ errorUnavailable: "Localized safe failure" }}
+      >
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Localized safe failure",
+    );
+    list.unmount();
+
+    render(
+      <FeedbackProvider
+        transport={transport()}
+        messages={{ attachmentUnsupported: "Unsupported: {name}" }}
+      >
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    fireEvent.click(await screen.findByText("New feedback"));
+    const file = new File(["text"], "notes.txt", { type: "text/plain" });
+    fireEvent.change(screen.getByLabelText("Screenshots (up to 3)"), {
+      target: { files: [file] },
+    });
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Unsupported: notes.txt",
+    );
+  });
+
   it("lands on the Hands-backed list and reports authoritative unread changes", async () => {
     const adapter = transport();
     const onUnreadChanged = vi.fn();

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeedbackWorkspace } from "./components.js";
 import { FeedbackProvider } from "./provider.js";
@@ -34,7 +40,9 @@ const page: FeedbackTicketPage = {
 
 const detail: FeedbackTicketDetail = {
   ticket: { ...ticket, unread: false, unreadCount: 0 },
-  comments: [{ id: "comment-1", authorType: "staff", body: "Thanks", createdAt: 3 }],
+  comments: [
+    { id: "comment-1", authorType: "staff", body: "Thanks", createdAt: 3 },
+  ],
   attachments: [],
   nextCommentCursor: null,
   unreadTotal: 0,
@@ -54,25 +62,45 @@ describe("FeedbackWorkspace browser behavior", () => {
     const adapter = transport();
     const onUnreadChanged = vi.fn();
     const { container } = render(
-      <FeedbackProvider transport={adapter} theme="brutal" onUnreadChanged={onUnreadChanged}>
+      <FeedbackProvider
+        transport={adapter}
+        theme="brutal"
+        onUnreadChanged={onUnreadChanged}
+      >
         <FeedbackWorkspace />
       </FeedbackProvider>,
     );
 
-    expect(container.querySelector("[data-hands-feedback-theme='brutal']")).not.toBeNull();
+    expect(
+      container.querySelector("[data-hands-feedback-theme='brutal']"),
+    ).not.toBeNull();
     expect(await screen.findByText(ticket.message)).toBeTruthy();
-    expect(adapter.listTickets).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }));
-    expect(adapter.listTickets).not.toHaveBeenCalledWith(expect.objectContaining({ reporterId: expect.anything() }));
+    expect(adapter.listTickets).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 20 }),
+    );
+    expect(adapter.listTickets).not.toHaveBeenCalledWith(
+      expect.objectContaining({ reporterId: expect.anything() }),
+    );
     expect(onUnreadChanged).toHaveBeenCalledTimes(1);
-    expect(onUnreadChanged).toHaveBeenLastCalledWith({ total: 2, source: "list" });
+    expect(onUnreadChanged).toHaveBeenLastCalledWith({
+      total: 2,
+      source: "list",
+    });
 
     fireEvent.click(screen.getByText(ticket.message));
     expect(await screen.findByText("Thanks")).toBeTruthy();
-    expect(adapter.getTicket).toHaveBeenCalledWith(expect.objectContaining({
-      ticketId: ticket.id,
-      commentLimit: 100,
-    }));
-    await waitFor(() => expect(onUnreadChanged).toHaveBeenLastCalledWith({ total: 0, source: "detail" }));
+    expect(adapter.getTicket).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ticketId: ticket.id,
+        commentLimit: 100,
+      }),
+    );
+    await waitFor(() =>
+      expect(onUnreadChanged).toHaveBeenLastCalledWith({
+        total: 0,
+        source: "detail",
+      }),
+    );
 
     fireEvent.click(screen.getByText("Back"));
     expect(await screen.findByText(ticket.message)).toBeTruthy();
@@ -80,7 +108,10 @@ describe("FeedbackWorkspace browser behavior", () => {
 
   it("does not re-notify when list and detail return the same authoritative total", async () => {
     const adapter = transport();
-    adapter.getTicket = vi.fn(async () => ({ ...detail, unreadTotal: page.unreadTotal }));
+    adapter.getTicket = vi.fn(async () => ({
+      ...detail,
+      unreadTotal: page.unreadTotal,
+    }));
     const onUnreadChanged = vi.fn();
     render(
       <FeedbackProvider transport={adapter} onUnreadChanged={onUnreadChanged}>
@@ -94,6 +125,181 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(onUnreadChanged).toHaveBeenCalledWith({ total: 2, source: "list" });
   });
 
+  it("preserves list filter, scroll position, and originating row focus after Back", async () => {
+    const adapter = transport();
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    const row = await screen.findByRole("button", {
+      name: /A reporter-visible ticket/,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    const listScroll = document.querySelector<HTMLElement>(
+      "[data-feedback-list-scroll]",
+    )!;
+    listScroll.scrollTop = 91;
+    fireEvent.click(row);
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => expect(document.activeElement).toBe(row));
+    expect(listScroll.scrollTop).toBe(91);
+    expect(
+      screen.getByRole("button", { name: "Open" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(row.getAttribute("data-unread")).toBeNull();
+  });
+
+  it("never advances authoritative unread or clears the row when detail read fails", async () => {
+    const adapter = transport();
+    adapter.getTicket = vi.fn(async () => {
+      throw new FeedbackTransportError("unavailable");
+    });
+    const onUnreadChanged = vi.fn();
+    render(
+      <FeedbackProvider transport={adapter} onUnreadChanged={onUnreadChanged}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    const row = await screen.findByRole("button", {
+      name: /A reporter-visible ticket/,
+    });
+    expect(row.getAttribute("data-unread")).toBe("true");
+    fireEvent.click(row);
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(onUnreadChanged).toHaveBeenCalledTimes(1);
+    expect(onUnreadChanged).toHaveBeenCalledWith({ total: 2, source: "list" });
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(
+      (
+        await screen.findByRole("button", { name: /A reporter-visible ticket/ })
+      ).getAttribute("data-unread"),
+    ).toBe("true");
+  });
+
+  it("keeps per-ticket drafts and honors IME-safe Enter semantics", async () => {
+    const second = {
+      ...ticket,
+      id: "ticket-2",
+      message: "Second ticket",
+      unread: false,
+      unreadCount: 0,
+    };
+    const adapter = transport();
+    adapter.listTickets = vi.fn(async () => ({
+      ...page,
+      tickets: [ticket, second],
+    }));
+    adapter.getTicket = vi.fn(async ({ ticketId }) => ({
+      ...detail,
+      ticket: { ...detail.ticket, id: ticketId },
+    }));
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    fireEvent.click(await screen.findByText(ticket.message));
+    const firstDraft = await screen.findByLabelText("Reply");
+    fireEvent.change(firstDraft, { target: { value: "draft one" } });
+    fireEvent.keyDown(firstDraft, { key: "Enter", isComposing: true });
+    fireEvent.keyDown(firstDraft, { key: "Enter", shiftKey: true });
+    expect(adapter.addComment).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Back"));
+    fireEvent.click(await screen.findByText("Second ticket"));
+    fireEvent.change(await screen.findByLabelText("Reply"), {
+      target: { value: "draft two" },
+    });
+    fireEvent.click(screen.getByText("Back"));
+    fireEvent.click(await screen.findByText(ticket.message));
+    const restored = (await screen.findByLabelText(
+      "Reply",
+    )) as HTMLTextAreaElement;
+    expect(restored.value).toBe("draft one");
+    fireEvent.keyDown(restored, { key: "Enter" });
+    await waitFor(() => expect(adapter.addComment).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(adapter.addComment).mock.calls[0]![0].body).toBe(
+      "draft one",
+    );
+  });
+
+  it("keeps create text and attachments across failure, reports progress, and reuses the retry ID", async () => {
+    const adapter = transport();
+    let attempt = 0;
+    adapter.createTicket = vi.fn(async (input) => {
+      input.onAttachmentProgress?.({ index: 0, progress: 0.5 });
+      attempt += 1;
+      if (attempt === 1) throw new FeedbackTransportError("unavailable");
+      return detail;
+    });
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    fireEvent.click(await screen.findByText("New feedback"));
+    const editor = screen.getByLabelText(
+      "What would you like us to know?",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Keep this text" } });
+    const file = new File(["image"], "proof.png", {
+      type: "image/png",
+      lastModified: 7,
+    });
+    fireEvent.change(screen.getByLabelText("Screenshots (up to 3)"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByText("Submit feedback"));
+    expect(await screen.findByText("Upload failed")).toBeTruthy();
+    expect(editor.value).toBe("Keep this text");
+    expect(screen.getByText("proof.png")).toBeTruthy();
+    fireEvent.click(screen.getByText("Retry upload"));
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    const calls = vi.mocked(adapter.createTicket).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]![0].submissionId).toBe(calls[1]![0].submissionId);
+    expect(calls[0]![0].attachments[0]).toBe(file);
+  });
+
+  it("prevents duplicate create submission and lets the reporter cancel an in-flight upload", async () => {
+    const adapter = transport();
+    let uploadSignal: AbortSignal | undefined;
+    adapter.createTicket = vi.fn(
+      ({ signal }) =>
+        new Promise<FeedbackTicketDetail>((_resolve, reject) => {
+          uploadSignal = signal;
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    fireEvent.click(await screen.findByText("New feedback"));
+    const editor = screen.getByLabelText(
+      "What would you like us to know?",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Only once" } });
+    const submit = screen.getByText("Submit feedback");
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+    expect(adapter.createTicket).toHaveBeenCalledTimes(1);
+    const cancelButtons = await screen.findAllByRole("button", {
+      name: "Cancel",
+    });
+    fireEvent.click(cancelButtons.at(-1)!);
+    expect(uploadSignal?.aborted).toBe(true);
+    expect(editor.value).toBe("Only once");
+    expect(screen.getByText("Submit feedback")).toBeTruthy();
+  });
+
   it("loads, deduplicates, and orders conversations beyond the first 100 comments", async () => {
     const adapter = transport();
     const firstComments = Array.from({ length: 100 }, (_, index) => ({
@@ -102,18 +308,23 @@ describe("FeedbackWorkspace browser behavior", () => {
       body: `Reply ${index + 1}`,
       createdAt: index + 1,
     }));
-    adapter.getTicket = vi.fn(async ({ commentCursor }) => commentCursor
-      ? {
-          ...detail,
-          comments: [firstComments[99]!, {
-            id: "comment-101",
-            authorType: "reporter",
-            body: "Reply 101",
-            createdAt: 101,
-          }],
-          nextCommentCursor: null,
-        }
-      : { ...detail, comments: firstComments, nextCommentCursor: "page-2" });
+    adapter.getTicket = vi.fn(async ({ commentCursor }) =>
+      commentCursor
+        ? {
+            ...detail,
+            comments: [
+              firstComments[99]!,
+              {
+                id: "comment-101",
+                authorType: "reporter",
+                body: "Reply 101",
+                createdAt: 101,
+              },
+            ],
+            nextCommentCursor: null,
+          }
+        : { ...detail, comments: firstComments, nextCommentCursor: "page-2" },
+    );
     render(
       <FeedbackProvider transport={adapter}>
         <FeedbackWorkspace initialTicketId={ticket.id} />
@@ -124,20 +335,64 @@ describe("FeedbackWorkspace browser behavior", () => {
     fireEvent.click(screen.getByText("Load more replies"));
     expect(await screen.findByText("Reply 101")).toBeTruthy();
     expect(screen.getAllByText("Reply 100")).toHaveLength(1);
-    expect(adapter.getTicket).toHaveBeenLastCalledWith(expect.objectContaining({ commentCursor: "page-2" }));
+    expect(adapter.getTicket).toHaveBeenLastCalledWith(
+      expect.objectContaining({ commentCursor: "page-2" }),
+    );
     expect(screen.queryByText("Load more replies")).toBeNull();
+  });
+
+  it("preserves historical reading position and exposes a new-reply affordance away from bottom", async () => {
+    const adapter = transport();
+    let reads = 0;
+    adapter.getTicket = vi.fn(async () => {
+      reads += 1;
+      return reads === 1
+        ? detail
+        : {
+            ...detail,
+            comments: [
+              ...detail.comments,
+              {
+                id: "comment-2",
+                authorType: "staff" as const,
+                body: "Fresh reply",
+                createdAt: 4,
+              },
+            ],
+          };
+    });
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    const conversation = screen.getByLabelText("Conversation");
+    Object.defineProperties(conversation, {
+      scrollHeight: { configurable: true, value: 500 },
+      clientHeight: { configurable: true, value: 100 },
+      scrollTop: { configurable: true, writable: true, value: 100 },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(await screen.findByText("Fresh reply")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "New replies" })).toBeTruthy();
+    expect(conversation.scrollTop).toBe(100);
+    fireEvent.click(screen.getByRole("button", { name: "New replies" }));
+    expect(conversation.scrollTop).toBe(500);
   });
 
   it("aborts an in-flight comment page when detail unmounts", async () => {
     const adapter = transport();
     let pageSignal: AbortSignal | undefined;
     let resolvePage: ((value: FeedbackTicketDetail) => void) | undefined;
-    adapter.getTicket = vi.fn(({ commentCursor, signal }) => commentCursor
-      ? new Promise<FeedbackTicketDetail>((resolve) => {
-          pageSignal = signal;
-          resolvePage = resolve;
-        })
-      : Promise.resolve({ ...detail, nextCommentCursor: "page-2" }));
+    adapter.getTicket = vi.fn(({ commentCursor, signal }) =>
+      commentCursor
+        ? new Promise<FeedbackTicketDetail>((resolve) => {
+            pageSignal = signal;
+            resolvePage = resolve;
+          })
+        : Promise.resolve({ ...detail, nextCommentCursor: "page-2" }),
+    );
     render(
       <FeedbackProvider transport={adapter}>
         <FeedbackWorkspace initialTicketId={ticket.id} />
@@ -149,7 +404,9 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(pageSignal?.aborted).toBe(true);
     resolvePage?.({
       ...detail,
-      comments: [{ id: "late", authorType: "staff", body: "Late reply", createdAt: 100 }],
+      comments: [
+        { id: "late", authorType: "staff", body: "Late reply", createdAt: 100 },
+      ],
       nextCommentCursor: null,
     });
     await waitFor(() => expect(screen.queryByText("Late reply")).toBeNull());
@@ -159,54 +416,92 @@ describe("FeedbackWorkspace browser behavior", () => {
     const secretText = "internal database host and sk_agent_FAKE_SECRET";
 
     const listAdapter = transport();
-    listAdapter.listTickets = vi.fn(async () => { throw new Error(secretText); });
+    listAdapter.listTickets = vi.fn(async () => {
+      throw new Error(secretText);
+    });
     const listView = render(
-      <FeedbackProvider transport={listAdapter}><FeedbackWorkspace /></FeedbackProvider>,
+      <FeedbackProvider transport={listAdapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
     );
-    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Feedback is temporarily unavailable.",
+    );
     expect(screen.queryByText(secretText)).toBeNull();
     listView.unmount();
 
     const detailAdapter = transport();
-    detailAdapter.getTicket = vi.fn(async () => { throw new Error(secretText); });
+    detailAdapter.getTicket = vi.fn(async () => {
+      throw new Error(secretText);
+    });
     const detailView = render(
-      <FeedbackProvider transport={detailAdapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+      <FeedbackProvider transport={detailAdapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
     );
-    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
-    expect(screen.getByRole("heading", { name: "Feedback ticket" })).toBeTruthy();
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Feedback is temporarily unavailable.",
+    );
+    expect(
+      screen.getByRole("heading", { name: "Feedback ticket" }),
+    ).toBeTruthy();
     expect(screen.queryByText(secretText)).toBeNull();
     detailView.unmount();
 
     const createAdapter = transport();
-    createAdapter.createTicket = vi.fn(async () => { throw new Error(secretText); });
+    createAdapter.createTicket = vi.fn(async () => {
+      throw new Error(secretText);
+    });
     const createView = render(
-      <FeedbackProvider transport={createAdapter}><FeedbackWorkspace /></FeedbackProvider>,
+      <FeedbackProvider transport={createAdapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
     );
     fireEvent.click(await screen.findByText("New feedback"));
-    fireEvent.change(screen.getByLabelText("What would you like us to know?"), { target: { value: "Idea" } });
+    fireEvent.change(screen.getByLabelText("What would you like us to know?"), {
+      target: { value: "Idea" },
+    });
     fireEvent.click(screen.getByText("Submit feedback"));
-    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Feedback is temporarily unavailable.",
+    );
     expect(screen.queryByText(secretText)).toBeNull();
     createView.unmount();
 
     const commentAdapter = transport();
-    commentAdapter.addComment = vi.fn(async () => { throw new Error(secretText); });
+    commentAdapter.addComment = vi.fn(async () => {
+      throw new Error(secretText);
+    });
     render(
-      <FeedbackProvider transport={commentAdapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+      <FeedbackProvider transport={commentAdapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
     );
-    fireEvent.change(await screen.findByLabelText("Reply"), { target: { value: "Hello" } });
+    fireEvent.change(await screen.findByLabelText("Reply"), {
+      target: { value: "Hello" },
+    });
     fireEvent.click(screen.getByText("Send reply"));
-    expect((await screen.findByRole("alert")).textContent).toContain("Feedback is temporarily unavailable.");
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Feedback is temporarily unavailable.",
+    );
     expect(screen.queryByText(secretText)).toBeNull();
   });
 
   it("maps only closed transport error codes to fixed user-safe copy", async () => {
     const adapter = transport();
     adapter.listTickets = vi.fn(async () => {
-      throw new FeedbackTransportError("rate_limited", { cause: new Error("hidden internal detail") });
+      throw new FeedbackTransportError("rate_limited", {
+        cause: new Error("hidden internal detail"),
+      });
     });
-    render(<FeedbackProvider transport={adapter}><FeedbackWorkspace /></FeedbackProvider>);
-    expect((await screen.findByRole("alert")).textContent).toContain("Too many feedback requests. Try again later.");
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Too many feedback requests. Try again later.",
+    );
     expect(screen.queryByText("hidden internal detail")).toBeNull();
   });
 
@@ -219,17 +514,23 @@ describe("FeedbackWorkspace browser behavior", () => {
       return detail;
     });
     const createView = render(
-      <FeedbackProvider transport={createAdapter}><FeedbackWorkspace /></FeedbackProvider>,
+      <FeedbackProvider transport={createAdapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
     );
     fireEvent.click(await screen.findByText("New feedback"));
-    fireEvent.change(screen.getByLabelText("What would you like us to know?"), { target: { value: "Retry me" } });
+    fireEvent.change(screen.getByLabelText("What would you like us to know?"), {
+      target: { value: "Retry me" },
+    });
     fireEvent.click(screen.getByText("Submit feedback"));
     expect(await screen.findByRole("alert")).toBeTruthy();
     fireEvent.click(screen.getByText("Submit feedback"));
     expect(await screen.findByText("Thanks")).toBeTruthy();
     const createCalls = vi.mocked(createAdapter.createTicket).mock.calls;
     expect(createCalls).toHaveLength(2);
-    expect(createCalls[0]![0].submissionId).toBe(createCalls[1]![0].submissionId);
+    expect(createCalls[0]![0].submissionId).toBe(
+      createCalls[1]![0].submissionId,
+    );
     createView.unmount();
 
     const commentAdapter = transport();
@@ -240,30 +541,53 @@ describe("FeedbackWorkspace browser behavior", () => {
       return detail;
     });
     render(
-      <FeedbackProvider transport={commentAdapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+      <FeedbackProvider transport={commentAdapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
     );
-    fireEvent.change(await screen.findByLabelText("Reply"), { target: { value: "Same reply" } });
+    fireEvent.change(await screen.findByLabelText("Reply"), {
+      target: { value: "Same reply" },
+    });
     fireEvent.click(screen.getByText("Send reply"));
     expect(await screen.findByRole("alert")).toBeTruthy();
     fireEvent.click(screen.getByText("Send reply"));
-    await waitFor(() => expect(vi.mocked(commentAdapter.addComment).mock.calls).toHaveLength(2));
+    await waitFor(() =>
+      expect(vi.mocked(commentAdapter.addComment).mock.calls).toHaveLength(2),
+    );
     const commentCalls = vi.mocked(commentAdapter.addComment).mock.calls;
-    expect(commentCalls[0]![0].submissionId).toBe(commentCalls[1]![0].submissionId);
+    expect(commentCalls[0]![0].submissionId).toBe(
+      commentCalls[1]![0].submissionId,
+    );
   });
 
   it("exposes stable headings and programmatic feedback-kind selection", async () => {
     const adapter = transport();
     let resolveDetail: ((value: FeedbackTicketDetail) => void) | undefined;
-    adapter.getTicket = vi.fn(() => new Promise((resolve) => { resolveDetail = resolve; }));
-    const loading = render(
-      <FeedbackProvider transport={adapter}><FeedbackWorkspace initialTicketId={ticket.id} /></FeedbackProvider>,
+    adapter.getTicket = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveDetail = resolve;
+        }),
     );
-    expect(screen.getByRole("heading", { name: "Feedback ticket" })).toBeTruthy();
-    expect(loading.container.querySelector(".hands-feedback-skeleton-detail")).not.toBeNull();
+    const loading = render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Feedback ticket" }),
+    ).toBeTruthy();
+    expect(
+      loading.container.querySelector(".hands-feedback-skeleton-detail"),
+    ).not.toBeNull();
     loading.unmount();
     resolveDetail?.(detail);
 
-    render(<FeedbackProvider transport={transport()}><FeedbackWorkspace /></FeedbackProvider>);
+    render(
+      <FeedbackProvider transport={transport()}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
     fireEvent.click(await screen.findByText("New feedback"));
     const feedback = screen.getByRole("button", { name: "Feedback" });
     const problem = screen.getByRole("button", { name: "Problem" });

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -14,7 +14,7 @@ import {
   nextUnreadReport,
   useHandsFeedback,
 } from "./provider.js";
-import { resolveFeedbackLocale } from "./locale.js";
+import { feedbackMessage, resolveFeedbackLocale } from "./locale.js";
 import type { HandsFeedbackTransport } from "./types.js";
 
 const transport = {} as HandsFeedbackTransport;
@@ -43,6 +43,14 @@ describe("FeedbackProvider", () => {
     );
     expect(html).toContain("新建反馈");
     expect(resolveFeedbackLocale("en")).toBe("en");
+    expect(
+      feedbackMessage(
+        "en",
+        "attachmentTooMany",
+        { attachmentTooMany: "Limit {count}" },
+        { count: 3 },
+      ),
+    ).toBe("Limit 3");
   });
 
   it("renders the ticket inbox as the landing surface", () => {

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -3,12 +3,18 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   FeedbackWorkspace,
+  isNearConversationBottom,
   MAX_FEEDBACK_ATTACHMENT_BYTES,
   mergeCommentPages,
   mergeTicketPages,
   validateFeedbackAttachments,
 } from "./components.js";
-import { FeedbackProvider, nextUnreadReport, useHandsFeedback } from "./provider.js";
+import {
+  FeedbackProvider,
+  nextUnreadReport,
+  useHandsFeedback,
+} from "./provider.js";
+import { resolveFeedbackLocale } from "./locale.js";
 import type { HandsFeedbackTransport } from "./types.js";
 
 const transport = {} as HandsFeedbackTransport;
@@ -29,6 +35,16 @@ describe("FeedbackProvider", () => {
     expect(html).toMatch(/>unknown/);
   });
 
+  it("supports explicit locale and has deterministic browser fallback", () => {
+    const html = renderToStaticMarkup(
+      <FeedbackProvider transport={transport} locale="zh-CN">
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+    expect(html).toContain("新建反馈");
+    expect(resolveFeedbackLocale("en")).toBe("en");
+  });
+
   it("renders the ticket inbox as the landing surface", () => {
     const html = renderToStaticMarkup(
       <FeedbackProvider transport={transport} theme="brutal">
@@ -42,16 +58,33 @@ describe("FeedbackProvider", () => {
   });
 
   it("fails closed outside a reporter-scoped provider", () => {
-    expect(() => renderToStaticMarkup(<Probe />)).toThrow(/require FeedbackProvider/);
+    expect(() => renderToStaticMarkup(<Probe />)).toThrow(
+      /require FeedbackProvider/,
+    );
   });
 
   it("emits only authoritative unread total changes", () => {
-    expect(nextUnreadReport(null, { total: 3, source: "list" })).toEqual({ next: 3, notify: true });
-    expect(nextUnreadReport(3, { total: 3, source: "detail" })).toEqual({ next: 3, notify: false });
-    expect(nextUnreadReport(3, { total: 1, source: "detail" })).toEqual({ next: 1, notify: true });
-    expect(() => nextUnreadReport(1, { total: -1, source: "list" })).toThrow(/non-negative/);
-    expect(() => nextUnreadReport(1, { total: 1.5, source: "list" })).toThrow(/safe integer/);
-    expect(() => nextUnreadReport(1, { total: Number.NaN, source: "list" })).toThrow(/safe integer/);
+    expect(nextUnreadReport(null, { total: 3, source: "list" })).toEqual({
+      next: 3,
+      notify: true,
+    });
+    expect(nextUnreadReport(3, { total: 3, source: "detail" })).toEqual({
+      next: 3,
+      notify: false,
+    });
+    expect(nextUnreadReport(3, { total: 1, source: "detail" })).toEqual({
+      next: 1,
+      notify: true,
+    });
+    expect(() => nextUnreadReport(1, { total: -1, source: "list" })).toThrow(
+      /non-negative/,
+    );
+    expect(() => nextUnreadReport(1, { total: 1.5, source: "list" })).toThrow(
+      /safe integer/,
+    );
+    expect(() =>
+      nextUnreadReport(1, { total: Number.NaN, source: "list" }),
+    ).toThrow(/safe integer/);
   });
 
   it("deduplicates overlapping cursor pages and keeps the fresh ticket value", () => {
@@ -67,10 +100,13 @@ describe("FeedbackProvider", () => {
       attachmentCount: 0,
       commentCount: 0,
     };
-    const result = mergeTicketPages([ticket], [
-      { ...ticket, message: "Fresh", updatedAt: 2 },
-      { ...ticket, id: "ticket-2", message: "Second" },
-    ]);
+    const result = mergeTicketPages(
+      [ticket],
+      [
+        { ...ticket, message: "Fresh", updatedAt: 2 },
+        { ...ticket, id: "ticket-2", message: "Second" },
+      ],
+    );
     expect(result.map(({ id, message }) => ({ id, message }))).toEqual([
       { id: "ticket-1", message: "Fresh" },
       { id: "ticket-2", message: "Second" },
@@ -84,14 +120,12 @@ describe("FeedbackProvider", () => {
       body,
       authorType: "staff" as const,
     });
-    expect(mergeCommentPages(
-      [comment("b", 2), comment("a", 1)],
-      [comment("b", 2, "fresh"), comment("c", 3)],
-    )).toEqual([
-      comment("a", 1),
-      comment("b", 2, "fresh"),
-      comment("c", 3),
-    ]);
+    expect(
+      mergeCommentPages(
+        [comment("b", 2), comment("a", 1)],
+        [comment("b", 2, "fresh"), comment("c", 3)],
+      ),
+    ).toEqual([comment("a", 1), comment("b", 2, "fresh"), comment("c", 3)]);
   });
 
   it("ships package-owned nonzero skeleton sizing without Tailwind utilities", () => {
@@ -100,28 +134,58 @@ describe("FeedbackProvider", () => {
     expect(css).toMatch(/\.hands-feedback-skeleton-detail[^}]*height:\s*10rem/);
     expect(css).not.toMatch(/\.h-16\b|\.h-40\b|\.w-full\b/);
     expect(css).toMatch(/@media \(max-width: 640px\)/);
+    expect(css).toMatch(/\.hands-feedback-middle[^}]*overflow-y:\s*auto/);
+    expect(css).toMatch(/env\(safe-area-inset-bottom\)/);
+    expect(css).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(css).not.toMatch(/display:\s*none[^}]*hands-feedback-conversation/);
+  });
+
+  it("classifies the conversation follow threshold deterministically", () => {
+    expect(
+      isNearConversationBottom({
+        scrollHeight: 500,
+        scrollTop: 336,
+        clientHeight: 100,
+      }),
+    ).toBe(true);
+    expect(
+      isNearConversationBottom({
+        scrollHeight: 500,
+        scrollTop: 100,
+        clientHeight: 100,
+      }),
+    ).toBe(false);
   });
 
   it("rejects unsafe screenshot selections before calling the transport", () => {
-    const image = (name: string, type: string, size: number) => ({
-      name,
-      type,
-      size,
-      lastModified: 0,
-    }) as File;
-    expect(validateFeedbackAttachments([
-      image("1.png", "image/png", 1),
-      image("2.webp", "image/webp", 1),
-    ])).toBeNull();
-    expect(validateFeedbackAttachments([
-      image("1.png", "image/png", 1),
-      image("2.png", "image/png", 1),
-      image("3.png", "image/png", 1),
-      image("4.png", "image/png", 1),
-    ])).toMatch(/no more than 3/);
-    expect(validateFeedbackAttachments([image("notes.txt", "text/plain", 1)])).toMatch(/supported image/);
-    expect(validateFeedbackAttachments([
-      image("huge.png", "image/png", MAX_FEEDBACK_ATTACHMENT_BYTES + 1),
-    ])).toMatch(/larger than 10 MB/);
+    const image = (name: string, type: string, size: number) =>
+      ({
+        name,
+        type,
+        size,
+        lastModified: 0,
+      }) as File;
+    expect(
+      validateFeedbackAttachments([
+        image("1.png", "image/png", 1),
+        image("2.webp", "image/webp", 1),
+      ]),
+    ).toBeNull();
+    expect(
+      validateFeedbackAttachments([
+        image("1.png", "image/png", 1),
+        image("2.png", "image/png", 1),
+        image("3.png", "image/png", 1),
+        image("4.png", "image/png", 1),
+      ]),
+    ).toMatch(/no more than 3/);
+    expect(
+      validateFeedbackAttachments([image("notes.txt", "text/plain", 1)]),
+    ).toMatch(/supported image/);
+    expect(
+      validateFeedbackAttachments([
+        image("huge.png", "image/png", MAX_FEEDBACK_ATTACHMENT_BYTES + 1),
+      ]),
+    ).toMatch(/larger than 10 MB/);
   });
 });

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -14,7 +14,11 @@ import {
   nextUnreadReport,
   useHandsFeedback,
 } from "./provider.js";
-import { feedbackMessage, resolveFeedbackLocale } from "./locale.js";
+import {
+  feedbackMessage,
+  resolveFeedbackLocale,
+  resolveFeedbackLocaleFromPreferences,
+} from "./locale.js";
 import type { HandsFeedbackTransport } from "./types.js";
 
 const transport = {} as HandsFeedbackTransport;
@@ -43,6 +47,10 @@ describe("FeedbackProvider", () => {
     );
     expect(html).toContain("新建反馈");
     expect(resolveFeedbackLocale("en")).toBe("en");
+    expect(resolveFeedbackLocaleFromPreferences(["en-US", "zh-CN"])).toBe("en");
+    expect(
+      resolveFeedbackLocaleFromPreferences(["fr-FR", "zh-CN", "en-US"]),
+    ).toBe("zh-CN");
     expect(
       feedbackMessage(
         "en",
@@ -145,6 +153,12 @@ describe("FeedbackProvider", () => {
     expect(css).toMatch(/\.hands-feedback-middle[^}]*overflow-y:\s*auto/);
     expect(css).toMatch(/env\(safe-area-inset-bottom\)/);
     expect(css).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(css).toMatch(
+      /\.hands-feedback-detail \.hands-feedback-middle[^}]*overflow:\s*hidden/,
+    );
+    expect(css).toMatch(
+      /\.hands-feedback-conversation[^}]*flex:\s*1[^}]*overflow-y:\s*auto/,
+    );
     expect(css).not.toMatch(/display:\s*none[^}]*hands-feedback-conversation/);
   });
 

--- a/packages/feedback-react/src/provider.tsx
+++ b/packages/feedback-react/src/provider.tsx
@@ -17,13 +17,16 @@ import {
   feedbackMessage,
   resolveFeedbackLocale,
   type FeedbackMessageKey,
+  type FeedbackMessages,
+  type FeedbackMessageValues,
 } from "./locale.js";
 
 type FeedbackContextValue = {
   transport: HandsFeedbackTransport;
   theme: FeedbackTheme;
   locale: FeedbackLocale;
-  message(key: FeedbackMessageKey): string;
+  message(key: FeedbackMessageKey, values?: FeedbackMessageValues): string;
+  formatDate(value: number): string;
   unreadTotal: number | null;
   reportUnread(change: FeedbackUnreadChange): void;
 };
@@ -45,6 +48,10 @@ export type FeedbackProviderProps = {
   theme?: FeedbackTheme;
   /** Defaults to browser language (`zh*` -> `zh-CN`, otherwise `en`). */
   locale?: FeedbackLocale;
+  /** Partial copy override; missing keys fall back to the selected SDK locale. */
+  messages?: Partial<FeedbackMessages>;
+  /** Override date/time presentation while retaining the resolved SDK locale. */
+  formatDate?: (value: Date, context: { locale: FeedbackLocale }) => string;
   onUnreadChanged?: (change: FeedbackUnreadChange) => void;
   children: ReactNode;
 };
@@ -53,14 +60,26 @@ export function FeedbackProvider({
   transport,
   theme = "elegant",
   locale: localeOverride,
+  messages,
+  formatDate: formatDateOverride,
   onUnreadChanged,
   children,
 }: FeedbackProviderProps) {
   const [unreadTotal, setUnreadTotal] = useState<number | null>(null);
   const locale = resolveFeedbackLocale(localeOverride);
   const message = useCallback(
-    (key: FeedbackMessageKey) => feedbackMessage(locale, key),
-    [locale],
+    (key: FeedbackMessageKey, values?: FeedbackMessageValues) =>
+      feedbackMessage(locale, key, messages, values),
+    [locale, messages],
+  );
+  const formatDate = useCallback(
+    (value: number) =>
+      formatDateOverride?.(new Date(value), { locale }) ??
+      new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(value)),
+    [formatDateOverride, locale],
   );
   const lastReported = useRef<{
     transport: HandsFeedbackTransport;
@@ -88,10 +107,11 @@ export function FeedbackProvider({
       theme,
       locale,
       message,
+      formatDate,
       unreadTotal,
       reportUnread,
     }),
-    [transport, theme, locale, message, unreadTotal, reportUnread],
+    [transport, theme, locale, message, formatDate, unreadTotal, reportUnread],
   );
   return (
     <FeedbackContext.Provider value={value}>

--- a/packages/feedback-react/src/provider.tsx
+++ b/packages/feedback-react/src/provider.tsx
@@ -27,6 +27,7 @@ type FeedbackContextValue = {
   locale: FeedbackLocale;
   message(key: FeedbackMessageKey, values?: FeedbackMessageValues): string;
   formatDate(value: number): string;
+  formatFileSize(value: number): string;
   unreadTotal: number | null;
   reportUnread(change: FeedbackUnreadChange): void;
 };
@@ -52,6 +53,11 @@ export type FeedbackProviderProps = {
   messages?: Partial<FeedbackMessages>;
   /** Override date/time presentation while retaining the resolved SDK locale. */
   formatDate?: (value: Date, context: { locale: FeedbackLocale }) => string;
+  /** Override attachment size presentation for the selected locale. */
+  formatFileSize?: (
+    bytes: number,
+    context: { locale: FeedbackLocale },
+  ) => string;
   onUnreadChanged?: (change: FeedbackUnreadChange) => void;
   children: ReactNode;
 };
@@ -62,6 +68,7 @@ export function FeedbackProvider({
   locale: localeOverride,
   messages,
   formatDate: formatDateOverride,
+  formatFileSize: formatFileSizeOverride,
   onUnreadChanged,
   children,
 }: FeedbackProviderProps) {
@@ -80,6 +87,17 @@ export function FeedbackProvider({
         timeStyle: "short",
       }).format(new Date(value)),
     [formatDateOverride, locale],
+  );
+  const formatFileSize = useCallback(
+    (bytes: number) =>
+      formatFileSizeOverride?.(bytes, { locale }) ??
+      new Intl.NumberFormat(locale, {
+        style: "unit",
+        unit: "kilobyte",
+        unitDisplay: "short",
+        maximumFractionDigits: 0,
+      }).format(Math.ceil(bytes / 1024)),
+    [formatFileSizeOverride, locale],
   );
   const lastReported = useRef<{
     transport: HandsFeedbackTransport;
@@ -108,10 +126,20 @@ export function FeedbackProvider({
       locale,
       message,
       formatDate,
+      formatFileSize,
       unreadTotal,
       reportUnread,
     }),
-    [transport, theme, locale, message, formatDate, unreadTotal, reportUnread],
+    [
+      transport,
+      theme,
+      locale,
+      message,
+      formatDate,
+      formatFileSize,
+      unreadTotal,
+      reportUnread,
+    ],
   );
   return (
     <FeedbackContext.Provider value={value}>

--- a/packages/feedback-react/src/provider.tsx
+++ b/packages/feedback-react/src/provider.tsx
@@ -8,14 +8,22 @@ import {
   useState,
 } from "react";
 import type {
+  FeedbackLocale,
   FeedbackTheme,
   FeedbackUnreadChange,
   HandsFeedbackTransport,
 } from "./types.js";
+import {
+  feedbackMessage,
+  resolveFeedbackLocale,
+  type FeedbackMessageKey,
+} from "./locale.js";
 
 type FeedbackContextValue = {
   transport: HandsFeedbackTransport;
   theme: FeedbackTheme;
+  locale: FeedbackLocale;
+  message(key: FeedbackMessageKey): string;
   unreadTotal: number | null;
   reportUnread(change: FeedbackUnreadChange): void;
 };
@@ -35,6 +43,8 @@ export function nextUnreadReport(
 export type FeedbackProviderProps = {
   transport: HandsFeedbackTransport;
   theme?: FeedbackTheme;
+  /** Defaults to browser language (`zh*` -> `zh-CN`, otherwise `en`). */
+  locale?: FeedbackLocale;
   onUnreadChanged?: (change: FeedbackUnreadChange) => void;
   children: ReactNode;
 };
@@ -42,30 +52,57 @@ export type FeedbackProviderProps = {
 export function FeedbackProvider({
   transport,
   theme = "elegant",
+  locale: localeOverride,
   onUnreadChanged,
   children,
 }: FeedbackProviderProps) {
   const [unreadTotal, setUnreadTotal] = useState<number | null>(null);
-  const lastReported = useRef<number | null>(null);
-  const reportUnread = useCallback((change: FeedbackUnreadChange) => {
-    const report = nextUnreadReport(lastReported.current, change);
-    setUnreadTotal(report.next);
-    if (report.notify) {
-      lastReported.current = report.next;
-      onUnreadChanged?.(change);
-    }
-  }, [onUnreadChanged]);
-  const value = useMemo(() => ({
-    transport,
-    theme,
-    unreadTotal,
-    reportUnread,
-  }), [transport, theme, unreadTotal, reportUnread]);
-  return <FeedbackContext.Provider value={value}>{children}</FeedbackContext.Provider>;
+  const locale = resolveFeedbackLocale(localeOverride);
+  const message = useCallback(
+    (key: FeedbackMessageKey) => feedbackMessage(locale, key),
+    [locale],
+  );
+  const lastReported = useRef<{
+    transport: HandsFeedbackTransport;
+    total: number;
+  } | null>(null);
+  const reportUnread = useCallback(
+    (change: FeedbackUnreadChange) => {
+      const report = nextUnreadReport(
+        lastReported.current?.transport === transport
+          ? lastReported.current.total
+          : null,
+        change,
+      );
+      setUnreadTotal(report.next);
+      if (report.notify) {
+        lastReported.current = { transport, total: report.next };
+        onUnreadChanged?.(change);
+      }
+    },
+    [onUnreadChanged, transport],
+  );
+  const value = useMemo(
+    () => ({
+      transport,
+      theme,
+      locale,
+      message,
+      unreadTotal,
+      reportUnread,
+    }),
+    [transport, theme, locale, message, unreadTotal, reportUnread],
+  );
+  return (
+    <FeedbackContext.Provider value={value}>
+      {children}
+    </FeedbackContext.Provider>
+  );
 }
 
 export function useHandsFeedback(): FeedbackContextValue {
   const value = useContext(FeedbackContext);
-  if (!value) throw new Error("Hands feedback components require FeedbackProvider");
+  if (!value)
+    throw new Error("Hands feedback components require FeedbackProvider");
   return value;
 }

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -1,87 +1,340 @@
 .hands-feedback-root {
-  --hf-bg: #ffffff;
-  --hf-surface: #f8fafc;
-  --hf-border: #d9e0e8;
-  --hf-text: #111827;
-  --hf-muted: #64748b;
-  --hf-accent: #2563eb;
-  --hf-danger: #b91c1c;
+  --hf-bg: var(--layer-primary, #fff);
+  --hf-surface: var(--layer-secondary, #f8fafc);
+  --hf-border: var(--line-subtle, #d9e0e8);
+  --hf-border-strong: var(--line-strong, #111827);
+  --hf-text: var(--foreground-primary, #111827);
+  --hf-muted: var(--foreground-muted, #64748b);
+  --hf-accent: var(--primary, #2563eb);
+  --hf-danger: var(--danger, #b91c1c);
   --hf-radius: 12px;
   --hf-shadow: 0 8px 24px rgb(15 23 42 / 8%);
+  background: var(--hf-bg);
   box-sizing: border-box;
   color: var(--hf-text);
-  background: var(--hf-bg);
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  min-height: 100%;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  height: 100%;
+  max-height: var(--hf-visual-viewport-height, 100%);
+  min-height: 0;
+  overflow: hidden;
 }
-
 .hands-feedback-root[data-hands-feedback-theme="brutal"] {
-  --hf-bg: #fffdf4;
-  --hf-surface: #fff7bf;
-  --hf-border: #151515;
-  --hf-text: #151515;
-  --hf-muted: #4b4b43;
-  --hf-accent: #ffcc00;
-  --hf-danger: #d92d20;
   --hf-radius: 0;
-  --hf-shadow: 4px 4px 0 #151515;
+  --hf-shadow: 4px 4px 0 var(--hf-border-strong);
 }
-
 .hands-feedback-root *,
 .hands-feedback-root *::before,
-.hands-feedback-root *::after { box-sizing: inherit; }
+.hands-feedback-root *::after {
+  box-sizing: inherit;
+}
+.hands-feedback-root [hidden] {
+  display: none !important;
+}
 .hands-feedback-root h2,
-.hands-feedback-root p { margin: 0; }
+.hands-feedback-root h3,
+.hands-feedback-root p {
+  margin: 0;
+}
 .hands-feedback-inbox,
 .hands-feedback-detail,
-.hands-feedback-new { display: grid; gap: 16px; padding: 20px; }
-.hands-feedback-header { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.hands-feedback-header p { color: var(--hf-muted); font-size: 14px; margin-top: 4px; }
-.hands-feedback-stack { display: grid; gap: 8px; }
-.hands-feedback-skeleton-row { display: block; height: 4rem; width: 100%; }
-.hands-feedback-skeleton-detail { display: block; height: 10rem; width: 100%; }
-.hands-feedback-ticket-list { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); box-shadow: var(--hf-shadow); list-style: none; margin: 0; overflow: hidden; padding: 0; }
-.hands-feedback-ticket-list li { margin: 0; padding: 0; }
-.hands-feedback-ticket-row { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 16px; border: 0; border-bottom: 1px solid var(--hf-border); background: var(--hf-bg); color: inherit; padding: 14px 16px; text-align: left; cursor: pointer; }
-.hands-feedback-ticket-list li:last-child .hands-feedback-ticket-row { border-bottom: 0; }
+.hands-feedback-new {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  padding: 18px;
+}
+.hands-feedback-header {
+  align-items: center;
+  display: flex;
+  flex: none;
+  gap: 12px;
+  justify-content: space-between;
+}
+.hands-feedback-header p {
+  color: var(--hf-muted);
+  font-size: 14px;
+  margin-top: 4px;
+}
+.hands-feedback-header h2:focus {
+  outline: none;
+}
+.hands-feedback-middle {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+.hands-feedback-list-scroll,
+.hands-feedback-new-fields {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 2px;
+}
+.hands-feedback-filter,
+.hands-feedback-kind {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.hands-feedback-stack {
+  display: grid;
+  gap: 8px;
+}
+.hands-feedback-skeleton-row {
+  display: block;
+  height: 4rem;
+  width: 100%;
+}
+.hands-feedback-skeleton-detail {
+  display: block;
+  height: 10rem;
+  width: 100%;
+}
+.hands-feedback-ticket-list {
+  border: 1px solid var(--hf-border);
+  border-radius: var(--hf-radius);
+  box-shadow: var(--hf-shadow);
+  list-style: none;
+  margin: 0 4px 4px 0;
+  overflow: hidden;
+  padding: 0;
+}
+.hands-feedback-ticket-list li {
+  margin: 0;
+  padding: 0;
+}
+.hands-feedback-ticket-row {
+  align-items: center;
+  background: var(--hf-bg);
+  border: 0;
+  border-bottom: 1px solid var(--hf-border);
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 13px 14px;
+  text-align: left;
+  width: 100%;
+}
+.hands-feedback-ticket-list li:last-child .hands-feedback-ticket-row {
+  border-bottom: 0;
+}
 .hands-feedback-ticket-row:hover,
-.hands-feedback-ticket-row:focus-visible { background: var(--hf-surface); outline: 2px solid var(--hf-accent); outline-offset: -2px; }
-.hands-feedback-ticket-row[data-unread="true"] .hands-feedback-ticket-title { font-weight: 750; }
-.hands-feedback-ticket-copy { display: grid; gap: 5px; min-width: 0; }
-.hands-feedback-ticket-title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hands-feedback-ticket-row:focus-visible {
+  background: var(--hf-surface);
+  outline: 2px solid var(--hf-accent);
+  outline-offset: -2px;
+}
+.hands-feedback-ticket-row[data-unread="true"] .hands-feedback-ticket-title {
+  font-weight: 750;
+}
+.hands-feedback-ticket-copy {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+.hands-feedback-ticket-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .hands-feedback-ticket-meta,
 .hands-feedback-comment-meta,
-.hands-feedback-ticket-body > span { color: var(--hf-muted); font-size: 12px; }
-.hands-feedback-ticket-state { display: flex; align-items: center; gap: 8px; flex: none; }
-.hands-feedback-unread-dot { width: 9px; height: 9px; background: #e11d48; border: 1px solid var(--hf-border); border-radius: 50%; }
-.hands-feedback-status { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-surface); font-size: 12px; padding: 3px 8px; white-space: nowrap; }
-.hands-feedback-status[data-status="resolved"],
-.hands-feedback-status[data-status="closed"] { color: var(--hf-muted); }
-.hands-feedback-error { display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 1px solid var(--hf-danger); color: var(--hf-danger); background: color-mix(in srgb, var(--hf-danger) 7%, white); padding: 12px; }
+.hands-feedback-ticket-body > span,
+.hands-feedback-muted {
+  color: var(--hf-muted);
+  font-size: 12px;
+}
+.hands-feedback-ticket-state {
+  align-items: center;
+  display: flex;
+  flex: none;
+  gap: 8px;
+}
+.hands-feedback-unread-dot {
+  background: var(--danger, #e11d48);
+  border: 1px solid var(--hf-border-strong);
+  border-radius: 50%;
+  height: 9px;
+  width: 9px;
+}
+.hands-feedback-error {
+  align-items: center;
+  background: color-mix(in srgb, var(--hf-danger) 7%, var(--hf-bg));
+  border: 1px solid var(--hf-danger);
+  color: var(--hf-danger);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 12px;
+}
 .hands-feedback-ticket-body,
 .hands-feedback-conversation article,
 .hands-feedback-composer,
-.hands-feedback-attachments { border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-bg); padding: 16px; }
-.hands-feedback-ticket-body { display: grid; gap: 8px; }
-.hands-feedback-ticket-body h3 { margin: 0; }
-.hands-feedback-conversation { display: grid; gap: 10px; }
-.hands-feedback-conversation article[data-author="reporter"] { margin-left: min(48px, 8vw); background: var(--hf-surface); }
-.hands-feedback-conversation article[data-author="staff"] { margin-right: min(48px, 8vw); }
-.hands-feedback-comment-meta { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
-.hands-feedback-attachments { display: flex; flex-wrap: wrap; gap: 8px; }
-.hands-feedback-attachments button { border: 1px solid var(--hf-border); background: var(--hf-surface); color: inherit; padding: 8px 10px; cursor: pointer; }
-.hands-feedback-composer,
-.hands-feedback-new { align-content: start; }
-.hands-feedback-composer { display: grid; gap: 8px; }
-.hands-feedback-root textarea { width: 100%; min-height: 110px; resize: vertical; border: 1px solid var(--hf-border); border-radius: var(--hf-radius); background: var(--hf-bg); color: var(--hf-text); padding: 10px 12px; font: inherit; }
-.hands-feedback-root textarea:focus { outline: 2px solid var(--hf-accent); outline-offset: 1px; }
-.hands-feedback-kind { display: flex; gap: 8px; }
+.hands-feedback-attachments {
+  background: var(--hf-bg);
+  border: 1px solid var(--hf-border);
+  border-radius: var(--hf-radius);
+  padding: 14px;
+}
+.hands-feedback-ticket-body {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.hands-feedback-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.hands-feedback-attachments button {
+  background: var(--hf-surface);
+  border: 1px solid var(--hf-border);
+  color: inherit;
+  cursor: pointer;
+  padding: 8px 10px;
+}
+.hands-feedback-conversation-toolbar {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.hands-feedback-conversation {
+  display: grid;
+  gap: 10px;
+  max-height: min(56vh, 520px);
+  min-height: 120px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 2px;
+}
+.hands-feedback-conversation article[data-author="reporter"] {
+  background: var(--hf-surface);
+  margin-left: min(48px, 8vw);
+}
+.hands-feedback-conversation article[data-author="staff"] {
+  margin-right: min(48px, 8vw);
+}
+.hands-feedback-comment-meta {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.hands-feedback-new-replies {
+  bottom: 8px;
+  margin: 8px auto;
+  position: sticky;
+}
+.hands-feedback-composer {
+  display: grid;
+  flex: none;
+  gap: 8px;
+  padding-bottom: max(14px, env(safe-area-inset-bottom));
+}
+.hands-feedback-submit-bar {
+  display: flex;
+  flex: none;
+  gap: 8px;
+  justify-content: flex-end;
+  padding-bottom: max(4px, env(safe-area-inset-bottom));
+}
+.hands-feedback-root textarea {
+  background: var(--hf-bg);
+  border: 1px solid var(--hf-border);
+  border-radius: var(--hf-radius);
+  color: var(--hf-text);
+  font: inherit;
+  max-height: 240px;
+  min-height: 44px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  resize: none;
+  width: 100%;
+}
+.hands-feedback-root textarea:focus {
+  outline: 2px solid var(--hf-accent);
+  outline-offset: 1px;
+}
+.hands-feedback-pending-attachments {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.hands-feedback-pending-attachments li {
+  align-items: center;
+  border: 1px solid var(--hf-border);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) minmax(60px, 140px) auto;
+  padding: 8px;
+}
+.hands-feedback-pending-attachments li > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hands-feedback-live {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
 
 @media (max-width: 640px) {
   .hands-feedback-inbox,
   .hands-feedback-detail,
-  .hands-feedback-new { padding: 14px; }
-  .hands-feedback-header { align-items: flex-start; }
-  .hands-feedback-ticket-row { align-items: flex-start; }
-  .hands-feedback-status { max-width: 96px; overflow: hidden; text-overflow: ellipsis; }
+  .hands-feedback-new {
+    padding: 12px;
+  }
+  .hands-feedback-header {
+    align-items: flex-start;
+  }
+  .hands-feedback-ticket-row {
+    align-items: center;
+    flex-wrap: nowrap;
+  }
+  .hands-feedback-ticket-state {
+    white-space: nowrap;
+  }
+  .hands-feedback-conversation {
+    max-height: none;
+  }
+  .hands-feedback-pending-attachments li {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .hands-feedback-pending-attachments progress {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hands-feedback-root *,
+  .hands-feedback-root *::before,
+  .hands-feedback-root *::after {
+    animation-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -74,6 +74,16 @@
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
 }
+.hands-feedback-detail .hands-feedback-middle {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.hands-feedback-detail
+  .hands-feedback-middle
+  > *:not(.hands-feedback-conversation) {
+  flex: none;
+}
 .hands-feedback-list-scroll,
 .hands-feedback-new-fields {
   display: grid;
@@ -216,9 +226,10 @@
 }
 .hands-feedback-conversation {
   display: grid;
+  flex: 1;
   gap: 10px;
-  max-height: min(56vh, 520px);
-  min-height: 120px;
+  max-height: none;
+  min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 2px;
@@ -316,9 +327,6 @@
   }
   .hands-feedback-ticket-state {
     white-space: nowrap;
-  }
-  .hands-feedback-conversation {
-    max-height: none;
   }
   .hands-feedback-pending-attachments li {
     grid-template-columns: minmax(0, 1fr) auto;

--- a/packages/feedback-react/src/types.ts
+++ b/packages/feedback-react/src/types.ts
@@ -1,4 +1,5 @@
 export type FeedbackTheme = "elegant" | "brutal";
+export type FeedbackLocale = "en" | "zh-CN";
 export type FeedbackKind = "feedback" | "bug";
 export type FeedbackStatus = "open" | "in_progress" | "resolved" | "closed";
 
@@ -51,6 +52,8 @@ export type CreateFeedbackInput = {
   message: string;
   submissionId: string;
   attachments: File[];
+  /** Optional upload progress bridge. Values are clamped by the SDK to 0..1. */
+  onAttachmentProgress?: (input: { index: number; progress: number }) => void;
 };
 
 export type AddFeedbackCommentInput = {
@@ -79,8 +82,12 @@ export type HandsFeedbackTransport = {
     commentLimit: number;
     signal: AbortSignal;
   }): Promise<FeedbackTicketDetail>;
-  createTicket(input: CreateFeedbackInput & { signal: AbortSignal }): Promise<FeedbackTicketDetail>;
-  addComment(input: AddFeedbackCommentInput & { signal: AbortSignal }): Promise<FeedbackTicketDetail>;
+  createTicket(
+    input: CreateFeedbackInput & { signal: AbortSignal },
+  ): Promise<FeedbackTicketDetail>;
+  addComment(
+    input: AddFeedbackCommentInput & { signal: AbortSignal },
+  ): Promise<FeedbackTicketDetail>;
 };
 
 export type FeedbackUnreadChange = {


### PR DESCRIPTION
## Summary

- make the feedback workspace own list/detail/new navigation state, list filter/scroll/focus restoration, and controlled route integration
- keep Hands-authoritative unread semantics: only successful detail reads update the reporter read state, while failed, aborted, stale, unmounted, and replaced-transport reads/actions do not
- add per-ticket drafts, autosizing and IME-safe reply submission, stable idempotent retries, attachment progress/retry/remove/cancel, and one canonical conversation scroller with near-bottom following
- add recoverable list/detail/comment pagination states, delayed controlled-route focus restoration, live-region announcements, narrow safe-area/visual-viewport handling, and reduced-motion coverage
- add provider-driven localization: ordered browser negotiation, built-in `en` / `zh-CN` fallback bundles, explicit locale, typed interpolated message overrides, and host date/file-size formatters

## Validation

- `pnpm --filter @botiverse/hands-feedback-react typecheck`
- `pnpm --filter @botiverse/hands-feedback-react test` (28 tests)
- `pnpm --filter @botiverse/hands-feedback-react build`
- compiled ESM/localizer import probe
- 390x520 real Chromium geometry: outer detail middle `286/286` hidden, conversation `174/4754` auto; away-from-bottom `scrollTop=120` preserved with affordance; at-bottom refresh ends with `gap=0`
- `npm pack --dry-run` (24 files, including compiled and source locale entries)
- `git diff --check`

## Boundaries

- no package publication or deployment
- no reporter credential, app token, secret, or consumer-owned read cursor is introduced
