### PR TITLE
fix(delta): restore patch download fallback path

### DIFF
--- a/.github/workflows/android-sdk-check.yml
+++ b/.github/workflows/android-sdk-check.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "8.10.2"
-      - name: Assemble release AAR (includes NDK build)
-        run: gradle -p clients/android assembleRelease
+      - name: Assemble release AAR and run unit tests
+        run: gradle -p clients/android assembleRelease testReleaseUnitTest

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -1,8 +1,10 @@
 package build.hands.update
 
 import android.app.DownloadManager
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
+import android.os.Build
 import build.hands.update.installer.ApkInstaller
 import build.hands.update.internal.DeltaUpdater
 import build.hands.update.internal.HandsClient
@@ -12,6 +14,27 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/**
+ * Dynamic receivers must declare their export policy when the host targets
+ * Android 13 (API 33) or newer. Older Android releases only expose the legacy
+ * two-argument overload.
+ */
+internal fun downloadReceiverRegistrationFlags(sdkInt: Int): Int? =
+    if (sdkInt >= Build.VERSION_CODES.TIRAMISU) Context.RECEIVER_NOT_EXPORTED else null
+
+private fun Context.registerDownloadReceiver(
+    receiver: BroadcastReceiver,
+    filter: IntentFilter,
+) {
+    val flags = downloadReceiverRegistrationFlags(Build.VERSION.SDK_INT)
+    if (flags == null) {
+        @Suppress("DEPRECATION")
+        registerReceiver(receiver, filter)
+    } else {
+        registerReceiver(receiver, filter, flags)
+    }
+}
 
 /**
  * High-level entry point for "check if there's a new version on the quiver
@@ -137,7 +160,7 @@ class UpdateChecker(
         val receiver = installer.createInstallReceiver(downloadId)
         // Register on Application context so the receiver survives Activity death.
         if (context is android.app.Application) {
-            context.registerReceiver(
+            context.registerDownloadReceiver(
                 receiver,
                 IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
             )

--- a/clients/android/src/test/kotlin/build/hands/update/UpdateCheckerTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/UpdateCheckerTest.kt
@@ -1,0 +1,26 @@
+package build.hands.update
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UpdateCheckerTest {
+    @Test
+    fun `API 33 and newer register the download receiver as not exported`() {
+        assertEquals(
+            Context.RECEIVER_NOT_EXPORTED,
+            downloadReceiverRegistrationFlags(33),
+        )
+        assertEquals(
+            Context.RECEIVER_NOT_EXPORTED,
+            downloadReceiverRegistrationFlags(34),
+        )
+    }
+
+    @Test
+    fun `older Android releases keep the legacy registration overload`() {
+        assertNull(downloadReceiverRegistrationFlags(24))
+        assertNull(downloadReceiverRegistrationFlags(32))
+    }
+}

--- a/docs/delta-download-design.md
+++ b/docs/delta-download-design.md
@@ -84,6 +84,10 @@ old SDKs (they ignore the new field).
 ## Security
 
 - Patch served over a signed, expiring R2 URL (same as full APK today).
+- The public download proxy serves a patch only when the exact R2 object is a
+  `delta-patch`/`patch` asset on a non-QA build with an active or draft release;
+  unrelated build assets and cancelled releases stay inaccessible even if a
+  caller has a syntactically valid URL signature.
 - The reconstructed APK is verified by **sha256 against the server's recorded
   target hash** (integrity) **and signer-cert equality** (authenticity) before
   install. A corrupted/tampered patch can only produce a hash mismatch → full
@@ -114,6 +118,10 @@ let the client take the full download. This keeps delta a strict win.
   target_sha256}` when a matching `delta-patch` asset exists and is
   < `DELTA_MAX_SIZE_RATIO` (0.7) of the full APK. Full asset stays the
   fallback; old SDKs ignore the field.
+- **P1a public download authorization — FIXED**: signed patch URLs now resolve
+  through the public proxy only for release-bound `delta-patch` assets. The
+  previous proxy allowlist accepted only `installable`, causing every canonical
+  patch URL to return 404 even when `/updates/check` offered it.
 - **P1b storage — DONE (free)**: the existing build-asset API already accepts
   any `artifact_kind` + `metadata_json`, so no server change was needed to
   store `delta-patch` assets.

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -969,7 +969,10 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
      JOIN apps a ON a.id = b.app_id
      JOIN releases r ON r.build_id = b.id
      WHERE ba.r2_key = ?1
-       AND ba.artifact_kind = 'installable'
+       AND (
+         ba.artifact_kind = 'installable'
+         OR (ba.artifact_kind = 'delta-patch' AND ba.filetype = 'patch')
+       )
        AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
        AND r.status IN ('active', 'draft')
      LIMIT 1`,

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -974,6 +974,7 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
          OR (ba.artifact_kind = 'delta-patch' AND ba.filetype = 'patch')
        )
        AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
+       AND r.product_type != 'ios-simulator-qa' AND r.release_type != 'qa'
        AND r.status IN ('active', 'draft')
      LIMIT 1`,
   )

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6799,6 +6799,83 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(await response.text()).toBe("apk");
   });
 
+  it("public R2 download serves only release-bound delta patches", async () => {
+    const env = makeEnv();
+    const { handlePublicR2Download, handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    await seedRelease(env, "rel-delta-download", "build-delta-download", [["full", "all"]], {
+      versionCode: 20,
+      versionName: "1.0.20",
+    });
+    await seedAsset(env, "build-delta-download", "asset-delta-download-full", {
+      arch: "arm64-v8a",
+      sizeBytes: 1000,
+    });
+    const key = "apps/app-scope/patch-download-10-20.patch";
+    await seedAsset(env, "build-delta-download", "asset-delta-download", {
+      artifactKind: "delta-patch",
+      arch: "arm64-v8a",
+      filetype: "patch",
+      sizeBytes: 200,
+      r2Key: key,
+      metadata: {
+        from_version_code: 10,
+        to_version_code: 20,
+        algorithm: "archive-patcher-v1",
+        target_sha256: "target-apk-sha256",
+      },
+    });
+    await env.DB.prepare(
+      `INSERT INTO feature_flags (id, app_id, key, default_enabled, updated_at)
+       VALUES ('ff-delta-download', 'app-scope', 'delta_updates', 1, ?1)`,
+    ).bind(Date.now()).run();
+    env.APK_BUCKET = {
+      get: async (requestedKey: string) => {
+        if (requestedKey !== key) return null;
+        return {
+          body: new Blob(["patch"]).stream(),
+          httpEtag: '"asset-delta-download"',
+          writeHttpMetadata: () => undefined,
+        };
+      },
+    };
+
+    const check = await handlePublicV2UpdateCheck(
+      makePublicContext(env, {
+        channel: "production",
+        product_type: "android-apk",
+        current_version_code: "10",
+        platform: "android",
+        arch: "arm64-v8a",
+      }),
+    );
+    const body = await responseJson<any>(check);
+    const url = new URL(body.patch.download_url);
+    const request = () => handlePublicR2Download(
+      makePublicDownloadContext(env, decodeURIComponent(url.pathname.replace("/public/r2/", "")), {
+        expires: url.searchParams.get("expires") ?? undefined,
+        sig: url.searchParams.get("sig") ?? undefined,
+      }),
+    );
+
+    const active = await request();
+    expect(active.status).toBe(200);
+    expect(active.headers.get("content-type")).toBe("application/octet-stream");
+    expect(active.headers.get("content-length")).toBe("200");
+    expect(active.headers.get("content-disposition")).toBe(
+      `attachment; filename="scope-app-1.0.20-20.patch"; filename*=UTF-8''scope-app-1.0.20-20.patch`,
+    );
+    expect(await active.text()).toBe("patch");
+
+    // A still-valid URL must stop working as soon as its release is no longer
+    // active or draft. The HMAC alone never authorizes an arbitrary R2 object.
+    await env.DB.prepare("UPDATE releases SET status = 'cancelled' WHERE id = ?1")
+      .bind("rel-delta-download")
+      .run();
+    const cancelled = await request();
+    expect(cancelled.status).toBe(404);
+    expect(await responseJson<any>(cancelled)).toEqual({ error: "asset not found" });
+  });
+
   it("public R2 download redirects to presigned R2 when S3 credentials are configured", async () => {
     const env = makeEnv();
     configureR2Presign(env);

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6801,7 +6801,11 @@ describe("quiver public API v2 — scope resolution", () => {
 
   it("public R2 download serves only release-bound delta patches", async () => {
     const env = makeEnv();
-    const { handlePublicR2Download, handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");
+    const {
+      generateSignedR2Url,
+      handlePublicR2Download,
+      handlePublicV2UpdateCheck,
+    } = await import("../src/routes/public_v2");
     await seedRelease(env, "rel-delta-download", "build-delta-download", [["full", "all"]], {
       versionCode: 20,
       versionName: "1.0.20",
@@ -6850,12 +6854,21 @@ describe("quiver public API v2 — scope resolution", () => {
     );
     const body = await responseJson<any>(check);
     const url = new URL(body.patch.download_url);
-    const request = () => handlePublicR2Download(
-      makePublicDownloadContext(env, decodeURIComponent(url.pathname.replace("/public/r2/", "")), {
-        expires: url.searchParams.get("expires") ?? undefined,
-        sig: url.searchParams.get("sig") ?? undefined,
-      }),
+    const requestUrl = (downloadUrl: URL) => handlePublicR2Download(
+      makePublicDownloadContext(
+        env,
+        decodeURIComponent(downloadUrl.pathname.replace("/public/r2/", "")),
+        {
+          expires: downloadUrl.searchParams.get("expires") ?? undefined,
+          sig: downloadUrl.searchParams.get("sig") ?? undefined,
+        },
+      ),
     );
+    const request = () => requestUrl(url);
+    const expectAssetNotFound = async (response: Response) => {
+      expect(response.status).toBe(404);
+      expect(await responseJson<any>(response)).toEqual({ error: "asset not found" });
+    };
 
     const active = await request();
     expect(active.status).toBe(200);
@@ -6866,14 +6879,75 @@ describe("quiver public API v2 — scope resolution", () => {
     );
     expect(await active.text()).toBe("patch");
 
+    // Release identity is independently writable from the build identity.
+    // Both sides must remain non-QA for a signed URL to authorize the object.
+    await env.DB.prepare("UPDATE releases SET release_type = 'qa' WHERE id = ?1")
+      .bind("rel-delta-download")
+      .run();
+    await expectAssetNotFound(await request());
+    await env.DB.prepare("UPDATE releases SET release_type = 'stable' WHERE id = ?1")
+      .bind("rel-delta-download")
+      .run();
+
+    await env.DB.prepare("UPDATE builds SET product_type = 'ios-simulator-qa' WHERE id = ?1")
+      .bind("build-delta-download")
+      .run();
+    await expectAssetNotFound(await request());
+    await env.DB.prepare("UPDATE builds SET product_type = 'android-apk' WHERE id = ?1")
+      .bind("build-delta-download")
+      .run();
+
+    // A support asset on the same active release does not become public merely
+    // because the caller can present a valid Worker-minted signature.
+    const supportKey = "apps/app-scope/delta-download-symbols.zip";
+    await seedAsset(env, "build-delta-download", "asset-delta-download-support", {
+      artifactKind: "native-symbols",
+      filetype: "zip",
+      r2Key: supportKey,
+    });
+    const supportUrl = new URL(
+      await generateSignedR2Url(env as any, supportKey, 3600, "https://quiver-worker.test"),
+    );
+    await expectAssetNotFound(await requestUrl(supportUrl));
+
+    // The delta allowlist is deliberately narrow: a delta-patch row with the
+    // wrong filetype is still private.
+    const wrongFiletypeKey = "apps/app-scope/delta-download-wrong-filetype.zip";
+    await seedAsset(env, "build-delta-download", "asset-delta-download-wrong-filetype", {
+      artifactKind: "delta-patch",
+      filetype: "zip",
+      r2Key: wrongFiletypeKey,
+    });
+    const wrongFiletypeUrl = new URL(
+      await generateSignedR2Url(env as any, wrongFiletypeKey, 3600, "https://quiver-worker.test"),
+    );
+    await expectAssetNotFound(await requestUrl(wrongFiletypeUrl));
+
+    // A delta-patch on a build with no release lifecycle is not public.
+    await seedRelease(env, "rel-unreleased-delta", "build-unreleased-delta", [["full", "all"]], {
+      versionCode: 21,
+      versionName: "1.0.21",
+    });
+    const unreleasedKey = "apps/app-scope/unreleased-delta.patch";
+    await seedAsset(env, "build-unreleased-delta", "asset-unreleased-delta", {
+      artifactKind: "delta-patch",
+      filetype: "patch",
+      r2Key: unreleasedKey,
+    });
+    await env.DB.prepare("DELETE FROM releases WHERE id = ?1")
+      .bind("rel-unreleased-delta")
+      .run();
+    const unreleasedUrl = new URL(
+      await generateSignedR2Url(env as any, unreleasedKey, 3600, "https://quiver-worker.test"),
+    );
+    await expectAssetNotFound(await requestUrl(unreleasedUrl));
+
     // A still-valid URL must stop working as soon as its release is no longer
     // active or draft. The HMAC alone never authorizes an arbitrary R2 object.
     await env.DB.prepare("UPDATE releases SET status = 'cancelled' WHERE id = ?1")
       .bind("rel-delta-download")
       .run();
-    const cancelled = await request();
-    expect(cancelled.status).toBe(404);
-    expect(await responseJson<any>(cancelled)).toEqual({ error: "asset not found" });
+    await expectAssetNotFound(await request());
   });
 
   it("public R2 download redirects to presigned R2 when S3 credentials are configured", async () => {


### PR DESCRIPTION
## Summary

- authorize signed public downloads for release-bound `delta-patch` / `patch` assets while preserving active-or-draft, non-QA release gates
- register the Android full-download receiver with `Context.RECEIVER_NOT_EXPORTED` on API 33+ while keeping the legacy overload on API 24–32
- add regression coverage for canonical patch download, cancellation invalidation, and receiver flag selection
- document the public download authorization boundary and the former 404 failure mode

## Validation

- `pnpm --filter @botiverse/hands-worker test` — 18 files / 252 tests PASS
- `pnpm --filter @botiverse/hands-worker exec vitest run test/routes.test.ts` — 165 tests PASS
- `pnpm --filter @botiverse/hands-worker build` — PASS after generating `worker-configuration.d.ts` from `wrangler.hands.jsonc`
- `git diff --check` — PASS
- local Android Gradle test not run: this VM has neither Gradle nor an Android SDK; Hosted Android SDK Check is the compile/test gate
- worker lint command is currently non-runnable on main because ESLint 9 finds no `eslint.config.*`; no lint assertion is claimed

## Boundaries

Source-only. No merge, Worker deploy, SDK publication/tag, production release/channel/share, or Mobile repin is performed by this PR.

Task: #187
