### PR TITLE
fix(admin): align asset removal identity

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -22,9 +22,11 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.7.2",

--- a/admin/src/components/BuildAssetIdentitySummary.dom.test.tsx
+++ b/admin/src/components/BuildAssetIdentitySummary.dom.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BuildAsset } from "../lib/api";
+import { BuildAssetIdentitySummary } from "./BuildAssetIdentitySummary";
+
+afterEach(cleanup);
+
+const asset: BuildAsset = {
+  id: "3b445f1e-cf82-42ae-a5cf-f8842b4a93f6",
+  build_id: "d8fb5fc5-edc1-4cb4-8ce6-5205c4265cd6",
+  artifact_kind: "delta-patch",
+  platform: "android",
+  arch: "arm64-v8a",
+  variant: null,
+  filetype: "patch",
+  r2_key:
+    "apps/98b90005-90a7-4eee-9fd1-1569a1f5d18b/pending/efc3bdcecd439fa66dc3106e07b71e7b3ab6178cd82cc9af9b103de6073b5163.gz",
+  file_hash:
+    "efc3bdcecd439fa66dc3106e07b71e7b3ab6178cd82cc9af9b103de6073b5163",
+  size_bytes: 11_295_525,
+  signature: null,
+  signing_credential_id: null,
+  metadata_json: JSON.stringify({
+    original_filename: "valid-1000002-to-1000003.patch.gz",
+  }),
+  download_count: 0,
+  created_at: 0,
+};
+
+describe("BuildAssetIdentitySummary", () => {
+  it("renders every exact identifier needed to verify a destructive action", () => {
+    render(<BuildAssetIdentitySummary asset={asset} />);
+
+    expect(
+      screen.getByText("valid-1000002-to-1000003.patch.gz"),
+    ).toBeTruthy();
+    expect(screen.getByText(asset.id)).toBeTruthy();
+    expect(screen.getByText(asset.build_id)).toBeTruthy();
+    expect(screen.getByText(asset.artifact_kind)).toBeTruthy();
+    expect(screen.getByText(asset.file_hash)).toBeTruthy();
+    expect(screen.getByText(asset.r2_key)).toBeTruthy();
+    expect(screen.getByText("10.77 MiB (11,295,525 bytes)")).toBeTruthy();
+    expect(screen.getByLabelText("Copy asset id")).toBeTruthy();
+    expect(screen.getByLabelText("Copy build id")).toBeTruthy();
+    expect(screen.getByLabelText("Copy sha256")).toBeTruthy();
+    expect(screen.getByLabelText("Copy r2 key")).toBeTruthy();
+  });
+});

--- a/admin/src/components/BuildAssetIdentitySummary.tsx
+++ b/admin/src/components/BuildAssetIdentitySummary.tsx
@@ -1,0 +1,64 @@
+import { CopyableCode } from "raft-ui";
+import type { BuildAsset } from "../lib/api";
+import {
+  buildAssetFilename,
+  formatBuildAssetExactSize,
+} from "../lib/buildAssetDisplay";
+
+function CopyableAssetValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <>
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="min-w-0">
+        <CopyableCode
+          size="sm"
+          className="w-full"
+          ariaLabel={`Copy ${label}`}
+          copiedAriaLabel={`Copied ${label}`}
+          codeClassName="min-w-0 font-mono text-[11px] text-slate-700"
+        >
+          {value}
+        </CopyableCode>
+      </dd>
+    </>
+  );
+}
+
+function AssetValue({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="min-w-0 break-words font-mono text-slate-800">{value}</dd>
+    </>
+  );
+}
+
+export function BuildAssetIdentitySummary({ asset }: { asset: BuildAsset }) {
+  return (
+    <dl
+      className="grid min-w-0 grid-cols-1 gap-y-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:gap-x-4"
+      data-testid="build-asset-identity-summary"
+    >
+      <AssetValue label="filename" value={buildAssetFilename(asset)} />
+      <CopyableAssetValue label="asset id" value={asset.id} />
+      <CopyableAssetValue label="build id" value={asset.build_id} />
+      <AssetValue label="kind" value={asset.artifact_kind} />
+      <AssetValue label="platform" value={asset.platform} />
+      <AssetValue label="arch" value={asset.arch ?? "—"} />
+      <AssetValue label="variant" value={asset.variant ?? "—"} />
+      <AssetValue label="filetype" value={asset.filetype} />
+      <AssetValue
+        label="size"
+        value={formatBuildAssetExactSize(asset.size_bytes)}
+      />
+      <CopyableAssetValue label="sha256" value={asset.file_hash} />
+      <CopyableAssetValue label="r2 key" value={asset.r2_key} />
+    </dl>
+  );
+}

