### PR TITLE
Add authoritative reporter unread receipts and reply attachments

### DIFF
--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -205,7 +205,10 @@ by the immutable database-assigned sequence and clamps the page size to
 whose random UUID sorts earlier. Sequence cursors carry an explicit version.
 During a rolling upgrade, a pre-sequence `(created_at, id)` cursor stays in
 legacy ordering and emits another legacy cursor until that pagination session
-is exhausted; the server never switches ordering mid-session. A successful
+is exhausted; the server never switches ordering mid-session. Because a legacy
+page can be sparse in sequence order, legacy pagination never advances the new
+single high-water read receipt. The next fresh sequence session advances it
+without falsely marking unseen legacy rows read. A successful
 detail response advances the ticket's monotonic read receipt only through the
 latest visible staff/system comment in that returned page, so a concurrent
 reply outside the response snapshot remains unread. The response returns the

--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -344,7 +344,11 @@ store a database-assigned monotonic comment sequence plus the corresponding
 comment id. Only visible staff/system comments after that sequence count as
 unread; reporter comments and internal comments do not. The sequence is fixed
 at insertion, so equal-millisecond replies cannot be lost regardless of random
-UUID lexical order.
+UUID lexical order. Allocation comes from a declared singleton high-water row
+that advances in the same transaction as comment insertion; deletes, cascades,
+and SQL export/import cannot compact or reuse earlier sequence values. Hidden
+SQLite rowids are used only for the one-time migration backfill, never as the
+ongoing allocator.
 
 Before uploading reporter attachments, the Worker records durable leased R2
 cleanup intents. Cleanup cannot claim an `uploading` intent until its bounded

--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -200,7 +200,9 @@ GET /api/apps/{appId}/reporter-feedback/{ticketId}?comment_cursor=<opaque>&comme
 
 The response contains the same reporter-safe ticket projection, original
 attachment metadata, and non-internal comments only. Comment pagination orders
-by `(created_at ASC, id ASC)` and clamps the page size to `1..100`. A successful
+by the immutable database-assigned sequence and clamps the page size to
+`1..100`; opaque cursors therefore cannot skip a same-millisecond later insert
+whose random UUID sorts earlier. A successful
 detail response advances the ticket's monotonic read receipt only through the
 latest visible staff/system comment in that returned page, so a concurrent
 reply outside the response snapshot remains unread. The response returns the
@@ -338,16 +340,21 @@ must choose visibility explicitly; reporter DTOs never select staff/internal
 rows merely because they share the ticket.
 
 Reporter unread receipts are keyed by the full ownership tuple plus ticket and
-store a monotonic `(created_at, comment_id)` cursor. Only visible staff/system
-comments after that cursor count as unread; reporter comments and internal
-comments do not. The comment id tie-breaker prevents equal-millisecond replies
-from being lost.
+store a database-assigned monotonic comment sequence plus the corresponding
+comment id. Only visible staff/system comments after that sequence count as
+unread; reporter comments and internal comments do not. The sequence is fixed
+at insertion, so equal-millisecond replies cannot be lost regardless of random
+UUID lexical order.
 
-Before uploading reporter attachments, the Worker records durable R2 cleanup
-intents. Every attempted generated key is cleaned on upload or D1 failure;
-failed deletes remain due for the scheduled cleanup pass. Cleanup first checks
-for a committed attachment reference, so a stale intent can never delete a
-successfully committed reply file.
+Before uploading reporter attachments, the Worker records durable leased R2
+cleanup intents. Cleanup cannot claim an `uploading` intent until its bounded
+15-minute writer lease expires. Reporter attachment insertion requires the
+intent to remain `uploading`, and the attachment rows plus intent deletion
+commit in one D1 batch; if cleanup claims first, the writer must fail rather
+than commit a missing object. Every attempted key is reconciled after upload or
+D1 failure. Ambiguous D1 outcomes preserve keys already referenced by committed
+attachments, while failed deletes remain `cleanup_claimed` for the scheduled
+retry pass.
 
 Comments remain immutable in v1. Deletion/edit history is outside this slice.
 

--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -177,16 +177,20 @@ The server clamps `limit` to `1..50`. The opaque cursor orders by
       "updated_at": 0,
       "attachment_count": 1,
       "comment_count": 2,
-      "latest_comment_at": 0
+      "latest_comment_at": 0,
+      "unread": true,
+      "unread_count": 2
     }
   ],
-  "next_cursor": "opaque-or-null"
+  "next_cursor": "opaque-or-null",
+  "unread_total": 1
 }
 ```
 
 `comment_count` counts only non-internal comments. The response excludes
 contact data, assignee, client hashes, device identifiers, raw metadata,
-symbolication internals, and internal comment counts.
+symbolication internals, and internal comment counts. `unread_total` counts
+owned tickets with at least one unread visible staff/system comment.
 
 ### Get ticket conversation
 
@@ -196,7 +200,9 @@ GET /api/apps/{appId}/reporter-feedback/{ticketId}?comment_cursor=<opaque>&comme
 
 The response contains the same reporter-safe ticket projection, original
 attachment metadata, and non-internal comments only. Comment pagination orders
-by `(created_at ASC, id ASC)` and clamps the page size to `1..100`.
+by `(created_at ASC, id ASC)` and clamps the page size to `1..100`. A successful
+detail response advances the ticket's monotonic read receipt and returns the
+updated authoritative `unread_total`.
 
 Comment DTO:
 
@@ -221,7 +227,9 @@ GET /api/apps/{appId}/reporter-feedback/{ticketId}/attachments/{attachmentId}
 
 The query verifies app, integration, reporter, ticket, and attachment
 ownership before streaming bytes. Reporter queries return only rows whose
-`origin = 'submission'` and `visibility = 'reporter'`. Presigned URLs, if
+`origin IN ('submission', 'reporter')` and `visibility = 'reporter'`. Reporter
+origin rows are additionally bound to a visible reporter comment on the same
+ticket. Presigned URLs, if
 supported, remain short lived (maximum five minutes) and are created only after
 the same ownership check. Existing filename sanitization, safe content type,
 `Content-Disposition`, and no-sniff response rules remain mandatory.
@@ -238,11 +246,18 @@ Content-Type: application/json
 }
 ```
 
+Text-only JSON remains supported. To attach images, send multipart form fields
+`body`, `submission_id`, and up to three repeated `attachments`. Attachments are
+limited to GIF, JPEG, PNG, or WebP and 10 MiB each.
+
 Comments are plain text. Normalization is exactly ECMAScript `trim()` followed
 by UTF-8 encoding; v1 performs no NFC/NFKC Unicode normalization. The normalized
 body must be non-empty and is limited to 10,000 Unicode code points.
 `submission_id` is required, must be a full UUID, and is normalized to
-lowercase. The fingerprint is SHA-256 of the exact normalized UTF-8 bytes.
+lowercase. Text-only requests retain the existing SHA-256 fingerprint of the
+normalized body bytes. Requests with attachments use a versioned composite of
+the body plus ordered attachment metadata and byte digests, so changing
+filenames, types, sizes, order, or bytes conflicts under the same submission id.
 
 Idempotency is scoped to
 `(ticket_id, reporter_integration_id, reporter_id, submission_id)`:
@@ -252,8 +267,8 @@ Idempotency is scoped to
 - Same id with a different normalized body: `409`.
 - Ticket not owned by the reporter: `404`.
 
-Reporter comments are always non-internal. Comment attachments and reporter
-status changes are outside this first conversation slice.
+Reporter comments and their attachments are always reporter-visible and
+non-internal. Reporter status changes remain outside this slice.
 
 Ownership is checked before idempotency conflict handling. An exact replay does
 not update the ticket timestamp, write another audit row, create another event,
@@ -312,11 +327,18 @@ Schema checks enforce:
 - `author_type IN ('staff', 'system')` implies all reporter ownership and
   idempotency fields are null.
 
-`feedback_attachments` gains explicit `origin` (`submission`, `staff`, or
-`system`) and `visibility` (`reporter` or `internal`) fields. Existing rows
+`feedback_attachments` gains explicit `origin` (`submission`, `reporter`,
+`staff`, or `system`), `visibility` (`reporter` or `internal`), and nullable
+`comment_id` fields. Existing rows
 backfill to submission/reporter visibility. Any future staff or system upload
 must choose visibility explicitly; reporter DTOs never select staff/internal
 rows merely because they share the ticket.
+
+Reporter unread receipts are keyed by the full ownership tuple plus ticket and
+store a monotonic `(created_at, comment_id)` cursor. Only visible staff/system
+comments after that cursor count as unread; reporter comments and internal
+comments do not. The comment id tie-breaker prevents equal-millisecond replies
+from being lost.
 
 Comments remain immutable in v1. Deletion/edit history is outside this slice.
 

--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -201,7 +201,9 @@ GET /api/apps/{appId}/reporter-feedback/{ticketId}?comment_cursor=<opaque>&comme
 The response contains the same reporter-safe ticket projection, original
 attachment metadata, and non-internal comments only. Comment pagination orders
 by `(created_at ASC, id ASC)` and clamps the page size to `1..100`. A successful
-detail response advances the ticket's monotonic read receipt and returns the
+detail response advances the ticket's monotonic read receipt only through the
+latest visible staff/system comment in that returned page, so a concurrent
+reply outside the response snapshot remains unread. The response returns the
 updated authoritative `unread_total`.
 
 Comment DTO:
@@ -256,7 +258,8 @@ body must be non-empty and is limited to 10,000 Unicode code points.
 `submission_id` is required, must be a full UUID, and is normalized to
 lowercase. Text-only requests retain the existing SHA-256 fingerprint of the
 normalized body bytes. Requests with attachments use a versioned composite of
-the body plus ordered attachment metadata and byte digests, so changing
+the body plus each original ordered filename, content type, size, and byte
+digest, so changing
 filenames, types, sizes, order, or bytes conflicts under the same submission id.
 
 Idempotency is scoped to
@@ -339,6 +342,12 @@ store a monotonic `(created_at, comment_id)` cursor. Only visible staff/system
 comments after that cursor count as unread; reporter comments and internal
 comments do not. The comment id tie-breaker prevents equal-millisecond replies
 from being lost.
+
+Before uploading reporter attachments, the Worker records durable R2 cleanup
+intents. Every attempted generated key is cleaned on upload or D1 failure;
+failed deletes remain due for the scheduled cleanup pass. Cleanup first checks
+for a committed attachment reference, so a stale intent can never delete a
+successfully committed reply file.
 
 Comments remain immutable in v1. Deletion/edit history is outside this slice.
 

--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -202,7 +202,10 @@ The response contains the same reporter-safe ticket projection, original
 attachment metadata, and non-internal comments only. Comment pagination orders
 by the immutable database-assigned sequence and clamps the page size to
 `1..100`; opaque cursors therefore cannot skip a same-millisecond later insert
-whose random UUID sorts earlier. A successful
+whose random UUID sorts earlier. Sequence cursors carry an explicit version.
+During a rolling upgrade, a pre-sequence `(created_at, id)` cursor stays in
+legacy ordering and emits another legacy cursor until that pagination session
+is exhausted; the server never switches ordering mid-session. A successful
 detail response advances the ticket's monotonic read receipt only through the
 latest visible staff/system comment in that returned page, so a concurrent
 reply outside the response snapshot remains unread. The response returns the

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -359,7 +359,8 @@ malformed ticket UUIDs return `404` without revealing another reporter's data.
 List and detail responses include Hands-authoritative unread state: each ticket
 has `unread` and `unread_count`, while the response has `unread_total` (the
 number of owned tickets with unread visible staff/system replies). A successful
-detail read advances a monotonic receipt through the latest visible reply;
+detail read advances a monotonic receipt through the latest visible reply in
+the returned comment page; concurrent or later replies remain unread;
 reporter comments and internal staff notes never create unread state.
 
 Reporter comments require a client-generated UUID `submission_id`: new comments

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -356,11 +356,19 @@ the route's `feedback:read` or `feedback:comment` scope, and contain no
 non-feedback scope. Ownership is the exact tuple `(app, reporter integration,
 reporter id)`. Lists return only owned tickets; targeted ownership misses and
 malformed ticket UUIDs return `404` without revealing another reporter's data.
-Reporter comments are text-only and require a client-generated UUID
-`submission_id`: new comments return `201`, exact replays return `200`, and
-reuse with different trimmed UTF-8 text returns `409`. Reporter-visible
-attachments are limited to original submission attachments and are served with
-private/no-store, safe-disposition, and no-sniff headers.
+List and detail responses include Hands-authoritative unread state: each ticket
+has `unread` and `unread_count`, while the response has `unread_total` (the
+number of owned tickets with unread visible staff/system replies). A successful
+detail read advances a monotonic receipt through the latest visible reply;
+reporter comments and internal staff notes never create unread state.
+
+Reporter comments require a client-generated UUID `submission_id`: new comments
+return `201`, exact replays return `200`, and reuse with different trimmed text
+or attachment bytes returns `409`. JSON remains supported for text-only replies.
+Multipart replies use `body`, `submission_id`, and up to three `attachments`;
+each file must be GIF, JPEG, PNG, or WebP and at most 10 MiB. Original submission
+attachments and reporter-comment attachments are served with private/no-store,
+safe-disposition, and no-sniff headers.
 
 Reporter comment and status webhooks carry a stable logical event id in both
 the signed JSON body and `X-Hands-Event-Id`. Each subscription delivery also

