### PR TITLE
fix(android-sdk): receive completed downloads securely

### DIFF
--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -15,24 +15,43 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+internal const val DOWNLOAD_COMPLETED_SENDER_PERMISSION =
+    "android.permission.SEND_DOWNLOAD_COMPLETED_INTENTS"
+
 /**
- * Dynamic receivers must declare their export policy when the host targets
- * Android 13 (API 33) or newer. Older Android releases only expose the legacy
- * two-argument overload.
+ * DownloadManager completion is sent by a privileged package rather than the
+ * system UID on some Android builds. The receiver must therefore be exported,
+ * while the signature sender permission prevents third-party spoofing.
  */
 internal fun downloadReceiverRegistrationFlags(sdkInt: Int): Int? =
-    if (sdkInt >= Build.VERSION_CODES.TIRAMISU) Context.RECEIVER_NOT_EXPORTED else null
+    if (sdkInt >= Build.VERSION_CODES.TIRAMISU) Context.RECEIVER_EXPORTED else null
 
 private fun Context.registerDownloadReceiver(
     receiver: BroadcastReceiver,
     filter: IntentFilter,
 ) {
-    val flags = downloadReceiverRegistrationFlags(Build.VERSION.SDK_INT)
+    registerDownloadReceiverForSdk(
+        sdkInt = Build.VERSION.SDK_INT,
+        registerLegacy = { senderPermission ->
+            @Suppress("DEPRECATION")
+            registerReceiver(receiver, filter, senderPermission, null)
+        },
+        registerModern = { senderPermission, flags ->
+            registerReceiver(receiver, filter, senderPermission, null, flags)
+        },
+    )
+}
+
+internal fun registerDownloadReceiverForSdk(
+    sdkInt: Int,
+    registerLegacy: (senderPermission: String) -> Unit,
+    registerModern: (senderPermission: String, flags: Int) -> Unit,
+) {
+    val flags = downloadReceiverRegistrationFlags(sdkInt)
     if (flags == null) {
-        @Suppress("DEPRECATION")
-        registerReceiver(receiver, filter)
+        registerLegacy(DOWNLOAD_COMPLETED_SENDER_PERMISSION)
     } else {
-        registerReceiver(receiver, filter, flags)
+        registerModern(DOWNLOAD_COMPLETED_SENDER_PERMISSION, flags)
     }
 }
 

--- a/clients/android/src/test/kotlin/build/hands/update/UpdateCheckerTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/UpdateCheckerTest.kt
@@ -3,18 +3,27 @@ package build.hands.update
 import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class UpdateCheckerTest {
     @Test
-    fun `API 33 and newer register the download receiver as not exported`() {
+    fun `API 33 and newer export the receiver for privileged download senders`() {
         assertEquals(
-            Context.RECEIVER_NOT_EXPORTED,
+            Context.RECEIVER_EXPORTED,
             downloadReceiverRegistrationFlags(33),
         )
         assertEquals(
-            Context.RECEIVER_NOT_EXPORTED,
+            Context.RECEIVER_EXPORTED,
             downloadReceiverRegistrationFlags(34),
+        )
+    }
+
+    @Test
+    fun `download completion receiver requires the platform signature sender permission`() {
+        assertEquals(
+            "android.permission.SEND_DOWNLOAD_COMPLETED_INTENTS",
+            DOWNLOAD_COMPLETED_SENDER_PERMISSION,
         )
     }
 
@@ -22,5 +31,38 @@ class UpdateCheckerTest {
     fun `older Android releases keep the legacy registration overload`() {
         assertNull(downloadReceiverRegistrationFlags(24))
         assertNull(downloadReceiverRegistrationFlags(32))
+    }
+
+    @Test
+    fun `API 33 registration uses only the permission-gated modern overload`() {
+        val legacyPermissions = mutableListOf<String>()
+        val modernCalls = mutableListOf<Pair<String, Int>>()
+
+        registerDownloadReceiverForSdk(
+            sdkInt = 33,
+            registerLegacy = legacyPermissions::add,
+            registerModern = { permission, flags -> modernCalls += permission to flags },
+        )
+
+        assertTrue(legacyPermissions.isEmpty())
+        assertEquals(
+            listOf(DOWNLOAD_COMPLETED_SENDER_PERMISSION to Context.RECEIVER_EXPORTED),
+            modernCalls,
+        )
+    }
+
+    @Test
+    fun `legacy registration uses only the permission-gated four-argument overload`() {
+        val legacyPermissions = mutableListOf<String>()
+        val modernCalls = mutableListOf<Pair<String, Int>>()
+
+        registerDownloadReceiverForSdk(
+            sdkInt = 32,
+            registerLegacy = legacyPermissions::add,
+            registerModern = { permission, flags -> modernCalls += permission to flags },
+        )
+
+        assertEquals(listOf(DOWNLOAD_COMPLETED_SENDER_PERMISSION), legacyPermissions)
+        assertTrue(modernCalls.isEmpty())
     }
 }


### PR DESCRIPTION
## Summary

- register `ACTION_DOWNLOAD_COMPLETE` as exported on API 33+ so privileged DownloadManager senders can deliver the targeted completion broadcast
- require the platform signature sender permission `android.permission.SEND_DOWNLOAD_COMPLETED_INTENTS` on both modern and legacy registration overloads
- lock the export flag and sender-permission contract with focused unit tests

## Runtime evidence

Task #187's real Android 14 C-to-D fallback downloaded the exact 93,973,268-byte full APK successfully, but the installer never opened. The broadcast ledger recorded the targeted completion twice as skipped:

```text
Exported Denial ... from com.android.mtp (uid=10021) ... not specifying RECEIVER_EXPORTED
```

The same sender has `android.permission.SEND_DOWNLOAD_COMPLETED_INTENTS` as an installed signature permission. Using that permission keeps the exported receiver unavailable to ordinary third-party senders.

## Validation

- `assembleRelease testReleaseUnitTest` PASS with Gradle 8.13, JDK 17, and installed NDK 27.1
- `git diff --check` PASS

The repository remains pinned to NDK 26.3; this machine's 26.3 directory is an incomplete local SDK installation, so the local run used an uncommitted NDK 27.1 override that was reverted before commit. GitHub `Android SDK Check` remains the exact pinned-NDK gate.

No SDK publication, Mobile bump, Hands deploy, or runtime mutation is included.
