### PR TITLE
feat(worker): expose guarded build asset deletion

### DIFF
--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -16,6 +16,10 @@ import {
 
 const AppBuildParams = AppIdParam.merge(BuildIdParam);
 const AppBuildAssetParams = AppBuildParams.merge(AssetIdParam);
+const GuardedBuildAssetDeleteQuery = z.object({
+  expected_file_hash: z.string().regex(/^[a-f0-9]{64}$/i).optional(),
+  expected_size_bytes: z.coerce.number().int().nonnegative().optional(),
+});
 const AppQaArtifactParams = AppIdParam.merge(AssetIdParam);
 const AppBuildUploadParams = AppIdParam.merge(
   z.object({ buildUploadId: z.string().openapi({ param: { name: "buildUploadId", in: "path" } }) }),
@@ -531,13 +535,18 @@ export function registerBuildRoutes(registry: OpenApiRegistry) {
     method: "delete",
     path: "/api/apps/{appId}/builds/{buildId}/assets/{assetId}",
     tags: ["Builds"],
-    summary: "Delete a build asset",
+    summary: "Delete build-asset metadata without deleting its stored object",
+    description:
+      "App-admin metadata deletion. Supplying both expected_file_hash and expected_size_bytes enables the guarded Agent path: non-installable only, R2 existence/size preflight, immutable byte preconditions, atomic audit+delete, and audit-backed idempotent absence readback. Arbitrary absent ids fail closed. The R2 object is never deleted.",
     security: auth,
-    request: { params: AppBuildAssetParams },
+    request: { params: AppBuildAssetParams, query: GuardedBuildAssetDeleteQuery },
     responses: {
-      200: success("Deleted build asset.", GenericObject),
+      200: success("Build-asset metadata is absent; the R2 object was preserved.", GenericObject),
+      400: error("Guarded delete preconditions were malformed or incomplete."),
       403: error("Current principal cannot delete build assets."),
       404: error("Build asset was not found."),
+      409: error("Guarded delete preconditions failed or the asset is installable."),
+      503: error("R2 readback was unavailable. Post-commit failures return metadata_absent, r2_preserved=null, and the durable audit_id."),
     },
   });
 

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1343,6 +1343,22 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "delete-build-asset",
+        description:
+          "Delete one non-installable build-asset metadata row while preserving its R2 object. Requires app admin, exact app/build/asset binding, and immutable SHA-256/size preconditions. Audit and deletion commit atomically; an absent-row retry succeeds only by recovering the matching audit and rechecking R2. Installable assets, arbitrary absent ids, and missing/mismatched stored objects fail closed.",
+        endpoint: {
+          method: "DELETE",
+          path: "/api/apps/{app_id}/builds/{build_id}/assets/{asset_id}",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          build_id: { type: "string", in: "path", required: true, description: "Build UUID." },
+          asset_id: { type: "string", in: "path", required: true, description: "Non-installable build asset UUID." },
+          expected_file_hash: { type: "string", in: "query", required: true, description: "Expected lowercase or uppercase SHA-256 hex digest from a fresh list-build-assets read." },
+          expected_size_bytes: { type: "integer", in: "query", required: true, description: "Expected immutable byte size from the same fresh read." },
+        },
+      },
+      {
         name: "list-ios-simulator-artifacts",
         description:
           "List exact-byte iOS simulator .app.zip QA fixtures. Optional source_commit, github_run_id, and sha256 filters select the exact provenance coordinate. Requires app viewer.",

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -1025,20 +1025,309 @@ export async function handleDeleteBuildAsset(c: Context<{ Bindings: Env }>) {
   const appId = c.req.param("appId") ?? "";
   const buildId = c.req.param("buildId") ?? "";
   const assetId = c.req.param("assetId") ?? "";
+  const expectedFileHash = c.req.query("expected_file_hash")?.trim().toLowerCase() ?? null;
+  const expectedSizeRaw = c.req.query("expected_size_bytes")?.trim() ?? null;
+  const guardedAgentDelete = expectedFileHash !== null || expectedSizeRaw !== null;
+
+  if (guardedAgentDelete) {
+    if (!expectedFileHash || expectedSizeRaw === null) {
+      return c.json(
+        {
+          error: "expected_file_hash and expected_size_bytes are required together",
+          code: "ASSET_DELETE_PRECONDITION_REQUIRED",
+        },
+        400,
+      );
+    }
+    if (!/^[a-f0-9]{64}$/.test(expectedFileHash)) {
+      return c.json({ error: "expected_file_hash must be a SHA-256 hex digest" }, 400);
+    }
+    if (!/^\d+$/.test(expectedSizeRaw) || !Number.isSafeInteger(Number(expectedSizeRaw))) {
+      return c.json({ error: "expected_size_bytes must be a non-negative safe integer" }, 400);
+    }
+  }
+
   const build = await getBuildForApp(c.env.DB, appId, buildId);
   if (!build) return c.json({ error: "build not found" }, 404);
   const asset = await c.env.DB.prepare(
-    "SELECT id FROM build_assets WHERE id = ?1 AND build_id = ?2",
+    `SELECT id, artifact_kind, r2_key, file_hash, size_bytes
+     FROM build_assets
+     WHERE id = ?1 AND build_id = ?2`,
   )
     .bind(assetId, buildId)
-    .first<{ id: string }>();
-  if (!asset) return c.json({ error: "asset not found" }, 404);
+    .first<{
+      id: string;
+      artifact_kind: string;
+      r2_key: string;
+      file_hash: string;
+      size_bytes: number;
+    }>();
+  if (!asset) {
+    if (guardedAgentDelete) {
+      const prior = await c.env.DB.prepare(
+        `SELECT id, payload
+         FROM audit_logs
+         WHERE app_id = ?1 AND action = 'build_asset.delete'
+           AND json_extract(payload, '$.buildId') = ?2
+           AND json_extract(payload, '$.assetId') = ?3
+           AND lower(json_extract(payload, '$.fileHash')) = ?4
+           AND CAST(json_extract(payload, '$.sizeBytes') AS INTEGER) = ?5
+           AND json_extract(payload, '$.r2Preserved') = 1
+         ORDER BY created_at DESC
+         LIMIT 1`,
+      )
+        .bind(appId, buildId, assetId, expectedFileHash, Number(expectedSizeRaw))
+        .first<{ id: string; payload: string }>();
+      if (!prior) {
+        return c.json(
+          {
+            error: "asset metadata is absent without a matching successful delete audit",
+            code: "ASSET_DELETE_PROVENANCE_NOT_FOUND",
+            metadata_absent: true,
+            r2_preserved: null,
+          },
+          404,
+        );
+      }
+      let payload: {
+        r2Key?: unknown;
+        fileHash?: unknown;
+        sizeBytes?: unknown;
+      };
+      try {
+        payload = JSON.parse(prior.payload) as typeof payload;
+      } catch {
+        return c.json(
+          { error: "matching delete audit is malformed", code: "ASSET_DELETE_AUDIT_INVALID" },
+          500,
+        );
+      }
+      if (
+        typeof payload.r2Key !== "string" ||
+        payload.fileHash !== expectedFileHash ||
+        payload.sizeBytes !== Number(expectedSizeRaw)
+      ) {
+        return c.json(
+          { error: "matching delete audit is incomplete", code: "ASSET_DELETE_AUDIT_INVALID" },
+          500,
+        );
+      }
+      let object: R2Object | null;
+      try {
+        object = await c.env.APK_BUCKET.head(payload.r2Key);
+      } catch {
+        return c.json(
+          {
+            error: "stored object readback is temporarily unavailable",
+            code: "ASSET_OBJECT_READBACK_FAILED",
+            metadata_absent: true,
+            r2_preserved: null,
+            audit_id: prior.id,
+          },
+          503,
+        );
+      }
+      if (!object || object.size !== payload.sizeBytes) {
+        return c.json(
+          {
+            error: "stored object from the successful delete audit is missing or changed",
+            code: "ASSET_OBJECT_PRECONDITION_FAILED",
+            metadata_absent: true,
+            r2_preserved: false,
+          },
+          409,
+        );
+      }
+      return c.json({
+        ok: true,
+        deleted: false,
+        idempotent_replay: true,
+        asset_id: assetId,
+        build_id: buildId,
+        metadata_absent: true,
+        r2_preserved: true,
+        r2_key: payload.r2Key,
+        file_hash: payload.fileHash,
+        size_bytes: payload.sizeBytes,
+        audit_id: prior.id,
+      });
+    }
+    return c.json({ error: "asset not found" }, 404);
+  }
 
-  await c.env.DB.prepare("DELETE FROM build_assets WHERE id = ?1 AND build_id = ?2")
-    .bind(assetId, buildId)
-    .run();
-  await insertAuditLog(c.env.DB, appId, "build_asset.delete", currentActor(c), { buildId, assetId });
-  return c.json({ ok: true });
+  if (guardedAgentDelete) {
+    const expectedSize = Number(expectedSizeRaw);
+    if (asset.artifact_kind === "installable") {
+      return c.json(
+        {
+          error: "guarded Agent deletion does not allow installable assets",
+          code: "INSTALLABLE_ASSET_DELETE_FORBIDDEN",
+        },
+        409,
+      );
+    }
+    if (asset.file_hash.toLowerCase() !== expectedFileHash || asset.size_bytes !== expectedSize) {
+      return c.json(
+        {
+          error: "build asset no longer matches the expected immutable bytes",
+          code: "ASSET_DELETE_PRECONDITION_FAILED",
+        },
+        409,
+      );
+    }
+    let object: R2Object | null;
+    try {
+      object = await c.env.APK_BUCKET.head(asset.r2_key);
+    } catch {
+      return c.json(
+        {
+          error: "stored object preflight is temporarily unavailable",
+          code: "ASSET_OBJECT_READBACK_FAILED",
+          r2_preserved: null,
+        },
+        503,
+      );
+    }
+    if (!object || object.size !== asset.size_bytes) {
+      return c.json(
+        {
+          error: "stored object is missing or its size no longer matches the asset metadata",
+          code: "ASSET_OBJECT_PRECONDITION_FAILED",
+        },
+        409,
+      );
+    }
+  }
+
+  const auditId = crypto.randomUUID();
+  const auditPayload = JSON.stringify({
+    buildId,
+    assetId,
+    artifactKind: asset.artifact_kind,
+    r2Key: asset.r2_key,
+    fileHash: asset.file_hash.toLowerCase(),
+    sizeBytes: asset.size_bytes,
+    r2Preserved: true,
+    guarded: guardedAgentDelete,
+  });
+  const now = Date.now();
+  const actor = currentActor(c);
+  const auditStatement = guardedAgentDelete
+    ? c.env.DB.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       SELECT ?1, ?2, 'build_asset.delete', ?3, ?4, ?5
+       FROM build_assets
+       WHERE id = ?6 AND build_id = ?7 AND artifact_kind <> 'installable'
+         AND lower(file_hash) = ?8 AND size_bytes = ?9
+         AND artifact_kind = ?10 AND r2_key = ?11`,
+    ).bind(
+      auditId,
+      appId,
+      actor,
+      auditPayload,
+      now,
+      assetId,
+      buildId,
+      expectedFileHash,
+      Number(expectedSizeRaw),
+      asset.artifact_kind,
+      asset.r2_key,
+    )
+    : c.env.DB.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       SELECT ?1, ?2, 'build_asset.delete', ?3, ?4, ?5
+       FROM build_assets
+       WHERE id = ?6 AND build_id = ?7 AND artifact_kind = ?8 AND r2_key = ?9`,
+    ).bind(
+      auditId,
+      appId,
+      actor,
+      auditPayload,
+      now,
+      assetId,
+      buildId,
+      asset.artifact_kind,
+      asset.r2_key,
+    );
+  const deleteStatement = guardedAgentDelete
+    ? c.env.DB.prepare(
+      `DELETE FROM build_assets
+       WHERE id = ?1 AND build_id = ?2 AND artifact_kind <> 'installable'
+         AND lower(file_hash) = ?3 AND size_bytes = ?4
+         AND artifact_kind = ?5 AND r2_key = ?6`,
+    ).bind(
+      assetId,
+      buildId,
+      expectedFileHash,
+      Number(expectedSizeRaw),
+      asset.artifact_kind,
+      asset.r2_key,
+    )
+    : c.env.DB.prepare(
+      `DELETE FROM build_assets
+       WHERE id = ?1 AND build_id = ?2 AND artifact_kind = ?3 AND r2_key = ?4`,
+    ).bind(assetId, buildId, asset.artifact_kind, asset.r2_key);
+  const results = await c.env.DB.batch([auditStatement, deleteStatement]);
+  const auditWrite = results[0];
+  const deletion = results[1];
+  if (!auditWrite || !deletion) {
+    throw new Error("atomic build-asset audit/delete batch returned an incomplete result");
+  }
+  const audited = Number(auditWrite.meta?.changes ?? 0) === 1;
+  const deleted = Number(deletion.meta?.changes ?? 0) === 1;
+  if (audited !== deleted) {
+    throw new Error("atomic build-asset audit/delete result mismatch");
+  }
+  if (!deleted) {
+    return c.json(
+      {
+        error: "build asset changed before the guarded delete committed",
+        code: "ASSET_DELETE_PRECONDITION_FAILED",
+      },
+      409,
+    );
+  }
+  if (guardedAgentDelete) {
+    let object: R2Object | null;
+    try {
+      object = await c.env.APK_BUCKET.head(asset.r2_key);
+    } catch {
+      return c.json(
+        {
+          error: "metadata was deleted and audited, but preserved object readback is temporarily unavailable",
+          code: "ASSET_OBJECT_READBACK_FAILED",
+          metadata_absent: true,
+          r2_preserved: null,
+          audit_id: auditId,
+        },
+        503,
+      );
+    }
+    if (!object || object.size !== asset.size_bytes) {
+      return c.json(
+        {
+          error: "metadata was deleted and audited, but the preserved object readback failed",
+          code: "ASSET_OBJECT_READBACK_FAILED",
+          metadata_absent: true,
+          r2_preserved: false,
+          audit_id: auditId,
+        },
+        503,
+      );
+    }
+  }
+  return c.json({
+    ok: true,
+    deleted,
+    asset_id: assetId,
+    build_id: buildId,
+    metadata_absent: true,
+    r2_preserved: true,
+    r2_key: asset.r2_key,
+    file_hash: asset.file_hash,
+    size_bytes: asset.size_bytes,
+    audit_id: auditId,
+  });
 }
 
 export async function handleDeleteBuild(c: Context<{ Bindings: Env }>) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -5083,6 +5083,7 @@ describe("quiver public API v2 — scope resolution", () => {
       sizeBytes?: number;
       variant?: string | null;
       r2Key?: string;
+      fileHash?: string;
       metadata?: Record<string, unknown>;
     } = {},
   ) {
@@ -5100,7 +5101,7 @@ describe("quiver public API v2 — scope resolution", () => {
         opts.variant ?? null,
         opts.filetype ?? "apk",
         opts.r2Key ?? `apps/app-scope/${assetId}.apk`,
-        `${assetId}-hash`,
+        opts.fileHash ?? `${assetId}-hash`,
         opts.sizeBytes ?? 42,
         `${assetId}-sig`,
         JSON.stringify(opts.metadata ?? {}),
@@ -5209,6 +5210,7 @@ describe("quiver public API v2 — scope resolution", () => {
           status,
           headers: { location: url },
         }),
+      get: (name: string) => (name === "admin_actor" ? "raft:delete-agent@test" : undefined),
     } as any;
   }
 
@@ -7307,6 +7309,438 @@ describe("quiver public API v2 — scope resolution", () => {
       .bind("asset-presign-metadata")
       .first() as { download_count: number } | null;
     expect(row?.download_count).toBe(0);
+  });
+
+  it("guarded Agent delete removes only non-installable metadata and preserves R2", async () => {
+    const env = makeEnv();
+    const { handleDeleteBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-delete-metadata", "build-delete-metadata", [["full", "all"]], {
+      versionCode: 14,
+      versionName: "1.0.14",
+    });
+    const hash = "a".repeat(64);
+    const r2Key = "apps/app-scope/delete-metadata.patch.gz";
+    await seedAsset(env, "build-delete-metadata", "asset-delete-metadata", {
+      artifactKind: "android-delta",
+      filetype: "patch",
+      sizeBytes: 123,
+      fileHash: hash,
+      r2Key,
+    });
+    let deleteCalls = 0;
+    let objectPresent = true;
+    env.APK_BUCKET = {
+      head: async (key: string) => objectPresent && key === r2Key ? { size: 123 } : null,
+      delete: async () => {
+        deleteCalls += 1;
+      },
+    };
+
+    const response = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-metadata", "asset-delete-metadata", {
+        expected_file_hash: hash,
+        expected_size_bytes: "123",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      ok: true,
+      deleted: true,
+      asset_id: "asset-delete-metadata",
+      build_id: "build-delete-metadata",
+      metadata_absent: true,
+      r2_preserved: true,
+      r2_key: r2Key,
+      file_hash: hash,
+      size_bytes: 123,
+    });
+    expect(deleteCalls).toBe(0);
+    await expect(
+      env.DB.prepare("SELECT id FROM build_assets WHERE id = ?").bind("asset-delete-metadata").first(),
+    ).resolves.toBeNull();
+    const audit = await env.DB.prepare(
+      "SELECT actor, payload FROM audit_logs WHERE app_id = ? AND action = 'build_asset.delete'",
+    ).bind("app-scope").first() as { actor: string; payload: string } | null;
+    expect(audit?.actor).toBe("raft:delete-agent@test");
+    expect(JSON.parse(audit?.payload ?? "{}")).toMatchObject({
+      buildId: "build-delete-metadata",
+      assetId: "asset-delete-metadata",
+      artifactKind: "android-delta",
+      r2Key,
+      fileHash: hash,
+      sizeBytes: 123,
+      r2Preserved: true,
+      guarded: true,
+    });
+
+    const retry = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-metadata", "asset-delete-metadata", {
+        expected_file_hash: hash,
+        expected_size_bytes: "123",
+      }),
+    );
+    expect(retry.status).toBe(200);
+    await expect(responseJson<any>(retry)).resolves.toMatchObject({
+      ok: true,
+      deleted: false,
+      idempotent_replay: true,
+      metadata_absent: true,
+      r2_preserved: true,
+      r2_key: r2Key,
+    });
+
+    objectPresent = false;
+    const missingObjectRetry = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-metadata", "asset-delete-metadata", {
+        expected_file_hash: hash,
+        expected_size_bytes: "123",
+      }),
+    );
+    expect(missingObjectRetry.status).toBe(409);
+    await expect(responseJson<any>(missingObjectRetry)).resolves.toMatchObject({
+      code: "ASSET_OBJECT_PRECONDITION_FAILED",
+      metadata_absent: true,
+      r2_preserved: false,
+    });
+
+    const arbitraryAbsent = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-metadata", "asset-never-existed", {
+        expected_file_hash: hash,
+        expected_size_bytes: "123",
+      }),
+    );
+    expect(arbitraryAbsent.status).toBe(404);
+    await expect(responseJson<any>(arbitraryAbsent)).resolves.toMatchObject({
+      code: "ASSET_DELETE_PROVENANCE_NOT_FOUND",
+      metadata_absent: true,
+      r2_preserved: null,
+    });
+  });
+
+  it("rolls back metadata deletion when the atomic audit insert fails", async () => {
+    const env = makeEnv();
+    const { handleDeleteBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-delete-audit-fail", "build-delete-audit-fail", [["full", "all"]], {
+      versionCode: 16,
+      versionName: "1.0.16",
+    });
+    const hash = "e".repeat(64);
+    const r2Key = "apps/app-scope/delete-audit-fail.patch.gz";
+    await seedAsset(env, "build-delete-audit-fail", "asset-delete-audit-fail", {
+      artifactKind: "android-delta",
+      filetype: "patch",
+      sizeBytes: 77,
+      fileHash: hash,
+      r2Key,
+    });
+    env.APK_BUCKET = {
+      head: async (key: string) => key === r2Key ? { size: 77 } : null,
+    };
+    await env.DB.prepare(
+      `CREATE TRIGGER force_build_asset_audit_failure
+       BEFORE INSERT ON audit_logs
+       WHEN NEW.action = 'build_asset.delete'
+       BEGIN
+         SELECT RAISE(ABORT, 'forced build asset audit failure');
+       END`,
+    ).run();
+
+    await expect(
+      handleDeleteBuildAsset(
+        makeBuildAssetDownloadContext(env, "build-delete-audit-fail", "asset-delete-audit-fail", {
+          expected_file_hash: hash,
+          expected_size_bytes: "77",
+        }),
+      ),
+    ).rejects.toThrow("forced build asset audit failure");
+
+    const asset = await env.DB.prepare(
+      "SELECT id, r2_key FROM build_assets WHERE id = ? AND build_id = ?",
+    ).bind("asset-delete-audit-fail", "build-delete-audit-fail").first();
+    expect(asset).toMatchObject({ id: "asset-delete-audit-fail", r2_key: r2Key });
+    const audit = await env.DB.prepare(
+      "SELECT id FROM audit_logs WHERE app_id = ? AND action = 'build_asset.delete'",
+    ).bind("app-scope").first();
+    expect(audit).toBeNull();
+  });
+
+  it("fails closed when the asset R2 key changes between preflight and the atomic batch", async () => {
+    const env = makeEnv();
+    const { handleDeleteBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-delete-key-race", "build-delete-key-race", [["full", "all"]], {
+      versionCode: 17,
+      versionName: "1.0.17",
+    });
+    const hash = "f".repeat(64);
+    const oldKey = "apps/app-scope/delete-key-race-old.patch.gz";
+    const newKey = "apps/app-scope/delete-key-race-new.patch.gz";
+    await seedAsset(env, "build-delete-key-race", "asset-delete-key-race", {
+      artifactKind: "android-delta",
+      filetype: "patch",
+      sizeBytes: 88,
+      fileHash: hash,
+      r2Key: oldKey,
+    });
+    let preflightMutated = false;
+    env.APK_BUCKET = {
+      head: async (key: string) => {
+        if (key !== oldKey) return null;
+        if (!preflightMutated) {
+          preflightMutated = true;
+          await env.DB.prepare(
+            "UPDATE build_assets SET r2_key = ? WHERE id = ? AND build_id = ?",
+          ).bind(newKey, "asset-delete-key-race", "build-delete-key-race").run();
+        }
+        return { size: 88 };
+      },
+    };
+
+    const response = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-key-race", "asset-delete-key-race", {
+        expected_file_hash: hash,
+        expected_size_bytes: "88",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "ASSET_DELETE_PRECONDITION_FAILED",
+    });
+    const asset = await env.DB.prepare(
+      "SELECT id, r2_key FROM build_assets WHERE id = ? AND build_id = ?",
+    ).bind("asset-delete-key-race", "build-delete-key-race").first();
+    expect(asset).toMatchObject({ id: "asset-delete-key-race", r2_key: newKey });
+    const audit = await env.DB.prepare(
+      "SELECT id FROM audit_logs WHERE app_id = ? AND action = 'build_asset.delete'",
+    ).bind("app-scope").first();
+    expect(audit).toBeNull();
+  });
+
+  it("returns a durable audit receipt when first post-delete R2 readback fails and recovers on retry", async () => {
+    const env = makeEnv();
+    const { handleDeleteBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-delete-post-head", "build-delete-post-head", [["full", "all"]], {
+      versionCode: 18,
+      versionName: "1.0.18",
+    });
+    const hash = "1".repeat(64);
+    const r2Key = "apps/app-scope/delete-post-head.patch.gz";
+    await seedAsset(env, "build-delete-post-head", "asset-delete-post-head", {
+      artifactKind: "android-delta",
+      filetype: "patch",
+      sizeBytes: 66,
+      fileHash: hash,
+      r2Key,
+    });
+    let headCalls = 0;
+    let readbackRecovered = false;
+    env.APK_BUCKET = {
+      head: async (key: string) => {
+        if (key !== r2Key) return null;
+        headCalls += 1;
+        if (headCalls === 1 || readbackRecovered) return { size: 66 };
+        return null;
+      },
+    };
+
+    const first = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-post-head", "asset-delete-post-head", {
+        expected_file_hash: hash,
+        expected_size_bytes: "66",
+      }),
+    );
+    expect(first.status).toBe(503);
+    const firstBody = await responseJson<any>(first);
+    expect(firstBody).toMatchObject({
+      code: "ASSET_OBJECT_READBACK_FAILED",
+      metadata_absent: true,
+      r2_preserved: false,
+    });
+    expect(firstBody.audit_id).toMatch(/^[0-9a-f-]{36}$/);
+    await expect(
+      env.DB.prepare("SELECT id FROM build_assets WHERE id = ?").bind("asset-delete-post-head").first(),
+    ).resolves.toBeNull();
+    const audit = await env.DB.prepare(
+      "SELECT id, payload FROM audit_logs WHERE id = ? AND action = 'build_asset.delete'",
+    ).bind(firstBody.audit_id).first() as { id: string; payload: string } | null;
+    expect(audit?.id).toBe(firstBody.audit_id);
+    expect(JSON.parse(audit?.payload ?? "{}")).toMatchObject({
+      buildId: "build-delete-post-head",
+      assetId: "asset-delete-post-head",
+      r2Key,
+      fileHash: hash,
+      sizeBytes: 66,
+    });
+
+    readbackRecovered = true;
+    const retry = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-post-head", "asset-delete-post-head", {
+        expected_file_hash: hash,
+        expected_size_bytes: "66",
+      }),
+    );
+    expect(retry.status).toBe(200);
+    await expect(responseJson<any>(retry)).resolves.toMatchObject({
+      ok: true,
+      deleted: false,
+      idempotent_replay: true,
+      metadata_absent: true,
+      r2_preserved: true,
+      r2_key: r2Key,
+      audit_id: firstBody.audit_id,
+    });
+  });
+
+  it("preserves a durable unknown receipt when post-delete and replay R2 HEAD reject", async () => {
+    const env = makeEnv();
+    const { handleDeleteBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-delete-head-reject", "build-delete-head-reject", [["full", "all"]], {
+      versionCode: 19,
+      versionName: "1.0.19",
+    });
+    const hash = "2".repeat(64);
+    const r2Key = "apps/app-scope/delete-head-reject.patch.gz";
+    await seedAsset(env, "build-delete-head-reject", "asset-delete-head-reject", {
+      artifactKind: "android-delta",
+      filetype: "patch",
+      sizeBytes: 65,
+      fileHash: hash,
+      r2Key,
+    });
+    let headCalls = 0;
+    let readbackRecovered = false;
+    env.APK_BUCKET = {
+      head: async (key: string) => {
+        if (key !== r2Key) return null;
+        headCalls += 1;
+        if (headCalls === 1 || readbackRecovered) return { size: 65 };
+        throw new Error("forced transient R2 HEAD failure");
+      },
+    };
+
+    const first = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-head-reject", "asset-delete-head-reject", {
+        expected_file_hash: hash,
+        expected_size_bytes: "65",
+      }),
+    );
+    expect(first.status).toBe(503);
+    const firstBody = await responseJson<any>(first);
+    expect(firstBody).toMatchObject({
+      code: "ASSET_OBJECT_READBACK_FAILED",
+      metadata_absent: true,
+      r2_preserved: null,
+    });
+    expect(firstBody.audit_id).toMatch(/^[0-9a-f-]{36}$/);
+    await expect(
+      env.DB.prepare("SELECT id FROM build_assets WHERE id = ?").bind("asset-delete-head-reject").first(),
+    ).resolves.toBeNull();
+    const audit = await env.DB.prepare(
+      "SELECT id FROM audit_logs WHERE id = ? AND action = 'build_asset.delete'",
+    ).bind(firstBody.audit_id).first();
+    expect(audit).toMatchObject({ id: firstBody.audit_id });
+
+    const unavailableReplay = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-head-reject", "asset-delete-head-reject", {
+        expected_file_hash: hash,
+        expected_size_bytes: "65",
+      }),
+    );
+    expect(unavailableReplay.status).toBe(503);
+    await expect(responseJson<any>(unavailableReplay)).resolves.toMatchObject({
+      code: "ASSET_OBJECT_READBACK_FAILED",
+      metadata_absent: true,
+      r2_preserved: null,
+      audit_id: firstBody.audit_id,
+    });
+
+    readbackRecovered = true;
+    const recovered = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-head-reject", "asset-delete-head-reject", {
+        expected_file_hash: hash,
+        expected_size_bytes: "65",
+      }),
+    );
+    expect(recovered.status).toBe(200);
+    await expect(responseJson<any>(recovered)).resolves.toMatchObject({
+      ok: true,
+      deleted: false,
+      idempotent_replay: true,
+      metadata_absent: true,
+      r2_preserved: true,
+      r2_key: r2Key,
+      audit_id: firstBody.audit_id,
+    });
+  });
+
+  it("guarded Agent delete fails closed for stale facts, installables, and missing R2", async () => {
+    const env = makeEnv();
+    const { handleDeleteBuildAsset } = await import("../src/routes/builds");
+    await seedRelease(env, "rel-delete-guards", "build-delete-guards", [["full", "all"]], {
+      versionCode: 15,
+      versionName: "1.0.15",
+    });
+    const metadataHash = "b".repeat(64);
+    const installableHash = "c".repeat(64);
+    await seedAsset(env, "build-delete-guards", "asset-guarded-metadata", {
+      artifactKind: "metadata-file",
+      filetype: "json",
+      sizeBytes: 55,
+      fileHash: metadataHash,
+      r2Key: "apps/app-scope/guarded-metadata.json",
+    });
+    await seedAsset(env, "build-delete-guards", "asset-guarded-installable", {
+      artifactKind: "installable",
+      filetype: "apk",
+      sizeBytes: 99,
+      fileHash: installableHash,
+      r2Key: "apps/app-scope/guarded-installable.apk",
+    });
+    env.APK_BUCKET = {
+      head: async (key: string) => key.endsWith("guarded-installable.apk") ? { size: 99 } : null,
+    };
+
+    const stale = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-guards", "asset-guarded-metadata", {
+        expected_file_hash: "d".repeat(64),
+        expected_size_bytes: "55",
+      }),
+    );
+    expect(stale.status).toBe(409);
+    await expect(responseJson<any>(stale)).resolves.toMatchObject({
+      code: "ASSET_DELETE_PRECONDITION_FAILED",
+    });
+
+    const missingObject = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-guards", "asset-guarded-metadata", {
+        expected_file_hash: metadataHash,
+        expected_size_bytes: "55",
+      }),
+    );
+    expect(missingObject.status).toBe(409);
+    await expect(responseJson<any>(missingObject)).resolves.toMatchObject({
+      code: "ASSET_OBJECT_PRECONDITION_FAILED",
+    });
+
+    const installable = await handleDeleteBuildAsset(
+      makeBuildAssetDownloadContext(env, "build-delete-guards", "asset-guarded-installable", {
+        expected_file_hash: installableHash,
+        expected_size_bytes: "99",
+      }),
+    );
+    expect(installable.status).toBe(409);
+    await expect(responseJson<any>(installable)).resolves.toMatchObject({
+      code: "INSTALLABLE_ASSET_DELETE_FORBIDDEN",
+    });
+
+    const remaining = await env.DB.prepare(
+      "SELECT id FROM build_assets WHERE build_id = ? ORDER BY id",
+    ).bind("build-delete-guards").all();
+    expect(remaining.results.map((row: any) => row.id)).toEqual([
+      "asset-guarded-installable",
+      "asset-guarded-metadata",
+    ]);
   });
 
   it("creates public release shares with hashed tokens only", async () => {
@@ -9937,6 +10371,10 @@ describe("Hands iOS simulator QA artifacts", () => {
         method: "GET",
         path: "/api/apps/{app_id}/builds/{build_id}/testflight-publish",
       },
+      "delete-build-asset": {
+        method: "DELETE",
+        path: "/api/apps/{app_id}/builds/{build_id}/assets/{asset_id}",
+      },
     });
     const byName = Object.fromEntries(manifest.actions.map((action: any) => [action.name, action]));
     expect(byName["create-app"].parameters).toMatchObject({
@@ -10029,6 +10467,15 @@ describe("Hands iOS simulator QA artifacts", () => {
       type: "string",
       in: "path",
       required: true,
+    });
+    expect(byName["delete-build-asset"]).toMatchObject({
+      parameters: {
+        app_id: { type: "string", in: "path", required: true },
+        build_id: { type: "string", in: "path", required: true },
+        asset_id: { type: "string", in: "path", required: true },
+        expected_file_hash: { type: "string", in: "query", required: true },
+        expected_size_bytes: { type: "integer", in: "query", required: true },
+      },
     });
     expect(byName["add-app-member"].parameters).toMatchObject({
       app_id: { type: "string", in: "path", required: true },


### PR DESCRIPTION
## Summary

- expose the existing app-admin build-asset metadata deletion route as a `delete-build-asset` Agent Login action
- require exact fresh `file_hash` + `size_bytes` facts for the guarded Agent path
- reject installable assets and missing/mismatched R2 objects
- conditionally delete only the exact non-installable row, preserve R2 bytes, return idempotent absence/readback facts, and audit the immutable coordinate
- document the guarded query contract in OpenAPI and lock manifest parity with tests

## Safety boundary

- source only; no production deploy or runtime deletion
- the existing Console/raw route remains compatible when guard parameters are absent
- the Agent action cannot delete installables and never calls R2 delete

## Verification

- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-worker build:shim`
- `pnpm --filter @botiverse/hands-worker test` (19 files, 256 tests)
- `git diff --check`

Raft task #203