--- a/migrations/sql/0054_feedback_reporter_interactions.sql
+++ b/migrations/sql/0054_feedback_reporter_interactions.sql
@@ -1,0 +1,97 @@
+CREATE TABLE feedback_reporter_ticket_reads (
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  reporter_integration_id TEXT NOT NULL
+    REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+  reporter_id TEXT NOT NULL,
+  ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  read_through_created_at INTEGER NOT NULL CHECK (read_through_created_at >= 0),
+  read_through_comment_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (app_id, reporter_integration_id, reporter_id, ticket_id)
+);
+
+CREATE INDEX idx_feedback_reporter_ticket_reads_ticket
+  ON feedback_reporter_ticket_reads(ticket_id, updated_at);
+
+CREATE TRIGGER feedback_reporter_ticket_reads_owner_insert
+BEFORE INSERT ON feedback_reporter_ticket_reads
+WHEN NOT EXISTS (
+  SELECT 1 FROM feedback_tickets t
+  WHERE t.id = NEW.ticket_id
+    AND t.app_id = NEW.app_id
+    AND t.reporter_integration_id = NEW.reporter_integration_id
+    AND t.reporter_id = NEW.reporter_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'feedback reporter read owner mismatch');
+END;
+
+CREATE TRIGGER feedback_reporter_ticket_reads_owner_update
+BEFORE UPDATE OF app_id, reporter_integration_id, reporter_id, ticket_id
+ON feedback_reporter_ticket_reads
+WHEN NOT EXISTS (
+  SELECT 1 FROM feedback_tickets t
+  WHERE t.id = NEW.ticket_id
+    AND t.app_id = NEW.app_id
+    AND t.reporter_integration_id = NEW.reporter_integration_id
+    AND t.reporter_id = NEW.reporter_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'feedback reporter read owner mismatch');
+END;
+
+ALTER TABLE feedback_attachments RENAME TO feedback_attachments_legacy;
+
+CREATE TABLE feedback_attachments (
+  id TEXT PRIMARY KEY,
+  ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  comment_id TEXT REFERENCES feedback_comments(id) ON DELETE CASCADE,
+  r2_key TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  content_type TEXT,
+  size_bytes INTEGER NOT NULL,
+  origin TEXT NOT NULL DEFAULT 'submission'
+    CHECK (origin IN ('submission', 'reporter', 'staff', 'system')),
+  visibility TEXT NOT NULL DEFAULT 'reporter'
+    CHECK (visibility IN ('reporter', 'internal')),
+  created_at INTEGER NOT NULL,
+  CHECK (
+    (origin = 'reporter' AND comment_id IS NOT NULL AND visibility = 'reporter')
+    OR origin != 'reporter'
+  )
+);
+
+INSERT INTO feedback_attachments
+  (id, ticket_id, comment_id, r2_key, filename, content_type, size_bytes,
+   origin, visibility, created_at)
+SELECT id, ticket_id, NULL, r2_key, filename, content_type, size_bytes,
+       origin, visibility, created_at
+FROM feedback_attachments_legacy;
+
+DROP TABLE feedback_attachments_legacy;
+
+CREATE INDEX idx_feedback_attachments_ticket
+  ON feedback_attachments(ticket_id, visibility, origin, created_at, id);
+
+CREATE TRIGGER feedback_reporter_attachments_owner_insert
+BEFORE INSERT ON feedback_attachments
+WHEN NEW.origin = 'reporter' AND NOT EXISTS (
+  SELECT 1 FROM feedback_comments c
+  WHERE c.id = NEW.comment_id AND c.ticket_id = NEW.ticket_id
+    AND c.author_type = 'reporter' AND c.internal = 0
+)
+BEGIN
+  SELECT RAISE(ABORT, 'feedback reporter attachment owner mismatch');
+END;
+
+CREATE TRIGGER feedback_reporter_attachments_owner_update
+BEFORE UPDATE OF ticket_id, comment_id, origin, visibility
+ON feedback_attachments
+WHEN NEW.origin = 'reporter' AND NOT EXISTS (
+  SELECT 1 FROM feedback_comments c
+  WHERE c.id = NEW.comment_id AND c.ticket_id = NEW.ticket_id
+    AND c.author_type = 'reporter' AND c.internal = 0
+)
+BEGIN
+  SELECT RAISE(ABORT, 'feedback reporter attachment owner mismatch');
+END;

