### PR TITLE
fix(cli): mark manual Android deltas as gzip

### DIFF
--- a/docs/delta-download-design.md
+++ b/docs/delta-download-design.md
@@ -41,10 +41,10 @@ versions** to the new one, per arch (matching how we already split assets by
 (covers the vast majority of active installs; anyone older falls back to full).
 
 - New CLI step (or `publish-android` extension): for each `(prev_apk,
-  new_apk)` pair the generator emits `patch-<from_vc>-to-<to_vc>-<arch>.patch`.
+  new_apk)` pair the generator emits `patch-<from_vc>-to-<to_vc>-<arch>.patch.gz`.
 - Upload as build assets with `artifact_kind = 'delta-patch'` and
   `metadata_json = {from_version_code, to_version_code, algorithm:
-  "archive-patcher-v1"}`; store `file_hash` (patch sha256) and the **target
+  "archive-patcher-v1+gzip"}`; store `file_hash` (patch sha256) and the **target
   APK sha256** so the client can verify the reconstructed file.
 
 ### 2. Server (`/updates/check`)
@@ -55,7 +55,7 @@ stays the fallback, always present). When the client sends `current_version_code
 ```jsonc
 "patch": {
   "from_version_code": 1020100,
-  "algorithm": "archive-patcher-v1",
+  "algorithm": "archive-patcher-v1+gzip",
   "download_url": "<signed R2 url>",
   "size_bytes": 3145728,
   "target_sha256": "<sha256 of the reconstructed APK>"
@@ -71,7 +71,8 @@ old SDKs (they ignore the new field).
 1. Locate the installed base APK: `context.applicationInfo.sourceDir` (the
    currently-running APK — this *is* the `from_version_code` artifact).
 2. Download the patch (signed URL) to app storage.
-3. `FileByFileV1DeltaApplier().applyDelta(oldApk, patchStream, newApkOut)`.
+3. Gunzip the patch, then call
+   `FileByFileV1DeltaApplier().applyDelta(oldApk, patchStream, newApkOut)`.
 4. **Verify** the reconstructed APK: sha256 == `target_sha256` **and** its
    signing certificate matches the running app's (reject on mismatch — a delta
    must never install a differently-signed APK). PackageManager also rejects a
