### PR TITLE
fix(feedback): match Raft reply composer

### DIFF
--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -34,6 +34,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
+    "lucide-react": ">=0.575.0 <2.0.0",
     "raft-ui": "^0.0.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
@@ -43,6 +44,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "jsdom": "^26.1.0",
+    "lucide-react": "^1.23.0",
     "raft-ui": "^0.0.18",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -496,6 +496,14 @@ export function FeedbackTicket({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const scrollIntent = useRef<"bottom" | "preserve" | null>(null);
 
+  useEffect(() => {
+    actionController.current?.abort();
+    actionController.current = null;
+    commentSubmission.current = null;
+    setSending(false);
+    setReplyAttachments([]);
+  }, [ticketId, transport]);
+
   const load = useCallback(
     async (commentCursor?: string, refresh = false) => {
       loadController.current?.abort();

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { ImagePlus, Paperclip, Send } from "lucide-react";
+import { ArrowLeft, ImagePlus, Paperclip, Send } from "lucide-react";
 import {
   Badge,
   Button,
@@ -630,8 +630,14 @@ export function FeedbackTicket({
       aria-labelledby="hands-feedback-ticket-heading"
     >
       <header className="hands-feedback-header">
-        <Button variant="outline" onClick={onBack}>
-          {message("back")}
+        <Button
+          aria-label={message("back")}
+          title={message("back")}
+          size="icon-sm"
+          variant="outline"
+          onClick={onBack}
+        >
+          <ArrowLeft aria-hidden="true" size={16} />
         </Button>
         <h2 id="hands-feedback-ticket-heading" tabIndex={-1}>
           {message("ticketHeading")}

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -26,6 +26,74 @@ import type {
   FeedbackTicketSummary,
 } from "./types.js";
 
+function ImageAttachmentIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+      <rect
+        x="3"
+        y="3"
+        width="18"
+        height="18"
+        rx="1"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <circle
+        cx="8.5"
+        cy="8.5"
+        r="1.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <path
+        d="m4 18 5-5 3 3 3-4 5 6M17 5v6M14 8h6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function FileAttachmentIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+      <path
+        d="m20 11.5-8.5 8.5a6 6 0 0 1-8.5-8.5l9-9a4 4 0 0 1 5.5 5.8l-9 9a2 2 0 1 1-2.8-2.8l8.3-8.3"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+      <path
+        d="m22 2-7 20-4-9-9-4Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <path
+        d="M22 2 11 13"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
 export const MAX_FEEDBACK_ATTACHMENTS = 3;
 export const MAX_FEEDBACK_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 export const FEEDBACK_ATTACHMENT_TYPES = [
@@ -405,6 +473,9 @@ export function FeedbackTicket({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [sending, setSending] = useState(false);
+  const [replyAttachments, setReplyAttachments] = useState<PendingAttachment[]>(
+    [],
+  );
   const [loadError, setLoadError] = useState<string | null>(null);
   const [retryLoad, setRetryLoad] = useState<{
     cursor: string | undefined;
@@ -421,6 +492,8 @@ export function FeedbackTicket({
   );
   const conversationRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useAutosize(reply);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const scrollIntent = useRef<"bottom" | "preserve" | null>(null);
 
   const load = useCallback(
@@ -504,27 +577,56 @@ export function FeedbackTicket({
   const send = async () => {
     const body = reply.trim();
     if (!body || sending) return;
+    const files = replyAttachments.map(({ file }) => file);
+    const attachmentError = localizedAttachmentError(files, message);
+    if (attachmentError) {
+      setActionError(attachmentError);
+      return;
+    }
     setSending(true);
     setActionError(null);
+    setReplyAttachments((current) =>
+      current.map((item) => ({ ...item, state: "uploading", progress: 0 })),
+    );
     actionController.current?.abort();
     const controller = new AbortController();
     actionController.current = controller;
     commentSubmission.current = stableFeedbackSubmission(
       commentSubmission.current,
-      body,
+      JSON.stringify([
+        body,
+        ...files.map((file) => [
+          file.name,
+          file.type,
+          file.size,
+          file.lastModified,
+        ]),
+      ]),
     );
     try {
       const result = await transport.addComment({
         ticketId,
         body,
         submissionId: commentSubmission.current.id,
+        attachments: files,
         signal: controller.signal,
+        onAttachmentProgress: ({ index, progress }) => {
+          if (controller.signal.aborted) return;
+          setReplyAttachments((current) =>
+            current.map((item, itemIndex) =>
+              itemIndex === index
+                ? { ...item, progress: Math.max(0, Math.min(1, progress)) }
+                : item,
+            ),
+          );
+        },
       });
       if (controller.signal.aborted) return;
       reportUnread({ total: result.unreadTotal, source: "comment" });
       scrollIntent.current = "bottom";
       setDetail(result);
       setReply("");
+      setReplyAttachments([]);
       setNewReplies(false);
       commentSubmission.current = null;
       setAnnouncement(message("replySent"));
@@ -533,10 +635,40 @@ export function FeedbackTicket({
       if (!controller.signal.aborted) {
         setActionError(safeError(cause));
         setAnnouncement(safeError(cause));
+        setReplyAttachments((current) =>
+          current.map((item) =>
+            item.state === "uploading" ? { ...item, state: "failed" } : item,
+          ),
+        );
       }
     } finally {
       if (!controller.signal.aborted) setSending(false);
     }
+  };
+
+  const chooseReplyAttachments = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(event.currentTarget.files ?? []);
+    const combined = [
+      ...replyAttachments.map(({ file }) => file),
+      ...selected,
+    ];
+    const attachmentError = localizedAttachmentError(combined, message);
+    if (attachmentError) {
+      setActionError(attachmentError);
+      event.currentTarget.value = "";
+      return;
+    }
+    setActionError(null);
+    setReplyAttachments((current) => [
+      ...current,
+      ...selected.map((file) => ({
+        id: submissionId(),
+        file,
+        progress: 0,
+        state: "ready" as const,
+      })),
+    ]);
+    event.currentTarget.value = "";
   };
 
   const onReplyKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -681,7 +813,10 @@ export function FeedbackTicket({
       </div>
       {detail && (
         <div className="hands-feedback-composer">
-          <label htmlFor={`hands-feedback-reply-${ticketId}`}>
+          <label
+            className="hands-feedback-sr-only"
+            htmlFor={`hands-feedback-reply-${ticketId}`}
+          >
             {message("reply")}
           </label>
           <textarea
@@ -693,17 +828,110 @@ export function FeedbackTicket({
             onKeyDown={onReplyKeyDown}
             rows={1}
           />
+          <input
+            ref={imageInputRef}
+            data-testid="hands-feedback-reply-image-input"
+            className="hands-feedback-sr-only"
+            type="file"
+            accept={FEEDBACK_ATTACHMENT_TYPES.join(",")}
+            multiple
+            disabled={
+              sending || replyAttachments.length >= MAX_FEEDBACK_ATTACHMENTS
+            }
+            onChange={chooseReplyAttachments}
+          />
+          <input
+            ref={fileInputRef}
+            data-testid="hands-feedback-reply-file-input"
+            className="hands-feedback-sr-only"
+            type="file"
+            accept={FEEDBACK_ATTACHMENT_TYPES.join(",")}
+            multiple
+            disabled={
+              sending || replyAttachments.length >= MAX_FEEDBACK_ATTACHMENTS
+            }
+            onChange={chooseReplyAttachments}
+          />
+          {replyAttachments.length > 0 && (
+            <ul className="hands-feedback-pending-attachments hands-feedback-reply-attachments">
+              {replyAttachments.map((item) => (
+                <li key={item.id}>
+                  <span>{item.file.name}</span>
+                  {item.state === "uploading" && (
+                    <progress
+                      max={1}
+                      value={item.progress || undefined}
+                      aria-label={message("uploadProgress", {
+                        name: item.file.name,
+                      })}
+                    />
+                  )}
+                  {item.state === "failed" && (
+                    <span role="status">{message("uploadFailed")}</span>
+                  )}
+                  <Button
+                    variant="outline"
+                    disabled={sending}
+                    onClick={() =>
+                      setReplyAttachments((current) =>
+                        current.filter(({ id }) => id !== item.id),
+                      )
+                    }
+                  >
+                    {message("remove")}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
           {actionError && (
             <div className="hands-feedback-error" role="alert">
               {actionError}
             </div>
           )}
-          <Button
-            disabled={!reply.trim() || sending}
-            onClick={() => void send()}
-          >
-            {sending ? message("sending") : message("sendReply")}
-          </Button>
+          <div className="hands-feedback-composer-toolbar">
+            <div className="hands-feedback-composer-attachments">
+              <Button
+                aria-label={message("attachImage")}
+                title={message("attachImage")}
+                size="icon-sm"
+                variant="outline"
+                disabled={
+                  sending ||
+                  replyAttachments.length >= MAX_FEEDBACK_ATTACHMENTS
+                }
+                onClick={() => imageInputRef.current?.click()}
+              >
+                <ImageAttachmentIcon />
+              </Button>
+              <Button
+                aria-label={message("attachFile")}
+                title={message("attachFile")}
+                size="icon-sm"
+                variant="outline"
+                disabled={
+                  sending ||
+                  replyAttachments.length >= MAX_FEEDBACK_ATTACHMENTS
+                }
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <FileAttachmentIcon />
+              </Button>
+            </div>
+            <Button
+              aria-label={sending ? message("sending") : message("sendReply")}
+              title={sending ? message("sending") : message("sendReply")}
+              size="icon-sm"
+              variant="accent"
+              disabled={!reply.trim() || sending}
+              onClick={() => void send()}
+            >
+              <SendIcon />
+              <span className="hands-feedback-sr-only">
+                {sending ? message("sending") : message("sendReply")}
+              </span>
+            </Button>
+          </div>
         </div>
       )}
       <div

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { ImagePlus, Paperclip, Send } from "lucide-react";
 import {
   Badge,
   Button,
@@ -25,74 +26,6 @@ import type {
   FeedbackTicketDetail,
   FeedbackTicketSummary,
 } from "./types.js";
-
-function ImageAttachmentIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
-      <rect
-        x="3"
-        y="3"
-        width="18"
-        height="18"
-        rx="1"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      />
-      <circle
-        cx="8.5"
-        cy="8.5"
-        r="1.5"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      />
-      <path
-        d="m4 18 5-5 3 3 3-4 5 6M17 5v6M14 8h6"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-      />
-    </svg>
-  );
-}
-
-function FileAttachmentIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
-      <path
-        d="m20 11.5-8.5 8.5a6 6 0 0 1-8.5-8.5l9-9a4 4 0 0 1 5.5 5.8l-9 9a2 2 0 1 1-2.8-2.8l8.3-8.3"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-      />
-    </svg>
-  );
-}
-
-function SendIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
-      <path
-        d="m22 2-7 20-4-9-9-4Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-      />
-      <path
-        d="M22 2 11 13"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="2"
-      />
-    </svg>
-  );
-}
 
 export const MAX_FEEDBACK_ATTACHMENTS = 3;
 export const MAX_FEEDBACK_ATTACHMENT_BYTES = 10 * 1024 * 1024;
@@ -910,7 +843,7 @@ export function FeedbackTicket({
                 }
                 onClick={() => imageInputRef.current?.click()}
               >
-                <ImageAttachmentIcon />
+                <ImagePlus aria-hidden="true" size={14} />
               </Button>
               <Button
                 aria-label={message("attachFile")}
@@ -923,7 +856,7 @@ export function FeedbackTicket({
                 }
                 onClick={() => fileInputRef.current?.click()}
               >
-                <FileAttachmentIcon />
+                <Paperclip aria-hidden="true" size={14} />
               </Button>
             </div>
             <Button
@@ -934,7 +867,7 @@ export function FeedbackTicket({
               disabled={!reply.trim() || sending}
               onClick={() => void send()}
             >
-              <SendIcon />
+              <Send aria-hidden="true" size={14} />
               <span className="hands-feedback-sr-only">
                 {sending ? message("sending") : message("sendReply")}
               </span>

--- a/packages/feedback-react/src/locale.ts
+++ b/packages/feedback-react/src/locale.ts
@@ -11,6 +11,8 @@ export type FeedbackMessageKey =
   | "attachmentUnsupported"
   | "attachmentSummary"
   | "attachments"
+  | "attachFile"
+  | "attachImage"
   | "back"
   | "cancel"
   | "conversation"
@@ -74,6 +76,8 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     attachmentUnsupported: "{name} is not a supported image.",
     attachmentSummary: "{name} · {size}",
     attachments: "Attachments",
+    attachFile: "Attach file",
+    attachImage: "Attach image",
     back: "Back",
     cancel: "Cancel",
     conversation: "Conversation",
@@ -134,6 +138,8 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     attachmentUnsupported: "{name} 不是支持的图片格式。",
     attachmentSummary: "{name} · {size}",
     attachments: "附件",
+    attachFile: "添加文件",
+    attachImage: "添加图片",
     back: "返回",
     cancel: "取消",
     conversation: "对话",

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -181,7 +181,7 @@ describe("FeedbackWorkspace browser behavior", () => {
       }),
     );
 
-    fireEvent.click(screen.getByText("Back"));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
     expect(await screen.findByText(ticket.message)).toBeTruthy();
   });
 
@@ -290,12 +290,12 @@ describe("FeedbackWorkspace browser behavior", () => {
     fireEvent.keyDown(firstDraft, { key: "Enter", isComposing: true });
     fireEvent.keyDown(firstDraft, { key: "Enter", shiftKey: true });
     expect(adapter.addComment).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByText("Back"));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
     fireEvent.click(await screen.findByText("Second ticket"));
     fireEvent.change(await screen.findByLabelText("Reply"), {
       target: { value: "draft two" },
     });
-    fireEvent.click(screen.getByText("Back"));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
     fireEvent.click(await screen.findByText(ticket.message));
     const restored = (await screen.findByLabelText(
       "Reply",
@@ -625,7 +625,7 @@ describe("FeedbackWorkspace browser behavior", () => {
     );
 
     fireEvent.click(await screen.findByText("Load more replies"));
-    fireEvent.click(screen.getByText("Back"));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
     expect(pageSignal?.aborted).toBe(true);
     resolvePage?.({
       ...detail,

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -282,6 +282,10 @@ describe("FeedbackWorkspace browser behavior", () => {
 
     fireEvent.click(await screen.findByText(ticket.message));
     const firstDraft = await screen.findByLabelText("Reply");
+    expect(firstDraft.closest(".hands-feedback-composer")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Attach image" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Attach file" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send reply" })).toBeTruthy();
     fireEvent.change(firstDraft, { target: { value: "draft one" } });
     fireEvent.keyDown(firstDraft, { key: "Enter", isComposing: true });
     fireEvent.keyDown(firstDraft, { key: "Enter", shiftKey: true });
@@ -302,6 +306,40 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(vi.mocked(adapter.addComment).mock.calls[0]![0].body).toBe(
       "draft one",
     );
+    expect(
+      vi.mocked(adapter.addComment).mock.calls[0]![0].attachments,
+    ).toEqual([]);
+  });
+
+  it("keeps reply attachments inside the composer and forwards upload progress", async () => {
+    const adapter = transport();
+    adapter.addComment = vi.fn(async (input) => {
+      input.onAttachmentProgress?.({ index: 0, progress: 0.5 });
+      return detail;
+    });
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+
+    const attachment = new File([new Uint8Array(128)], "reply.png", {
+      type: "image/png",
+    });
+    fireEvent.change(
+      await screen.findByTestId("hands-feedback-reply-image-input"),
+      { target: { files: [attachment] } },
+    );
+    expect(await screen.findByText("reply.png")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Reply with a screenshot" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send reply" }));
+
+    await waitFor(() => expect(adapter.addComment).toHaveBeenCalledTimes(1));
+    const input = vi.mocked(adapter.addComment).mock.calls[0]![0];
+    expect(input.attachments).toEqual([attachment]);
+    expect(screen.queryByText("reply.png")).toBeNull();
   });
 
   it("keeps create text and attachments across failure, reports progress, and reuses the retry ID", async () => {

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -342,6 +342,45 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(screen.queryByText("reply.png")).toBeNull();
   });
 
+  it("aborts and resets an in-flight reply when the reporter transport changes", async () => {
+    const first = transport();
+    const second = transport();
+    let firstSignal: AbortSignal | undefined;
+    let resolveFirst: ((value: FeedbackTicketDetail) => void) | undefined;
+    first.addComment = vi.fn(
+      ({ signal }) =>
+        new Promise<FeedbackTicketDetail>((resolve) => {
+          firstSignal = signal;
+          resolveFirst = resolve;
+        }),
+    );
+    const view = render(
+      <FeedbackProvider transport={first}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+    const editor = (await screen.findByLabelText("Reply")) as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Preserve this draft" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send reply" }));
+    expect(first.addComment).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <FeedbackProvider transport={second}>
+        <FeedbackWorkspace initialTicketId={ticket.id} />
+      </FeedbackProvider>,
+    );
+    await waitFor(() => expect(firstSignal?.aborted).toBe(true));
+    expect(editor.value).toBe("Preserve this draft");
+    expect(
+      (screen.getByRole("button", {
+        name: "Send reply",
+      }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+    resolveFirst?.(detail);
+    await Promise.resolve();
+    expect(second.addComment).not.toHaveBeenCalled();
+  });
+
   it("keeps create text and attachments across failure, reports progress, and reuses the retry ID", async () => {
     const adapter = transport();
     let attempt = 0;

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -253,10 +253,36 @@
   position: sticky;
 }
 .hands-feedback-composer {
-  display: grid;
+  background: var(--hf-bg);
+  border: 2px solid var(--hf-border-strong);
+  box-shadow: var(--hf-shadow);
+  display: flex;
+  flex-direction: column;
   flex: none;
   gap: 8px;
-  padding-bottom: max(14px, env(safe-area-inset-bottom));
+  margin: 0 4px max(4px, env(safe-area-inset-bottom)) 0;
+  padding: 8px;
+}
+.hands-feedback-composer-toolbar,
+.hands-feedback-composer-attachments {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+.hands-feedback-composer-toolbar {
+  justify-content: space-between;
+}
+.hands-feedback-sr-only {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.hands-feedback-reply-attachments {
+  margin: 0;
 }
 .hands-feedback-submit-bar {
   display: flex;
@@ -281,6 +307,16 @@
 .hands-feedback-root textarea:focus {
   outline: 2px solid var(--hf-accent);
   outline-offset: 1px;
+}
+.hands-feedback-composer textarea {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  min-height: 40px;
+  padding: 0 4px;
+}
+.hands-feedback-composer textarea:focus {
+  outline: none;
 }
 .hands-feedback-pending-attachments {
   display: grid;

--- a/packages/feedback-react/src/types.ts
+++ b/packages/feedback-react/src/types.ts
@@ -60,6 +60,9 @@ export type AddFeedbackCommentInput = {
   ticketId: string;
   body: string;
   submissionId: string;
+  attachments: File[];
+  /** Optional upload progress bridge. Values are clamped by the SDK to 0..1. */
+  onAttachmentProgress?: (input: { index: number; progress: number }) => void;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      lucide-react:
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.7)
       raft-ui:
         specifier: ^0.0.18
         version: 0.0.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)


### PR DESCRIPTION
## Summary

- make the reporter reply composer use the same single-card layout as the Raft message composer
- use the same Lucide `ArrowLeft`, `ImagePlus`, `Paperclip`, and `Send` icons as Raft
- make Back and Send icon-only actions with localized accessible names
- forward reply attachments and upload progress through the reporter-scoped transport contract
- preserve stable retry IDs by including attachment metadata in the request fingerprint
- abort and reset in-flight reply upload state when the reporter transport or ticket changes

## Validation

- feedback package typecheck
- feedback package build
- 30 feedback package tests
- real Chromium narrow composer computed-style, exact Lucide class, and interaction probes
- `git diff --check`
