### PR TITLE
chore(android-sdk): prepare 0.12.1 release

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.12.0"
+        default: "0.12.1"
   push:
     tags:
       - "android-sdk-v*"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.0")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.1")
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.11.0")
+    implementation("build.hands:hands-android-sdk:0.12.1")
 }
 ```
 
@@ -94,7 +94,7 @@ to catch that.
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.0`). That publishes to
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.1`). That publishes to
 GitHub Packages (`build.hands:hands-android-sdk:<version>`, including the
 `native-symbols` classifier) and, on the first
 request, builds the same version on JitPack

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.12.0"
+        const val SDK_VERSION = "0.12.1"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.0")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.1")
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.11.0")
+    implementation("build.hands:hands-android-sdk:0.12.1")
 }
 ```
 


### PR DESCRIPTION
## Summary

- align the Android SDK-reported version with 0.12.1
- set the publish workflow default to 0.12.1
- update both JitPack and GitHub Packages dependency coordinates and release examples

This is the release-preparation successor to the reviewed and landed delta fallback fix in PR #353.

## Validation

- version-coordinate readback: every touched Android SDK coordinate is exactly `0.12.1`; no stale `0.12.0` / `0.11.0` remains in the four release-prep files
- `git diff --check` PASS
- Hosted Android SDK check is the assemble + unit-test gate

## Boundaries

Release prep only. This PR does not itself publish the SDK, deploy the Worker, repin Mobile, or mutate a Hands release/channel/share.

Authorized by Artin in `#artifacts:2d09d26d`; requested live order is source prerequisite, SDK publication, then Worker deployment.