@@ -127,8 +128,11 @@ let the client take the full download. This keeps delta a strict win.
   store `delta-patch` assets.
 - **P1b upload outlet — DONE** (CLI 0.5.3, PR #209): `hands builds
   publish-android --delta-patch <from_version_code>=<path>` (repeatable)
-  uploads each patch as a `delta-patch` asset, stamping
-  `target_sha256` = the new APK's hash.
+  uploads official PatchGen `.patch.gz` output as a `delta-patch` asset,
+  stamping `algorithm = archive-patcher-v1+gzip` and `target_sha256` = the new
+  APK's hash. Before any API or upload request, the CLI decompresses the entire
+  stream, verifies gzip integrity and the archive-patcher v1 identifier, and
+  rejects raw or truncated input so bytes and metadata cannot disagree.
 - **P1b generation — NEXT**: an `android-release` CI step that, after building
   the new APK, downloads the last N (=3) published raft-android APKs, runs
   `FileByFileV1DeltaGenerator().generateDelta(old, new, out)`

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:http";
+import { gzipSync } from "node:zlib";
 import { Command } from "commander";
 import fixturePolicy from "./fixtures/collect-policy.json";
 
@@ -591,6 +592,170 @@ describe("electron build helpers", () => {
     expect(inferElectronFiletype("dist/Raft Setup 1.2.3.exe")).toBe("exe");
     expect(inferElectronFiletype("dist/Raft-1.2.3.AppImage")).toBe("AppImage");
     expect(inferElectronFiletype("dist/Raft Setup 1.2.3.exe.blockmap")).toBe("blockmap");
+  });
+});
+
+describe("Android delta patch metadata", () => {
+  it("marks metadata as gzip and rejects raw or truncated PatchGen output", async () => {
+    const {
+      ANDROID_DELTA_PATCH_ALGORITHM,
+      assertGzipAndroidDeltaPatch,
+      androidDeltaPatchMetadata,
+    } = await import("../src/commands/builds.js");
+
+    expect(ANDROID_DELTA_PATCH_ALGORITHM).toBe("archive-patcher-v1+gzip");
+    expect(
+      androidDeltaPatchMetadata({
+        fromVersionCode: 1000002,
+        toVersionCode: 1000003,
+        targetSha256: "a".repeat(64),
+      }),
+    ).toEqual({
+      from_version_code: 1000002,
+      to_version_code: 1000003,
+      algorithm: "archive-patcher-v1+gzip",
+      target_sha256: "a".repeat(64),
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), "hands-android-delta-"));
+    const gzipPatch = join(dir, "valid.patch.gz");
+    const rawPatch = join(dir, "raw.patch");
+    const truncatedPatch = join(dir, "truncated.patch.gz");
+    try {
+      const complete = gzipSync(Buffer.from("GFbFv1_0patch-body", "ascii"));
+      writeFileSync(gzipPatch, complete);
+      writeFileSync(rawPatch, Buffer.from("GFbFv1_0", "ascii"));
+      writeFileSync(truncatedPatch, complete.subarray(0, complete.length - 4));
+      await expect(assertGzipAndroidDeltaPatch(gzipPatch)).resolves.toBeUndefined();
+      await expect(assertGzipAndroidDeltaPatch(rawPatch)).rejects.toThrow(
+        "must be a complete gzip-compressed official PatchGen output",
+      );
+      await expect(assertGzipAndroidDeltaPatch(truncatedPatch)).rejects.toThrow(
+        "must be a complete gzip-compressed official PatchGen output",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preflights before HTTP and sends the exact gzip asset metadata", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hands-android-publish-"));
+    const apk = join(dir, "app.apk");
+    const validPatch = join(dir, "valid.patch.gz");
+    const rawPatch = join(dir, "raw.patch");
+    const truncatedPatch = join(dir, "truncated.patch.gz");
+    const complete = gzipSync(Buffer.from("GFbFv1_0patch-body", "ascii"));
+    writeFileSync(apk, "apk-bytes");
+    writeFileSync(validPatch, complete);
+    writeFileSync(rawPatch, Buffer.from("GFbFv1_0patch-body", "ascii"));
+    writeFileSync(truncatedPatch, complete.subarray(0, complete.length - 4));
+
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    let uploadCount = 0;
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } else {
+        for await (const _chunk of req) {
+          // Drain multipart uploads before responding.
+        }
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.method === "GET" && req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "android-app" }] }));
+      }
+      if (req.method === "GET" && req.url === "/api/apps/app-1/channels") {
+        return res.end(JSON.stringify({ channels: [{ id: "channel-1", slug: "main", name: "Main" }] }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/builds") {
+        return res.end(JSON.stringify({ id: "build-1" }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/upload") {
+        uploadCount += 1;
+        return res.end(JSON.stringify({
+          file_hash: uploadCount === 1 ? "a".repeat(64) : "b".repeat(64),
+          r2_key: `apps/app-1/upload-${uploadCount}`,
+          size_bytes: uploadCount === 1 ? 9 : complete.length,
+          original_filename: uploadCount === 1 ? "app.apk" : "valid.patch.gz",
+        }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/builds/build-1/assets") {
+        return res.end(JSON.stringify({ id: `asset-${uploadCount}` }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/releases") {
+        return res.end(JSON.stringify({ id: "release-1" }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    const runPublish = async (patchPath: string) => {
+      const { registerBuildCommands } = await import("../src/commands/builds.js");
+      const program = new Command().version("0.5.13").option("--json", "JSON output", false);
+      registerBuildCommands(program);
+      await program.parseAsync([
+        "node", "hands", "builds", "publish-android", "android-app",
+        "--apk", apk,
+        "--version-name", "1.0.0-alpha",
+        "--version-code", "1000003",
+        "--delta-patch", `1000002=${patchPath}`,
+        "--draft",
+      ]);
+    };
+
+    try {
+      await runPublish(validPatch);
+      const deltaAsset = requests.find(
+        (request) =>
+          request.method === "POST" &&
+          request.url.endsWith("/assets") &&
+          request.body?.artifact_kind === "delta-patch",
+      );
+      expect(deltaAsset?.body).toMatchObject({
+        artifact_kind: "delta-patch",
+        platform: "android",
+        arch: "arm64-v8a",
+        filetype: "patch",
+        file_hash: "b".repeat(64),
+        metadata_json: {
+          from_version_code: 1000002,
+          to_version_code: 1000003,
+          algorithm: "archive-patcher-v1+gzip",
+          target_sha256: "a".repeat(64),
+        },
+      });
+
+      requests.length = 0;
+      await expect(runPublish(rawPatch)).rejects.toThrow(
+        "must be a complete gzip-compressed official PatchGen output",
+      );
+      expect(requests).toEqual([]);
+
+      requests.length = 0;
+      await expect(runPublish(truncatedPatch)).rejects.toThrow(
+        "must be a complete gzip-compressed official PatchGen output",
+      );
+      expect(requests).toEqual([]);
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -5,13 +5,16 @@
  */
 
 import type { Command } from "commander";
-import { existsSync, readFileSync } from "node:fs";
+import { createReadStream, existsSync, readFileSync } from "node:fs";
 import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
+import { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
+import { createGunzip } from "node:zlib";
 import { apiRequest, apiUploadFile } from "../lib/api.js";
 
 const execFileAsync = promisify(execFile);
@@ -80,6 +83,79 @@ interface TestflightPublishStatus {
 
 function collect(value: string, previous: string[] = []): string[] {
   return previous.concat(value);
+}
+
+export const ANDROID_DELTA_PATCH_ALGORITHM = "archive-patcher-v1+gzip";
+const ANDROID_DELTA_PATCH_MAGIC = Buffer.from("GFbFv1_0", "ascii");
+
+interface AndroidDeltaPatchSpec {
+  fromVersionCode: number;
+  patchPath: string;
+}
+
+export function androidDeltaPatchMetadata(args: {
+  fromVersionCode: number;
+  toVersionCode: number;
+  targetSha256: string;
+}): Record<string, unknown> {
+  return {
+    from_version_code: args.fromVersionCode,
+    to_version_code: args.toVersionCode,
+    algorithm: ANDROID_DELTA_PATCH_ALGORITHM,
+    target_sha256: args.targetSha256,
+  };
+}
+
+export async function assertGzipAndroidDeltaPatch(filePath: string): Promise<void> {
+  let prefix = Buffer.alloc(0);
+  try {
+    await pipeline(
+      createReadStream(filePath),
+      createGunzip(),
+      new Writable({
+        write(chunk: Buffer, _encoding, callback) {
+          if (prefix.length < ANDROID_DELTA_PATCH_MAGIC.length) {
+            prefix = Buffer.concat([prefix, chunk]).subarray(
+              0,
+              ANDROID_DELTA_PATCH_MAGIC.length,
+            );
+          }
+          callback();
+        },
+      }),
+    );
+  } catch {
+    throw new Error(
+      `--delta-patch must be a complete gzip-compressed official PatchGen output (.patch.gz): ${filePath}`,
+    );
+  }
+  if (!prefix.equals(ANDROID_DELTA_PATCH_MAGIC)) {
+    throw new Error(
+      `--delta-patch does not contain an archive-patcher v1 stream: ${filePath}`,
+    );
+  }
+}
+
+async function preflightAndroidDeltaPatches(
+  specs: string[] = [],
+): Promise<AndroidDeltaPatchSpec[]> {
+  const parsed = specs.map((spec) => {
+    const eq = spec.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(`--delta-patch must be <from_version_code>=<path>, got: ${spec}`);
+    }
+    const fromVersionCode = Number(spec.slice(0, eq).trim());
+    const patchPath = spec.slice(eq + 1).trim();
+    if (!Number.isFinite(fromVersionCode)) {
+      throw new Error(`bad from_version_code in --delta-patch: ${spec}`);
+    }
+    if (!existsSync(patchPath)) throw new Error(`missing delta patch file: ${patchPath}`);
+    return { fromVersionCode, patchPath };
+  });
+  for (const patch of parsed) {
+    await assertGzipAndroidDeltaPatch(patch.patchPath);
+  }
+  return parsed;
 }
 
 export function shouldOutputJson(program: Command, localJson?: boolean): boolean {
@@ -530,7 +606,7 @@ export function registerBuildCommands(program: Command): void {
     .option("--metadata <path>", "Build metadata JSON support artifact.")
     .option(
       "--delta-patch <spec>",
-      "Delta patch as <from_version_code>=<path> (archive-patcher). Repeatable — clients on that version get offered this patch instead of the full APK.",
+      "Complete gzipped delta patch as <from_version_code>=<path> (official PatchGen .patch.gz output). Repeatable — clients on that version get offered this patch instead of the full APK.",
       collect,
       [],
     )
@@ -589,8 +665,6 @@ export function registerBuildCommands(program: Command): void {
           json?: boolean;
         },
       ) => {
-        const appId = await resolveAppId(appIdOrSlug);
-        const channelId = await resolveChannelId(appId, opts.channel);
         const versionCode = Number(opts.versionCode);
         if (!Number.isFinite(versionCode) || versionCode < 0) {
           throw new Error("--version-code must be a non-negative number");
@@ -602,6 +676,7 @@ export function registerBuildCommands(program: Command): void {
         const metadataJson = opts.metadata
           ? JSON.parse(readFileSync(opts.metadata, "utf8"))
           : {};
+        const deltaPatches = await preflightAndroidDeltaPatches(opts.deltaPatch);
         const provenance = {
           source_commit: opts.sourceCommit ?? null,
           source_branch: opts.sourceBranch ?? null,
@@ -610,6 +685,8 @@ export function registerBuildCommands(program: Command): void {
           ci_run_id: opts.ciRunId ?? null,
           ci_url: opts.ciUrl ?? null,
         };
+        const appId = await resolveAppId(appIdOrSlug);
+        const channelId = await resolveChannelId(appId, opts.channel);
 
         const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
           method: "POST",
@@ -636,28 +713,22 @@ export function registerBuildCommands(program: Command): void {
           filetype: "apk",
         });
         assets.push(installable);
-        // Delta patches: <from_version_code>=<path>. target_sha256 is the new
-        // APK's hash so the client can verify the reconstructed file. The
-        // server offers a patch only when it beats the full APK size.
-        for (const spec of opts.deltaPatch ?? []) {
-          const eq = spec.indexOf("=");
-          if (eq <= 0) throw new Error(`--delta-patch must be <from_version_code>=<path>, got: ${spec}`);
-          const fromVersionCode = Number(spec.slice(0, eq).trim());
-          const patchPath = spec.slice(eq + 1).trim();
-          if (!Number.isFinite(fromVersionCode)) throw new Error(`bad from_version_code in --delta-patch: ${spec}`);
-          if (!existsSync(patchPath)) throw new Error(`missing delta patch file: ${patchPath}`);
+        // Delta inputs were fully preflighted before any remote mutation.
+        // target_sha256 is the new APK's hash so the client can verify the
+        // reconstructed file. The server offers a patch only when it beats
+        // the full APK size.
+        for (const { fromVersionCode, patchPath } of deltaPatches) {
           assets.push(
             await uploadAndRegisterAsset(appId, build.id, patchPath, {
               artifact_kind: "delta-patch",
               platform: "android",
               arch: opts.arch,
               filetype: "patch",
-              metadata_json: {
-                from_version_code: fromVersionCode,
-                to_version_code: versionCode,
-                algorithm: "archive-patcher-v1",
-                target_sha256: installable.file_hash,
-              },
+              metadata_json: androidDeltaPatchMetadata({
+                fromVersionCode,
+                toVersionCode: versionCode,
+                targetSha256: installable.file_hash,
+              }),
             }),
           );
         }
@@ -1864,12 +1935,11 @@ async function generateAndUploadAndroidDeltas(args: {
           platform: "android",
           arch: args.arch,
           filetype: "patch",
-          metadata_json: {
-            from_version_code: src.from_version_code,
-            to_version_code: args.toVersionCode,
-            algorithm: "archive-patcher-v1+gzip",
-            target_sha256: args.targetSha256,
-          },
+          metadata_json: androidDeltaPatchMetadata({
+            fromVersionCode: src.from_version_code,
+            toVersionCode: args.toVersionCode,
+            targetSha256: args.targetSha256,
+          }),
         }),
       );
     }


### PR DESCRIPTION
## Summary

- stamp manual `publish-android --delta-patch` assets with `archive-patcher-v1+gzip`, matching the bundled official `PatchGen` output
- preflight every manual patch before any HTTP/API/upload request by fully decompressing it, validating gzip integrity, and checking the archive-patcher v1 identifier
- share one metadata helper between manual and generated delta uploads so the paths cannot drift again
- update CLI help/design docs and cover the real publish request plus raw/truncated zero-request rejection

## Runtime reason

Task #187 uploaded a valid `.patch.gz` through `--delta-patch`. The CLI stamped it as raw `archive-patcher-v1`, so the Android SDK correctly skipped gunzip and failed with `delta_fallback reason=apply err=Bad identifier`. The patch bytes and target SHA were otherwise exact.

## Verification

- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli test -- -t "Android delta patch metadata"` (2 passed)
- `pnpm --filter @botiverse/hands-cli test` (29 passed)
- `pnpm --filter @botiverse/hands-cli build`
- real 11,295,525-byte task #187 canonical patch full-stream preflight PASS
- real 64-byte truncated task #187 patch full-stream preflight REJECT PASS
- `git diff --check`

`pnpm --filter @botiverse/hands-cli lint` cannot start on current `main` because the repository has no ESLint 9 `eslint.config.*`; no lint config is changed here.