--- a/admin/src/components/ConfirmActionDialog.dom.test.tsx
+++ b/admin/src/components/ConfirmActionDialog.dom.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConfirmActionDialog } from "./ConfirmActionDialog";
+
+afterEach(cleanup);
+
+describe("ConfirmActionDialog responsive identity header", () => {
+  it("keeps the title and long object identity in separate full-width rows", async () => {
+    render(
+      <ConfirmActionDialog
+        open
+        title="Remove asset registration?"
+        objectLabel="valid-1000002-to-1000003.patch.gz"
+        objectHint="delta-patch · android/arm64-v8a · patch · 10.77 MiB"
+        body="The underlying R2 binary is kept."
+        confirmLabel="Remove asset"
+        confirmKind="danger"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const dialog = await screen.findByRole("alertdialog");
+    const header = dialog.querySelector('[data-slot="alert-dialog-header"]');
+    const description = dialog.querySelector(
+      '[data-slot="alert-dialog-description"]',
+    );
+
+    expect(header?.className).toContain("grid-cols-1");
+    expect(header?.className).toContain("items-start");
+    expect(description?.className).toContain("w-full");
+    expect(description?.className).toContain("min-w-0");
+    expect(
+      screen.getByText("valid-1000002-to-1000003.patch.gz"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("delta-patch · android/arm64-v8a · patch · 10.77 MiB"),
+    ).toBeTruthy();
+  });
+});

--- a/admin/src/components/ConfirmActionDialog.tsx
+++ b/admin/src/components/ConfirmActionDialog.tsx
@@ -91,20 +91,24 @@ export function ConfirmActionDialog({
         if (!next) onCancel();
       }}
     >
-      <AlertDialogContent className="max-w-md w-full">
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription className="flex items-center gap-2 flex-wrap">
-            <span className="font-medium">{objectLabel}</span>
+      <AlertDialogContent className="w-[calc(100%-2rem)] max-w-xl">
+        <AlertDialogHeader className="grid-cols-1 items-start gap-1">
+          <AlertDialogTitle className="w-full break-words">
+            {title}
+          </AlertDialogTitle>
+          <AlertDialogDescription className="flex min-w-0 w-full flex-col items-start gap-1 sm:flex-row sm:flex-wrap sm:items-baseline sm:gap-x-2 sm:gap-y-1">
+            <span className="min-w-0 max-w-full break-words font-medium">
+              {objectLabel}
+            </span>
             {objectHint && (
-              <span className="font-mono text-xs text-slate-500">
+              <span className="min-w-0 max-w-full break-words font-mono text-xs text-slate-500">
                 {objectHint}
               </span>
             )}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
-        <AlertDialogBody>
+        <AlertDialogBody className="max-h-[70vh] overflow-y-auto">
           {objectSummary && (
             <div className="mb-3 p-3 border border-slate-200 rounded-sm bg-slate-50 text-xs">
               {objectSummary}
@@ -126,12 +130,17 @@ export function ConfirmActionDialog({
           )}
         </AlertDialogBody>
 
-        <AlertDialogFooter>
-          <AlertDialogCancel variant="outline" disabled={pending}>
+        <AlertDialogFooter className="flex-col-reverse items-stretch gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+          <AlertDialogCancel
+            variant="outline"
+            className="w-full sm:w-auto"
+            disabled={pending}
+          >
             {cancelLabel}
           </AlertDialogCancel>
           <AlertDialogAction
             variant={confirmVariant}
+            className="w-full sm:w-auto"
             loading={pending}
             disabled={pending || confirmDisabled}
             onClick={onConfirm}

--- a/admin/src/components/ReleaseAssetUploader.tsx
+++ b/admin/src/components/ReleaseAssetUploader.tsx
@@ -37,12 +37,17 @@ import {
 } from "../lib/api";
 import { useToast } from "./Toast";
 import { ConfirmActionDialog } from "./ConfirmActionDialog";
+import { BuildAssetIdentitySummary } from "./BuildAssetIdentitySummary";
 import {
   KNOWN_FILETYPES,
   KNOWN_PLATFORMS,
   pendingFileFromFile,
   type PendingFile,
 } from "../lib/releaseFileDetect";
+import {
+  buildAssetFilename,
+  formatBuildAssetSize,
+} from "../lib/buildAssetDisplay";
 
 interface BaseProps {
   appId: string;
@@ -184,44 +189,64 @@ export function ReleaseAssetUploader(props: Props) {
       {props.variant === "panel" && existing.length > 0 && (
         <div className="mb-3 text-xs text-slate-500">
           {existing.length} asset{existing.length === 1 ? "" : "s"} ·{" "}
-          {(totalBytes / 1024 / 1024).toFixed(2)} MB total
+          {formatBuildAssetSize(totalBytes)} total
         </div>
       )}
 
       {props.variant === "panel" && existing.length > 0 && (
-        <table className="w-full text-xs mb-3">
-          <thead>
-            <tr className="text-slate-500 text-left border-b border-slate-100">
-              <th className="font-normal pr-2 py-1">Platform</th>
-              <th className="font-normal pr-2 py-1">Arch</th>
-              <th className="font-normal pr-2 py-1">Filetype</th>
-              <th className="font-normal pr-2 py-1">Size</th>
-              <th className="font-normal pr-2 py-1"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {existing.map((a: BuildAsset) => (
-              <tr key={a.id} className="border-b border-slate-50">
-                <td className="pr-2 py-1 font-mono">{a.platform}</td>
-                <td className="pr-2 py-1 font-mono">{a.arch ?? "—"}</td>
-                <td className="pr-2 py-1 font-mono">{a.filetype}</td>
-                <td className="pr-2 py-1 font-mono">
-                  {(a.size_bytes / 1024 / 1024).toFixed(2)} MB
-                </td>
-                <td className="pr-2 py-1">
-                  <Button
-                    variant="outline"
-                    className="text-[10px]"
-                    onClick={() => setRemoveTarget(a)}
-                    disabled={remove.isPending}
-                  >
-                    Remove
-                  </Button>
-                </td>
+        <div className="mb-3 overflow-x-auto">
+          <table className="w-full min-w-[760px] text-xs">
+            <thead>
+              <tr className="border-b border-slate-100 text-left text-slate-500">
+                <th className="py-1 pr-3 font-normal">Asset</th>
+                <th className="py-1 pr-3 font-normal">Kind</th>
+                <th className="py-1 pr-3 font-normal">Platform</th>
+                <th className="py-1 pr-3 font-normal">Arch</th>
+                <th className="py-1 pr-3 font-normal">Size</th>
+                <th className="py-1 pr-2 font-normal"></th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {existing.map((a: BuildAsset) => {
+                const filename = buildAssetFilename(a);
+                return (
+                  <tr key={a.id} className="border-b border-slate-50 align-top">
+                    <td className="min-w-[16rem] py-2 pr-3">
+                      <div className="break-all font-mono text-slate-800">
+                        {filename}
+                      </div>
+                      <div className="mt-0.5 break-all font-mono text-[10px] text-slate-400">
+                        {a.id}
+                      </div>
+                    </td>
+                    <td className="py-2 pr-3 font-mono">
+                      <div>{a.artifact_kind}</div>
+                      <div className="text-[10px] text-slate-400">
+                        {a.filetype}
+                      </div>
+                    </td>
+                    <td className="py-2 pr-3 font-mono">{a.platform}</td>
+                    <td className="py-2 pr-3 font-mono">{a.arch ?? "—"}</td>
+                    <td className="py-2 pr-3 font-mono whitespace-nowrap">
+                      {formatBuildAssetSize(a.size_bytes)}
+                    </td>
+                    <td className="py-2 pr-2 text-right">
+                      <Button
+                        variant="outline"
+                        className="text-[10px]"
+                        aria-label={`Remove ${filename}`}
+                        onClick={() => setRemoveTarget(a)}
+                        disabled={remove.isPending}
+                      >
+                        Remove
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
 
       {/* Drop zone */}
@@ -275,39 +300,32 @@ export function ReleaseAssetUploader(props: Props) {
 
       <ConfirmActionDialog
         open={removeTarget !== null}
-        title="Remove asset from this release?"
-        objectLabel={`${removeTarget?.platform ?? ""}${
-          removeTarget?.arch ? `/${removeTarget.arch}` : ""
-        } ${removeTarget?.filetype ?? ""}`}
+        title="Remove asset registration?"
+        objectLabel={removeTarget ? buildAssetFilename(removeTarget) : ""}
         objectSummary={
           removeTarget ? (
-            <div className="grid grid-cols-2 gap-x-3 gap-y-1 font-mono">
-              <div className="text-slate-500">platform</div>
-              <div>{removeTarget.platform}</div>
-              <div className="text-slate-500">arch</div>
-              <div>{removeTarget.arch ?? "—"}</div>
-              <div className="text-slate-500">filetype</div>
-              <div>{removeTarget.filetype}</div>
-              <div className="text-slate-500">r2_key</div>
-              <div className="truncate">{removeTarget.r2_key}</div>
-            </div>
+            <BuildAssetIdentitySummary asset={removeTarget} />
           ) : undefined
         }
         body={
           <>
-            Removing this asset detaches the registration from the release.{" "}
-            <strong>The release row and build metadata are kept.</strong> The
-            underlying R2 binary is also kept (we never auto-delete uploaded
-            blobs); if you want to reclaim the storage, delete it from R2
-            separately after removing this row.
+            Removing this asset detaches its registration from the build and
+            release. <strong>The release row and build metadata are kept.</strong>{" "}
+            The underlying R2 binary is also kept (we never auto-delete uploaded
+            blobs). Delete that object from R2 separately only if you intend to
+            reclaim its storage.
           </>
         }
         confirmLabel="Remove asset"
         confirmKind="danger"
         pending={remove.isPending}
-        {...(removeTarget?.size_bytes != null && removeTarget?.r2_key
+        {...(removeTarget
           ? {
-              objectHint: `${(removeTarget.size_bytes / 1024 / 1024).toFixed(2)} MB · ${removeTarget.r2_key.slice(0, 24)}${removeTarget.r2_key.length > 24 ? "…" : ""}`,
+              objectHint: `${removeTarget.artifact_kind} · ${removeTarget.platform}${
+                removeTarget.arch ? `/${removeTarget.arch}` : ""
+              } · ${removeTarget.filetype} · ${formatBuildAssetSize(
+                removeTarget.size_bytes,
+              )}`,
             }
           : {})}
         onConfirm={() => {

--- a/admin/src/lib/buildAssetDisplay.test.ts
+++ b/admin/src/lib/buildAssetDisplay.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAssetFilename,
+  formatBuildAssetExactSize,
+  formatBuildAssetSize,
+} from "./buildAssetDisplay";
+
+describe("build-asset display identity", () => {
+  it("prefers the original filename and supports historical filename metadata", () => {
+    expect(
+      buildAssetFilename({
+        metadata_json: JSON.stringify({
+          original_filename: "valid-1000002-to-1000003.patch.gz",
+          filename: "renamed.patch.gz",
+        }),
+        r2_key: "apps/example/pending/hash.gz",
+      }),
+    ).toBe("valid-1000002-to-1000003.patch.gz");
+
+    expect(
+      buildAssetFilename({
+        metadata_json: JSON.stringify({ filename: "legacy.apk" }),
+        r2_key: "apps/example/pending/hash.apk",
+      }),
+    ).toBe("legacy.apk");
+  });
+
+  it("falls back safely when legacy metadata is malformed", () => {
+    expect(
+      buildAssetFilename({
+        metadata_json: "{not-json",
+        r2_key: "apps/example/pending/fallback.patch.gz",
+      }),
+    ).toBe("fallback.patch.gz");
+  });
+
+  it("keeps tiny patches exact instead of rounding them to zero megabytes", () => {
+    expect(formatBuildAssetSize(64)).toBe("64 B");
+    expect(formatBuildAssetSize(11_295_525)).toBe("10.77 MiB");
+    expect(formatBuildAssetExactSize(11_295_525)).toBe(
+      "10.77 MiB (11,295,525 bytes)",
+    );
+  });
+});

--- a/admin/src/lib/buildAssetDisplay.ts
+++ b/admin/src/lib/buildAssetDisplay.ts
@@ -1,0 +1,61 @@
+import type { BuildAsset } from "./api";
+
+type AssetDisplaySource = Pick<BuildAsset, "metadata_json" | "r2_key">;
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function assetMetadata(metadataJson: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(metadataJson || "{}");
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Prefer the upload-time filename retained in asset metadata. Historical rows
+ * may not have it, so fall back to the final R2 path segment rather than
+ * rendering an empty identity in a destructive-action dialog.
+ */
+export function buildAssetFilename(asset: AssetDisplaySource): string {
+  const metadata = assetMetadata(asset.metadata_json);
+  return (
+    nonEmptyString(metadata.original_filename) ??
+    nonEmptyString(metadata.filename) ??
+    nonEmptyString(asset.r2_key.split("/").filter(Boolean).at(-1)) ??
+    "Unnamed asset"
+  );
+}
+
+/**
+ * Human-readable binary size. Bytes stay exact so a 64-byte patch is never
+ * shown as 0.00 MB.
+ */
+export function formatBuildAssetSize(sizeBytes: number): string {
+  if (!Number.isFinite(sizeBytes) || sizeBytes < 0) return "Unknown size";
+
+  const roundedBytes = Math.round(sizeBytes);
+  if (roundedBytes < 1024) return `${roundedBytes.toLocaleString("en-US")} B`;
+
+  const units = ["KiB", "MiB", "GiB", "TiB"] as const;
+  let value = roundedBytes / 1024;
+  let unitIndex = 0;
+  while (unitIndex < units.length - 1 && value >= 1024) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(2)} ${units[unitIndex]!}`;
+}
+
+export function formatBuildAssetExactSize(sizeBytes: number): string {
+  const readable = formatBuildAssetSize(sizeBytes);
+  if (!Number.isFinite(sizeBytes) || sizeBytes < 0) return readable;
+  return `${readable} (${Math.round(sizeBytes).toLocaleString("en-US")} bytes)`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.2
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -51,6 +54,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       postcss:
         specifier: ^8.4.49
         version: 8.5.15


### PR DESCRIPTION
## Summary

- fix the destructive-dialog header collapse caused by the default two-column `AlertDialogHeader` placing a long asset identity in a `max-content` column
- show the retained upload filename, full asset/build IDs, kind, platform/arch/variant/filetype, exact byte size, SHA-256, and full copyable R2 key before removal
- make the asset table identify rows by filename + full asset ID, preserve tiny sizes such as `64 B`, and keep desktop/mobile dialog content and actions usable
- keep deletion semantics unchanged: remove only the registration; release/build metadata and the underlying R2 object remain

## Verification

- `pnpm --filter @botiverse/hands-admin typecheck`
- `pnpm --filter @botiverse/hands-admin test` — 7 files / 30 tests
- `pnpm --filter @botiverse/hands-admin build`
- `pnpm -w build` — all workspace build targets passed after generating the local Worker binding types from the checked-in Hands Wrangler config
- `pnpm -w test` — all workspace suites passed (Admin 30, Worker 254, CLI 29, Feedback React 30, Node 13, Electron 3, Container 3)
- `git diff --check`

`pnpm -w lint` still cannot start on unchanged `main` because the Worker uses ESLint 9 without an `eslint.config.{js,mjs,cjs}` file; this PR does not alter Worker lint configuration and the Admin package has no separate lint script.

Raft task #204. Source only; no deployment or production-state change.
