### PR TITLE
chore(android-sdk): prepare 0.12.2 release

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.12.1"
+        default: "0.12.2"
   push:
     tags:
       - "android-sdk-v*"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.1")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.2")
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.12.1")
+    implementation("build.hands:hands-android-sdk:0.12.2")
 }
 ```
 
@@ -94,7 +94,7 @@ to catch that.
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.1`). That publishes to
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.2`). That publishes to
 GitHub Packages (`build.hands:hands-android-sdk:<version>`, including the
 `native-symbols` classifier) and, on the first
 request, builds the same version on JitPack

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.12.1"
+        const val SDK_VERSION = "0.12.2"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.1")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.2")
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.12.1")
+    implementation("build.hands:hands-android-sdk:0.12.2")
 }
 ```
 


### PR DESCRIPTION
## Problem

The Android installer fix has landed on `main` and needs a new immutable SDK version. Runtime metadata, publishing defaults, dependency examples, and public documentation must agree before a tag is created.

## Changes

- Set the Android SDK publish workflow default to `0.12.2`.
- Report `0.12.2` in Android feedback and crash environment metadata.
- Update GitHub Packages, JitPack, and release-tag examples in the Android SDK README.
- Update the public Android SDK dependency examples to `0.12.2`.

## Follow-up

This PR does not create a tag or publish an artifact. After it lands and receives separate authorization, `android-sdk-v0.12.2` must be published and verified before Mobile can consume the new coordinates.

## Testing

- JDK 17 / Gradle 8.13 with an available NDK 27.1 and `VERSION_NAME=0.12.2`: `clean testReleaseUnitTest assembleRelease packageReleaseNativeSymbols` passed.
- Native-symbol packaging produced arm64-v8a, armeabi-v7a, and x86_64 unstripped symbols.
- The repository remains pinned to NDK 26.3 for Hosted verification.
- `git diff --check` passed.
