### PR TITLE
fix(android-sdk): install downloads through content URIs

### DIFF
--- a/.github/workflows/android-sdk-check.yml
+++ b/.github/workflows/android-sdk-check.yml
@@ -20,3 +20,30 @@ jobs:
           gradle-version: "8.10.2"
       - name: Assemble release AAR and run unit tests
         run: gradle -p clients/android assembleRelease testReleaseUnitTest
+
+  api31-instrumentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.10.2"
+      - name: Enable KVM access
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run Android 12 installer platform tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 31
+          target: google_apis
+          arch: x86_64
+          profile: pixel_2
+          disable-animations: true
+          script: gradle -p clients/android connectedDebugAndroidTest

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 
     defaultConfig {
         minSdk = 24
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
@@ -79,6 +80,9 @@ dependencies {
     // file-by-file engine; the CLI/CI side generates patches with the SAME jar.
     implementation("com.eidu:archive-patcher:3.0.0")
     testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test:core-ktx:1.6.1")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
 }
 
 tasks.matching { it.name == "testReleaseUnitTest" }.configureEach {

--- a/clients/android/src/androidTest/kotlin/build/hands/update/installer/ApkInstallerPlatformTest.kt
+++ b/clients/android/src/androidTest/kotlin/build/hands/update/installer/ApkInstallerPlatformTest.kt
@@ -1,0 +1,164 @@
+package build.hands.update.installer
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import androidx.core.content.FileProvider
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class ApkInstallerPlatformTest {
+    private val targetContext: Context = ApplicationProvider.getApplicationContext()
+    private val authority = "${targetContext.packageName}.hands.fileprovider"
+
+    @Test
+    fun platformGateRunsOnAndroid12() {
+        assertEquals(Build.VERSION_CODES.S, Build.VERSION.SDK_INT)
+    }
+
+    @Test
+    fun appScopedDownloadManagerFileUsesMergedFileProviderAndReadOnlyInstallerGrant() {
+        val downloadDir = requireNotNull(
+            targetContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+        )
+        val apk = File(downloadDir, "hands-platform-${System.nanoTime()}.apk")
+        apk.writeBytes(byteArrayOf(0x50, 0x4b))
+
+        try {
+            val provider = targetContext.packageManager.resolveContentProvider(
+                authority,
+                PackageManager.GET_META_DATA,
+            )
+            assertNotNull(provider)
+            assertFalse(provider!!.exported)
+            assertTrue(provider.grantUriPermissions)
+
+            val capturingContext = CapturingContext(targetContext)
+            val result = handleCompletedDownload(
+                expectedDownloadId = 42L,
+                completedDownloadId = 42L,
+                downloadedUri = { apk.toURI().toString() },
+                fileProviderUri = {
+                    FileProvider.getUriForFile(targetContext, authority, it).toString()
+                },
+                launchInstaller = {
+                    triggerApkInstall(capturingContext, Uri.parse(it))
+                },
+            )
+
+            assertEquals(DownloadInstallResult.INSTALL_STARTED, result)
+            assertEquals(1, capturingContext.startedActivities.size)
+            val expectedUri = requireNotNull(capturingContext.startedActivities.single().data)
+            assertEquals("content", expectedUri.scheme)
+            assertEquals(authority, expectedUri.authority)
+            assertTrue(expectedUri.path.orEmpty().startsWith("/hands_downloads/"))
+            assertReadOnlyInstallIntent(capturingContext.startedActivities.single(), expectedUri)
+        } finally {
+            apk.delete()
+        }
+    }
+
+    @Test
+    fun reconstructedDeltaCacheUsesTheSameReadOnlyInstallerContract() {
+        val apk = File(targetContext.cacheDir, "hands-delta-${System.nanoTime()}.apk")
+        apk.writeBytes(byteArrayOf(0x50, 0x4b))
+
+        try {
+            val capturingContext = CapturingContext(targetContext)
+            ApkInstaller(capturingContext).installLocalApk(apk)
+
+            assertEquals(1, capturingContext.startedActivities.size)
+            val expectedUri = requireNotNull(capturingContext.startedActivities.single().data)
+            assertEquals("content", expectedUri.scheme)
+            assertEquals(authority, expectedUri.authority)
+            assertTrue(expectedUri.path.orEmpty().startsWith("/hands_delta_cache/"))
+            assertReadOnlyInstallIntent(capturingContext.startedActivities.single(), expectedUri)
+        } finally {
+            apk.delete()
+        }
+    }
+
+    @Test
+    fun DownloadManagerContentUriPassesThroughWithReadOnlyInstallerGrant() {
+        val downloadedUri = Uri.parse("content://downloads/all_downloads/42")
+        var fileProviderCalled = false
+        val resolved = resolveDownloadedApkContentUri(downloadedUri.toString()) {
+            fileProviderCalled = true
+            error("FileProvider must not resolve an existing content URI")
+        }
+
+        assertEquals(downloadedUri.toString(), resolved)
+        assertFalse(fileProviderCalled)
+
+        val capturingContext = CapturingContext(targetContext)
+        triggerApkInstall(capturingContext, Uri.parse(requireNotNull(resolved)))
+
+        assertEquals(1, capturingContext.startedActivities.size)
+        assertReadOnlyInstallIntent(capturingContext.startedActivities.single(), downloadedUri)
+    }
+
+    @Test
+    fun outsideRootAndUnsafeSchemesNeverLaunchInstaller() {
+        val outsideRoot = File(
+            targetContext.filesDir,
+            "hands-outside-root-${System.nanoTime()}.apk",
+        )
+        outsideRoot.writeBytes(byteArrayOf(0x50, 0x4b))
+        val capturingContext = CapturingContext(targetContext)
+        var failure: Exception? = null
+
+        try {
+            val result = handleCompletedDownload(
+                expectedDownloadId = 42L,
+                completedDownloadId = 42L,
+                downloadedUri = { outsideRoot.toURI().toString() },
+                fileProviderUri = {
+                    FileProvider.getUriForFile(targetContext, authority, it).toString()
+                },
+                launchInstaller = {
+                    triggerApkInstall(capturingContext, Uri.parse(it))
+                },
+                onFailure = { failure = it },
+            )
+
+            assertEquals(DownloadInstallResult.INSTALL_FAILED, result)
+            assertTrue(failure is IllegalArgumentException)
+            assertTrue(capturingContext.startedActivities.isEmpty())
+
+            triggerApkInstall(capturingContext, Uri.fromFile(outsideRoot))
+            triggerApkInstall(capturingContext, Uri.parse("https://example.test/update.apk"))
+            assertTrue(capturingContext.startedActivities.isEmpty())
+        } finally {
+            outsideRoot.delete()
+        }
+    }
+
+    private fun assertReadOnlyInstallIntent(intent: Intent, expectedUri: Uri) {
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals(expectedUri, intent.data)
+        assertEquals("application/vnd.android.package-archive", intent.type)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertFalse(intent.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0)
+    }
+
+    private class CapturingContext(base: Context) : ContextWrapper(base) {
+        val startedActivities = mutableListOf<Intent>()
+
+        override fun startActivity(intent: Intent) {
+            startedActivities += Intent(intent)
+        }
+    }
+}

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -4,14 +4,98 @@ import android.app.DownloadManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
-import android.database.Cursor
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import java.io.File
+import java.net.URI
+
+internal enum class DownloadInstallResult {
+    IGNORED,
+    UNAVAILABLE_OR_UNSAFE_URI,
+    INSTALL_STARTED,
+    INSTALL_FAILED,
+}
+
+internal fun validatedApkContentUri(uriString: String?): String? {
+    val candidate = uriString?.takeIf { it.isNotBlank() } ?: return null
+    val parsed = try {
+        URI(candidate)
+    } catch (_: Exception) {
+        return null
+    }
+    return candidate.takeIf {
+        parsed.scheme.equals("content", ignoreCase = true) &&
+            !parsed.rawAuthority.isNullOrBlank()
+    }
+}
+
+internal fun resolveDownloadedApkContentUri(
+    uriString: String?,
+    fileProviderUri: (File) -> String,
+): String? {
+    val candidate = uriString?.takeIf { it.isNotBlank() } ?: return null
+    val parsed = try {
+        URI(candidate)
+    } catch (_: Exception) {
+        return null
+    }
+    return when {
+        parsed.scheme.equals("content", ignoreCase = true) ->
+            validatedApkContentUri(candidate)
+        parsed.scheme.equals("file", ignoreCase = true) -> {
+            val file = try {
+                File(parsed)
+            } catch (_: Exception) {
+                return null
+            }
+            validatedApkContentUri(fileProviderUri(file))
+        }
+        else -> null
+    }
+}
+
+internal fun handleCompletedDownload(
+    expectedDownloadId: Long,
+    completedDownloadId: Long,
+    downloadedUri: (Long) -> String?,
+    fileProviderUri: (File) -> String,
+    launchInstaller: (String) -> Unit,
+    onFailure: (Exception) -> Unit = {},
+): DownloadInstallResult {
+    if (completedDownloadId != expectedDownloadId) return DownloadInstallResult.IGNORED
+
+    return try {
+        val apkUri = resolveDownloadedApkContentUri(
+            downloadedUri(completedDownloadId),
+            fileProviderUri,
+        )
+            ?: return DownloadInstallResult.UNAVAILABLE_OR_UNSAFE_URI
+        launchInstaller(apkUri)
+        DownloadInstallResult.INSTALL_STARTED
+    } catch (exception: Exception) {
+        try {
+            onFailure(exception)
+        } catch (_: Exception) {
+            // Receiver failures must never escape into the host process.
+        }
+        DownloadInstallResult.INSTALL_FAILED
+    }
+}
+
+internal fun apkInstallIntentFlags(): Int =
+    Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION
+
+internal fun triggerApkInstall(ctx: Context, apkUri: Uri) {
+    if (validatedApkContentUri(apkUri.toString()) == null) return
+    val install = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(apkUri, "application/vnd.android.package-archive")
+        flags = apkInstallIntentFlags()
+    }
+    ctx.startActivity(install)
+}
 
 /**
  * Downloads the APK from [downloadUrl] using Android's DownloadManager and
@@ -43,21 +127,13 @@ class ApkInstaller(private val context: Context) {
             .setAllowedOverRoaming(true)
             .setMimeType("application/vnd.android.package-archive")
 
-        // For Android 10+, use a public Downloads subdir so the system
-        // installer can read the file without scoped storage gymnastics.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            request.setDestinationInExternalPublicDir(
-                Environment.DIRECTORY_DOWNLOADS,
-                fileName,
-            )
-        } else {
-            @Suppress("DEPRECATION")
-            request.setDestinationInExternalFilesDir(
-                context,
-                Environment.DIRECTORY_DOWNLOADS,
-                fileName,
-            )
-        }
+        // Keep the file app-scoped. DownloadManager may still report it as a
+        // file:// URI, which the completion path converts through FileProvider.
+        request.setDestinationInExternalFilesDir(
+            context,
+            Environment.DIRECTORY_DOWNLOADS,
+            fileName,
+        )
 
         return dm.enqueue(request)
     }
@@ -71,13 +147,35 @@ class ApkInstaller(private val context: Context) {
     fun createInstallReceiver(downloadId: Long): BroadcastReceiver {
         return object : BroadcastReceiver() {
             override fun onReceive(ctx: Context?, intent: Intent?) {
-                val dm = ContextCompat.getSystemService(
-                    ctx ?: context,
-                    DownloadManager::class.java,
-                ) ?: return
-                val id = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
-                if (id != downloadId) return
-                triggerInstall(ctx ?: context, dm, id)
+                try {
+                    val receiverContext = ctx ?: context
+                    val dm = ContextCompat.getSystemService(
+                        receiverContext,
+                        DownloadManager::class.java,
+                    ) ?: return
+                    val id = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
+                    val result = handleCompletedDownload(
+                        expectedDownloadId = downloadId,
+                        completedDownloadId = id ?: -1L,
+                        downloadedUri = { dm.getUriForDownloadedFile(it)?.toString() },
+                        fileProviderUri = {
+                            FileProvider.getUriForFile(
+                                receiverContext,
+                                "${receiverContext.packageName}.hands.fileprovider",
+                                it,
+                            ).toString()
+                        },
+                        launchInstaller = { triggerApkInstall(receiverContext, Uri.parse(it)) },
+                        onFailure = {
+                            Log.e(TAG, "Unable to launch the package installer", it)
+                        },
+                    )
+                    if (result == DownloadInstallResult.UNAVAILABLE_OR_UNSAFE_URI) {
+                        Log.e(TAG, "Downloaded APK URI was unavailable or unsafe")
+                    }
+                } catch (exception: Exception) {
+                    Log.e(TAG, "Unable to handle the completed APK download", exception)
+                }
             }
         }
     }
@@ -95,34 +193,10 @@ class ApkInstaller(private val context: Context) {
     fun installLocalApk(file: File) {
         val authority = "${context.packageName}.hands.fileprovider"
         val apkUri = FileProvider.getUriForFile(context, authority, file)
-
-        val install = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(apkUri, "application/vnd.android.package-archive")
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
-        }
-        context.startActivity(install)
+        triggerApkInstall(context, apkUri)
     }
 
-    private fun triggerInstall(ctx: Context, dm: DownloadManager, downloadId: Long) {
-        val query = DownloadManager.Query().setFilterById(downloadId)
-        val cursor: Cursor = dm.query(query)
-        if (!cursor.moveToFirst()) {
-            cursor.close()
-            return
-        }
-        val columnIndex = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
-        val localUriString = if (columnIndex >= 0) cursor.getString(columnIndex) else null
-        cursor.close()
-
-        if (localUriString == null) return
-        val apkUri = Uri.parse(localUriString)
-
-        val install = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(apkUri, "application/vnd.android.package-archive")
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
-        }
-        ctx.startActivity(install)
+    private companion object {
+        const val TAG = "HandsApkInstaller"
     }
 }

--- a/clients/android/src/main/res/xml/hands_file_paths.xml
+++ b/clients/android/src/main/res/xml/hands_file_paths.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Exposes the host app's internal cacheDir (Context.getCacheDir()) to the
-  FileProvider declared in AndroidManifest.xml. The delta updater writes the
-  reconstructed APK here and shares it with the system installer via a
-  content:// URI + FLAG_GRANT_READ_URI_PERMISSION.
+  Exposes only the two SDK-owned APK locations to the FileProvider declared in
+  AndroidManifest.xml: cacheDir for reconstructed deltas and the app-scoped
+  external Downloads directory for DownloadManager results.
 -->
 <paths>
     <cache-path
         name="hands_delta_cache"
         path="." />
+    <external-files-path
+        name="hands_downloads"
+        path="Download/" />
 </paths>

--- a/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
@@ -1,0 +1,174 @@
+package build.hands.update.installer
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ApkInstallerTest {
+    @Test
+    fun `DownloadManager file URI converts through FileProvider before installer launch`() {
+        val expectedContentUri =
+            "content://build.raft.app.alpha.hands.fileprovider/hands_downloads/update.apk"
+        var providerFile: File? = null
+        var launchedUri: String? = null
+
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 42L,
+            downloadedUri = {
+                "file:///storage/emulated/0/Android/data/build.raft.app.alpha/files/Download/update.apk"
+            },
+            fileProviderUri = {
+                providerFile = it
+                expectedContentUri
+            },
+            launchInstaller = { launchedUri = it },
+        )
+
+        assertEquals(DownloadInstallResult.INSTALL_STARTED, result)
+        assertEquals(
+            File(
+                "/storage/emulated/0/Android/data/build.raft.app.alpha/files/Download/update.apk"
+            ),
+            providerFile,
+        )
+        assertEquals(expectedContentUri, launchedUri)
+    }
+
+    @Test
+    fun `DownloadManager content URI launches installer with the exact URI`() {
+        val expectedUri = "content://downloads/all_downloads/42"
+        var launchedUri: String? = null
+        var fileProviderCalled = false
+
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 42L,
+            downloadedUri = { expectedUri },
+            fileProviderUri = {
+                fileProviderCalled = true
+                "content://unused"
+            },
+            launchInstaller = { launchedUri = it },
+        )
+
+        assertEquals(DownloadInstallResult.INSTALL_STARTED, result)
+        assertEquals(expectedUri, launchedUri)
+        assertFalse(fileProviderCalled)
+    }
+
+    @Test
+    fun `unrelated completion never resolves or launches an APK`() {
+        var resolved = false
+        var launched = false
+
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 41L,
+            downloadedUri = {
+                resolved = true
+                "content://downloads/all_downloads/41"
+            },
+            fileProviderUri = { "content://unused" },
+            launchInstaller = { launched = true },
+        )
+
+        assertEquals(DownloadInstallResult.IGNORED, result)
+        assertFalse(resolved)
+        assertFalse(launched)
+    }
+
+    @Test
+    fun `receiver contains installer exceptions instead of crashing the host`() {
+        val failure = IllegalStateException("installer unavailable")
+        var captured: Exception? = null
+
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 42L,
+            downloadedUri = { "content://downloads/all_downloads/42" },
+            fileProviderUri = { "content://unused" },
+            launchInstaller = { throw failure },
+            onFailure = { captured = it },
+        )
+
+        assertEquals(DownloadInstallResult.INSTALL_FAILED, result)
+        assertSame(failure, captured)
+    }
+
+    @Test
+    fun `receiver also contains failure reporter exceptions`() {
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 42L,
+            downloadedUri = { "content://downloads/all_downloads/42" },
+            fileProviderUri = { "content://unused" },
+            launchInstaller = { throw IllegalStateException("installer unavailable") },
+            onFailure = { throw IllegalStateException("logger unavailable") },
+        )
+
+        assertEquals(DownloadInstallResult.INSTALL_FAILED, result)
+    }
+
+    @Test
+    fun `unsafe FileProvider output fails closed before installer launch`() {
+        var launched = false
+
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 42L,
+            downloadedUri = { "file:///storage/emulated/0/Download/update.apk" },
+            fileProviderUri = { it.toURI().toString() },
+            launchInstaller = { launched = true },
+        )
+
+        assertEquals(DownloadInstallResult.UNAVAILABLE_OR_UNSAFE_URI, result)
+        assertFalse(launched)
+    }
+
+    @Test
+    fun `FileProvider exceptions are contained by the receiver boundary`() {
+        val failure = IllegalArgumentException("outside configured roots")
+        var captured: Exception? = null
+
+        val result = handleCompletedDownload(
+            expectedDownloadId = 42L,
+            completedDownloadId = 42L,
+            downloadedUri = { "file:///storage/emulated/0/Download/update.apk" },
+            fileProviderUri = { throw failure },
+            launchInstaller = { error("must not launch") },
+            onFailure = { captured = it },
+        )
+
+        assertEquals(DownloadInstallResult.INSTALL_FAILED, result)
+        assertSame(failure, captured)
+    }
+
+    @Test
+    fun `only authority-backed content URIs are accepted`() {
+        assertEquals(
+            "content://downloads/all_downloads/42",
+            validatedApkContentUri("content://downloads/all_downloads/42"),
+        )
+        assertNull(validatedApkContentUri(null))
+        assertNull(validatedApkContentUri(""))
+        assertNull(validatedApkContentUri("content:missing-authority"))
+        assertNull(validatedApkContentUri("file:///storage/emulated/0/Download/update.apk"))
+        assertNull(validatedApkContentUri("https://example.test/update.apk"))
+        assertNull(validatedApkContentUri("not a URI"))
+    }
+
+    @Test
+    fun `installer intent contract grants read access and starts outside an Activity`() {
+        val flags = apkInstallIntentFlags()
+
+        assertTrue(flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertTrue(flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        assertFalse(flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0)
+    }
+}


### PR DESCRIPTION
## Problem

`DownloadManager` can expose a completed APK as a `file://` URI. Passing that URI to the external package installer throws `FileUriExposedException` on Android 7+, and the exception could escape the completion receiver.

## Changes

- Store full APK downloads in the host app's app-scoped external `Download/` directory.
- Convert DownloadManager `file://` results through the SDK's non-exported FileProvider.
- Pass through only authority-backed `content://` results and reject other URI schemes.
- Use the same `ACTION_VIEW`, read-only URI grant, and new-task installer contract for full and delta APKs.
- Contain resolver, FileProvider, launcher, reporter, and receiver failures.
- Limit FileProvider roots to the SDK cache and app-scoped external Download directories.
- Add an API 31 instrumentation job that exercises the merged provider, both allowed roots, existing content URIs, installer flags, and rejected paths/schemes.

## Follow-up

This PR does not bump or publish the SDK, update Mobile's dependency, change Worker behavior, activate a release, modify rollout state, or touch test devices. Those steps require separate reviewed changes after this fix lands.

## Testing

- Local JDK 17 / Gradle 8.13 with an available NDK 27.1: `clean testReleaseUnitTest assembleRelease assembleDebugAndroidTest` passed; the repository remains pinned to NDK 26.3.
- Hosted Android SDK check run `30214934915`: pinned-NDK release/unit job passed.
- Hosted Android 12 API 31 instrumentation: 5 tests started and 5 finished successfully.
- CodeQL actions, C/C++, and JavaScript/TypeScript jobs passed.
- `git diff --check` passed.