--- a/migrations/sql/0054_feedback_reporter_interactions.sql
+++ b/migrations/sql/0054_feedback_reporter_interactions.sql
@@ -1,10 +1,37 @@
+ALTER TABLE feedback_comments ADD COLUMN reporter_sequence INTEGER;
+
+UPDATE feedback_comments SET reporter_sequence = rowid;
+
+CREATE UNIQUE INDEX idx_feedback_comments_reporter_sequence
+  ON feedback_comments(reporter_sequence);
+
+CREATE TRIGGER feedback_comments_reporter_sequence_managed
+BEFORE INSERT ON feedback_comments
+WHEN NEW.reporter_sequence IS NOT NULL
+BEGIN
+  SELECT RAISE(ABORT, 'feedback comment sequence is managed');
+END;
+
+CREATE TRIGGER feedback_comments_reporter_sequence_insert
+AFTER INSERT ON feedback_comments
+BEGIN
+  UPDATE feedback_comments SET reporter_sequence = NEW.rowid WHERE rowid = NEW.rowid;
+END;
+
+CREATE TRIGGER feedback_comments_reporter_sequence_immutable
+BEFORE UPDATE OF reporter_sequence ON feedback_comments
+WHEN OLD.reporter_sequence IS NOT NULL
+BEGIN
+  SELECT RAISE(ABORT, 'feedback comment sequence is immutable');
+END;
+
 CREATE TABLE feedback_reporter_ticket_reads (
   app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
   reporter_integration_id TEXT NOT NULL
     REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
   reporter_id TEXT NOT NULL,
   ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
-  read_through_created_at INTEGER NOT NULL CHECK (read_through_created_at >= 0),
+  read_through_sequence INTEGER NOT NULL CHECK (read_through_sequence > 0),
   read_through_comment_id TEXT NOT NULL,
   updated_at INTEGER NOT NULL,
   PRIMARY KEY (app_id, reporter_integration_id, reporter_id, ticket_id)
@@ -98,6 +125,8 @@ END;
 
 CREATE TABLE feedback_reporter_r2_cleanup (
   r2_key TEXT PRIMARY KEY,
+  state TEXT NOT NULL CHECK (state IN ('uploading', 'cleanup_claimed')),
+  lease_expires_at INTEGER NOT NULL,
   attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
   last_error TEXT,
   next_attempt_at INTEGER NOT NULL,
@@ -107,3 +136,13 @@ CREATE TABLE feedback_reporter_r2_cleanup (
 
 CREATE INDEX idx_feedback_reporter_r2_cleanup_due
   ON feedback_reporter_r2_cleanup(next_attempt_at, r2_key);
+
+CREATE TRIGGER feedback_reporter_attachments_cleanup_insert
+BEFORE INSERT ON feedback_attachments
+WHEN NEW.origin = 'reporter' AND NOT EXISTS (
+  SELECT 1 FROM feedback_reporter_r2_cleanup cleanup
+  WHERE cleanup.r2_key = NEW.r2_key AND cleanup.state = 'uploading'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'feedback reporter attachment cleanup intent missing');
+END;

--- a/migrations/sql/0054_feedback_reporter_interactions.sql
+++ b/migrations/sql/0054_feedback_reporter_interactions.sql
@@ -5,6 +5,27 @@ UPDATE feedback_comments SET reporter_sequence = rowid;
 CREATE UNIQUE INDEX idx_feedback_comments_reporter_sequence
   ON feedback_comments(reporter_sequence);
 
+CREATE TABLE feedback_comment_sequence_state (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  high_water INTEGER NOT NULL CHECK (high_water >= 0)
+);
+
+INSERT INTO feedback_comment_sequence_state (singleton, high_water)
+SELECT 1, COALESCE(MAX(reporter_sequence), 0) FROM feedback_comments;
+
+CREATE TRIGGER feedback_comment_sequence_state_no_delete
+BEFORE DELETE ON feedback_comment_sequence_state
+BEGIN
+  SELECT RAISE(ABORT, 'feedback comment sequence state is durable');
+END;
+
+CREATE TRIGGER feedback_comment_sequence_state_monotonic
+BEFORE UPDATE ON feedback_comment_sequence_state
+WHEN NEW.singleton != OLD.singleton OR NEW.high_water != OLD.high_water + 1
+BEGIN
+  SELECT RAISE(ABORT, 'feedback comment sequence high-water must advance by one');
+END;
+
 CREATE TRIGGER feedback_comments_reporter_sequence_managed
 BEFORE INSERT ON feedback_comments
 WHEN NEW.reporter_sequence IS NOT NULL
@@ -15,7 +36,13 @@ END;
 CREATE TRIGGER feedback_comments_reporter_sequence_insert
 AFTER INSERT ON feedback_comments
 BEGIN
-  UPDATE feedback_comments SET reporter_sequence = NEW.rowid WHERE rowid = NEW.rowid;
+  UPDATE feedback_comment_sequence_state
+  SET high_water = high_water + 1 WHERE singleton = 1;
+  UPDATE feedback_comments
+  SET reporter_sequence = (
+    SELECT high_water FROM feedback_comment_sequence_state WHERE singleton = 1
+  )
+  WHERE rowid = NEW.rowid;
 END;
 
 CREATE TRIGGER feedback_comments_reporter_sequence_immutable

--- a/migrations/sql/0054_feedback_reporter_interactions.sql
+++ b/migrations/sql/0054_feedback_reporter_interactions.sql
@@ -95,3 +95,15 @@ WHEN NEW.origin = 'reporter' AND NOT EXISTS (
 BEGIN
   SELECT RAISE(ABORT, 'feedback reporter attachment owner mismatch');
 END;
+
+CREATE TABLE feedback_reporter_r2_cleanup (
+  r2_key TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  last_error TEXT,
+  next_attempt_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_feedback_reporter_r2_cleanup_due
+  ON feedback_reporter_r2_cleanup(next_attempt_at, r2_key);

--- a/worker/src/openapi/feedback.ts
+++ b/worker/src/openapi/feedback.ts
@@ -8,6 +8,7 @@ import {
   binary,
   error,
   json,
+  multipart,
   register,
   success,
   type OpenApiRegistry,
@@ -119,7 +120,7 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
       query: z.object({ limit: z.coerce.number().int().min(1).max(50).default(20), cursor: z.string().optional() }),
     },
     responses: {
-      200: success("Reporter-owned feedback list.", GenericObject),
+      200: success("Reporter-owned feedback list with authoritative unread totals.", GenericObject),
       400: error("Missing or malformed reporter id or cursor."),
       401: error("Missing or invalid bearer token."),
       403: error("Bearer grant is not an active reporter integration grant."),
@@ -142,7 +143,7 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
       }),
     },
     responses: {
-      200: success("Reporter-owned feedback details.", GenericObject),
+      200: success("Reporter-owned feedback details; successful reads advance the authoritative receipt.", GenericObject),
       400: error("Missing or malformed reporter id."),
       401: error("Missing or invalid bearer token."),
       403: error("Invalid reporter integration grant."),
@@ -155,21 +156,24 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
     method: "post",
     path: "/api/apps/{appId}/reporter-feedback/{ticketId}/comments",
     tags: ["Reporter Feedback"],
-    summary: "Add an idempotent reporter comment",
+    summary: "Add an idempotent reporter comment with optional image attachments",
     security: auth,
     request: {
       params: AppTicketParams,
       headers: ReporterHeaders,
-      body: { content: json(ReporterCommentInput), required: true },
+      body: {
+        content: { ...json(ReporterCommentInput), ...multipart() },
+        required: true,
+      },
     },
     responses: {
       200: success("Exact idempotent replay.", GenericObject),
       201: success("Reporter comment created.", GenericObject),
-      400: error("Invalid reporter id, body, or submission id."),
+      400: error("Invalid reporter id, body, submission id, or attachment."),
       401: error("Missing or invalid bearer token."),
       403: error("Invalid reporter integration grant."),
       404: error("Ticket is not owned by this reporter integration."),
-      409: error("Submission id was already used with a different body."),
+      409: error("Submission id was already used with a different body or attachment set."),
       429: error("Reporter rate limit exceeded."),
     },
   });
@@ -178,7 +182,7 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
     method: "get",
     path: "/api/apps/{appId}/reporter-feedback/{ticketId}/attachments/{attachmentId}",
     tags: ["Reporter Feedback"],
-    summary: "Download a reporter-visible submission attachment",
+    summary: "Download a reporter-visible submission or reporter-comment attachment",
     security: auth,
     request: { params: AttachmentParams, headers: ReporterHeaders },
     responses: {

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -7,6 +7,14 @@ type ReporterContext = Context<{ Bindings: Env }>;
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const COMMENT_MAX_CHARS = 10_000;
+const COMMENT_MAX_ATTACHMENTS = 3;
+const COMMENT_MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const COMMENT_ATTACHMENT_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
 
 type ReporterEnv = Env & {
   FEEDBACK_AUDIT_HMAC_KEY?: string;
@@ -190,6 +198,9 @@ function ticketNotFound(c: ReporterContext) {
 }
 
 function ticketDto(row: Record<string, unknown>) {
+  const unreadCount = typeof row.unread_count === "number"
+    ? Math.max(0, row.unread_count)
+    : 0;
   return {
     id: row.id,
     kind: row.kind,
@@ -203,7 +214,40 @@ function ticketDto(row: Record<string, unknown>) {
     attachment_count: row.attachment_count,
     comment_count: row.comment_count,
     latest_comment_at: row.latest_comment_at,
+    unread: unreadCount > 0,
+    unread_count: unreadCount,
   };
+}
+
+const unreadCountSql = `(SELECT COUNT(*) FROM feedback_comments unread_comment
+  WHERE unread_comment.ticket_id = t.id
+    AND unread_comment.internal = 0
+    AND unread_comment.author_type IN ('staff', 'system')
+    AND (
+      rr.ticket_id IS NULL
+      OR unread_comment.created_at > rr.read_through_created_at
+      OR (
+        unread_comment.created_at = rr.read_through_created_at
+        AND unread_comment.id > rr.read_through_comment_id
+      )
+    ))`;
+
+async function unreadTotal(
+  c: ReporterContext,
+  principal: ReporterPrincipal,
+): Promise<number> {
+  const row = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS unread_total FROM feedback_tickets t
+     LEFT JOIN feedback_reporter_ticket_reads rr
+       ON rr.app_id = t.app_id
+      AND rr.reporter_integration_id = t.reporter_integration_id
+      AND rr.reporter_id = t.reporter_id
+      AND rr.ticket_id = t.id
+     WHERE t.app_id = ?1 AND t.reporter_integration_id = ?2
+       AND t.reporter_id = ?3 AND ${unreadCountSql} > 0`,
+  ).bind(principal.appId, principal.integrationId, principal.reporterId)
+    .first<{ unread_total: number }>();
+  return Math.max(0, row?.unread_total ?? 0);
 }
 
 export async function handleListReporterFeedback(c: ReporterContext) {
@@ -213,17 +257,24 @@ export async function handleListReporterFeedback(c: ReporterContext) {
   const decodedCursor = decodeCursor(c.req.query("cursor"));
   if (!decodedCursor) return c.json({ error: "invalid cursor" }, 400);
   const [cursorCreatedAt, cursorId] = decodedCursor;
-  const { results } = await c.env.DB.prepare(
+  const [{ results }, totalUnread] = await Promise.all([
+    c.env.DB.prepare(
     `SELECT t.id, t.kind, t.status, t.message, t.version_name, t.version_code,
             t.channel, t.created_at, t.updated_at,
             (SELECT COUNT(*) FROM feedback_attachments fa
-             WHERE fa.ticket_id = t.id AND fa.origin = 'submission'
+             WHERE fa.ticket_id = t.id AND fa.origin IN ('submission', 'reporter')
                AND fa.visibility = 'reporter') AS attachment_count,
             (SELECT COUNT(*) FROM feedback_comments fc
              WHERE fc.ticket_id = t.id AND fc.internal = 0) AS comment_count,
             (SELECT MAX(fc.created_at) FROM feedback_comments fc
-             WHERE fc.ticket_id = t.id AND fc.internal = 0) AS latest_comment_at
+             WHERE fc.ticket_id = t.id AND fc.internal = 0) AS latest_comment_at,
+            ${unreadCountSql} AS unread_count
      FROM feedback_tickets t
+     LEFT JOIN feedback_reporter_ticket_reads rr
+       ON rr.app_id = t.app_id
+      AND rr.reporter_integration_id = t.reporter_integration_id
+      AND rr.reporter_id = t.reporter_id
+      AND rr.ticket_id = t.id
      WHERE t.app_id = ?1 AND t.reporter_integration_id = ?2 AND t.reporter_id = ?3
        AND (t.created_at < ?4 OR (t.created_at = ?4 AND t.id < ?5))
      ORDER BY t.created_at DESC, t.id DESC LIMIT ?6`,
@@ -234,14 +285,20 @@ export async function handleListReporterFeedback(c: ReporterContext) {
     cursorCreatedAt,
     cursorId,
     limit + 1,
-  ).all<Record<string, unknown>>();
+  ).all<Record<string, unknown>>(),
+    unreadTotal(c, authorized.principal),
+  ]);
   const page = results.slice(0, limit);
   const last = page.at(-1);
   const nextCursor = results.length > limit && last
     ? encodeCursor(last.created_at, last.id)
     : null;
   await auditRead(c, authorized.principal, authorized.pseudonym, "list");
-  return c.json({ tickets: page.map(ticketDto), next_cursor: nextCursor });
+  return c.json({
+    tickets: page.map(ticketDto),
+    next_cursor: nextCursor,
+    unread_total: totalUnread,
+  });
 }
 
 async function ownedTicket(c: ReporterContext, principal: ReporterPrincipal, ticketId: string) {
@@ -249,17 +306,65 @@ async function ownedTicket(c: ReporterContext, principal: ReporterPrincipal, tic
     `SELECT t.id, t.kind, t.status, t.message, t.version_name, t.version_code,
             t.channel, t.created_at, t.updated_at, a.org_id,
             (SELECT COUNT(*) FROM feedback_attachments fa
-             WHERE fa.ticket_id = t.id AND fa.origin = 'submission'
+             WHERE fa.ticket_id = t.id AND fa.origin IN ('submission', 'reporter')
                AND fa.visibility = 'reporter') AS attachment_count,
             (SELECT COUNT(*) FROM feedback_comments fc
              WHERE fc.ticket_id = t.id AND fc.internal = 0) AS comment_count,
             (SELECT MAX(fc.created_at) FROM feedback_comments fc
-             WHERE fc.ticket_id = t.id AND fc.internal = 0) AS latest_comment_at
+             WHERE fc.ticket_id = t.id AND fc.internal = 0) AS latest_comment_at,
+            ${unreadCountSql} AS unread_count
      FROM feedback_tickets t JOIN apps a ON a.id = t.app_id
+     LEFT JOIN feedback_reporter_ticket_reads rr
+       ON rr.app_id = t.app_id
+      AND rr.reporter_integration_id = t.reporter_integration_id
+      AND rr.reporter_id = t.reporter_id
+      AND rr.ticket_id = t.id
      WHERE t.id = ?1 AND t.app_id = ?2
        AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4`,
   ).bind(ticketId, principal.appId, principal.integrationId, principal.reporterId)
     .first<Record<string, unknown> & { org_id: string | null }>();
+}
+
+async function markTicketRead(
+  c: ReporterContext,
+  principal: ReporterPrincipal,
+  ticketId: string,
+): Promise<void> {
+  const latest = await c.env.DB.prepare(
+    `SELECT id, created_at FROM feedback_comments
+     WHERE ticket_id = ?1 AND internal = 0
+       AND author_type IN ('staff', 'system')
+     ORDER BY created_at DESC, id DESC LIMIT 1`,
+  ).bind(ticketId).first<{ id: string; created_at: number }>();
+  if (!latest) return;
+  const now = Date.now();
+  await c.env.DB.prepare(
+    `INSERT INTO feedback_reporter_ticket_reads
+     (app_id, reporter_integration_id, reporter_id, ticket_id,
+      read_through_created_at, read_through_comment_id, updated_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+     ON CONFLICT(app_id, reporter_integration_id, reporter_id, ticket_id)
+     DO UPDATE SET
+       read_through_created_at = CASE
+         WHEN excluded.read_through_created_at > read_through_created_at
+           OR (excluded.read_through_created_at = read_through_created_at
+               AND excluded.read_through_comment_id > read_through_comment_id)
+         THEN excluded.read_through_created_at ELSE read_through_created_at END,
+       read_through_comment_id = CASE
+         WHEN excluded.read_through_created_at > read_through_created_at
+           OR (excluded.read_through_created_at = read_through_created_at
+               AND excluded.read_through_comment_id > read_through_comment_id)
+         THEN excluded.read_through_comment_id ELSE read_through_comment_id END,
+       updated_at = excluded.updated_at`,
+  ).bind(
+    principal.appId,
+    principal.integrationId,
+    principal.reporterId,
+    ticketId,
+    latest.created_at,
+    latest.id,
+    now,
+  ).run();
 }
 
 export async function handleGetReporterFeedback(c: ReporterContext) {
@@ -284,11 +389,13 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
     c.env.DB.prepare(
       `SELECT id, filename, content_type, size_bytes, created_at
        FROM feedback_attachments
-       WHERE ticket_id = ?1 AND origin = 'submission' AND visibility = 'reporter'
+       WHERE ticket_id = ?1 AND origin IN ('submission', 'reporter') AND visibility = 'reporter'
        ORDER BY created_at, id`,
     ).bind(ticketId).all(),
   ]);
   await auditRead(c, authorized.principal, authorized.pseudonym, "detail", { ticketId });
+  await markTicketRead(c, authorized.principal, ticketId);
+  const totalUnread = await unreadTotal(c, authorized.principal);
   const { org_id: _orgId, ...safeTicket } = ticket;
   const commentPage = comments.slice(0, commentLimit);
   const lastComment = commentPage.at(-1);
@@ -296,16 +403,77 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
     ? encodeCursor(lastComment.created_at, lastComment.id)
     : null;
   return c.json({
-    ticket: ticketDto(safeTicket),
+    ticket: { ...ticketDto(safeTicket), unread: false, unread_count: 0 },
     comments: commentPage,
     next_comment_cursor: nextCommentCursor,
     attachments,
+    unread_total: totalUnread,
   });
 }
 
 async function sha256Hex(input: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
   return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+type ReporterCommentAttachment = {
+  bytes: ArrayBuffer;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  digest: string;
+};
+
+async function parseReporterCommentInput(c: ReporterContext): Promise<{
+  text: string;
+  submissionId: string | null;
+  attachments: ReporterCommentAttachment[];
+} | null> {
+  const contentType = c.req.header("content-type") ?? "";
+  let rawText: unknown;
+  let rawSubmissionId: unknown;
+  let files: File[] = [];
+  if (contentType.toLowerCase().startsWith("multipart/form-data")) {
+    let form: FormData;
+    try {
+      form = await c.req.formData();
+    } catch {
+      return null;
+    }
+    rawText = form.get("body");
+    rawSubmissionId = form.get("submission_id");
+    for (const value of form.getAll("attachments")) {
+      if (typeof value !== "string") files.push(value as File);
+    }
+  } else {
+    const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!body) return null;
+    rawText = body.body;
+    rawSubmissionId = body.submission_id;
+  }
+  const text = typeof rawText === "string" ? rawText.trim() : "";
+  const submissionId = fullUuid(typeof rawSubmissionId === "string" ? rawSubmissionId : undefined);
+  if (!text || [...text].length > COMMENT_MAX_CHARS || !submissionId) return null;
+  if (files.length > COMMENT_MAX_ATTACHMENTS) return null;
+  const attachments: ReporterCommentAttachment[] = [];
+  for (const file of files) {
+    if (
+      file.size > COMMENT_MAX_ATTACHMENT_BYTES
+      || !COMMENT_ATTACHMENT_TYPES.has(file.type.toLowerCase())
+    ) return null;
+    const bytes = await file.arrayBuffer();
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    attachments.push({
+      bytes,
+      filename: safeFilename(file.name),
+      contentType: file.type.toLowerCase(),
+      sizeBytes: file.size,
+      digest: Array.from(new Uint8Array(digest))
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join(""),
+    });
+  }
+  return { text, submissionId, attachments };
 }
 
 export async function handleAddReporterComment(c: ReporterContext) {
@@ -315,13 +483,21 @@ export async function handleAddReporterComment(c: ReporterContext) {
   if (!ticketId) return ticketNotFound(c);
   const ticket = await ownedTicket(c, authorized.principal, ticketId);
   if (!ticket) return ticketNotFound(c);
-  const body = (await c.req.json().catch(() => ({}))) as { body?: unknown; submission_id?: unknown };
-  const text = typeof body.body === "string" ? body.body.trim() : "";
-  const submissionId = fullUuid(typeof body.submission_id === "string" ? body.submission_id : undefined);
-  if (!text) return c.json({ error: "body is required" }, 400);
-  if ([...text].length > COMMENT_MAX_CHARS) return c.json({ error: `body too long (max ${COMMENT_MAX_CHARS} chars)` }, 400);
-  if (!submissionId) return c.json({ error: "submission_id must be a UUID" }, 400);
-  const fingerprint = await sha256Hex(text);
+  const input = await parseReporterCommentInput(c);
+  if (!input) return c.json({ error: "invalid reporter comment" }, 400);
+  const { text, submissionId, attachments } = input;
+  const fingerprint = attachments.length === 0
+    ? await sha256Hex(text)
+    : await sha256Hex(JSON.stringify([
+        "reporter-comment-v2",
+        text,
+        ...attachments.map((attachment) => [
+          attachment.filename,
+          attachment.contentType,
+          attachment.sizeBytes,
+          attachment.digest,
+        ]),
+      ]));
   const existingComment = async () => c.env.DB.prepare(
     `SELECT id, submission_fingerprint, created_at FROM feedback_comments
      WHERE ticket_id = ?1 AND reporter_integration_id = ?2
@@ -339,6 +515,11 @@ export async function handleAddReporterComment(c: ReporterContext) {
   const now = Date.now();
   const commentId = crypto.randomUUID();
   const eventId = crypto.randomUUID();
+  const attachmentRows = attachments.map((attachment, index) => ({
+    ...attachment,
+    id: crypto.randomUUID(),
+    r2Key: `feedback/${authorized.principal.appId}/${ticketId}/comments/${commentId}/${index}-${attachment.filename}`,
+  }));
   const eventBody = buildFeedbackCommentEvent({
     eventId,
     eventType: "feedback:comment_created",
@@ -356,7 +537,14 @@ export async function handleAddReporterComment(c: ReporterContext) {
     reporter_hash: authorized.pseudonym.hash,
     audit_key_version: authorized.pseudonym.version,
   });
+  const uploadedKeys: string[] = [];
   try {
+    for (const attachment of attachmentRows) {
+      await c.env.APK_BUCKET.put(attachment.r2Key, attachment.bytes, {
+        httpMetadata: { contentType: attachment.contentType },
+      });
+      uploadedKeys.push(attachment.r2Key);
+    }
     await c.env.DB.batch([
       c.env.DB.prepare(
         `INSERT INTO feedback_comments
@@ -376,6 +564,21 @@ export async function handleAddReporterComment(c: ReporterContext) {
         now,
       ),
       c.env.DB.prepare("UPDATE feedback_tickets SET updated_at = ?1 WHERE id = ?2").bind(now, ticketId),
+      ...attachmentRows.map((attachment) => c.env.DB.prepare(
+        `INSERT INTO feedback_attachments
+         (id, ticket_id, comment_id, r2_key, filename, content_type,
+          size_bytes, origin, visibility, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'reporter', 'reporter', ?8)`,
+      ).bind(
+        attachment.id,
+        ticketId,
+        commentId,
+        attachment.r2Key,
+        attachment.filename,
+        attachment.contentType,
+        attachment.sizeBytes,
+        now,
+      )),
       c.env.DB.prepare(
         `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
          VALUES (?1, ?2, 'feedback.reporter_comment', ?3, ?4, ?5)`,
@@ -462,6 +665,7 @@ export async function handleAddReporterComment(c: ReporterContext) {
       ).bind(eventId, now, ticket.org_id),
     ]);
   } catch (error) {
+    await Promise.allSettled(uploadedKeys.map((key) => c.env.APK_BUCKET.delete(key)));
     const concurrent = await existingComment();
     if (concurrent) {
       if (concurrent.submission_fingerprint !== fingerprint) {
@@ -486,7 +690,7 @@ export async function handleDownloadReporterAttachment(c: ReporterContext) {
      JOIN feedback_tickets t ON t.id = fa.ticket_id
      WHERE t.id = ?1 AND t.app_id = ?2
        AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4
-       AND fa.id = ?5 AND fa.origin = 'submission' AND fa.visibility = 'reporter'`,
+       AND fa.id = ?5 AND fa.origin IN ('submission', 'reporter') AND fa.visibility = 'reporter'`,
   ).bind(
     ticketId,
     authorized.principal.appId,

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -430,11 +430,17 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
     ).bind(ticketId).all(),
   ]);
   const commentPage = comments.slice(0, commentLimit);
-  const readWatermark = [...commentPage].reverse().find((comment) =>
-    (comment.author_type === "staff" || comment.author_type === "system")
-    && typeof comment.reporter_sequence === "number"
-    && typeof comment.id === "string"
-  ) as { id: string; reporter_sequence: number } | undefined;
+  // A legacy (created_at, id)-ordered page is not necessarily contiguous in
+  // reporter_sequence, so a single high-water receipt cannot represent it
+  // without false-reading unseen rows. Legacy sessions paginate only; the next
+  // fresh sequence session advances the authoritative receipt.
+  const readWatermark = commentCursor.mode === "sequence"
+    ? [...commentPage].reverse().find((comment) =>
+        (comment.author_type === "staff" || comment.author_type === "system")
+        && typeof comment.reporter_sequence === "number"
+        && typeof comment.id === "string"
+      ) as { id: string; reporter_sequence: number } | undefined
+    : undefined;
   await auditRead(c, authorized.principal, authorized.pseudonym, "detail", { ticketId });
   await markTicketRead(c, authorized.principal, ticketId, readWatermark ?? null);
   const [totalUnread, refreshedTicket] = await Promise.all([

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -40,24 +40,70 @@ function safeFilename(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) || "attachment";
 }
 
-function encodeCursor(createdAt: unknown, id: unknown): string {
-  return btoa(JSON.stringify([createdAt, id]))
+function encodeCursorValue(value: unknown): string {
+  return btoa(JSON.stringify(value))
     .replaceAll("+", "-")
     .replaceAll("/", "_")
     .replaceAll("=", "");
 }
 
-function decodeCursor(value: string | undefined): [number, string] | null {
-  if (!value) return [Number.MAX_SAFE_INTEGER, "~"];
+function decodeCursorValue(value: string): unknown {
   try {
     const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
     const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
-    const decoded = JSON.parse(atob(padded)) as [number, string];
+    return JSON.parse(atob(padded));
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(createdAt: unknown, id: unknown): string {
+  return encodeCursorValue([createdAt, id]);
+}
+
+function decodeCursor(value: string | undefined): [number, string] | null {
+  if (!value) return [Number.MAX_SAFE_INTEGER, "~"];
+  try {
+    const decoded = decodeCursorValue(value) as [number, string];
     if (!Number.isSafeInteger(decoded[0]) || !UUID_RE.test(decoded[1])) return null;
     return [decoded[0], decoded[1].toLowerCase()];
   } catch {
     return null;
   }
+}
+
+type CommentCursor =
+  | { mode: "sequence"; sequence: number; id: string }
+  | { mode: "legacy"; createdAt: number; id: string };
+
+function decodeCommentCursor(value: string | undefined): CommentCursor | null {
+  if (!value) return { mode: "sequence", sequence: 0, id: "" };
+  const decoded = decodeCursorValue(value);
+  if (
+    Array.isArray(decoded)
+    && decoded.length === 3
+    && decoded[0] === "sequence-v1"
+    && Number.isSafeInteger(decoded[1])
+    && decoded[1] >= 0
+    && typeof decoded[2] === "string"
+    && UUID_RE.test(decoded[2])
+  ) {
+    return { mode: "sequence", sequence: decoded[1], id: decoded[2].toLowerCase() };
+  }
+  if (
+    Array.isArray(decoded)
+    && decoded.length === 2
+    && Number.isSafeInteger(decoded[0])
+    && typeof decoded[1] === "string"
+    && UUID_RE.test(decoded[1])
+  ) {
+    return { mode: "legacy", createdAt: decoded[0], id: decoded[1].toLowerCase() };
+  }
+  return null;
+}
+
+function encodeCommentSequenceCursor(sequence: unknown, id: unknown): string {
+  return encodeCursorValue(["sequence-v1", sequence, id]);
 }
 
 async function reporterHash(c: ReporterContext, principal: ReporterPrincipal) {
@@ -358,31 +404,24 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
   const ticket = await ownedTicket(c, authorized.principal, ticketId);
   if (!ticket) return ticketNotFound(c);
   const commentLimit = Math.min(100, Math.max(1, Number(c.req.query("comment_limit") ?? "50") || 50));
-  const rawCommentCursor = c.req.query("comment_cursor");
-  const decodedCommentCursor = rawCommentCursor ? decodeCursor(rawCommentCursor) : [0, ""] as [number, string];
-  if (!decodedCommentCursor) return c.json({ error: "invalid comment cursor" }, 400);
-  const [commentCursorPosition, commentCursorId] = decodedCommentCursor;
-  // Pre-sequence cursors encoded epoch-millisecond created_at as their first
-  // coordinate. Accept those during rolling upgrades; all new cursors use the
-  // immutable database-assigned reporter_sequence.
-  const legacyCommentCursor = rawCommentCursor && commentCursorPosition > 10_000_000_000 ? 1 : 0;
+  const commentCursor = decodeCommentCursor(c.req.query("comment_cursor"));
+  if (!commentCursor) return c.json({ error: "invalid comment cursor" }, 400);
+  const commentStatement = commentCursor.mode === "sequence"
+    ? c.env.DB.prepare(
+        `SELECT id, author_type, body, created_at, reporter_sequence
+         FROM feedback_comments
+         WHERE ticket_id = ?1 AND internal = 0 AND reporter_sequence > ?2
+         ORDER BY reporter_sequence ASC LIMIT ?3`,
+      ).bind(ticketId, commentCursor.sequence, commentLimit + 1)
+    : c.env.DB.prepare(
+        `SELECT id, author_type, body, created_at, reporter_sequence
+         FROM feedback_comments
+         WHERE ticket_id = ?1 AND internal = 0
+           AND (created_at > ?2 OR (created_at = ?2 AND id > ?3))
+         ORDER BY created_at ASC, id ASC LIMIT ?4`,
+      ).bind(ticketId, commentCursor.createdAt, commentCursor.id, commentLimit + 1);
   const [{ results: comments }, { results: attachments }] = await Promise.all([
-    c.env.DB.prepare(
-      `SELECT id, author_type, body, created_at, reporter_sequence
-       FROM feedback_comments
-       WHERE ticket_id = ?1 AND internal = 0
-         AND (
-           (?4 = 0 AND reporter_sequence > ?2)
-           OR (?4 = 1 AND (created_at > ?2 OR (created_at = ?2 AND id > ?3)))
-         )
-       ORDER BY reporter_sequence ASC LIMIT ?5`,
-    ).bind(
-      ticketId,
-      commentCursorPosition,
-      commentCursorId,
-      legacyCommentCursor,
-      commentLimit + 1,
-    ).all<Record<string, unknown>>(),
+    commentStatement.all<Record<string, unknown>>(),
     c.env.DB.prepare(
       `SELECT id, filename, content_type, size_bytes, created_at
        FROM feedback_attachments
@@ -405,7 +444,9 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
   const { org_id: _orgId, ...safeTicket } = refreshedTicket ?? ticket;
   const lastComment = commentPage.at(-1);
   const nextCommentCursor = comments.length > commentLimit && lastComment
-    ? encodeCursor(lastComment.reporter_sequence, lastComment.id)
+    ? commentCursor.mode === "legacy"
+      ? encodeCursor(lastComment.created_at, lastComment.id)
+      : encodeCommentSequenceCursor(lastComment.reporter_sequence, lastComment.id)
     : null;
   return c.json({
     ticket: ticketDto(safeTicket),

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -9,6 +9,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 const COMMENT_MAX_CHARS = 10_000;
 const COMMENT_MAX_ATTACHMENTS = 3;
 const COMMENT_MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const COMMENT_UPLOAD_LEASE_MS = 15 * 60_000;
 const COMMENT_ATTACHMENT_TYPES = new Set([
   "image/gif",
   "image/jpeg",
@@ -57,11 +58,6 @@ function decodeCursor(value: string | undefined): [number, string] | null {
   } catch {
     return null;
   }
-}
-
-function decodeAscendingCursor(value: string | undefined): [number, string] | null {
-  if (!value) return [-1, ""];
-  return decodeCursor(value);
 }
 
 async function reporterHash(c: ReporterContext, principal: ReporterPrincipal) {
@@ -225,11 +221,7 @@ const unreadCountSql = `(SELECT COUNT(*) FROM feedback_comments unread_comment
     AND unread_comment.author_type IN ('staff', 'system')
     AND (
       rr.ticket_id IS NULL
-      OR unread_comment.created_at > rr.read_through_created_at
-      OR (
-        unread_comment.created_at = rr.read_through_created_at
-        AND unread_comment.id > rr.read_through_comment_id
-      )
+      OR unread_comment.reporter_sequence > rr.read_through_sequence
     ))`;
 
 async function unreadTotal(
@@ -329,26 +321,22 @@ async function markTicketRead(
   c: ReporterContext,
   principal: ReporterPrincipal,
   ticketId: string,
-  latest: { id: string; created_at: number } | null,
+  latest: { id: string; reporter_sequence: number } | null,
 ): Promise<void> {
   if (!latest) return;
   const now = Date.now();
   await c.env.DB.prepare(
     `INSERT INTO feedback_reporter_ticket_reads
      (app_id, reporter_integration_id, reporter_id, ticket_id,
-      read_through_created_at, read_through_comment_id, updated_at)
+      read_through_sequence, read_through_comment_id, updated_at)
      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
      ON CONFLICT(app_id, reporter_integration_id, reporter_id, ticket_id)
      DO UPDATE SET
-       read_through_created_at = CASE
-         WHEN excluded.read_through_created_at > read_through_created_at
-           OR (excluded.read_through_created_at = read_through_created_at
-               AND excluded.read_through_comment_id > read_through_comment_id)
-         THEN excluded.read_through_created_at ELSE read_through_created_at END,
+       read_through_sequence = CASE
+         WHEN excluded.read_through_sequence > read_through_sequence
+         THEN excluded.read_through_sequence ELSE read_through_sequence END,
        read_through_comment_id = CASE
-         WHEN excluded.read_through_created_at > read_through_created_at
-           OR (excluded.read_through_created_at = read_through_created_at
-               AND excluded.read_through_comment_id > read_through_comment_id)
+         WHEN excluded.read_through_sequence > read_through_sequence
          THEN excluded.read_through_comment_id ELSE read_through_comment_id END,
        updated_at = excluded.updated_at`,
   ).bind(
@@ -356,7 +344,7 @@ async function markTicketRead(
     principal.integrationId,
     principal.reporterId,
     ticketId,
-    latest.created_at,
+    latest.reporter_sequence,
     latest.id,
     now,
   ).run();
@@ -370,17 +358,31 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
   const ticket = await ownedTicket(c, authorized.principal, ticketId);
   if (!ticket) return ticketNotFound(c);
   const commentLimit = Math.min(100, Math.max(1, Number(c.req.query("comment_limit") ?? "50") || 50));
-  const decodedCommentCursor = decodeAscendingCursor(c.req.query("comment_cursor"));
+  const rawCommentCursor = c.req.query("comment_cursor");
+  const decodedCommentCursor = rawCommentCursor ? decodeCursor(rawCommentCursor) : [0, ""] as [number, string];
   if (!decodedCommentCursor) return c.json({ error: "invalid comment cursor" }, 400);
-  const [commentCursorCreatedAt, commentCursorId] = decodedCommentCursor;
+  const [commentCursorPosition, commentCursorId] = decodedCommentCursor;
+  // Pre-sequence cursors encoded epoch-millisecond created_at as their first
+  // coordinate. Accept those during rolling upgrades; all new cursors use the
+  // immutable database-assigned reporter_sequence.
+  const legacyCommentCursor = rawCommentCursor && commentCursorPosition > 10_000_000_000 ? 1 : 0;
   const [{ results: comments }, { results: attachments }] = await Promise.all([
     c.env.DB.prepare(
-      `SELECT id, author_type, body, created_at
+      `SELECT id, author_type, body, created_at, reporter_sequence
        FROM feedback_comments
        WHERE ticket_id = ?1 AND internal = 0
-         AND (created_at > ?2 OR (created_at = ?2 AND id > ?3))
-       ORDER BY created_at ASC, id ASC LIMIT ?4`,
-    ).bind(ticketId, commentCursorCreatedAt, commentCursorId, commentLimit + 1).all<Record<string, unknown>>(),
+         AND (
+           (?4 = 0 AND reporter_sequence > ?2)
+           OR (?4 = 1 AND (created_at > ?2 OR (created_at = ?2 AND id > ?3)))
+         )
+       ORDER BY reporter_sequence ASC LIMIT ?5`,
+    ).bind(
+      ticketId,
+      commentCursorPosition,
+      commentCursorId,
+      legacyCommentCursor,
+      commentLimit + 1,
+    ).all<Record<string, unknown>>(),
     c.env.DB.prepare(
       `SELECT id, filename, content_type, size_bytes, created_at
        FROM feedback_attachments
@@ -391,9 +393,9 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
   const commentPage = comments.slice(0, commentLimit);
   const readWatermark = [...commentPage].reverse().find((comment) =>
     (comment.author_type === "staff" || comment.author_type === "system")
-    && typeof comment.created_at === "number"
+    && typeof comment.reporter_sequence === "number"
     && typeof comment.id === "string"
-  ) as { id: string; created_at: number } | undefined;
+  ) as { id: string; reporter_sequence: number } | undefined;
   await auditRead(c, authorized.principal, authorized.pseudonym, "detail", { ticketId });
   await markTicketRead(c, authorized.principal, ticketId, readWatermark ?? null);
   const [totalUnread, refreshedTicket] = await Promise.all([
@@ -403,11 +405,11 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
   const { org_id: _orgId, ...safeTicket } = refreshedTicket ?? ticket;
   const lastComment = commentPage.at(-1);
   const nextCommentCursor = comments.length > commentLimit && lastComment
-    ? encodeCursor(lastComment.created_at, lastComment.id)
+    ? encodeCursor(lastComment.reporter_sequence, lastComment.id)
     : null;
   return c.json({
     ticket: ticketDto(safeTicket),
-    comments: commentPage,
+    comments: commentPage.map(({ reporter_sequence: _sequence, ...comment }) => comment),
     next_comment_cursor: nextCommentCursor,
     attachments,
     unread_total: totalUnread,
@@ -481,6 +483,46 @@ async function parseReporterCommentInput(c: ReporterContext): Promise<{
   return { text, submissionId, attachments };
 }
 
+async function reconcileReporterR2Keys(env: Env, keys: string[], now: number) {
+  for (const key of keys) {
+    let referenced: { found: number } | null;
+    try {
+      referenced = await env.DB.prepare(
+        "SELECT 1 AS found FROM feedback_attachments WHERE r2_key = ?1 LIMIT 1",
+      ).bind(key).first<{ found: number }>();
+    } catch {
+      // The durable uploading intent remains. A later scheduled pass will
+      // reconcile it after the writer lease expires.
+      continue;
+    }
+    if (referenced) {
+      await env.DB.prepare(
+        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+      ).bind(key).run().catch(() => undefined);
+      continue;
+    }
+    await env.DB.prepare(
+      `UPDATE feedback_reporter_r2_cleanup
+       SET state = 'cleanup_claimed', next_attempt_at = ?2, updated_at = ?2
+       WHERE r2_key = ?1`,
+    ).bind(key, now).run().catch(() => undefined);
+    try {
+      await env.APK_BUCKET.delete(key);
+      await env.DB.prepare(
+        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+      ).bind(key).run().catch(() => undefined);
+    } catch {
+      await env.DB.prepare(
+        `UPDATE feedback_reporter_r2_cleanup
+         SET state = 'cleanup_claimed', attempts = attempts + 1,
+             last_error = 'r2 delete failed', next_attempt_at = ?2,
+             updated_at = ?3
+         WHERE r2_key = ?1`,
+      ).bind(key, now + 60_000, Date.now()).run().catch(() => undefined);
+    }
+  }
+}
+
 export async function handleAddReporterComment(c: ReporterContext) {
   const authorized = await authorize(c, "feedback:comment", "comment");
   if (!authorized.ok) return authorized.response;
@@ -547,10 +589,10 @@ export async function handleAddReporterComment(c: ReporterContext) {
     if (attachmentRows.length > 0) {
       await c.env.DB.batch(attachmentRows.map((attachment) => c.env.DB.prepare(
         `INSERT INTO feedback_reporter_r2_cleanup
-         (r2_key, created_at, updated_at, attempts, next_attempt_at)
-         VALUES (?1, ?2, ?2, 0, ?2)
-         ON CONFLICT(r2_key) DO NOTHING`,
-      ).bind(attachment.r2Key, now)));
+         (r2_key, state, lease_expires_at, created_at, updated_at,
+          attempts, next_attempt_at)
+         VALUES (?1, 'uploading', ?3, ?2, ?2, 0, ?3)`,
+      ).bind(attachment.r2Key, now, now + COMMENT_UPLOAD_LEASE_MS)));
     }
     for (const attachment of attachmentRows) {
       uploadedKeys.push(attachment.r2Key);
@@ -676,30 +718,13 @@ export async function handleAddReporterComment(c: ReporterContext) {
            ) ELSE 0 END
          ON CONFLICT(webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING`,
       ).bind(eventId, now, ticket.org_id),
+      ...attachmentRows.map((attachment) => c.env.DB.prepare(
+        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1 AND state = 'uploading'",
+      ).bind(attachment.r2Key)),
     ]);
-    if (attachmentRows.length > 0) {
-      await Promise.allSettled(attachmentRows.map((attachment) => c.env.DB.prepare(
-        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
-      ).bind(attachment.r2Key).run()));
-    }
   } catch (error) {
-    const cleanupResults = await Promise.allSettled(
-      uploadedKeys.map((key) => c.env.APK_BUCKET.delete(key)),
-    );
-    await Promise.allSettled(uploadedKeys.map((key, index) => {
-      const cleanup = cleanupResults[index];
-      return cleanup?.status === "fulfilled"
-        ? c.env.DB.prepare(
-            "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
-          ).bind(key).run()
-        : c.env.DB.prepare(
-            `UPDATE feedback_reporter_r2_cleanup
-             SET attempts = attempts + 1, last_error = 'r2 delete failed',
-                 next_attempt_at = ?2, updated_at = ?3
-             WHERE r2_key = ?1`,
-          ).bind(key, now + 60_000, Date.now()).run();
-    }));
     const concurrent = await existingComment();
+    await reconcileReporterR2Keys(c.env, uploadedKeys, now);
     if (concurrent) {
       if (concurrent.submission_fingerprint !== fingerprint) {
         return c.json({ error: "submission_id already used with a different body" }, 409);
@@ -753,7 +778,10 @@ export async function handleDownloadReporterAttachment(c: ReporterContext) {
 export async function cleanupReporterFeedbackData(env: Env, now = Date.now()) {
   const { results: cleanupRows } = await env.DB.prepare(
     `SELECT r2_key FROM feedback_reporter_r2_cleanup
-     WHERE next_attempt_at <= ?1 ORDER BY next_attempt_at, r2_key LIMIT 100`,
+     WHERE next_attempt_at <= ?1
+       AND (state = 'cleanup_claimed'
+            OR (state = 'uploading' AND lease_expires_at <= ?1))
+     ORDER BY next_attempt_at, r2_key LIMIT 100`,
   ).bind(now).all<{ r2_key: string }>();
   for (const row of cleanupRows) {
     const referenced = await env.DB.prepare(
@@ -765,19 +793,18 @@ export async function cleanupReporterFeedbackData(env: Env, now = Date.now()) {
       ).bind(row.r2_key).run();
       continue;
     }
-    try {
-      await env.APK_BUCKET.delete(row.r2_key);
-      await env.DB.prepare(
-        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
-      ).bind(row.r2_key).run();
-    } catch {
-      await env.DB.prepare(
-        `UPDATE feedback_reporter_r2_cleanup
-         SET attempts = attempts + 1, last_error = 'r2 delete failed',
-             next_attempt_at = ?2, updated_at = ?1
-         WHERE r2_key = ?3`,
-      ).bind(now, now + 60_000, row.r2_key).run();
-    }
+    await env.DB.prepare(
+      `UPDATE feedback_reporter_r2_cleanup
+       SET state = 'cleanup_claimed', updated_at = ?2
+       WHERE r2_key = ?1 AND NOT EXISTS (
+         SELECT 1 FROM feedback_attachments WHERE r2_key = ?1
+       ) AND (state = 'cleanup_claimed'
+              OR (state = 'uploading' AND lease_expires_at <= ?2))`,
+    ).bind(row.r2_key, now).run();
+    const claimed = await env.DB.prepare(
+      "SELECT 1 AS claimed FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1 AND state = 'cleanup_claimed'",
+    ).bind(row.r2_key).first<{ claimed: number }>();
+    if (claimed) await reconcileReporterR2Keys(env, [row.r2_key], now);
   }
   await env.DB.batch([
     env.DB.prepare(

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -329,13 +329,8 @@ async function markTicketRead(
   c: ReporterContext,
   principal: ReporterPrincipal,
   ticketId: string,
+  latest: { id: string; created_at: number } | null,
 ): Promise<void> {
-  const latest = await c.env.DB.prepare(
-    `SELECT id, created_at FROM feedback_comments
-     WHERE ticket_id = ?1 AND internal = 0
-       AND author_type IN ('staff', 'system')
-     ORDER BY created_at DESC, id DESC LIMIT 1`,
-  ).bind(ticketId).first<{ id: string; created_at: number }>();
   if (!latest) return;
   const now = Date.now();
   await c.env.DB.prepare(
@@ -393,17 +388,25 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
        ORDER BY created_at, id`,
     ).bind(ticketId).all(),
   ]);
-  await auditRead(c, authorized.principal, authorized.pseudonym, "detail", { ticketId });
-  await markTicketRead(c, authorized.principal, ticketId);
-  const totalUnread = await unreadTotal(c, authorized.principal);
-  const { org_id: _orgId, ...safeTicket } = ticket;
   const commentPage = comments.slice(0, commentLimit);
+  const readWatermark = [...commentPage].reverse().find((comment) =>
+    (comment.author_type === "staff" || comment.author_type === "system")
+    && typeof comment.created_at === "number"
+    && typeof comment.id === "string"
+  ) as { id: string; created_at: number } | undefined;
+  await auditRead(c, authorized.principal, authorized.pseudonym, "detail", { ticketId });
+  await markTicketRead(c, authorized.principal, ticketId, readWatermark ?? null);
+  const [totalUnread, refreshedTicket] = await Promise.all([
+    unreadTotal(c, authorized.principal),
+    ownedTicket(c, authorized.principal, ticketId),
+  ]);
+  const { org_id: _orgId, ...safeTicket } = refreshedTicket ?? ticket;
   const lastComment = commentPage.at(-1);
   const nextCommentCursor = comments.length > commentLimit && lastComment
     ? encodeCursor(lastComment.created_at, lastComment.id)
     : null;
   return c.json({
-    ticket: { ...ticketDto(safeTicket), unread: false, unread_count: 0 },
+    ticket: ticketDto(safeTicket),
     comments: commentPage,
     next_comment_cursor: nextCommentCursor,
     attachments,
@@ -418,6 +421,7 @@ async function sha256Hex(input: string): Promise<string> {
 
 type ReporterCommentAttachment = {
   bytes: ArrayBuffer;
+  fingerprintFilename: string;
   filename: string;
   contentType: string;
   sizeBytes: number;
@@ -465,6 +469,7 @@ async function parseReporterCommentInput(c: ReporterContext): Promise<{
     const digest = await crypto.subtle.digest("SHA-256", bytes);
     attachments.push({
       bytes,
+      fingerprintFilename: file.name,
       filename: safeFilename(file.name),
       contentType: file.type.toLowerCase(),
       sizeBytes: file.size,
@@ -492,7 +497,7 @@ export async function handleAddReporterComment(c: ReporterContext) {
         "reporter-comment-v2",
         text,
         ...attachments.map((attachment) => [
-          attachment.filename,
+          attachment.fingerprintFilename,
           attachment.contentType,
           attachment.sizeBytes,
           attachment.digest,
@@ -539,11 +544,19 @@ export async function handleAddReporterComment(c: ReporterContext) {
   });
   const uploadedKeys: string[] = [];
   try {
+    if (attachmentRows.length > 0) {
+      await c.env.DB.batch(attachmentRows.map((attachment) => c.env.DB.prepare(
+        `INSERT INTO feedback_reporter_r2_cleanup
+         (r2_key, created_at, updated_at, attempts, next_attempt_at)
+         VALUES (?1, ?2, ?2, 0, ?2)
+         ON CONFLICT(r2_key) DO NOTHING`,
+      ).bind(attachment.r2Key, now)));
+    }
     for (const attachment of attachmentRows) {
+      uploadedKeys.push(attachment.r2Key);
       await c.env.APK_BUCKET.put(attachment.r2Key, attachment.bytes, {
         httpMetadata: { contentType: attachment.contentType },
       });
-      uploadedKeys.push(attachment.r2Key);
     }
     await c.env.DB.batch([
       c.env.DB.prepare(
@@ -664,8 +677,28 @@ export async function handleAddReporterComment(c: ReporterContext) {
          ON CONFLICT(webhook_id, event_id) WHERE event_id IS NOT NULL DO NOTHING`,
       ).bind(eventId, now, ticket.org_id),
     ]);
+    if (attachmentRows.length > 0) {
+      await Promise.allSettled(attachmentRows.map((attachment) => c.env.DB.prepare(
+        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+      ).bind(attachment.r2Key).run()));
+    }
   } catch (error) {
-    await Promise.allSettled(uploadedKeys.map((key) => c.env.APK_BUCKET.delete(key)));
+    const cleanupResults = await Promise.allSettled(
+      uploadedKeys.map((key) => c.env.APK_BUCKET.delete(key)),
+    );
+    await Promise.allSettled(uploadedKeys.map((key, index) => {
+      const cleanup = cleanupResults[index];
+      return cleanup?.status === "fulfilled"
+        ? c.env.DB.prepare(
+            "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+          ).bind(key).run()
+        : c.env.DB.prepare(
+            `UPDATE feedback_reporter_r2_cleanup
+             SET attempts = attempts + 1, last_error = 'r2 delete failed',
+                 next_attempt_at = ?2, updated_at = ?3
+             WHERE r2_key = ?1`,
+          ).bind(key, now + 60_000, Date.now()).run();
+    }));
     const concurrent = await existingComment();
     if (concurrent) {
       if (concurrent.submission_fingerprint !== fingerprint) {
@@ -718,6 +751,34 @@ export async function handleDownloadReporterAttachment(c: ReporterContext) {
 }
 
 export async function cleanupReporterFeedbackData(env: Env, now = Date.now()) {
+  const { results: cleanupRows } = await env.DB.prepare(
+    `SELECT r2_key FROM feedback_reporter_r2_cleanup
+     WHERE next_attempt_at <= ?1 ORDER BY next_attempt_at, r2_key LIMIT 100`,
+  ).bind(now).all<{ r2_key: string }>();
+  for (const row of cleanupRows) {
+    const referenced = await env.DB.prepare(
+      "SELECT 1 AS found FROM feedback_attachments WHERE r2_key = ?1 LIMIT 1",
+    ).bind(row.r2_key).first<{ found: number }>();
+    if (referenced) {
+      await env.DB.prepare(
+        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+      ).bind(row.r2_key).run();
+      continue;
+    }
+    try {
+      await env.APK_BUCKET.delete(row.r2_key);
+      await env.DB.prepare(
+        "DELETE FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+      ).bind(row.r2_key).run();
+    } catch {
+      await env.DB.prepare(
+        `UPDATE feedback_reporter_r2_cleanup
+         SET attempts = attempts + 1, last_error = 'r2 delete failed',
+             next_attempt_at = ?2, updated_at = ?1
+         WHERE r2_key = ?3`,
+      ).bind(now, now + 60_000, row.r2_key).run();
+    }
+  }
   await env.DB.batch([
     env.DB.prepare(
       "DELETE FROM feedback_reporter_rate_windows WHERE updated_at < ?1",

--- a/worker/test/feedback_reporter_interactions_migration.test.ts
+++ b/worker/test/feedback_reporter_interactions_migration.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0054_feedback_reporter_interactions.sql", import.meta.url),
+);
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE apps (id TEXT PRIMARY KEY);
+    CREATE TABLE app_reporter_integrations (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE
+    );
+    CREATE TABLE feedback_tickets (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      reporter_integration_id TEXT NOT NULL REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+      reporter_id TEXT NOT NULL
+    );
+    CREATE TABLE feedback_comments (
+      id TEXT PRIMARY KEY,
+      ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+      author_type TEXT NOT NULL,
+      internal INTEGER NOT NULL
+    );
+    CREATE TABLE feedback_attachments (
+      id TEXT PRIMARY KEY,
+      ticket_id TEXT NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+      r2_key TEXT NOT NULL,
+      filename TEXT NOT NULL,
+      content_type TEXT,
+      size_bytes INTEGER NOT NULL,
+      origin TEXT NOT NULL DEFAULT 'submission'
+        CHECK (origin IN ('submission', 'staff', 'system')),
+      visibility TEXT NOT NULL DEFAULT 'reporter'
+        CHECK (visibility IN ('reporter', 'internal')),
+      created_at INTEGER NOT NULL
+    );
+    CREATE INDEX idx_feedback_attachments_ticket
+      ON feedback_attachments(ticket_id, visibility, origin, created_at, id);
+
+    INSERT INTO apps (id) VALUES ('app-a'), ('app-b');
+    INSERT INTO app_reporter_integrations (id, app_id)
+      VALUES ('integration-a', 'app-a'), ('integration-b', 'app-b');
+    INSERT INTO feedback_tickets (id, app_id, reporter_integration_id, reporter_id)
+      VALUES
+        ('ticket-a', 'app-a', 'integration-a', 'reporter-a'),
+        ('ticket-b', 'app-b', 'integration-b', 'reporter-b');
+    INSERT INTO feedback_comments (id, ticket_id, author_type, internal)
+      VALUES
+        ('comment-a', 'ticket-a', 'reporter', 0),
+        ('comment-staff', 'ticket-a', 'staff', 0),
+        ('comment-b', 'ticket-b', 'reporter', 0);
+    INSERT INTO feedback_attachments
+      (id, ticket_id, r2_key, filename, content_type, size_bytes,
+       origin, visibility, created_at)
+      VALUES ('legacy', 'ticket-a', 'legacy/key', 'legacy.png', 'image/png', 4,
+              'submission', 'reporter', 1);
+  `);
+  db.exec(readFileSync(migrationPath, "utf8"));
+  return db;
+}
+
+describe("feedback reporter interactions migration", () => {
+  it("preserves attachments and enforces exact reporter read ownership", () => {
+    const db = makeDb();
+    expect(db.prepare(
+      "SELECT id, comment_id, origin, visibility FROM feedback_attachments WHERE id = 'legacy'",
+    ).get()).toEqual({
+      id: "legacy",
+      comment_id: null,
+      origin: "submission",
+      visibility: "reporter",
+    });
+
+    const insertRead = db.prepare(`
+      INSERT INTO feedback_reporter_ticket_reads
+        (app_id, reporter_integration_id, reporter_id, ticket_id,
+         read_through_created_at, read_through_comment_id, updated_at)
+      VALUES (?, ?, ?, ?, 10, 'comment-a', 10)
+    `);
+    expect(() => insertRead.run(
+      "app-a", "integration-a", "reporter-a", "ticket-a",
+    )).not.toThrow();
+    expect(() => insertRead.run(
+      "app-a", "integration-a", "reporter-a", "ticket-b",
+    )).toThrow("feedback reporter read owner mismatch");
+    expect(() => db.prepare(`
+      UPDATE feedback_reporter_ticket_reads SET reporter_id = 'reporter-b'
+      WHERE ticket_id = 'ticket-a'
+    `).run()).toThrow("feedback reporter read owner mismatch");
+  });
+
+  it("requires reporter attachments to belong to a visible reporter comment on the same ticket", () => {
+    const db = makeDb();
+    const insertAttachment = db.prepare(`
+      INSERT INTO feedback_attachments
+        (id, ticket_id, comment_id, r2_key, filename, content_type, size_bytes,
+         origin, visibility, created_at)
+      VALUES (?, ?, ?, ?, 'reply.png', 'image/png', 4, 'reporter', 'reporter', 2)
+    `);
+    expect(() => insertAttachment.run(
+      "reply-a", "ticket-a", "comment-a", "reply/a",
+    )).not.toThrow();
+    expect(() => insertAttachment.run(
+      "wrong-ticket", "ticket-a", "comment-b", "reply/b",
+    )).toThrow("feedback reporter attachment owner mismatch");
+    expect(() => insertAttachment.run(
+      "staff-comment", "ticket-a", "comment-staff", "reply/c",
+    )).toThrow("feedback reporter attachment owner mismatch");
+    expect(() => db.prepare(`
+      INSERT INTO feedback_attachments
+        (id, ticket_id, comment_id, r2_key, filename, content_type, size_bytes,
+         origin, visibility, created_at)
+      VALUES ('internal', 'ticket-a', 'comment-a', 'reply/internal', 'reply.png',
+              'image/png', 4, 'reporter', 'internal', 2)
+    `).run()).toThrow();
+  });
+});

--- a/worker/test/feedback_reporter_interactions_migration.test.ts
+++ b/worker/test/feedback_reporter_interactions_migration.test.ts
@@ -81,7 +81,7 @@ describe("feedback reporter interactions migration", () => {
     const insertRead = db.prepare(`
       INSERT INTO feedback_reporter_ticket_reads
         (app_id, reporter_integration_id, reporter_id, ticket_id,
-         read_through_created_at, read_through_comment_id, updated_at)
+         read_through_sequence, read_through_comment_id, updated_at)
       VALUES (?, ?, ?, ?, 10, 'comment-a', 10)
     `);
     expect(() => insertRead.run(
@@ -94,6 +94,23 @@ describe("feedback reporter interactions migration", () => {
       UPDATE feedback_reporter_ticket_reads SET reporter_id = 'reporter-b'
       WHERE ticket_id = 'ticket-a'
     `).run()).toThrow("feedback reporter read owner mismatch");
+
+    const existingSequences = db.prepare(
+      "SELECT reporter_sequence FROM feedback_comments ORDER BY reporter_sequence",
+    ).all() as Array<{ reporter_sequence: number }>;
+    expect(existingSequences.every((row) => row.reporter_sequence > 0)).toBe(true);
+    expect(new Set(existingSequences.map((row) => row.reporter_sequence)).size).toBe(existingSequences.length);
+    db.prepare(
+      "INSERT INTO feedback_comments (id, ticket_id, author_type, internal) VALUES ('later', 'ticket-a', 'staff', 0)",
+    ).run();
+    expect((db.prepare(
+      "SELECT reporter_sequence FROM feedback_comments WHERE id = 'later'",
+    ).get() as { reporter_sequence: number }).reporter_sequence).toBeGreaterThan(
+      existingSequences.at(-1)!.reporter_sequence,
+    );
+    expect(() => db.prepare(
+      "UPDATE feedback_comments SET reporter_sequence = 999 WHERE id = 'later'",
+    ).run()).toThrow("feedback comment sequence is immutable");
   });
 
   it("requires reporter attachments to belong to a visible reporter comment on the same ticket", () => {
@@ -104,15 +121,28 @@ describe("feedback reporter interactions migration", () => {
          origin, visibility, created_at)
       VALUES (?, ?, ?, ?, 'reply.png', 'image/png', 4, 'reporter', 'reporter', 2)
     `);
+    const insertIntent = db.prepare(`
+      INSERT INTO feedback_reporter_r2_cleanup
+        (r2_key, state, lease_expires_at, attempts, next_attempt_at,
+         created_at, updated_at)
+      VALUES (?, 'uploading', 100, 0, 100, 1, 1)
+    `);
+    expect(() => insertAttachment.run(
+      "missing-intent", "ticket-a", "comment-a", "reply/missing",
+    )).toThrow("feedback reporter attachment cleanup intent missing");
+    insertIntent.run("reply/a");
     expect(() => insertAttachment.run(
       "reply-a", "ticket-a", "comment-a", "reply/a",
     )).not.toThrow();
+    insertIntent.run("reply/b");
     expect(() => insertAttachment.run(
       "wrong-ticket", "ticket-a", "comment-b", "reply/b",
     )).toThrow("feedback reporter attachment owner mismatch");
+    insertIntent.run("reply/c");
     expect(() => insertAttachment.run(
       "staff-comment", "ticket-a", "comment-staff", "reply/c",
     )).toThrow("feedback reporter attachment owner mismatch");
+    insertIntent.run("reply/internal");
     expect(() => db.prepare(`
       INSERT INTO feedback_attachments
         (id, ticket_id, comment_id, r2_key, filename, content_type, size_bytes,

--- a/worker/test/feedback_reporter_interactions_migration.test.ts
+++ b/worker/test/feedback_reporter_interactions_migration.test.ts
@@ -100,14 +100,23 @@ describe("feedback reporter interactions migration", () => {
     ).all() as Array<{ reporter_sequence: number }>;
     expect(existingSequences.every((row) => row.reporter_sequence > 0)).toBe(true);
     expect(new Set(existingSequences.map((row) => row.reporter_sequence)).size).toBe(existingSequences.length);
+    const oldMax = existingSequences.at(-1)!.reporter_sequence;
+    db.prepare("DELETE FROM feedback_comments WHERE id = 'comment-staff'").run();
+    // Model a SQL export/import: declared sequence values survive, while the
+    // hidden rowid of the remaining high-sequence row is compacted into the gap.
+    db.prepare("UPDATE feedback_comments SET rowid = 2 WHERE id = 'comment-b'").run();
+    expect(db.prepare(
+      "SELECT rowid, reporter_sequence FROM feedback_comments WHERE id = 'comment-b'",
+    ).get()).toEqual({ rowid: 2, reporter_sequence: oldMax });
+    expect(db.prepare(
+      "SELECT high_water FROM feedback_comment_sequence_state WHERE singleton = 1",
+    ).get()).toEqual({ high_water: oldMax });
     db.prepare(
       "INSERT INTO feedback_comments (id, ticket_id, author_type, internal) VALUES ('later', 'ticket-a', 'staff', 0)",
     ).run();
     expect((db.prepare(
       "SELECT reporter_sequence FROM feedback_comments WHERE id = 'later'",
-    ).get() as { reporter_sequence: number }).reporter_sequence).toBeGreaterThan(
-      existingSequences.at(-1)!.reporter_sequence,
-    );
+    ).get() as { reporter_sequence: number }).reporter_sequence).toBe(oldMax + 1);
     expect(() => db.prepare(
       "UPDATE feedback_comments SET reporter_sequence = 999 WHERE id = 'later'",
     ).run()).toThrow("feedback comment sequence is immutable");

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -10527,6 +10527,58 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect(legacyPage2Body.comments.map((comment: any) => comment.id)).not.toContain(bridgeLow);
     await env.DB.prepare("DELETE FROM feedback_tickets WHERE id = ?1").bind(legacyTicket).run();
 
+    const sparseLegacyTicket = "91909090-9090-4090-8090-909090909090";
+    const sparsePrevious = "01010101-0101-4101-8101-010101010101";
+    const sparseMid = "88888888-8888-4888-8888-888888888888";
+    const sparseHigh = "ffffffff-ffff-4fff-8fff-fffffffffff0";
+    const sparseLow = "11111111-1111-4111-8111-111111111110";
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+       VALUES (?1, 'app-ios', 'feedback', 'open', 'Sparse legacy receipt', '{}',
+               ?2, ?3, ?4, ?4)`,
+    ).bind(sparseLegacyTicket, reporterId, integrationA, bridgeTime).run();
+    await env.DB.prepare(
+      `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES (?1, ?2, 'staff:test', 'staff', 'previous', 0, ?3)`,
+    ).bind(sparsePrevious, sparseLegacyTicket, bridgeTime - 1).run();
+    for (const id of [sparseMid, sparseHigh, sparseLow]) {
+      await env.DB.prepare(
+        `INSERT INTO feedback_comments
+         (id, ticket_id, author_actor, author_type, body, internal, created_at)
+         VALUES (?1, ?2, 'staff:test', 'staff', ?1, 0, ?3)`,
+      ).bind(id, sparseLegacyTicket, bridgeTime).run();
+    }
+    const sparsePreviousRow = await env.DB.prepare(
+      "SELECT reporter_sequence FROM feedback_comments WHERE id = ?1",
+    ).bind(sparsePrevious).first() as any;
+    await env.DB.prepare(
+      `INSERT INTO feedback_reporter_ticket_reads
+       (app_id, reporter_integration_id, reporter_id, ticket_id,
+        read_through_sequence, read_through_comment_id, updated_at)
+       VALUES ('app-ios', ?1, ?2, ?3, ?4, ?5, ?6)`,
+    ).bind(
+      integrationA,
+      reporterId,
+      sparseLegacyTicket,
+      sparsePreviousRow.reporter_sequence,
+      sparsePrevious,
+      now,
+    ).run();
+    const sparseCursor = btoa(JSON.stringify([bridgeTime - 1, sparsePrevious]))
+      .replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+    const sparsePage = await handleGetReporterFeedback(context(
+      "detail", credentialA.token, sparseLegacyTicket, undefined, reporterId,
+      { comment_limit: "1", comment_cursor: sparseCursor },
+    ));
+    const sparseBody = await sparsePage.json() as any;
+    expect(sparseBody.comments.map((comment: any) => comment.id)).toEqual([sparseLow]);
+    expect(sparseBody.ticket).toMatchObject({ unread: true, unread_count: 3 });
+    expect(sparseBody.unread_total).toBeGreaterThanOrEqual(1);
+    await env.DB.prepare("DELETE FROM feedback_tickets WHERE id = ?1").bind(sparseLegacyTicket).run();
+
     const afterRead = await handleListReporterFeedback(context("list", credentialA.token));
     expect(await afterRead.json()).toMatchObject({
       unread_total: 0,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -479,6 +479,22 @@ function makeMockDb() {
     );
     CREATE UNIQUE INDEX idx_feedback_comments_reporter_sequence
       ON feedback_comments(reporter_sequence);
+    CREATE TABLE feedback_comment_sequence_state (
+      singleton INTEGER PRIMARY KEY,
+      high_water INTEGER NOT NULL
+    );
+    INSERT INTO feedback_comment_sequence_state (singleton, high_water) VALUES (1, 0);
+    CREATE TRIGGER feedback_comment_sequence_state_no_delete
+    BEFORE DELETE ON feedback_comment_sequence_state
+    BEGIN
+      SELECT RAISE(ABORT, 'feedback comment sequence state is durable');
+    END;
+    CREATE TRIGGER feedback_comment_sequence_state_monotonic
+    BEFORE UPDATE ON feedback_comment_sequence_state
+    WHEN NEW.singleton != OLD.singleton OR NEW.high_water != OLD.high_water + 1
+    BEGIN
+      SELECT RAISE(ABORT, 'feedback comment sequence high-water must advance by one');
+    END;
     CREATE TRIGGER feedback_comments_reporter_sequence_managed
     BEFORE INSERT ON feedback_comments
     WHEN NEW.reporter_sequence IS NOT NULL
@@ -488,7 +504,13 @@ function makeMockDb() {
     CREATE TRIGGER feedback_comments_reporter_sequence_insert
     AFTER INSERT ON feedback_comments
     BEGIN
-      UPDATE feedback_comments SET reporter_sequence = NEW.rowid WHERE rowid = NEW.rowid;
+      UPDATE feedback_comment_sequence_state
+      SET high_water = high_water + 1 WHERE singleton = 1;
+      UPDATE feedback_comments
+      SET reporter_sequence = (
+        SELECT high_water FROM feedback_comment_sequence_state WHERE singleton = 1
+      )
+      WHERE rowid = NEW.rowid;
     END;
     CREATE TRIGGER feedback_comments_reporter_sequence_immutable
     BEFORE UPDATE OF reporter_sequence ON feedback_comments

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -725,6 +725,14 @@ function makeMockDb() {
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (app_id, reporter_integration_id, reporter_id, ticket_id)
     );
+    CREATE TABLE feedback_reporter_r2_cleanup (
+      r2_key TEXT PRIMARY KEY,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      next_attempt_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `);
 
   // Replace `?N` numbered placeholders with anonymous `?` (better-sqlite3 compat).
@@ -10233,6 +10241,7 @@ describe("Hands iOS simulator QA artifacts", () => {
     const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
     const {
       handleAddReporterComment,
+      cleanupReporterFeedbackData,
       handleDownloadReporterAttachment,
       handleGetReporterFeedback,
       handleListReporterFeedback,
@@ -10413,13 +10422,15 @@ describe("Hands iOS simulator QA artifacts", () => {
       { comment_limit: "2" },
     ));
     const page1Body = await page1.json() as any;
-    expect(page1Body.ticket).toMatchObject({ unread: false, unread_count: 0 });
-    expect(page1Body.unread_total).toBe(0);
+    expect(page1Body.ticket).toMatchObject({ unread: true, unread_count: 2 });
+    expect(page1Body.unread_total).toBe(1);
     const page2 = await handleGetReporterFeedback(context(
       "detail", credentialA.token, ticketA, undefined, reporterId,
       { comment_limit: "2", comment_cursor: page1Body.next_comment_cursor },
     ));
     const page2Body = await page2.json() as any;
+    expect(page2Body.ticket).toMatchObject({ unread: false, unread_count: 0 });
+    expect(page2Body.unread_total).toBe(0);
     const firstFour = [...page1Body.comments, ...page2Body.comments].map((comment: any) => comment.id);
     const expectedFirstFour = (await env.DB.prepare(
       `SELECT id FROM feedback_comments WHERE ticket_id = ?1 AND internal = 0
@@ -10463,6 +10474,40 @@ describe("Hands iOS simulator QA artifacts", () => {
     ).bind(ticketA, now + 300).run();
     const unreadInternal = await handleListReporterFeedback(context("list", credentialA.token));
     expect((await unreadInternal.json() as any).tickets[0].unread_count).toBe(1);
+    await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
+
+    const raceCommentId = "45454545-4545-4454-8454-454545454545";
+    const originalPrepare = env.DB.prepare.bind(env.DB);
+    let injectRace = true;
+    env.DB.prepare = (sql: string) => {
+      const statement = originalPrepare(sql);
+      if (!sql.includes("SELECT id, author_type, body, created_at")) return statement;
+      const originalBind = statement.bind.bind(statement);
+      statement.bind = (...params: unknown[]) => {
+        const bound = originalBind(...params);
+        const originalAll = bound.all.bind(bound);
+        bound.all = async () => {
+          const snapshot = await originalAll();
+          if (injectRace) {
+            injectRace = false;
+            await originalPrepare(
+              `INSERT INTO feedback_comments
+               (id, ticket_id, author_actor, author_type, body, internal, created_at)
+               VALUES (?1, ?2, 'staff:test', 'staff', 'raced after snapshot', 0, ?3)`,
+            ).bind(raceCommentId, ticketA, now + 400).run();
+          }
+          return snapshot;
+        };
+        return bound;
+      };
+      return statement;
+    };
+    const raceDetail = await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
+    env.DB.prepare = originalPrepare;
+    const raceBody = await raceDetail.json() as any;
+    expect(raceBody.comments.some((comment: any) => comment.id === raceCommentId)).toBe(false);
+    expect(raceBody.ticket).toMatchObject({ unread: true, unread_count: 1 });
+    expect(raceBody.unread_total).toBe(1);
     await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
 
     const emojiSubmission = "12121212-1212-4212-8212-121212121212";
@@ -10519,6 +10564,17 @@ describe("Hands iOS simulator QA artifacts", () => {
     ));
     expect(attachmentReplay.status).toBe(200);
     expect(storedObjects.size).toBe(1);
+    const sanitizedCollisionForm = new FormData();
+    sanitizedCollisionForm.set("body", "reply with screenshot");
+    sanitizedCollisionForm.set("submission_id", attachmentSubmission);
+    sanitizedCollisionForm.append("attachments", new File(
+      [new Uint8Array([1, 2, 3, 4])],
+      "screen?shot.png",
+      { type: "image/png" },
+    ));
+    expect((await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, sanitizedCollisionForm,
+    ))).status).toBe(409);
     const changedFileForm = new FormData();
     changedFileForm.set("body", "reply with screenshot");
     changedFileForm.set("submission_id", attachmentSubmission);
@@ -10585,8 +10641,8 @@ describe("Hands iOS simulator QA artifacts", () => {
     let uploadAttempt = 0;
     env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
       uploadAttempt += 1;
-      if (uploadAttempt === 2) throw new Error("simulated R2 failure");
       storedObjects.set(key, new Uint8Array(value));
+      if (uploadAttempt === 2) throw new Error("simulated R2 failure");
     };
     const r2FailureForm = new FormData();
     r2FailureForm.set("body", "r2 failure");
@@ -10596,7 +10652,38 @@ describe("Hands iOS simulator QA artifacts", () => {
     await expect(handleAddReporterComment(context(
       "comment", credentialA.token, ticketA, r2FailureForm,
     ))).rejects.toThrow("simulated R2 failure");
-    expect(deletedObjects.some((key) => key.includes("/comments/"))).toBe(true);
+    expect([...storedObjects.keys()].some((key) => key.endsWith("/0-a.png") || key.endsWith("/1-b.png"))).toBe(false);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_r2_cleanup",
+    ).first() as any).count).toBe(0);
+
+    env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
+      storedObjects.set(key, new Uint8Array(value));
+      throw new Error("stored then failed");
+    };
+    env.APK_BUCKET.delete = async () => {
+      throw new Error("delete unavailable");
+    };
+    const compensatedForm = new FormData();
+    compensatedForm.set("body", "cleanup compensation");
+    compensatedForm.set("submission_id", "92929292-9292-4929-8929-929292929292");
+    compensatedForm.append("attachments", new File(["retry"], "retry.png", { type: "image/png" }));
+    await expect(handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, compensatedForm,
+    ))).rejects.toThrow("stored then failed");
+    const cleanupIntent = await env.DB.prepare(
+      "SELECT r2_key, attempts, last_error FROM feedback_reporter_r2_cleanup",
+    ).first() as any;
+    expect(cleanupIntent).toMatchObject({ attempts: 1, last_error: "r2 delete failed" });
+    expect(storedObjects.has(cleanupIntent.r2_key)).toBe(true);
+    env.APK_BUCKET.delete = async (key: string) => {
+      storedObjects.delete(key);
+    };
+    await cleanupReporterFeedbackData(env, Date.now() + 61_000);
+    expect(storedObjects.has(cleanupIntent.r2_key)).toBe(false);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_r2_cleanup",
+    ).first() as any).count).toBe(0);
 
     env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
       storedObjects.set(key, new Uint8Array(value));

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -10491,6 +10491,42 @@ describe("Hands iOS simulator QA artifacts", () => {
     ).bind(ticketA).all() as any).results.map((comment: any) => comment.id);
     expect(firstFour).toEqual(expectedFirstFour);
 
+    const legacyTicket = "90909090-9090-4090-8090-909090909090";
+    const bridgeTime = now + 150;
+    const bridgeHigh = "eeeeeeee-1111-4111-8111-111111111111";
+    const bridgeLow = "11111111-2222-4222-8222-222222222222";
+    const bridgeHigher = "ffffffff-3333-4333-8333-333333333333";
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+       VALUES (?1, 'app-ios', 'feedback', 'open', 'Legacy cursor bridge', '{}',
+               ?2, ?3, ?4, ?4)`,
+    ).bind(legacyTicket, reporterId, integrationA, bridgeTime).run();
+    for (const id of [bridgeHigh, bridgeLow, bridgeHigher]) {
+      await env.DB.prepare(
+        `INSERT INTO feedback_comments
+         (id, ticket_id, author_actor, author_type, body, internal, created_at)
+         VALUES (?1, ?2, 'staff:test', 'staff', ?1, 0, ?3)`,
+      ).bind(id, legacyTicket, bridgeTime).run();
+    }
+    const legacyCursor = btoa(JSON.stringify([bridgeTime, bridgeLow]))
+      .replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+    const legacyPage1 = await handleGetReporterFeedback(context(
+      "detail", credentialA.token, legacyTicket, undefined, reporterId,
+      { comment_limit: "1", comment_cursor: legacyCursor },
+    ));
+    const legacyPage1Body = await legacyPage1.json() as any;
+    expect(legacyPage1Body.comments.map((comment: any) => comment.id)).toEqual([bridgeHigh]);
+    const legacyPage2 = await handleGetReporterFeedback(context(
+      "detail", credentialA.token, legacyTicket, undefined, reporterId,
+      { comment_limit: "1", comment_cursor: legacyPage1Body.next_comment_cursor },
+    ));
+    const legacyPage2Body = await legacyPage2.json() as any;
+    expect(legacyPage2Body.comments.map((comment: any) => comment.id)).toEqual([bridgeHigher]);
+    expect(legacyPage2Body.comments.map((comment: any) => comment.id)).not.toContain(bridgeLow);
+    await env.DB.prepare("DELETE FROM feedback_tickets WHERE id = ?1").bind(legacyTicket).run();
+
     const afterRead = await handleListReporterFeedback(context("list", credentialA.token));
     expect(await afterRead.json()).toMatchObject({
       unread_total: 0,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -474,8 +474,28 @@ function makeMockDb() {
       reporter_id TEXT,
       submission_id TEXT,
       submission_fingerprint TEXT,
+      reporter_sequence INTEGER,
       created_at INTEGER NOT NULL
     );
+    CREATE UNIQUE INDEX idx_feedback_comments_reporter_sequence
+      ON feedback_comments(reporter_sequence);
+    CREATE TRIGGER feedback_comments_reporter_sequence_managed
+    BEFORE INSERT ON feedback_comments
+    WHEN NEW.reporter_sequence IS NOT NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'feedback comment sequence is managed');
+    END;
+    CREATE TRIGGER feedback_comments_reporter_sequence_insert
+    AFTER INSERT ON feedback_comments
+    BEGIN
+      UPDATE feedback_comments SET reporter_sequence = NEW.rowid WHERE rowid = NEW.rowid;
+    END;
+    CREATE TRIGGER feedback_comments_reporter_sequence_immutable
+    BEFORE UPDATE OF reporter_sequence ON feedback_comments
+    WHEN OLD.reporter_sequence IS NOT NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'feedback comment sequence is immutable');
+    END;
     CREATE TABLE app_reporter_integrations (
       id TEXT PRIMARY KEY,
       app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
@@ -720,19 +740,30 @@ function makeMockDb() {
       reporter_integration_id TEXT NOT NULL,
       reporter_id TEXT NOT NULL,
       ticket_id TEXT NOT NULL,
-      read_through_created_at INTEGER NOT NULL,
+      read_through_sequence INTEGER NOT NULL,
       read_through_comment_id TEXT NOT NULL,
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (app_id, reporter_integration_id, reporter_id, ticket_id)
     );
     CREATE TABLE feedback_reporter_r2_cleanup (
       r2_key TEXT PRIMARY KEY,
+      state TEXT NOT NULL,
+      lease_expires_at INTEGER NOT NULL,
       attempts INTEGER NOT NULL DEFAULT 0,
       last_error TEXT,
       next_attempt_at INTEGER NOT NULL,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
+    CREATE TRIGGER feedback_reporter_attachments_cleanup_insert
+    BEFORE INSERT ON feedback_attachments
+    WHEN NEW.origin = 'reporter' AND NOT EXISTS (
+      SELECT 1 FROM feedback_reporter_r2_cleanup cleanup
+      WHERE cleanup.r2_key = NEW.r2_key AND cleanup.state = 'uploading'
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'feedback reporter attachment cleanup intent missing');
+    END;
   `);
 
   // Replace `?N` numbered placeholders with anonymous `?` (better-sqlite3 compat).
@@ -10476,7 +10507,7 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect((await unreadInternal.json() as any).tickets[0].unread_count).toBe(1);
     await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
 
-    const raceCommentId = "45454545-4545-4454-8454-454545454545";
+    const raceCommentId = "10101010-1010-4010-8010-101010101010";
     const originalPrepare = env.DB.prepare.bind(env.DB);
     let injectRace = true;
     env.DB.prepare = (sql: string) => {
@@ -10494,7 +10525,7 @@ describe("Hands iOS simulator QA artifacts", () => {
               `INSERT INTO feedback_comments
                (id, ticket_id, author_actor, author_type, body, internal, created_at)
                VALUES (?1, ?2, 'staff:test', 'staff', 'raced after snapshot', 0, ?3)`,
-            ).bind(raceCommentId, ticketA, now + 400).run();
+            ).bind(raceCommentId, ticketA, now + 200).run();
           }
           return snapshot;
         };
@@ -10610,6 +10641,41 @@ describe("Hands iOS simulator QA artifacts", () => {
     } as any);
     expect(crossIntegrationDownload.status).toBe(404);
 
+    env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
+      storedObjects.set(key, new Uint8Array(value));
+      await cleanupReporterFeedbackData(env, Date.now());
+    };
+    const cronRaceForm = new FormData();
+    cronRaceForm.set("body", "cron must not delete in-flight upload");
+    cronRaceForm.set("submission_id", "52525252-5252-4525-8525-525252525252");
+    cronRaceForm.append("attachments", new File(["cron"], "cron.png", { type: "image/png" }));
+    expect((await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, cronRaceForm,
+    ))).status).toBe(201);
+    const cronRaceAttachment = await env.DB.prepare(
+      "SELECT r2_key FROM feedback_attachments WHERE filename = 'cron.png'",
+    ).first() as any;
+    expect(storedObjects.has(cronRaceAttachment.r2_key)).toBe(true);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+    ).bind(cronRaceAttachment.r2_key).first() as any).count).toBe(0);
+
+    env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
+      storedObjects.set(key, new Uint8Array(value));
+      await cleanupReporterFeedbackData(env, Date.now() + 16 * 60_000);
+    };
+    const expiredLeaseForm = new FormData();
+    expiredLeaseForm.set("body", "expired writer must lose cleanup claim");
+    expiredLeaseForm.set("submission_id", "53535353-5353-4535-8535-535353535353");
+    expiredLeaseForm.append("attachments", new File(["expired"], "expired.png", { type: "image/png" }));
+    await expect(handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, expiredLeaseForm,
+    ))).rejects.toThrow("feedback reporter attachment cleanup intent missing");
+    expect([...storedObjects.keys()].some((key) => key.endsWith("/0-expired.png"))).toBe(false);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_attachments WHERE filename = 'expired.png'",
+    ).first() as any).count).toBe(0);
+
     const invalidTypeForm = new FormData();
     invalidTypeForm.set("body", "bad type");
     invalidTypeForm.set("submission_id", "61616161-6161-4616-8616-616161616161");
@@ -10690,6 +10756,30 @@ describe("Hands iOS simulator QA artifacts", () => {
     };
     const originalBatch = env.DB.batch.bind(env.DB);
     env.DB.batch = async (statements: unknown[]) => {
+      if (statements.length > 2) {
+        await originalBatch(statements);
+        throw new Error("simulated ambiguous D1 success");
+      }
+      return originalBatch(statements);
+    };
+    const ambiguousForm = new FormData();
+    ambiguousForm.set("body", "ambiguous commit");
+    ambiguousForm.set("submission_id", "a0a0a0a0-a0a0-4a0a-8a0a-a0a0a0a0a0a0");
+    ambiguousForm.append("attachments", new File(["committed"], "committed.png", { type: "image/png" }));
+    const ambiguousResponse = await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, ambiguousForm,
+    ));
+    expect(ambiguousResponse.status).toBe(200);
+    expect(await ambiguousResponse.json()).toMatchObject({ idempotent_replay: true });
+    const committedAttachment = await env.DB.prepare(
+      "SELECT r2_key FROM feedback_attachments WHERE filename = 'committed.png'",
+    ).first() as any;
+    expect(storedObjects.has(committedAttachment.r2_key)).toBe(true);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_r2_cleanup WHERE r2_key = ?1",
+    ).bind(committedAttachment.r2_key).first() as any).count).toBe(0);
+
+    env.DB.batch = async (statements: unknown[]) => {
       if (statements.length > 2) throw new Error("simulated D1 failure");
       return originalBatch(statements);
     };
@@ -10720,7 +10810,7 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect((await handleAddFeedbackComment(adminContext({ body: "internal note", internal: true }))).status).toBe(201);
     expect((await env.DB.prepare(
       "SELECT COUNT(*) AS count FROM feedback_events WHERE ticket_id = ?1 AND event_type = 'feedback:comment_created'",
-    ).bind(ticketA).first() as any).count).toBe(4);
+    ).bind(ticketA).first() as any).count).toBe(6);
     const staffEvent = await env.DB.prepare(
       `SELECT payload_json FROM feedback_events
        WHERE ticket_id = ?1 AND event_type = 'feedback:comment_created'

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -454,6 +454,7 @@ function makeMockDb() {
     CREATE TABLE feedback_attachments (
       id TEXT PRIMARY KEY,
       ticket_id TEXT NOT NULL,
+      comment_id TEXT,
       r2_key TEXT NOT NULL,
       filename TEXT NOT NULL,
       content_type TEXT,
@@ -714,6 +715,16 @@ function makeMockDb() {
         app_id, reporter_integration_id, reporter_hash, audit_key_version,
         endpoint, throttle_window_started_at
       ) WHERE throttle_window_started_at IS NOT NULL;
+    CREATE TABLE feedback_reporter_ticket_reads (
+      app_id TEXT NOT NULL,
+      reporter_integration_id TEXT NOT NULL,
+      reporter_id TEXT NOT NULL,
+      ticket_id TEXT NOT NULL,
+      read_through_created_at INTEGER NOT NULL,
+      read_through_comment_id TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (app_id, reporter_integration_id, reporter_id, ticket_id)
+    );
   `);
 
   // Replace `?N` numbered placeholders with anonymous `?` (better-sqlite3 compat).
@@ -10220,7 +10231,12 @@ describe("Hands iOS simulator QA artifacts", () => {
     env.FEEDBACK_AUDIT_HMAC_KEY = "test-audit-key-with-enough-entropy";
     env.FEEDBACK_AUDIT_KEY_VERSION = "test-v1";
     const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
-    const { handleAddReporterComment, handleGetReporterFeedback, handleListReporterFeedback } =
+    const {
+      handleAddReporterComment,
+      handleDownloadReporterAttachment,
+      handleGetReporterFeedback,
+      handleListReporterFeedback,
+    } =
       await import("../src/routes/reporter_feedback");
     const now = Date.now();
     const reporterId = "r".repeat(64);
@@ -10275,7 +10291,7 @@ describe("Hands iOS simulator QA artifacts", () => {
       handler: "list" | "detail" | "comment",
       credential: string | null,
       ticketId?: string,
-      commentBody?: { body: string; submission_id: string },
+      commentBody?: { body: string; submission_id: string } | FormData,
       headerReporter = reporterId,
       queries: Record<string, string> = {},
     ) => {
@@ -10285,13 +10301,16 @@ describe("Hands iOS simulator QA artifacts", () => {
         header: (name: string, value: string) => responseHeaders.set(name, value),
         req: {
           param: (name: string) => name === "appId" ? "app-ios" : name === "ticketId" ? ticketId : undefined,
-          header: (name: string) => name === "X-Hands-Reporter-Id"
+          header: (name: string) => name.toLowerCase() === "content-type" && commentBody instanceof FormData
+            ? "multipart/form-data; boundary=test"
+            : name === "X-Hands-Reporter-Id"
             ? headerReporter
             : name === "authorization" && credential
               ? `Bearer ${credential}`
               : undefined,
           query: (name: string) => queries[name] ?? (handler === "list" && name === "limit" ? "50" : undefined),
-          json: async () => commentBody ?? {},
+          json: async () => commentBody instanceof FormData ? {} : commentBody ?? {},
+          formData: async () => commentBody instanceof FormData ? commentBody : new FormData(),
         },
         json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
           status,
@@ -10308,7 +10327,10 @@ describe("Hands iOS simulator QA artifacts", () => {
       attachment_count: 0,
       comment_count: 0,
       latest_comment_at: null,
+      unread: false,
+      unread_count: 0,
     });
+    expect(listABody.unread_total).toBe(0);
     expect((await handleGetReporterFeedback(context("detail", credentialA.token, ticketB))).status).toBe(404);
     expect((await handleListReporterFeedback(context("list", credentialA.token, undefined, undefined, ""))).status).toBe(400);
     expect((await handleListReporterFeedback(context("list", null))).status).toBe(401);
@@ -10332,6 +10354,11 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect((await env.DB.prepare(
       "SELECT COUNT(*) AS count FROM feedback_comments WHERE ticket_id = ?1 AND author_type = 'reporter'",
     ).bind(ticketA).first() as any).count).toBe(1);
+    expect((await env.DB.prepare(
+      "SELECT submission_fingerprint FROM feedback_comments WHERE ticket_id = ?1 AND submission_id = ?2",
+    ).bind(ticketA, submissionId).first() as any).submission_fingerprint).toBe(
+      createHash("sha256").update("hello reporter loop").digest("hex"),
+    );
     expect((await env.DB.prepare(
       "SELECT COUNT(*) AS count FROM feedback_events WHERE ticket_id = ?1",
     ).bind(ticketA).first() as any).count).toBe(1);
@@ -10386,6 +10413,8 @@ describe("Hands iOS simulator QA artifacts", () => {
       { comment_limit: "2" },
     ));
     const page1Body = await page1.json() as any;
+    expect(page1Body.ticket).toMatchObject({ unread: false, unread_count: 0 });
+    expect(page1Body.unread_total).toBe(0);
     const page2 = await handleGetReporterFeedback(context(
       "detail", credentialA.token, ticketA, undefined, reporterId,
       { comment_limit: "2", comment_cursor: page1Body.next_comment_cursor },
@@ -10398,6 +10427,44 @@ describe("Hands iOS simulator QA artifacts", () => {
     ).bind(ticketA).all() as any).results.map((comment: any) => comment.id);
     expect(firstFour).toEqual(expectedFirstFour);
 
+    const afterRead = await handleListReporterFeedback(context("list", credentialA.token));
+    expect(await afterRead.json()).toMatchObject({
+      unread_total: 0,
+      tickets: [{ id: ticketA, unread: false, unread_count: 0 }],
+    });
+    const tiedEarlier = "21212121-2121-4212-8212-212121212121";
+    const tiedLater = "31313131-3131-4313-8313-313131313131";
+    await env.DB.prepare(
+      `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES (?1, ?2, 'staff:test', 'staff', 'new visible reply', 0, ?3)`,
+    ).bind(tiedEarlier, ticketA, now + 200).run();
+    const unreadOnce = await handleListReporterFeedback(context("list", credentialA.token));
+    expect(await unreadOnce.json()).toMatchObject({
+      unread_total: 1,
+      tickets: [{ id: ticketA, unread: true, unread_count: 1 }],
+    });
+    await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
+    await env.DB.prepare(
+      `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES (?1, ?2, 'system', 'system', 'same timestamp later id', 0, ?3)`,
+    ).bind(tiedLater, ticketA, now + 200).run();
+    const unreadTie = await handleListReporterFeedback(context("list", credentialA.token));
+    expect(await unreadTie.json()).toMatchObject({
+      unread_total: 1,
+      tickets: [{ id: ticketA, unread: true, unread_count: 1 }],
+    });
+    await env.DB.prepare(
+      `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES ('41414141-4141-4414-8414-414141414141', ?1, 'staff:test', 'staff',
+               'internal does not count', 1, ?2)`,
+    ).bind(ticketA, now + 300).run();
+    const unreadInternal = await handleListReporterFeedback(context("list", credentialA.token));
+    expect((await unreadInternal.json() as any).tickets[0].unread_count).toBe(1);
+    await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
+
     const emojiSubmission = "12121212-1212-4212-8212-121212121212";
     expect((await handleAddReporterComment(context(
       "comment", credentialA.token, ticketA,
@@ -10407,6 +10474,150 @@ describe("Hands iOS simulator QA artifacts", () => {
       "comment", credentialA.token, ticketA,
       { body: "😀".repeat(10_001), submission_id: "13131313-1313-4313-8313-131313131313" },
     ))).status).toBe(400);
+
+    const storedObjects = new Map<string, Uint8Array>();
+    const deletedObjects: string[] = [];
+    env.APK_BUCKET = {
+      put: async (key: string, value: ArrayBuffer) => {
+        storedObjects.set(key, new Uint8Array(value));
+      },
+      get: async (key: string) => {
+        const value = storedObjects.get(key);
+        return value ? { body: new Blob([value]).stream() } : null;
+      },
+      delete: async (key: string) => {
+        deletedObjects.push(key);
+        storedObjects.delete(key);
+      },
+    };
+    const attachmentSubmission = "51515151-5151-4515-8515-515151515151";
+    const attachmentForm = new FormData();
+    attachmentForm.set("body", "reply with screenshot");
+    attachmentForm.set("submission_id", attachmentSubmission);
+    attachmentForm.append("attachments", new File([new Uint8Array([1, 2, 3, 4])], "screen shot.png", {
+      type: "image/png",
+    }));
+    const attachmentResponse = await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, attachmentForm,
+    ));
+    expect(attachmentResponse.status).toBe(201);
+    const attachmentRow = await env.DB.prepare(
+      `SELECT id, comment_id, r2_key, filename, content_type, size_bytes, origin, visibility
+       FROM feedback_attachments WHERE ticket_id = ?1 AND origin = 'reporter'`,
+    ).bind(ticketA).first() as any;
+    expect(attachmentRow).toMatchObject({
+      filename: "screen_shot.png",
+      content_type: "image/png",
+      size_bytes: 4,
+      origin: "reporter",
+      visibility: "reporter",
+    });
+    expect(attachmentRow.comment_id).toBe((await attachmentResponse.clone().json() as any).id);
+    expect(storedObjects.get(attachmentRow.r2_key)).toEqual(new Uint8Array([1, 2, 3, 4]));
+    const attachmentReplay = await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, attachmentForm,
+    ));
+    expect(attachmentReplay.status).toBe(200);
+    expect(storedObjects.size).toBe(1);
+    const changedFileForm = new FormData();
+    changedFileForm.set("body", "reply with screenshot");
+    changedFileForm.set("submission_id", attachmentSubmission);
+    changedFileForm.append("attachments", new File([new Uint8Array([4, 3, 2, 1])], "screen shot.png", {
+      type: "image/png",
+    }));
+    expect((await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, changedFileForm,
+    ))).status).toBe(409);
+    const detailWithAttachment = await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
+    expect((await detailWithAttachment.json() as any).attachments).toContainEqual(expect.objectContaining({
+      id: attachmentRow.id,
+      filename: "screen_shot.png",
+      content_type: "image/png",
+      size_bytes: 4,
+    }));
+    const downloadResponse = await handleDownloadReporterAttachment({
+      ...context("detail", credentialA.token, ticketA),
+      req: {
+        ...context("detail", credentialA.token, ticketA).req,
+        param: (name: string) => name === "appId" ? "app-ios" : name === "ticketId" ? ticketA : attachmentRow.id,
+      },
+    } as any);
+    expect(downloadResponse.status).toBe(200);
+    expect(new Uint8Array(await downloadResponse.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(downloadResponse.headers.get("cache-control")).toBe("private, no-store");
+    const crossIntegrationDownload = await handleDownloadReporterAttachment({
+      ...context("detail", credentialB.token, ticketA),
+      req: {
+        ...context("detail", credentialB.token, ticketA).req,
+        param: (name: string) => name === "appId" ? "app-ios" : name === "ticketId" ? ticketA : attachmentRow.id,
+      },
+    } as any);
+    expect(crossIntegrationDownload.status).toBe(404);
+
+    const invalidTypeForm = new FormData();
+    invalidTypeForm.set("body", "bad type");
+    invalidTypeForm.set("submission_id", "61616161-6161-4616-8616-616161616161");
+    invalidTypeForm.append("attachments", new File(["x"], "x.txt", { type: "text/plain" }));
+    expect((await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, invalidTypeForm,
+    ))).status).toBe(400);
+    const tooManyForm = new FormData();
+    tooManyForm.set("body", "too many");
+    tooManyForm.set("submission_id", "71717171-7171-4717-8717-717171717171");
+    for (let index = 0; index < 4; index += 1) {
+      tooManyForm.append("attachments", new File(["x"], `${index}.png`, { type: "image/png" }));
+    }
+    expect((await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, tooManyForm,
+    ))).status).toBe(400);
+    const tooLargeForm = new FormData();
+    tooLargeForm.set("body", "too large");
+    tooLargeForm.set("submission_id", "81818181-8181-4818-8818-818181818181");
+    tooLargeForm.append("attachments", new File(
+      [new Uint8Array(10 * 1024 * 1024 + 1)],
+      "large.png",
+      { type: "image/png" },
+    ));
+    expect((await handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, tooLargeForm,
+    ))).status).toBe(400);
+
+    let uploadAttempt = 0;
+    env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
+      uploadAttempt += 1;
+      if (uploadAttempt === 2) throw new Error("simulated R2 failure");
+      storedObjects.set(key, new Uint8Array(value));
+    };
+    const r2FailureForm = new FormData();
+    r2FailureForm.set("body", "r2 failure");
+    r2FailureForm.set("submission_id", "91919191-9191-4919-8919-919191919191");
+    r2FailureForm.append("attachments", new File(["a"], "a.png", { type: "image/png" }));
+    r2FailureForm.append("attachments", new File(["b"], "b.png", { type: "image/png" }));
+    await expect(handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, r2FailureForm,
+    ))).rejects.toThrow("simulated R2 failure");
+    expect(deletedObjects.some((key) => key.includes("/comments/"))).toBe(true);
+
+    env.APK_BUCKET.put = async (key: string, value: ArrayBuffer) => {
+      storedObjects.set(key, new Uint8Array(value));
+    };
+    const originalBatch = env.DB.batch.bind(env.DB);
+    env.DB.batch = async (statements: unknown[]) => {
+      if (statements.length > 2) throw new Error("simulated D1 failure");
+      return originalBatch(statements);
+    };
+    const d1FailureForm = new FormData();
+    d1FailureForm.set("body", "d1 failure");
+    d1FailureForm.set("submission_id", "a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1");
+    d1FailureForm.append("attachments", new File(["d1"], "d1.png", { type: "image/png" }));
+    await expect(handleAddReporterComment(context(
+      "comment", credentialA.token, ticketA, d1FailureForm,
+    ))).rejects.toThrow("simulated D1 failure");
+    env.DB.batch = originalBatch;
+    expect([...storedObjects.keys()].some((key) => key.endsWith("/0-d1.png"))).toBe(false);
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_comments WHERE submission_id = ?1",
+    ).bind("a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1").first() as any).count).toBe(0);
 
     const { handleAddFeedbackComment, handleUpdateFeedback } = await import("../src/routes/feedback");
     const adminContext = (body: unknown) => ({
@@ -10422,7 +10633,7 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect((await handleAddFeedbackComment(adminContext({ body: "internal note", internal: true }))).status).toBe(201);
     expect((await env.DB.prepare(
       "SELECT COUNT(*) AS count FROM feedback_events WHERE ticket_id = ?1 AND event_type = 'feedback:comment_created'",
-    ).bind(ticketA).first() as any).count).toBe(3);
+    ).bind(ticketA).first() as any).count).toBe(4);
     const staffEvent = await env.DB.prepare(
       `SELECT payload_json FROM feedback_events
        WHERE ticket_id = ?1 AND event_type = 'feedback:comment_created'


### PR DESCRIPTION
## Summary

- add server-owned, monotonic reporter read receipts keyed by the full app/integration/reporter/ticket ownership tuple
- return per-ticket `unread` / `unread_count` plus response-level `unread_total`, and advance receipts on successful detail reads
- accept JSON text replies or multipart replies with up to three GIF/JPEG/PNG/WebP attachments of 10 MiB each
- bind reporter-uploaded attachment rows to their originating visible reporter comment, include file digests in idempotency, and clean up R2 objects when uploads or the atomic D1 write fail
- document the reporter conversation contract and OpenAPI surface

## Compatibility and safety

- text-only comment fingerprints retain the existing SHA-256 format
- reporter comments and internal staff notes do not create unread state
- equal-millisecond staff/system comments use comment UUID as the cursor tie-breaker
- attachment reads retain full app/integration/reporter/ticket ownership checks and private, no-store response headers
- no deployment, secret, subscription, or production configuration changes

## Validation

- Worker TypeScript build
- Worker test suite: 253/253
- migration ownership and attachment-association counterexamples
- multipart success/replay/conflict/type/count/size/R2-failure/D1-failure coverage
- `git diff --check`

The existing Worker ESLint script remains unavailable because the repository has ESLint 9 but no flat `eslint.config.*`; no lint configuration is changed here.
