### PR TITLE
feat: add revocable test-device enrollment rebind

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1380,7 +1380,7 @@ export const listDeviceEnrollments = (appId: string) =>
 
 export const createDeviceEnrollment = (
   appId: string,
-  input: { alias: string; device_id: string; label?: string },
+  input: { alias: string; device_id: string; label?: string; operation_id: string },
 ) => request<DeviceEnrollmentResult>(`/api/apps/${appId}/device-enrollments`, {
   method: "POST",
   admin: true,

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -246,6 +246,9 @@ export interface DeviceGroupMember {
   device_id: string;
   label: string | null;
   created_at: number;
+  enrollment_id?: string | null;
+  enrollment_alias?: string | null;
+  enrollment_revision?: number | null;
 }
 
 export interface DeviceGroup {
@@ -257,6 +260,41 @@ export interface DeviceGroup {
   members: DeviceGroupMember[];
   created_at: number;
   updated_at: number;
+}
+
+export interface DeviceEnrollment {
+  id: string;
+  app_id: string;
+  alias: string;
+  label: string | null;
+  current_device_id: string | null;
+  status: "active" | "revoked";
+  revision: number;
+  created_by: string;
+  updated_by: string;
+  created_at: number;
+  updated_at: number;
+  last_rebound_at: number | null;
+  revoked_at: number | null;
+}
+
+export interface DeviceEnrollmentOperation {
+  operation_id: string;
+  kind: "create" | "rebind" | "revoke";
+  from_device_id: string | null;
+  to_device_id: string | null;
+  expected_revision: number | null;
+  resulting_revision: number;
+  migrated_group_memberships: number;
+  migrated_feature_flags: number;
+  actor: string;
+  created_at: number;
+}
+
+export interface DeviceEnrollmentResult {
+  enrollment: DeviceEnrollment;
+  operation: DeviceEnrollmentOperation;
+  replayed: boolean;
 }
 
 export interface Channel {
@@ -1336,6 +1374,38 @@ export const removeDeviceGroupMember = (appId: string, groupId: string, deviceId
     `/api/apps/${appId}/device-groups/${groupId}/members/${encodeURIComponent(deviceId)}`,
     { method: "DELETE", admin: true },
   );
+
+export const listDeviceEnrollments = (appId: string) =>
+  request<{ enrollments: DeviceEnrollment[] }>(`/api/apps/${appId}/device-enrollments`, { admin: true });
+
+export const createDeviceEnrollment = (
+  appId: string,
+  input: { alias: string; device_id: string; label?: string },
+) => request<DeviceEnrollmentResult>(`/api/apps/${appId}/device-enrollments`, {
+  method: "POST",
+  admin: true,
+  body: JSON.stringify(input),
+});
+
+export const rebindDeviceEnrollment = (
+  appId: string,
+  enrollmentId: string,
+  input: { device_id: string; expected_revision: number; operation_id: string },
+) => request<DeviceEnrollmentResult>(`/api/apps/${appId}/device-enrollments/${enrollmentId}/rebind`, {
+  method: "POST",
+  admin: true,
+  body: JSON.stringify(input),
+});
+
+export const revokeDeviceEnrollment = (
+  appId: string,
+  enrollmentId: string,
+  input: { expected_revision: number; operation_id: string },
+) => request<DeviceEnrollmentResult>(`/api/apps/${appId}/device-enrollments/${enrollmentId}/revoke`, {
+  method: "POST",
+  admin: true,
+  body: JSON.stringify(input),
+});
 
 export interface ReleaseCheck {
   id: string;

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -59,9 +59,14 @@ import {
   addDeviceGroupMember,
   createDeviceGroup,
   deleteDeviceGroup,
+  createDeviceEnrollment,
+  listDeviceEnrollments,
+  rebindDeviceEnrollment,
+  revokeDeviceEnrollment,
   listDeviceGroups,
   removeDeviceGroupMember,
   updateDeviceGroup,
+  type DeviceEnrollment,
   type DeviceGroup,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
@@ -414,10 +419,12 @@ function DeviceGroupsPanel({ appId }: { appId: string }) {
 
   return (
     <div className="border-t border-slate-100 pt-3 space-y-3">
+      <DeviceEnrollmentsPanel appId={appId} />
       <div>
         <div className="text-sm font-medium">Device groups</div>
         <p className="text-xs text-slate-500">
-          Exact rollout groups use the stable installation device id sent by the Hands update SDK.
+          Exact rollout groups still resolve the current random per-install id sent by the Hands update SDK.
+          Enrolled aliases above can rotate that id without changing the group slot.
         </p>
       </div>
       <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
@@ -432,6 +439,173 @@ function DeviceGroupsPanel({ appId }: { appId: string }) {
       {(groups.data?.groups ?? []).map((group) => (
         <DeviceGroupCard key={group.id} appId={appId} group={group} />
       ))}
+    </div>
+  );
+}
+
+function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const enrollments = useQuery({
+    queryKey: ["device-enrollments", appId],
+    queryFn: () => listDeviceEnrollments(appId),
+  });
+  const [alias, setAlias] = useState("");
+  const [deviceId, setDeviceId] = useState("");
+  const [label, setLabel] = useState("");
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: ["device-enrollments", appId] });
+    void queryClient.invalidateQueries({ queryKey: ["device-groups", appId] });
+  };
+  const create = useMutation({
+    mutationFn: () => createDeviceEnrollment(appId, {
+      alias: alias.trim(),
+      device_id: deviceId.trim(),
+      ...(label.trim() ? { label: label.trim() } : {}),
+    }),
+    onSuccess: () => {
+      setAlias("");
+      setDeviceId("");
+      setLabel("");
+      refresh();
+      toast.show({ kind: "success", title: "Test device enrolled" });
+    },
+    onError: (error) => toast.show({
+      kind: "error",
+      title: "Enrollment failed",
+      description: (error as Error).message,
+    }),
+  });
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-slate-50 p-3 space-y-3">
+      <div>
+        <div className="text-sm font-medium">Test-device enrollments</div>
+        <p className="text-xs text-slate-500">
+          Keep a stable, revocable operator alias while Android installation IDs rotate on uninstall or clear-data.
+          Rebind atomically replaces the old ID in this app&apos;s groups and feature flags. No hardware ID is used.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1.5fr_1fr_auto]">
+        <Input value={alias} onChange={(event) => setAlias(event.target.value)} placeholder="artin-huawei-tablet" />
+        <Input value={deviceId} onChange={(event) => setDeviceId(event.target.value)} placeholder="Current installation ID" />
+        <Input value={label} onChange={(event) => setLabel(event.target.value)} placeholder="Label (optional)" />
+        <Button
+          variant="outline"
+          disabled={!alias.trim() || !deviceId.trim() || create.isPending}
+          onClick={() => create.mutate()}
+        >
+          Enroll
+        </Button>
+      </div>
+      {enrollments.isLoading && <p className="text-xs text-slate-500">Loading enrollments…</p>}
+      {enrollments.error && <p className="text-xs text-red-700">{(enrollments.error as Error).message}</p>}
+      {(enrollments.data?.enrollments ?? []).map((enrollment) => (
+        <DeviceEnrollmentRow key={enrollment.id} appId={appId} enrollment={enrollment} onChanged={refresh} />
+      ))}
+      {!enrollments.isLoading && (enrollments.data?.enrollments.length ?? 0) === 0 && (
+        <p className="text-xs text-slate-500">No test-device aliases yet. Existing direct group members keep working.</p>
+      )}
+    </div>
+  );
+}
+
+function DeviceEnrollmentRow({
+  appId,
+  enrollment,
+  onChanged,
+}: {
+  appId: string;
+  enrollment: DeviceEnrollment;
+  onChanged: () => void;
+}) {
+  const toast = useToast();
+  const [nextDeviceId, setNextDeviceId] = useState("");
+  const rebind = useMutation({
+    mutationFn: () => rebindDeviceEnrollment(appId, enrollment.id, {
+      device_id: nextDeviceId.trim(),
+      expected_revision: enrollment.revision,
+      operation_id: crypto.randomUUID(),
+    }),
+    onSuccess: (result) => {
+      setNextDeviceId("");
+      onChanged();
+      toast.show({
+        kind: "success",
+        title: `${result.enrollment.alias} rebound`,
+        description:
+          `${result.operation.migrated_group_memberships} group slot(s), ` +
+          `${result.operation.migrated_feature_flags} feature flag(s) migrated.`,
+      });
+    },
+    onError: (error) => toast.show({
+      kind: "error",
+      title: "Rebind failed",
+      description: (error as Error).message,
+    }),
+  });
+  const revoke = useMutation({
+    mutationFn: () => revokeDeviceEnrollment(appId, enrollment.id, {
+      expected_revision: enrollment.revision,
+      operation_id: crypto.randomUUID(),
+    }),
+    onSuccess: () => {
+      onChanged();
+      toast.show({ kind: "success", title: `${enrollment.alias} revoked` });
+    },
+    onError: (error) => toast.show({
+      kind: "error",
+      title: "Revoke failed",
+      description: (error as Error).message,
+    }),
+  });
+
+  return (
+    <div className="rounded border border-slate-200 bg-white p-2 space-y-2 text-xs">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-medium">
+            {enrollment.alias}{" "}
+            <span className={enrollment.status === "active" ? "text-emerald-700" : "text-slate-500"}>
+              {enrollment.status} · rev {enrollment.revision}
+            </span>
+          </div>
+          {enrollment.label && <div className="text-slate-600">{enrollment.label}</div>}
+          <div className="font-mono text-slate-500 break-all">
+            {enrollment.current_device_id ?? "No active installation ID"}
+          </div>
+          <div className="font-mono text-[11px] text-slate-400">{enrollment.id}</div>
+        </div>
+        {enrollment.status === "active" && (
+          <Button
+            variant="outline"
+            disabled={revoke.isPending || rebind.isPending}
+            onClick={() => {
+              if (window.confirm(`Revoke '${enrollment.alias}' and remove its current ID from all exact targeting?`)) {
+                revoke.mutate();
+              }
+            }}
+          >
+            Revoke
+          </Button>
+        )}
+      </div>
+      {enrollment.status === "active" && (
+        <div className="flex gap-2">
+          <Input
+            value={nextDeviceId}
+            onChange={(event) => setNextDeviceId(event.target.value)}
+            placeholder="Replacement installation ID after reinstall"
+          />
+          <Button
+            variant="outline"
+            disabled={!nextDeviceId.trim() || rebind.isPending || revoke.isPending}
+            onClick={() => rebind.mutate()}
+          >
+            Rebind
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -536,6 +710,9 @@ function DeviceGroupCard({ appId, group }: { appId: string; group: DeviceGroup }
           <div key={member.device_id} className="flex items-center justify-between gap-2 text-xs">
             <span className="min-w-0 truncate">
               <span className="font-medium">{member.label || "Device"}</span>{" "}
+              {member.enrollment_alias && (
+                <span className="text-emerald-700">[{member.enrollment_alias} · rev {member.enrollment_revision}] </span>
+              )}
               <span className="font-mono text-slate-500">{member.device_id}</span>
             </span>
             <Button variant="outline" onClick={() => remove.mutate(member.device_id)} disabled={remove.isPending}>

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -68,6 +68,7 @@ import {
   updateDeviceGroup,
   type DeviceEnrollment,
   type DeviceGroup,
+  ApiError,
 } from "../lib/api";
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
@@ -424,7 +425,7 @@ export function DeviceGroupsPanel({ appId, platform }: { appId: string; platform
         <div className="text-sm font-medium">Device groups</div>
         <p className="text-xs text-slate-500">
           Exact rollout groups still resolve the current random per-install id sent by the Hands update SDK.
-          Enrolled aliases above can rotate that id without changing the group slot.
+          {platform === "android" && " Enrolled aliases above can rotate that id without changing the group slot."}
         </p>
       </div>
       <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
@@ -540,6 +541,10 @@ type EnrollmentActionIntent =
       fromDeviceId: string;
     };
 
+function isAmbiguousEnrollmentMutationError(error: unknown): boolean {
+  return !(error instanceof ApiError) || error.status >= 500;
+}
+
 export function DeviceEnrollmentRow({
   appId,
   enrollment,
@@ -578,11 +583,18 @@ export function DeviceEnrollmentRow({
     },
     onError: (error) => {
       confirmationSubmitted.current = false;
+      const ambiguous = isAmbiguousEnrollmentMutationError(error);
+      if (!ambiguous) {
+        setIntent(null);
+        setNextDeviceId("");
+      }
       onChanged();
       toast.show({
         kind: "error",
-        title: "Rebind result is not confirmed",
-        description: `${(error as Error).message} Refreshing receipts; Retry keeps operation ${intent?.operationId ?? "unknown"}.`,
+        title: ambiguous ? "Rebind result is not confirmed" : "Rebind was rejected",
+        description: ambiguous
+          ? `${(error as Error).message} Refreshing enrollment state; Retry keeps operation ${intent?.operationId ?? "unknown"}.`
+          : `${(error as Error).message} Refreshing enrollment state; review the new revision and confirm again.`,
       });
     },
   });
@@ -606,11 +618,15 @@ export function DeviceEnrollmentRow({
     },
     onError: (error) => {
       confirmationSubmitted.current = false;
+      const ambiguous = isAmbiguousEnrollmentMutationError(error);
+      if (!ambiguous) setIntent(null);
       onChanged();
       toast.show({
         kind: "error",
-        title: "Revoke result is not confirmed",
-        description: `${(error as Error).message} Refreshing receipts; Retry keeps operation ${intent?.operationId ?? "unknown"}.`,
+        title: ambiguous ? "Revoke result is not confirmed" : "Revoke was rejected",
+        description: ambiguous
+          ? `${(error as Error).message} Refreshing enrollment state; Retry keeps operation ${intent?.operationId ?? "unknown"}.`
+          : `${(error as Error).message} Refreshing enrollment state; review the new revision and confirm again.`,
       });
     },
   });

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -509,6 +509,7 @@ export function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
       createIntent.deviceId === next.deviceId && createIntent.label === next.label
       ? createIntent
       : { ...next, operationId: crypto.randomUUID() };
+    if (intent !== createIntent) setLastCreateReceipt(null);
     setCreateIntent(intent);
     create.mutate(intent);
   };

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -27,7 +27,7 @@ import {
 import { DeviceAnalytics } from "../components/DeviceAnalytics";
 import { ReleaseHealth } from "../components/ReleaseHealth";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ConfirmActionDialog, TypedConfirmField } from "../components/ConfirmActionDialog";
 import {
   archiveApp,
@@ -394,7 +394,7 @@ function ClientKeyPanel({ appId }: { appId: string }) {
   );
 }
 
-function DeviceGroupsPanel({ appId }: { appId: string }) {
+export function DeviceGroupsPanel({ appId, platform }: { appId: string; platform: string }) {
   const queryClient = useQueryClient();
   const toast = useToast();
   const groups = useQuery({
@@ -419,7 +419,7 @@ function DeviceGroupsPanel({ appId }: { appId: string }) {
 
   return (
     <div className="border-t border-slate-100 pt-3 space-y-3">
-      <DeviceEnrollmentsPanel appId={appId} />
+      {platform === "android" && <DeviceEnrollmentsPanel appId={appId} />}
       <div>
         <div className="text-sm font-medium">Device groups</div>
         <p className="text-xs text-slate-500">
@@ -443,7 +443,7 @@ function DeviceGroupsPanel({ appId }: { appId: string }) {
   );
 }
 
-function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
+export function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
   const queryClient = useQueryClient();
   const toast = useToast();
   const enrollments = useQuery({
@@ -487,9 +487,24 @@ function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
         </p>
       </div>
       <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1.5fr_1fr_auto]">
-        <Input value={alias} onChange={(event) => setAlias(event.target.value)} placeholder="artin-huawei-tablet" />
-        <Input value={deviceId} onChange={(event) => setDeviceId(event.target.value)} placeholder="Current installation ID" />
-        <Input value={label} onChange={(event) => setLabel(event.target.value)} placeholder="Label (optional)" />
+        <Input
+          aria-label="Enrollment alias"
+          value={alias}
+          onChange={(event) => setAlias(event.target.value)}
+          placeholder="artin-huawei-tablet"
+        />
+        <Input
+          aria-label="Current Android installation ID"
+          value={deviceId}
+          onChange={(event) => setDeviceId(event.target.value)}
+          placeholder="Current installation ID"
+        />
+        <Input
+          aria-label="Enrollment label"
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+          placeholder="Label (optional)"
+        />
         <Button
           variant="outline"
           disabled={!alias.trim() || !deviceId.trim() || create.isPending}
@@ -510,7 +525,22 @@ function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
   );
 }
 
-function DeviceEnrollmentRow({
+type EnrollmentActionIntent =
+  | {
+      kind: "rebind";
+      operationId: string;
+      expectedRevision: number;
+      fromDeviceId: string;
+      toDeviceId: string;
+    }
+  | {
+      kind: "revoke";
+      operationId: string;
+      expectedRevision: number;
+      fromDeviceId: string;
+    };
+
+export function DeviceEnrollmentRow({
   appId,
   enrollment,
   onChanged,
@@ -521,13 +551,19 @@ function DeviceEnrollmentRow({
 }) {
   const toast = useToast();
   const [nextDeviceId, setNextDeviceId] = useState("");
+  const [intent, setIntent] = useState<EnrollmentActionIntent | null>(null);
+  const [lastReceipt, setLastReceipt] = useState<Awaited<ReturnType<typeof rebindDeviceEnrollment>> | null>(null);
+  const confirmationSubmitted = useRef(false);
   const rebind = useMutation({
-    mutationFn: () => rebindDeviceEnrollment(appId, enrollment.id, {
-      device_id: nextDeviceId.trim(),
-      expected_revision: enrollment.revision,
-      operation_id: crypto.randomUUID(),
+    mutationFn: (action: Extract<EnrollmentActionIntent, { kind: "rebind" }>) => rebindDeviceEnrollment(appId, enrollment.id, {
+      device_id: action.toDeviceId,
+      expected_revision: action.expectedRevision,
+      operation_id: action.operationId,
     }),
     onSuccess: (result) => {
+      confirmationSubmitted.current = false;
+      setLastReceipt(result);
+      setIntent(null);
       setNextDeviceId("");
       onChanged();
       toast.show({
@@ -535,34 +571,83 @@ function DeviceEnrollmentRow({
         title: `${result.enrollment.alias} rebound`,
         description:
           `${result.operation.migrated_group_memberships} group slot(s), ` +
-          `${result.operation.migrated_feature_flags} feature flag(s) migrated.`,
+          `${result.operation.migrated_feature_flags} feature flag(s) migrated; ` +
+          `revision ${result.operation.resulting_revision}; ` +
+          `${result.replayed ? "receipt replayed" : "new receipt"}.`,
       });
     },
-    onError: (error) => toast.show({
-      kind: "error",
-      title: "Rebind failed",
-      description: (error as Error).message,
-    }),
+    onError: (error) => {
+      confirmationSubmitted.current = false;
+      onChanged();
+      toast.show({
+        kind: "error",
+        title: "Rebind result is not confirmed",
+        description: `${(error as Error).message} Refreshing receipts; Retry keeps operation ${intent?.operationId ?? "unknown"}.`,
+      });
+    },
   });
   const revoke = useMutation({
-    mutationFn: () => revokeDeviceEnrollment(appId, enrollment.id, {
-      expected_revision: enrollment.revision,
-      operation_id: crypto.randomUUID(),
+    mutationFn: (action: Extract<EnrollmentActionIntent, { kind: "revoke" }>) => revokeDeviceEnrollment(appId, enrollment.id, {
+      expected_revision: action.expectedRevision,
+      operation_id: action.operationId,
     }),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      confirmationSubmitted.current = false;
+      setLastReceipt(result);
+      setIntent(null);
       onChanged();
-      toast.show({ kind: "success", title: `${enrollment.alias} revoked` });
+      toast.show({
+        kind: "success",
+        title: `${enrollment.alias} revoked`,
+        description:
+          `Operation ${result.operation.operation_id}; revision ${result.operation.resulting_revision}; ` +
+          `${result.replayed ? "receipt replayed" : "new receipt"}.`,
+      });
     },
-    onError: (error) => toast.show({
-      kind: "error",
-      title: "Revoke failed",
-      description: (error as Error).message,
-    }),
+    onError: (error) => {
+      confirmationSubmitted.current = false;
+      onChanged();
+      toast.show({
+        kind: "error",
+        title: "Revoke result is not confirmed",
+        description: `${(error as Error).message} Refreshing receipts; Retry keeps operation ${intent?.operationId ?? "unknown"}.`,
+      });
+    },
   });
+
+  const pending = rebind.isPending || revoke.isPending;
+  const openRebind = () => {
+    const toDeviceId = nextDeviceId.trim();
+    if (!toDeviceId || !enrollment.current_device_id) return;
+    setIntent({
+      kind: "rebind",
+      operationId: crypto.randomUUID(),
+      expectedRevision: enrollment.revision,
+      fromDeviceId: enrollment.current_device_id,
+      toDeviceId,
+    });
+  };
+  const openRevoke = () => {
+    if (!enrollment.current_device_id) return;
+    setIntent({
+      kind: "revoke",
+      operationId: crypto.randomUUID(),
+      expectedRevision: enrollment.revision,
+      fromDeviceId: enrollment.current_device_id,
+    });
+  };
+  const confirmIntent = () => {
+    confirmationSubmitted.current = true;
+    if (intent?.kind === "rebind") rebind.mutate(intent);
+    if (intent?.kind === "revoke") revoke.mutate(intent);
+  };
+  const cancelIntent = () => {
+    if (!pending && !confirmationSubmitted.current) setIntent(null);
+  };
 
   return (
     <div className="rounded border border-slate-200 bg-white p-2 space-y-2 text-xs">
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="font-medium">
             {enrollment.alias}{" "}
@@ -578,34 +663,83 @@ function DeviceEnrollmentRow({
         </div>
         {enrollment.status === "active" && (
           <Button
-            variant="outline"
-            disabled={revoke.isPending || rebind.isPending}
-            onClick={() => {
-              if (window.confirm(`Revoke '${enrollment.alias}' and remove its current ID from all exact targeting?`)) {
-                revoke.mutate();
-              }
-            }}
+            variant="danger"
+            className="w-full sm:w-auto"
+            aria-label={`Revoke enrollment ${enrollment.alias}`}
+            disabled={pending}
+            onClick={openRevoke}
           >
             Revoke
           </Button>
         )}
       </div>
       {enrollment.status === "active" && (
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <Input
+            aria-label={`Replacement installation ID for ${enrollment.alias}`}
+            className="min-w-0 w-full"
             value={nextDeviceId}
             onChange={(event) => setNextDeviceId(event.target.value)}
             placeholder="Replacement installation ID after reinstall"
           />
           <Button
             variant="outline"
-            disabled={!nextDeviceId.trim() || rebind.isPending || revoke.isPending}
-            onClick={() => rebind.mutate()}
+            className="w-full sm:w-auto"
+            aria-label={`Rebind enrollment ${enrollment.alias}`}
+            disabled={!nextDeviceId.trim() || pending}
+            onClick={openRebind}
           >
             Rebind
           </Button>
         </div>
       )}
+      {lastReceipt && (
+        <div className="rounded border border-emerald-200 bg-emerald-50 p-2 font-mono text-[11px] text-emerald-900" role="status">
+          <div>operation: {lastReceipt.operation.operation_id}</div>
+          <div>revision: {lastReceipt.operation.resulting_revision}</div>
+          <div>replayed: {String(lastReceipt.replayed)}</div>
+          <div>
+            migrated: {lastReceipt.operation.migrated_group_memberships} group slot(s),{" "}
+            {lastReceipt.operation.migrated_feature_flags} feature flag(s)
+          </div>
+        </div>
+      )}
+      <ConfirmActionDialog
+        open={intent?.kind === "rebind"}
+        title="Rebind test-device enrollment?"
+        objectLabel={enrollment.alias}
+        objectHint={`enrollment ${enrollment.id} · revision ${intent?.expectedRevision ?? enrollment.revision}`}
+        objectSummary={intent?.kind === "rebind" ? (
+          <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono">
+            <div className="text-slate-500">from</div><div className="break-all">{intent.fromDeviceId}</div>
+            <div className="text-slate-500">to</div><div className="break-all">{intent.toDeviceId}</div>
+            <div className="text-slate-500">operation</div><div className="break-all">{intent.operationId}</div>
+          </div>
+        ) : undefined}
+        body="This atomically replaces the old installation ID in every device-group membership and feature-flag allow/deny target for this app. The old ID immediately loses that exact targeting. A retry uses the same operation receipt."
+        confirmLabel="Rebind installation"
+        pending={rebind.isPending}
+        onConfirm={confirmIntent}
+        onCancel={cancelIntent}
+      />
+      <ConfirmActionDialog
+        open={intent?.kind === "revoke"}
+        title="Revoke test-device enrollment?"
+        objectLabel={enrollment.alias}
+        objectHint={`enrollment ${enrollment.id} · revision ${intent?.expectedRevision ?? enrollment.revision}`}
+        objectSummary={intent?.kind === "revoke" ? (
+          <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono">
+            <div className="text-slate-500">current ID</div><div className="break-all">{intent.fromDeviceId}</div>
+            <div className="text-slate-500">operation</div><div className="break-all">{intent.operationId}</div>
+          </div>
+        ) : undefined}
+        body="This removes the current installation ID from every device-group membership and feature-flag allow/deny target for this app, then permanently marks the alias revoked. A retry uses the same operation receipt."
+        confirmLabel="Revoke enrollment"
+        confirmKind="danger"
+        pending={revoke.isPending}
+        onConfirm={confirmIntent}
+        onCancel={cancelIntent}
+      />
     </div>
   );
 }
@@ -1500,7 +1634,7 @@ export function AppSettings({ appId }: { appId: string }) {
         <ClientKeyPanel appId={appId} />
 
         {/* Exact per-installation rollout groups */}
-        <DeviceGroupsPanel appId={appId} />
+        <DeviceGroupsPanel appId={appId} platform={app.platform} />
 
         {/* TestFlight upload credentials — iOS apps only */}
         {app.platform === "ios" && <TestFlightPanel appId={appId} />}

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -454,29 +454,64 @@ export function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
   const [alias, setAlias] = useState("");
   const [deviceId, setDeviceId] = useState("");
   const [label, setLabel] = useState("");
+  const [createIntent, setCreateIntent] = useState<{
+    alias: string;
+    deviceId: string;
+    label?: string;
+    operationId: string;
+  } | null>(null);
+  const [lastCreateReceipt, setLastCreateReceipt] = useState<Awaited<ReturnType<typeof createDeviceEnrollment>> | null>(null);
   const refresh = () => {
     void queryClient.invalidateQueries({ queryKey: ["device-enrollments", appId] });
     void queryClient.invalidateQueries({ queryKey: ["device-groups", appId] });
   };
   const create = useMutation({
-    mutationFn: () => createDeviceEnrollment(appId, {
-      alias: alias.trim(),
-      device_id: deviceId.trim(),
-      ...(label.trim() ? { label: label.trim() } : {}),
+    mutationFn: (intent: NonNullable<typeof createIntent>) => createDeviceEnrollment(appId, {
+      alias: intent.alias,
+      device_id: intent.deviceId,
+      ...(intent.label ? { label: intent.label } : {}),
+      operation_id: intent.operationId,
     }),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      setLastCreateReceipt(result);
+      setCreateIntent(null);
       setAlias("");
       setDeviceId("");
       setLabel("");
       refresh();
-      toast.show({ kind: "success", title: "Test device enrolled" });
+      toast.show({
+        kind: "success",
+        title: "Test device enrolled",
+        description: `Operation ${result.operation.operation_id}; ${result.replayed ? "receipt replayed" : "new receipt"}.`,
+      });
     },
-    onError: (error) => toast.show({
-      kind: "error",
-      title: "Enrollment failed",
-      description: (error as Error).message,
-    }),
+    onError: (error) => {
+      const ambiguous = isAmbiguousEnrollmentMutationError(error);
+      if (!ambiguous) setCreateIntent(null);
+      refresh();
+      toast.show({
+        kind: "error",
+        title: ambiguous ? "Enrollment result is not confirmed" : "Enrollment was rejected",
+        description: ambiguous
+          ? `${(error as Error).message} Retry keeps operation ${createIntent?.operationId ?? "unknown"}.`
+          : (error as Error).message,
+      });
+    },
   });
+  const submitCreate = () => {
+    const next = {
+      alias: alias.trim(),
+      deviceId: deviceId.trim(),
+      ...(label.trim() ? { label: label.trim() } : {}),
+    };
+    if (!next.alias || !next.deviceId) return;
+    const intent = createIntent?.alias === next.alias &&
+      createIntent.deviceId === next.deviceId && createIntent.label === next.label
+      ? createIntent
+      : { ...next, operationId: crypto.randomUUID() };
+    setCreateIntent(intent);
+    create.mutate(intent);
+  };
 
   return (
     <div className="rounded-md border border-slate-200 bg-slate-50 p-3 space-y-3">
@@ -509,13 +544,21 @@ export function DeviceEnrollmentsPanel({ appId }: { appId: string }) {
         <Button
           variant="outline"
           disabled={!alias.trim() || !deviceId.trim() || create.isPending}
-          onClick={() => create.mutate()}
+          onClick={submitCreate}
         >
           Enroll
         </Button>
       </div>
       {enrollments.isLoading && <p className="text-xs text-slate-500">Loading enrollments…</p>}
       {enrollments.error && <p className="text-xs text-red-700">{(enrollments.error as Error).message}</p>}
+      {lastCreateReceipt && (
+        <div className="rounded border border-emerald-200 bg-emerald-50 p-2 font-mono text-[11px] text-emerald-900" role="status">
+          <div>created: {lastCreateReceipt.enrollment.id}</div>
+          <div>operation: {lastCreateReceipt.operation.operation_id}</div>
+          <div>revision: {lastCreateReceipt.operation.resulting_revision}</div>
+          <div>replayed: {String(lastCreateReceipt.replayed)}</div>
+        </div>
+      )}
       {(enrollments.data?.enrollments ?? []).map((enrollment) => (
         <DeviceEnrollmentRow key={enrollment.id} appId={appId} enrollment={enrollment} onChanged={refresh} />
       ))}

--- a/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
+++ b/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeviceEnrollment, DeviceEnrollmentResult } from "../lib/api";
+
+const mocks = vi.hoisted(() => ({
+  listDeviceGroups: vi.fn(),
+  listDeviceEnrollments: vi.fn(),
+  rebindDeviceEnrollment: vi.fn(),
+  revokeDeviceEnrollment: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("../lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api")>()),
+  listDeviceGroups: mocks.listDeviceGroups,
+  listDeviceEnrollments: mocks.listDeviceEnrollments,
+  rebindDeviceEnrollment: mocks.rebindDeviceEnrollment,
+  revokeDeviceEnrollment: mocks.revokeDeviceEnrollment,
+}));
+
+vi.mock("../components/Toast", () => ({
+  useToast: () => ({ show: mocks.toast }),
+}));
+
+import { DeviceEnrollmentRow, DeviceGroupsPanel } from "./AppDetail";
+
+const enrollment: DeviceEnrollment = {
+  id: "enrollment-123",
+  app_id: "app-1",
+  alias: "artin-huawei-tablet",
+  label: "Android 12 QA",
+  current_device_id: "install-old",
+  status: "active",
+  revision: 7,
+  created_by: "artin",
+  updated_by: "artin",
+  created_at: 1,
+  updated_at: 2,
+  last_rebound_at: null,
+  revoked_at: null,
+};
+
+function result(kind: "rebind" | "revoke", replayed = false): DeviceEnrollmentResult {
+  return {
+    enrollment: {
+      ...enrollment,
+      current_device_id: kind === "rebind" ? "install-new" : null,
+      status: kind === "rebind" ? "active" : "revoked",
+      revision: 8,
+    },
+    replayed,
+    operation: {
+      operation_id: "operation-fixed",
+      kind,
+      from_device_id: "install-old",
+      to_device_id: kind === "rebind" ? "install-new" : null,
+      expected_revision: 7,
+      resulting_revision: 8,
+      migrated_group_memberships: 2,
+      migrated_feature_flags: 3,
+      actor: "artin",
+      created_at: 3,
+    },
+  };
+}
+
+function wrapper(children: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listDeviceGroups.mockResolvedValue({ groups: [] });
+  mocks.listDeviceEnrollments.mockResolvedValue({ enrollments: [enrollment] });
+  vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "operation-fixed") });
+});
+
+describe("Android test-device enrollments", () => {
+  it("does not render or query Android enrollment controls for non-Android apps", async () => {
+    render(wrapper(<DeviceGroupsPanel appId="app-1" platform="ios" />));
+
+    expect(screen.queryByText("Test-device enrollments")).toBeNull();
+    expect(mocks.listDeviceEnrollments).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.listDeviceGroups).toHaveBeenCalledWith("app-1"));
+  });
+
+  it("renders the enrollment panel for Android apps", async () => {
+    render(wrapper(<DeviceGroupsPanel appId="app-1" platform="android" />));
+
+    expect(await screen.findByText("Test-device enrollments")).toBeTruthy();
+    expect(mocks.listDeviceEnrollments).toHaveBeenCalledWith("app-1");
+  });
+
+  it("confirms exact rebind impact and retries an ambiguous failure with the same receipt key", async () => {
+    mocks.rebindDeviceEnrollment
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce(result("rebind", true));
+    const changed = vi.fn();
+    render(wrapper(
+      <DeviceEnrollmentRow appId="app-1" enrollment={enrollment} onChanged={changed} />,
+    ));
+
+    const input = screen.getByRole("textbox", {
+      name: "Replacement installation ID for artin-huawei-tablet",
+    });
+    expect(input.className).toContain("min-w-0");
+    expect(input.className).toContain("w-full");
+    fireEvent.change(input, { target: { value: "install-new" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rebind enrollment artin-huawei-tablet" }));
+
+    expect(mocks.rebindDeviceEnrollment).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alertdialog")).toBeTruthy();
+    expect(screen.getAllByText("install-old").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("install-new")).toBeTruthy();
+    expect(screen.getByText("operation-fixed")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Rebind installation" }));
+
+    const expectedPayload = {
+      device_id: "install-new",
+      expected_revision: 7,
+      operation_id: "operation-fixed",
+    };
+    await waitFor(() => expect(mocks.rebindDeviceEnrollment).toHaveBeenCalledTimes(1));
+    expect(mocks.rebindDeviceEnrollment).toHaveBeenLastCalledWith(
+      "app-1",
+      "enrollment-123",
+      expectedPayload,
+    );
+    await waitFor(() => expect(changed).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Rebind installation" }));
+    await waitFor(() => expect(mocks.rebindDeviceEnrollment).toHaveBeenCalledTimes(2));
+    expect(mocks.rebindDeviceEnrollment).toHaveBeenLastCalledWith(
+      "app-1",
+      "enrollment-123",
+      expectedPayload,
+    );
+    expect(await screen.findByText("operation: operation-fixed")).toBeTruthy();
+    expect(screen.getByText("revision: 8")).toBeTruthy();
+    expect(screen.getByText("replayed: true")).toBeTruthy();
+    expect(screen.getByText(/migrated: 2 group slot/)).toBeTruthy();
+  });
+
+  it("uses a danger confirmation before revoke and shows exact identity receipt", async () => {
+    mocks.revokeDeviceEnrollment.mockResolvedValue(result("revoke"));
+    render(wrapper(
+      <DeviceEnrollmentRow appId="app-1" enrollment={enrollment} onChanged={vi.fn()} />,
+    ));
+
+    const open = screen.getByRole("button", { name: "Revoke enrollment artin-huawei-tablet" });
+    expect(open.className).toContain("w-full");
+    fireEvent.click(open);
+    expect(mocks.revokeDeviceEnrollment).not.toHaveBeenCalled();
+    expect(await screen.findByText("Revoke test-device enrollment?")).toBeTruthy();
+    expect(screen.getByText("current ID")).toBeTruthy();
+    expect(screen.getAllByText("install-old").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("operation-fixed")).toBeTruthy();
+
+    const confirm = screen.getByRole("button", { name: "Revoke enrollment" });
+    expect(confirm.className).toMatch(/danger|red/);
+    fireEvent.click(confirm);
+    await waitFor(() => expect(mocks.revokeDeviceEnrollment).toHaveBeenCalledWith(
+      "app-1",
+      "enrollment-123",
+      {
+        expected_revision: 7,
+        operation_id: "operation-fixed",
+      },
+    ));
+    expect(await screen.findByText("operation: operation-fixed")).toBeTruthy();
+  });
+});

--- a/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
+++ b/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
@@ -9,6 +9,7 @@ import { ApiError, type DeviceEnrollment, type DeviceEnrollmentResult } from "..
 const mocks = vi.hoisted(() => ({
   listDeviceGroups: vi.fn(),
   listDeviceEnrollments: vi.fn(),
+  createDeviceEnrollment: vi.fn(),
   rebindDeviceEnrollment: vi.fn(),
   revokeDeviceEnrollment: vi.fn(),
   toast: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("../lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/api")>()),
   listDeviceGroups: mocks.listDeviceGroups,
   listDeviceEnrollments: mocks.listDeviceEnrollments,
+  createDeviceEnrollment: mocks.createDeviceEnrollment,
   rebindDeviceEnrollment: mocks.rebindDeviceEnrollment,
   revokeDeviceEnrollment: mocks.revokeDeviceEnrollment,
 }));
@@ -27,14 +29,14 @@ vi.mock("../components/Toast", () => ({
   useToast: () => ({ show: mocks.toast }),
 }));
 
-import { DeviceEnrollmentRow, DeviceGroupsPanel } from "./AppDetail";
+import { DeviceEnrollmentRow, DeviceEnrollmentsPanel, DeviceGroupsPanel } from "./AppDetail";
 
 const enrollment: DeviceEnrollment = {
   id: "enrollment-123",
   app_id: "app-1",
   alias: "artin-huawei-tablet",
   label: "Android 12 QA",
-  current_device_id: "install-old",
+  current_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   status: "active",
   revision: 7,
   created_by: "artin",
@@ -49,7 +51,7 @@ function result(kind: "rebind" | "revoke", replayed = false): DeviceEnrollmentRe
   return {
     enrollment: {
       ...enrollment,
-      current_device_id: kind === "rebind" ? "install-new" : null,
+      current_device_id: kind === "rebind" ? "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" : null,
       status: kind === "rebind" ? "active" : "revoked",
       revision: 8,
     },
@@ -57,8 +59,8 @@ function result(kind: "rebind" | "revoke", replayed = false): DeviceEnrollmentRe
     operation: {
       operation_id: "operation-first",
       kind,
-      from_device_id: "install-old",
-      to_device_id: kind === "rebind" ? "install-new" : null,
+      from_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      to_device_id: kind === "rebind" ? "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" : null,
       expected_revision: 7,
       resulting_revision: 8,
       migrated_group_memberships: 2,
@@ -107,6 +109,57 @@ describe("Android test-device enrollments", () => {
     expect(mocks.listDeviceEnrollments).toHaveBeenCalledWith("app-1");
   });
 
+  it("retries ambiguous create with one frozen operation key and shows replay receipt", async () => {
+    const created: DeviceEnrollmentResult = {
+      enrollment: {
+        ...enrollment,
+        id: "created-enrollment",
+        current_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        revision: 1,
+      },
+      replayed: true,
+      operation: {
+        operation_id: "operation-first",
+        kind: "create",
+        from_device_id: null,
+        to_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        expected_revision: null,
+        resulting_revision: 1,
+        migrated_group_memberships: 0,
+        migrated_feature_flags: 0,
+        actor: "artin",
+        created_at: 3,
+      },
+    };
+    mocks.createDeviceEnrollment
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce(created);
+    render(wrapper(<DeviceEnrollmentsPanel appId="app-1" />));
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Enrollment alias" }), {
+      target: { value: "artin-huawei-tablet" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "Current Android installation ID" }), {
+      target: { value: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+    const payload = {
+      alias: "artin-huawei-tablet",
+      device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      operation_id: "operation-first",
+    };
+    await waitFor(() => expect(mocks.createDeviceEnrollment).toHaveBeenCalledTimes(1));
+    expect(mocks.createDeviceEnrollment).toHaveBeenLastCalledWith("app-1", payload);
+    expect(mocks.uuid).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Enroll" }));
+    await waitFor(() => expect(mocks.createDeviceEnrollment).toHaveBeenCalledTimes(2));
+    expect(mocks.createDeviceEnrollment).toHaveBeenLastCalledWith("app-1", payload);
+    expect(mocks.uuid).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("operation: operation-first")).toBeTruthy();
+    expect(screen.getByText("replayed: true")).toBeTruthy();
+  });
+
   it("confirms exact rebind impact and retries an ambiguous failure with the same receipt key", async () => {
     mocks.rebindDeviceEnrollment
       .mockRejectedValueOnce(new Error("response lost"))
@@ -121,18 +174,18 @@ describe("Android test-device enrollments", () => {
     });
     expect(input.className).toContain("min-w-0");
     expect(input.className).toContain("w-full");
-    fireEvent.change(input, { target: { value: "install-new" } });
+    fireEvent.change(input, { target: { value: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" } });
     fireEvent.click(screen.getByRole("button", { name: "Rebind enrollment artin-huawei-tablet" }));
 
     expect(mocks.rebindDeviceEnrollment).not.toHaveBeenCalled();
     expect(await screen.findByRole("alertdialog")).toBeTruthy();
-    expect(screen.getAllByText("install-old").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("install-new")).toBeTruthy();
+    expect(screen.getAllByText("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")).toBeTruthy();
     expect(screen.getByText("operation-first")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Rebind installation" }));
 
     const expectedPayload = {
-      device_id: "install-new",
+      device_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       expected_revision: 7,
       operation_id: "operation-first",
     };
@@ -172,7 +225,7 @@ describe("Android test-device enrollments", () => {
     expect(mocks.revokeDeviceEnrollment).not.toHaveBeenCalled();
     expect(await screen.findByText("Revoke test-device enrollment?")).toBeTruthy();
     expect(screen.getByText("current ID")).toBeTruthy();
-    expect(screen.getAllByText("install-old").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("operation-first")).toBeTruthy();
 
     const confirm = screen.getByRole("button", { name: "Revoke enrollment" });
@@ -201,7 +254,7 @@ describe("Android test-device enrollments", () => {
     const input = screen.getByRole("textbox", {
       name: "Replacement installation ID for artin-huawei-tablet",
     });
-    fireEvent.change(input, { target: { value: "install-new" } });
+    fireEvent.change(input, { target: { value: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" } });
     fireEvent.click(screen.getByRole("button", { name: "Rebind enrollment artin-huawei-tablet" }));
     fireEvent.click(await screen.findByRole("button", { name: "Rebind installation" }));
 
@@ -211,7 +264,7 @@ describe("Android test-device enrollments", () => {
     expect(changed).toHaveBeenCalledTimes(1);
     expect(mocks.uuid).toHaveBeenCalledTimes(1);
 
-    fireEvent.change(input, { target: { value: "install-newer" } });
+    fireEvent.change(input, { target: { value: "cccccccc-cccc-4ccc-8ccc-cccccccccccc" } });
     fireEvent.click(screen.getByRole("button", { name: "Rebind enrollment artin-huawei-tablet" }));
     expect(await screen.findByText("operation-second")).toBeTruthy();
     expect(mocks.uuid).toHaveBeenCalledTimes(2);

--- a/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
+++ b/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
@@ -71,6 +71,30 @@ function result(kind: "rebind" | "revoke", replayed = false): DeviceEnrollmentRe
   };
 }
 
+function createResult(id: string, replayed = false): DeviceEnrollmentResult {
+  return {
+    enrollment: {
+      ...enrollment,
+      id,
+      current_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      revision: 1,
+    },
+    replayed,
+    operation: {
+      operation_id: "operation-first",
+      kind: "create",
+      from_device_id: null,
+      to_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expected_revision: null,
+      resulting_revision: 1,
+      migrated_group_memberships: 0,
+      migrated_feature_flags: 0,
+      actor: "artin",
+      created_at: 3,
+    },
+  };
+}
+
 function wrapper(children: ReactNode) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -110,30 +134,9 @@ describe("Android test-device enrollments", () => {
   });
 
   it("retries ambiguous create with one frozen operation key and shows replay receipt", async () => {
-    const created: DeviceEnrollmentResult = {
-      enrollment: {
-        ...enrollment,
-        id: "created-enrollment",
-        current_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-        revision: 1,
-      },
-      replayed: true,
-      operation: {
-        operation_id: "operation-first",
-        kind: "create",
-        from_device_id: null,
-        to_device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-        expected_revision: null,
-        resulting_revision: 1,
-        migrated_group_memberships: 0,
-        migrated_feature_flags: 0,
-        actor: "artin",
-        created_at: 3,
-      },
-    };
     mocks.createDeviceEnrollment
       .mockRejectedValueOnce(new Error("response lost"))
-      .mockResolvedValueOnce(created);
+      .mockResolvedValueOnce(createResult("created-enrollment", true));
     render(wrapper(<DeviceEnrollmentsPanel appId="app-1" />));
 
     fireEvent.change(screen.getByRole("textbox", { name: "Enrollment alias" }), {
@@ -156,8 +159,58 @@ describe("Android test-device enrollments", () => {
     await waitFor(() => expect(mocks.createDeviceEnrollment).toHaveBeenCalledTimes(2));
     expect(mocks.createDeviceEnrollment).toHaveBeenLastCalledWith("app-1", payload);
     expect(mocks.uuid).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("created: created-enrollment")).toBeTruthy();
     expect(await screen.findByText("operation: operation-first")).toBeTruthy();
+    expect(screen.getByText("revision: 1")).toBeTruthy();
     expect(screen.getByText("replayed: true")).toBeTruthy();
+  });
+
+  it("clears the last confirmed create receipt when a different create starts and fails", async () => {
+    mocks.createDeviceEnrollment
+      .mockResolvedValueOnce(createResult("created-A"))
+      .mockRejectedValueOnce(new Error("B response lost"));
+    render(wrapper(<DeviceEnrollmentsPanel appId="app-1" />));
+    const alias = screen.getByRole("textbox", { name: "Enrollment alias" });
+    const device = screen.getByRole("textbox", { name: "Current Android installation ID" });
+    const submit = screen.getByRole("button", { name: "Enroll" });
+
+    fireEvent.change(alias, { target: { value: "device-A" } });
+    fireEvent.change(device, { target: { value: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" } });
+    fireEvent.click(submit);
+    expect(await screen.findByText("created: created-A")).toBeTruthy();
+
+    fireEvent.change(alias, { target: { value: "device-B" } });
+    fireEvent.change(device, { target: { value: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" } });
+    fireEvent.click(submit);
+    await waitFor(() => expect(mocks.createDeviceEnrollment).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText("created: created-A")).toBeNull());
+    expect(screen.queryByText("operation: operation-first")).toBeNull();
+  });
+
+  it("drops a definitive create 409 intent and uses a fresh operation key on resubmit", async () => {
+    mocks.createDeviceEnrollment.mockRejectedValue(
+      new ApiError(409, { error: "operation conflict" }, "operation conflict"),
+    );
+    render(wrapper(<DeviceEnrollmentsPanel appId="app-1" />));
+    fireEvent.change(screen.getByRole("textbox", { name: "Enrollment alias" }), {
+      target: { value: "artin-huawei-tablet" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "Current Android installation ID" }), {
+      target: { value: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+    });
+    const submit = screen.getByRole("button", { name: "Enroll" });
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(mocks.createDeviceEnrollment).toHaveBeenCalledTimes(1));
+    expect(mocks.createDeviceEnrollment.mock.calls[0]?.[1]).toMatchObject({
+      operation_id: "operation-first",
+    });
+    fireEvent.click(submit);
+    await waitFor(() => expect(mocks.createDeviceEnrollment).toHaveBeenCalledTimes(2));
+    expect(mocks.createDeviceEnrollment.mock.calls[1]?.[1]).toMatchObject({
+      operation_id: "operation-second",
+    });
+    expect(mocks.uuid).toHaveBeenCalledTimes(2);
   });
 
   it("confirms exact rebind impact and retries an ambiguous failure with the same receipt key", async () => {

--- a/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
+++ b/admin/src/pages/DeviceEnrollmentsPanel.dom.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DeviceEnrollment, DeviceEnrollmentResult } from "../lib/api";
+import { ApiError, type DeviceEnrollment, type DeviceEnrollmentResult } from "../lib/api";
 
 const mocks = vi.hoisted(() => ({
   listDeviceGroups: vi.fn(),
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   rebindDeviceEnrollment: vi.fn(),
   revokeDeviceEnrollment: vi.fn(),
   toast: vi.fn(),
+  uuid: vi.fn(),
 }));
 
 vi.mock("../lib/api", async (importOriginal) => ({
@@ -54,7 +55,7 @@ function result(kind: "rebind" | "revoke", replayed = false): DeviceEnrollmentRe
     },
     replayed,
     operation: {
-      operation_id: "operation-fixed",
+      operation_id: "operation-first",
       kind,
       from_device_id: "install-old",
       to_device_id: kind === "rebind" ? "install-new" : null,
@@ -84,7 +85,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.listDeviceGroups.mockResolvedValue({ groups: [] });
   mocks.listDeviceEnrollments.mockResolvedValue({ enrollments: [enrollment] });
-  vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "operation-fixed") });
+  mocks.uuid.mockReset();
+  mocks.uuid.mockReturnValueOnce("operation-first").mockReturnValueOnce("operation-second");
+  vi.stubGlobal("crypto", { randomUUID: mocks.uuid });
 });
 
 describe("Android test-device enrollments", () => {
@@ -92,6 +95,7 @@ describe("Android test-device enrollments", () => {
     render(wrapper(<DeviceGroupsPanel appId="app-1" platform="ios" />));
 
     expect(screen.queryByText("Test-device enrollments")).toBeNull();
+    expect(screen.queryByText(/Enrolled aliases above/)).toBeNull();
     expect(mocks.listDeviceEnrollments).not.toHaveBeenCalled();
     await waitFor(() => expect(mocks.listDeviceGroups).toHaveBeenCalledWith("app-1"));
   });
@@ -124,13 +128,13 @@ describe("Android test-device enrollments", () => {
     expect(await screen.findByRole("alertdialog")).toBeTruthy();
     expect(screen.getAllByText("install-old").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("install-new")).toBeTruthy();
-    expect(screen.getByText("operation-fixed")).toBeTruthy();
+    expect(screen.getByText("operation-first")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Rebind installation" }));
 
     const expectedPayload = {
       device_id: "install-new",
       expected_revision: 7,
-      operation_id: "operation-fixed",
+      operation_id: "operation-first",
     };
     await waitFor(() => expect(mocks.rebindDeviceEnrollment).toHaveBeenCalledTimes(1));
     expect(mocks.rebindDeviceEnrollment).toHaveBeenLastCalledWith(
@@ -138,6 +142,7 @@ describe("Android test-device enrollments", () => {
       "enrollment-123",
       expectedPayload,
     );
+    expect(mocks.uuid).toHaveBeenCalledTimes(1);
     await waitFor(() => expect(changed).toHaveBeenCalledTimes(1));
 
     expect(screen.getByRole("alertdialog")).toBeTruthy();
@@ -148,7 +153,8 @@ describe("Android test-device enrollments", () => {
       "enrollment-123",
       expectedPayload,
     );
-    expect(await screen.findByText("operation: operation-fixed")).toBeTruthy();
+    expect(mocks.uuid).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("operation: operation-first")).toBeTruthy();
     expect(screen.getByText("revision: 8")).toBeTruthy();
     expect(screen.getByText("replayed: true")).toBeTruthy();
     expect(screen.getByText(/migrated: 2 group slot/)).toBeTruthy();
@@ -167,7 +173,7 @@ describe("Android test-device enrollments", () => {
     expect(await screen.findByText("Revoke test-device enrollment?")).toBeTruthy();
     expect(screen.getByText("current ID")).toBeTruthy();
     expect(screen.getAllByText("install-old").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("operation-fixed")).toBeTruthy();
+    expect(screen.getByText("operation-first")).toBeTruthy();
 
     const confirm = screen.getByRole("button", { name: "Revoke enrollment" });
     expect(confirm.className).toMatch(/danger|red/);
@@ -177,9 +183,37 @@ describe("Android test-device enrollments", () => {
       "enrollment-123",
       {
         expected_revision: 7,
-        operation_id: "operation-fixed",
+        operation_id: "operation-first",
       },
     ));
-    expect(await screen.findByText("operation: operation-fixed")).toBeTruthy();
+    expect(await screen.findByText("operation: operation-first")).toBeTruthy();
+  });
+
+  it("closes a definitive 409 intent and requires a fresh confirmation key", async () => {
+    mocks.rebindDeviceEnrollment.mockRejectedValue(
+      new ApiError(409, { error: "revision conflict" }, "revision conflict"),
+    );
+    const changed = vi.fn();
+    render(wrapper(
+      <DeviceEnrollmentRow appId="app-1" enrollment={enrollment} onChanged={changed} />,
+    ));
+
+    const input = screen.getByRole("textbox", {
+      name: "Replacement installation ID for artin-huawei-tablet",
+    });
+    fireEvent.change(input, { target: { value: "install-new" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rebind enrollment artin-huawei-tablet" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Rebind installation" }));
+
+    await waitFor(() => expect(mocks.rebindDeviceEnrollment).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(input).toHaveProperty("value", "");
+    expect(changed).toHaveBeenCalledTimes(1);
+    expect(mocks.uuid).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(input, { target: { value: "install-newer" } });
+    fireEvent.click(screen.getByRole("button", { name: "Rebind enrollment artin-huawei-tablet" }));
+    expect(await screen.findByText("operation-second")).toBeTruthy();
+    expect(mocks.uuid).toHaveBeenCalledTimes(2);
   });
 });

--- a/docs/device-enrollment-design.md
+++ b/docs/device-enrollment-design.md
@@ -23,10 +23,11 @@ test slot survive the expected installation-id rotation.
 installation id, `active|revoked` state, and monotonically increasing revision.
 An app has at most one live enrollment for a given current installation id.
 
-`device_enrollment_operations` is an immutable receipt ledger. Rebind and
-revoke require an app-scoped `operation_id` plus `expected_revision`. A retry
-with the same exact input returns the original receipt; reusing the operation
-id with different input fails closed.
+`device_enrollment_operations` is an immutable receipt ledger. Create, rebind,
+and revoke all require a caller-held app-scoped `operation_id`; rebind and
+revoke also require `expected_revision`. A retry with the same exact input
+returns the original receipt; reusing the operation id with different input
+fails closed.
 
 The migration adds pre-insert triggers for rebind/revoke receipts. Because D1
 provides atomic `batch()` rather than an interactive transaction, the trigger
@@ -69,7 +70,9 @@ authenticated metadata and never appear in public update responses.
 ## Authentication and authority
 
 All enrollment endpoints use the existing app `publisher` role/deploy-token
-permission. There is no anonymous enrollment token and no client-side ability
+permission and authoritatively reject non-Android apps. Create and rebind accept
+only the canonical lower-case UUIDv4 shape produced by `HandsDeviceId`; direct
+legacy group members remain compatible. There is no anonymous enrollment token and no client-side ability
 to self-select a group. The app SDK continues to submit only its current random
 installation id. An operator obtains the replacement id from an authenticated
 test workflow (for example, the app's feedback receipt), then explicitly
@@ -81,7 +84,9 @@ rebinds the alias.
 - uninstall/clear-data: the id rotates unless Android happens to restore app
   data;
 - Auto Backup/OEM restore: opportunistic only, never an identity guarantee;
-- no hardware identifier is requested, derived, or stored;
+- enrollment create/rebind rejects values outside the SDK UUIDv4 contract, so
+  serial, IMEI, `ANDROID_ID`, and arbitrary long-lived strings cannot enter the
+  enrollment/operation/audit tables through any Console, CLI, or Agent route;
 - aliases are app-scoped, revocable, and invisible to public clients;
 - normal production percentage rollout continues to hash the random
   per-installation id, not the stable test alias.

--- a/docs/device-enrollment-design.md
+++ b/docs/device-enrollment-design.md
@@ -1,0 +1,102 @@
+# Android test-device enrollment and reinstall rebind
+
+## Decision
+
+Hands keeps two deliberately separate identities:
+
+- `device_id` is the Android SDK's random **per-installation** UUID. It remains
+  the only identity accepted by public update checks, percentage rollout,
+  device-group resolution, feature flags, feedback, and analytics. Uninstall or
+  clear-data may rotate it.
+- a device enrollment is a private, authenticated, app-scoped **operator
+  alias** for one physical QA/test device. It lets a publisher replace the
+  current per-installation UUID in exact targeting without deriving or storing
+  IMEI, serial, `ANDROID_ID`, advertising ID, or another permanent hardware
+  fingerprint.
+
+This preserves rollout privacy and bucketing semantics while making a managed
+test slot survive the expected installation-id rotation.
+
+## Data model
+
+`device_enrollments` stores the stable alias, optional human label, current
+installation id, `active|revoked` state, and monotonically increasing revision.
+An app has at most one live enrollment for a given current installation id.
+
+`device_enrollment_operations` is an immutable receipt ledger. Rebind and
+revoke require an app-scoped `operation_id` plus `expected_revision`. A retry
+with the same exact input returns the original receipt; reusing the operation
+id with different input fails closed.
+
+The migration adds pre-insert triggers for rebind/revoke receipts. Because D1
+provides atomic `batch()` rather than an interactive transaction, the trigger
+is the transaction guard: it checks app, enrollment, active state, current id,
+and revision before any group or feature-flag statement can commit. A stale or
+revoked request aborts the entire batch.
+
+## Rebind transaction
+
+For active enrollment `E(revision=N, current=old)` and request
+`(new, expected_revision=N, operation_id=K)`, one D1 batch:
+
+1. inserts the immutable operation receipt; the trigger validates the exact
+   current witness;
+2. copies each app-scoped device-group membership from `old` to `new`, merging
+   an already-present target row without creating duplicate membership;
+3. removes every app-scoped `old` membership;
+4. replaces and de-duplicates `old` in both `allow_device_ids` and
+   `deny_device_ids` for every app feature flag, preserving other values and
+   platform/cohort/default/rollout configuration;
+5. moves the enrollment to `new`, increments its revision, and records actor and
+   rebind time;
+6. writes an app audit entry bound to the operation id.
+
+Readers observe either the complete old state or complete new state. The public
+resolver never sees an alias or an intermediate targeting gap.
+
+## Revocation transaction
+
+Revocation uses the same witness and receipt guard. It removes the current id
+from all app device groups and feature-flag allow/deny arrays, clears the live
+id from the enrollment, marks it revoked, increments revision, and writes the
+audit record atomically. A revoked alias cannot be rebound; create a new alias
+if the operator intentionally starts a new managed lifecycle.
+
+Historical operation/audit rows retain the old installation ids for operator
+accountability under the existing app-audit retention policy. They are
+authenticated metadata and never appear in public update responses.
+
+## Authentication and authority
+
+All enrollment endpoints use the existing app `publisher` role/deploy-token
+permission. There is no anonymous enrollment token and no client-side ability
+to self-select a group. The app SDK continues to submit only its current random
+installation id. An operator obtains the replacement id from an authenticated
+test workflow (for example, the app's feedback receipt), then explicitly
+rebinds the alias.
+
+## Backup, uninstall, and privacy contract
+
+- cover-install: app-private data normally remains, so `device_id` remains;
+- uninstall/clear-data: the id rotates unless Android happens to restore app
+  data;
+- Auto Backup/OEM restore: opportunistic only, never an identity guarantee;
+- no hardware identifier is requested, derived, or stored;
+- aliases are app-scoped, revocable, and invisible to public clients;
+- normal production percentage rollout continues to hash the random
+  per-installation id, not the stable test alias.
+
+## Deployment and rollback
+
+The migration and Worker/Admin/CLI behavior ship together. Applying the
+migration alone is inert: no existing group member or flag changes, and no
+enrollment is backfilled without operator intent. Existing direct
+`device_group_members` remain supported.
+
+Rollback of application code is safe after the additive migration: old code
+ignores the new tables, while current raw installation-id memberships remain
+valid. Do not drop the enrollment/receipt tables during rollback. Re-enabling
+the feature later resumes from the stored revision and receipt history.
+
+This source change does not itself deploy production, create an enrollment,
+rebind a device, modify a release, or change a feature flag.

--- a/docs/feature-gate-design.md
+++ b/docs/feature-gate-design.md
@@ -71,6 +71,13 @@ Delta has **two** gates, deliberately separate:
 So you can keep generating patches for an app (column ON) while only *offering*
 them to your allow-listed test device (flag `allow_device_ids = [deviceId]`).
 
+If that physical test device is enrolled under a stable control-plane alias,
+`device-enrollments rebind` atomically replaces its old per-install id in both
+`allow_device_ids` and `deny_device_ids` (and in all device-group memberships)
+under an exact revision/idempotency guard. Feature evaluation remains unchanged
+and still receives only the current random per-install id; aliases are never
+accepted by the public resolver.
+
 ## Admin API
 
 - `GET /api/apps/:appId/feature-flags/:key` (viewer) — returns the flag row, or

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -168,6 +168,11 @@ metadata. Pass
 - All network calls are suspend functions; call them off the main thread.
 - The device id is a random UUID in SharedPreferences, not a hardware id; it
   resets on reinstall/clear-data, which is fine for rollout cohorting.
+- Android Auto Backup may restore that preference on some devices, but Hands
+  does not treat backup scheduling or OEM restore behavior as an identity
+  guarantee. Teams that need a physical QA device to keep an exact targeting
+  slot should use the authenticated, revocable device-enrollment alias in the
+  Console or CLI and explicitly rebind the new per-install id after reinstall.
 - The client key (`qk_…`) authenticates feedback/crash submissions. It ships
   inside the APK (Sentry-DSN model — app identifier, not a user secret); get
   it from the app's Settings tab and put it in `BuildConfig`.

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -460,8 +460,9 @@ current id under a private, revocable alias:
 ```bash
 hands device-enrollments create raft-android \
   --alias artin-huawei-tablet \
-  --device-id <current-installation-id> \
-  --label "Artin Huawei tablet"
+  --device-id <current-installation-uuid> \
+  --label "Artin Huawei tablet" \
+  --operation-id <create-request-id>
 hands device-enrollments list raft-android
 ```
 
@@ -473,7 +474,8 @@ hands device-enrollments rebind raft-android <enrollment-id> \
   --expected-revision 1
 ```
 
-The CLI generates an idempotency operation id and prints it. Hands atomically
+The CLI generates an idempotency operation id for create/rebind/revoke when
+omitted and prints it; pass an explicit id before a response-loss retry. Hands atomically
 replaces the old id in all app device groups and feature-flag allow/deny lists;
 the response reports how many rows were migrated. Pass `--operation-id <id>`
 to replay a known request after a response loss. Revoke and remove all current

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -453,6 +453,41 @@ remove members with `device-groups remove-member`. Rename or change the
 operator note with `device-groups update`. Do not use IMEI or hardware serial
 numbers.
 
+Android's SDK id is intentionally per installation, so uninstall or clear-data
+creates a new value. For a long-lived physical QA device, first adopt its
+current id under a private, revocable alias:
+
+```bash
+hands device-enrollments create raft-android \
+  --alias artin-huawei-tablet \
+  --device-id <current-installation-id> \
+  --label "Artin Huawei tablet"
+hands device-enrollments list raft-android
+```
+
+After a reinstall, use the current `revision` from `list` and rebind once:
+
+```bash
+hands device-enrollments rebind raft-android <enrollment-id> \
+  --device-id <replacement-installation-id> \
+  --expected-revision 1
+```
+
+The CLI generates an idempotency operation id and prints it. Hands atomically
+replaces the old id in all app device groups and feature-flag allow/deny lists;
+the response reports how many rows were migrated. Pass `--operation-id <id>`
+to replay a known request after a response loss. Revoke and remove all current
+exact targeting with:
+
+```bash
+hands device-enrollments revoke raft-android <enrollment-id> \
+  --expected-revision 2
+```
+
+Aliases are authenticated control-plane metadata. They never appear in public
+update responses and are not based on IMEI, serial, `ANDROID_ID`, or backup
+restoration.
+
 ### Percentage rollout with mandatory groups
 
 One release can combine a percentage-gated `full:all` scope with device groups

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -45,10 +45,33 @@ active release. The Android SDK sends the header automatically.
 
 For exact QA or customer-device targeting, publishers can create an app-scoped
 device group and use a `device_group` release scope. Membership is evaluated
-server-side against the same stable installation `device_id`; the client never
+server-side against the same per-installation `device_id`; the client never
 receives or chooses the group name. A non-member falls through to the previous
 matching active release. Device groups use installation identifiers, not IMEI,
 hardware serial numbers, or account identities.
+
+Android deliberately rotates that identifier after uninstall or clear-data.
+For a physical QA device that must keep the same operator-managed slot, create
+an authenticated **device enrollment**. The stable alias is private to the app
+control plane; public update checks still see only the current random
+installation id. A guarded rebind atomically replaces the old id in every
+device-group membership and every app feature-flag allow/deny list. It requires
+the enrollment's current `revision` plus a unique `operation_id`, returns a
+durable receipt, and is safe to retry with the same exact input. Revocation
+removes the current id from all of those targets and clears it from the active
+enrollment. These endpoints require app `publisher` authority:
+
+```text
+GET  /api/apps/:appId/device-enrollments
+POST /api/apps/:appId/device-enrollments
+POST /api/apps/:appId/device-enrollments/:enrollmentId/rebind
+POST /api/apps/:appId/device-enrollments/:enrollmentId/revoke
+```
+
+This is an explicit authenticated operator workflow, not device fingerprinting:
+Hands never derives the alias from IMEI, serial, `ANDROID_ID`, or another
+permanent hardware identifier. Android backup may restore app data on some
+devices, but it is not part of the rebind contract.
 
 A single release may contain `full:all` plus one or more `device_group` scopes.
 Group members always receive that release, even when their percentage bucket is

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -50,7 +50,7 @@ receives or chooses the group name. A non-member falls through to the previous
 matching active release. Device groups use installation identifiers, not IMEI,
 hardware serial numbers, or account identities.
 
-Android deliberately rotates that identifier after uninstall or clear-data.
+Android deliberately rotates that canonical random UUIDv4 identifier after uninstall or clear-data.
 For a physical QA device that must keep the same operator-managed slot, create
 an authenticated **device enrollment**. The stable alias is private to the app
 control plane; public update checks still see only the current random
@@ -59,7 +59,9 @@ device-group membership and every app feature-flag allow/deny list. It requires
 the enrollment's current `revision` plus a unique `operation_id`, returns a
 durable receipt, and is safe to retry with the same exact input. Revocation
 removes the current id from all of those targets and clears it from the active
-enrollment. These endpoints require app `publisher` authority:
+enrollment. Create also requires a caller-held `operation_id`, so a response-
+loss retry can recover the original durable receipt. These endpoints require
+app `publisher` authority and reject non-Android apps at the Worker boundary:
 
 ```text
 GET  /api/apps/:appId/device-enrollments

--- a/migrations/sql/0055_device_enrollments.sql
+++ b/migrations/sql/0055_device_enrollments.sql
@@ -1,0 +1,60 @@
+-- Stable, operator-managed aliases for physical QA/test devices.
+--
+-- The Android SDK device id remains a random per-install identifier and still
+-- resets on uninstall/clear-data.  An enrollment is an authenticated control-
+-- plane object that lets a publisher rebind the replacement installation id
+-- to the same device-group / feature-flag targeting slots without inventing a
+-- permanent hardware identifier.
+CREATE TABLE IF NOT EXISTS device_enrollments (
+  id                TEXT PRIMARY KEY,
+  app_id            TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  alias             TEXT NOT NULL,
+  label             TEXT,
+  current_device_id TEXT,
+  status            TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active', 'revoked')),
+  revision          INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+  created_by        TEXT NOT NULL,
+  updated_by        TEXT NOT NULL,
+  created_at        INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  last_rebound_at   INTEGER,
+  revoked_at        INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_device_enrollments_app_alias
+  ON device_enrollments(app_id, alias COLLATE NOCASE);
+
+-- One live installation can occupy only one stable enrollment slot per app.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_device_enrollments_app_current_device
+  ON device_enrollments(app_id, current_device_id)
+  WHERE status = 'active' AND current_device_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS device_enrollment_operations (
+  id                         TEXT PRIMARY KEY,
+  app_id                     TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  enrollment_id              TEXT NOT NULL REFERENCES device_enrollments(id) ON DELETE CASCADE,
+  operation_id               TEXT NOT NULL,
+  kind                       TEXT NOT NULL CHECK (kind IN ('create', 'rebind', 'revoke')),
+  from_device_id             TEXT,
+  to_device_id               TEXT,
+  expected_revision          INTEGER,
+  resulting_revision         INTEGER NOT NULL,
+  migrated_group_memberships INTEGER NOT NULL DEFAULT 0,
+  migrated_feature_flags     INTEGER NOT NULL DEFAULT 0,
+  actor                      TEXT NOT NULL,
+  created_at                 INTEGER NOT NULL,
+  UNIQUE (app_id, operation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_enrollment_operations_enrollment
+  ON device_enrollment_operations(enrollment_id, created_at DESC);
+
+-- D1 batch() is transactional but does not expose an interactive transaction.
+-- These operation guards make a stale/revoked rebind abort the entire batch
+-- before any group or feature-flag target is changed.
+-- Cloudflare's remote D1 migration parser requires compact one-line trigger
+-- bodies (workers-sdk#4998 / CFSQL-1402).
+CREATE TRIGGER IF NOT EXISTS trg_device_enrollment_rebind_guard BEFORE INSERT ON device_enrollment_operations WHEN NEW.kind = 'rebind' AND NOT EXISTS (SELECT 1 FROM device_enrollments e WHERE e.id = NEW.enrollment_id AND e.app_id = NEW.app_id AND e.status = 'active' AND e.current_device_id = NEW.from_device_id AND e.revision = NEW.expected_revision AND NEW.resulting_revision = e.revision + 1) BEGIN SELECT RAISE(ABORT, 'device enrollment rebind precondition failed'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_device_enrollment_revoke_guard BEFORE INSERT ON device_enrollment_operations WHEN NEW.kind = 'revoke' AND NOT EXISTS (SELECT 1 FROM device_enrollments e WHERE e.id = NEW.enrollment_id AND e.app_id = NEW.app_id AND e.status = 'active' AND e.current_device_id = NEW.from_device_id AND e.revision = NEW.expected_revision AND NEW.resulting_revision = e.revision + 1) BEGIN SELECT RAISE(ABORT, 'device enrollment revoke precondition failed'); END;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -406,12 +406,13 @@ describe("device-group rollout commands", () => {
       await run([
         "device-enrollments", "create", "raft-android",
         "--alias", "artin-huawei-tablet",
-        "--device-id", "install-old",
+        "--device-id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         "--label", "Artin tablet",
+        "--operation-id", "op-create-1",
       ]);
       await run([
         "device-enrollments", "rebind", "raft-android", "enroll-1",
-        "--device-id", "install-new",
+        "--device-id", "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
         "--expected-revision", "1",
         "--operation-id", "op-rebind-1",
       ]);
@@ -426,13 +427,14 @@ describe("device-group rollout commands", () => {
       )).toMatchObject({
         body: {
           alias: "artin-huawei-tablet",
-          device_id: "install-old",
+          device_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
           label: "Artin tablet",
+          operation_id: "op-create-1",
         },
       });
       expect(requests.find((request) => request.url.endsWith("/rebind"))).toMatchObject({
         body: {
-          device_id: "install-new",
+          device_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
           expected_revision: 1,
           operation_id: "op-rebind-1",
         },

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -348,6 +348,107 @@ describe("device-group rollout commands", () => {
     }
   });
 
+  it("creates, rebinds, and revokes a stable test-device enrollment", async () => {
+    const requests: Array<{ method: string; url: string; body?: any }> = [];
+    const server = createServer(async (req, res) => {
+      let body: any = undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      const enrollment = {
+        id: "enroll-1",
+        alias: "artin-huawei-tablet",
+        label: "Artin tablet",
+        current_device_id: body?.device_id ?? null,
+        status: req.url?.endsWith("/revoke") ? "revoked" : "active",
+        revision: req.url?.endsWith("/rebind") ? 2 : req.url?.endsWith("/revoke") ? 3 : 1,
+      };
+      if (req.url === "/api/apps/app-1/device-enrollments" && req.method === "POST") {
+        return res.end(JSON.stringify({ enrollment, operation: { kind: "create" }, replayed: false }));
+      }
+      if (req.url === "/api/apps/app-1/device-enrollments/enroll-1/rebind" && req.method === "POST") {
+        return res.end(JSON.stringify({
+          enrollment,
+          operation: { migrated_group_memberships: 1, migrated_feature_flags: 1 },
+          replayed: false,
+        }));
+      }
+      if (req.url === "/api/apps/app-1/device-enrollments/enroll-1/revoke" && req.method === "POST") {
+        return res.end(JSON.stringify({ enrollment, operation: {}, replayed: false }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    const run = async (args: string[]) => {
+      const program = new Command();
+      const { registerDeviceGroupCommands } = await import("../src/commands/device_groups.js");
+      registerDeviceGroupCommands(program);
+      return program.parseAsync(["node", "hands", ...args]);
+    };
+
+    try {
+      await run([
+        "device-enrollments", "create", "raft-android",
+        "--alias", "artin-huawei-tablet",
+        "--device-id", "install-old",
+        "--label", "Artin tablet",
+      ]);
+      await run([
+        "device-enrollments", "rebind", "raft-android", "enroll-1",
+        "--device-id", "install-new",
+        "--expected-revision", "1",
+        "--operation-id", "op-rebind-1",
+      ]);
+      await run([
+        "device-enrollments", "revoke", "raft-android", "enroll-1",
+        "--expected-revision", "2",
+        "--operation-id", "op-revoke-2",
+      ]);
+
+      expect(requests.find((request) =>
+        request.url === "/api/apps/app-1/device-enrollments" && request.method === "POST"
+      )).toMatchObject({
+        body: {
+          alias: "artin-huawei-tablet",
+          device_id: "install-old",
+          label: "Artin tablet",
+        },
+      });
+      expect(requests.find((request) => request.url.endsWith("/rebind"))).toMatchObject({
+        body: {
+          device_id: "install-new",
+          expected_revision: 1,
+          operation_id: "op-rebind-1",
+        },
+      });
+      expect(requests.find((request) => request.url.endsWith("/revoke"))).toMatchObject({
+        body: { expected_revision: 2, operation_id: "op-revoke-2" },
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("updates a full percentage rollout with mandatory groups and preserves full reset semantics", async () => {
     const requests: Array<{ method: string; url: string; body?: any }> = [];
     const server = createServer(async (req, res) => {

--- a/packages/cli/src/commands/device_groups.ts
+++ b/packages/cli/src/commands/device_groups.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { randomUUID } from "node:crypto";
 import { apiRequest } from "../lib/api.js";
 
 type AppRow = { id: string; slug: string };
@@ -8,6 +9,21 @@ type DeviceGroup = {
   description: string | null;
   member_count: number;
   members: Array<{ device_id: string; label: string | null }>;
+};
+
+type DeviceEnrollment = {
+  id: string;
+  alias: string;
+  label: string | null;
+  current_device_id: string | null;
+  status: "active" | "revoked";
+  revision: number;
+};
+
+type DeviceEnrollmentResult = {
+  enrollment: DeviceEnrollment;
+  operation: Record<string, unknown>;
+  replayed: boolean;
 };
 
 export function registerDeviceGroupCommands(program: Command): void {
@@ -90,6 +106,104 @@ export function registerDeviceGroupCommands(program: Command): void {
       if (opts.json) return console.log(JSON.stringify(result, null, 2));
       console.log(`Deleted device group ${groupId}.`);
     });
+
+  const enrollments = program.command("device-enrollments")
+    .description("Manage revocable test-device aliases across app reinstall/clear-data.");
+
+  enrollments.command("list <appIdOrSlug>").option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, opts: { json?: boolean }) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<{ enrollments: DeviceEnrollment[] }>(
+        `/api/apps/${appId}/device-enrollments`,
+      );
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      if (result.enrollments.length === 0) return console.log("No device enrollments.");
+      for (const enrollment of result.enrollments) {
+        console.log(
+          `${enrollment.id}  ${enrollment.alias}  status=${enrollment.status} revision=${enrollment.revision}` +
+          `${enrollment.current_device_id ? ` device=${enrollment.current_device_id}` : ""}`,
+        );
+      }
+    });
+
+  enrollments.command("create <appIdOrSlug>")
+    .requiredOption("--alias <alias>", "Stable app-scoped test-device alias.")
+    .requiredOption("--device-id <id>", "Current random Hands per-install id.")
+    .option("--label <label>", "Human-readable device label.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      opts: { alias: string; deviceId: string; label?: string; json?: boolean },
+    ) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<DeviceEnrollmentResult>(`/api/apps/${appId}/device-enrollments`, {
+        method: "POST",
+        body: { alias: opts.alias, device_id: opts.deviceId, label: opts.label },
+      });
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(`Created device enrollment ${result.enrollment.id} (${result.enrollment.alias}) at revision 1.`);
+    });
+
+  enrollments.command("rebind <appIdOrSlug> <enrollmentId>")
+    .requiredOption("--device-id <id>", "Replacement random Hands per-install id.")
+    .requiredOption("--expected-revision <n>", "Current enrollment revision.", parsePositiveInteger)
+    .option("--operation-id <id>", "Idempotency key; generated when omitted.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      enrollmentId: string,
+      opts: { deviceId: string; expectedRevision: number; operationId?: string; json?: boolean },
+    ) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const operationId = opts.operationId ?? randomUUID();
+      const result = await apiRequest<DeviceEnrollmentResult>(
+        `/api/apps/${appId}/device-enrollments/${enrollmentId}/rebind`,
+        {
+          method: "POST",
+          body: {
+            device_id: opts.deviceId,
+            expected_revision: opts.expectedRevision,
+            operation_id: operationId,
+          },
+        },
+      );
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(
+        `Rebound ${result.enrollment.alias} to revision ${result.enrollment.revision}` +
+        `${result.replayed ? " (idempotent replay)" : ""}; operation=${operationId}.`,
+      );
+    });
+
+  enrollments.command("revoke <appIdOrSlug> <enrollmentId>")
+    .requiredOption("--expected-revision <n>", "Current enrollment revision.", parsePositiveInteger)
+    .option("--operation-id <id>", "Idempotency key; generated when omitted.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      enrollmentId: string,
+      opts: { expectedRevision: number; operationId?: string; json?: boolean },
+    ) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const operationId = opts.operationId ?? randomUUID();
+      const result = await apiRequest<DeviceEnrollmentResult>(
+        `/api/apps/${appId}/device-enrollments/${enrollmentId}/revoke`,
+        {
+          method: "POST",
+          body: { expected_revision: opts.expectedRevision, operation_id: operationId },
+        },
+      );
+      if (opts.json) return console.log(JSON.stringify(result, null, 2));
+      console.log(
+        `Revoked ${result.enrollment.alias} at revision ${result.enrollment.revision}` +
+        `${result.replayed ? " (idempotent replay)" : ""}; operation=${operationId}.`,
+      );
+    });
+}
+
+function parsePositiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error("expected revision must be a positive integer");
+  return parsed;
 }
 
 async function resolveAppId(input: string): Promise<string> {

--- a/packages/cli/src/commands/device_groups.ts
+++ b/packages/cli/src/commands/device_groups.ts
@@ -130,18 +130,28 @@ export function registerDeviceGroupCommands(program: Command): void {
     .requiredOption("--alias <alias>", "Stable app-scoped test-device alias.")
     .requiredOption("--device-id <id>", "Current random Hands per-install id.")
     .option("--label <label>", "Human-readable device label.")
+    .option("--operation-id <id>", "Idempotency key; generated when omitted.")
     .option("--json", "Output JSON.", false)
     .action(async (
       appIdOrSlug: string,
-      opts: { alias: string; deviceId: string; label?: string; json?: boolean },
+      opts: { alias: string; deviceId: string; label?: string; operationId?: string; json?: boolean },
     ) => {
       const appId = await resolveAppId(appIdOrSlug);
+      const operationId = opts.operationId ?? randomUUID();
       const result = await apiRequest<DeviceEnrollmentResult>(`/api/apps/${appId}/device-enrollments`, {
         method: "POST",
-        body: { alias: opts.alias, device_id: opts.deviceId, label: opts.label },
+        body: {
+          alias: opts.alias,
+          device_id: opts.deviceId,
+          label: opts.label,
+          operation_id: operationId,
+        },
       });
       if (opts.json) return console.log(JSON.stringify(result, null, 2));
-      console.log(`Created device enrollment ${result.enrollment.id} (${result.enrollment.alias}) at revision 1.`);
+      console.log(
+        `Created device enrollment ${result.enrollment.id} (${result.enrollment.alias}) at revision 1` +
+        `${result.replayed ? " (idempotent replay)" : ""}; operation=${operationId}.`,
+      );
     });
 
   enrollments.command("rebind <appIdOrSlug> <enrollmentId>")

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -186,6 +186,12 @@ import {
   handleRemoveDeviceGroupMember,
   handleUpdateDeviceGroup,
 } from "./routes/device_groups";
+import {
+  handleCreateDeviceEnrollment,
+  handleListDeviceEnrollments,
+  handleRebindDeviceEnrollment,
+  handleRevokeDeviceEnrollment,
+} from "./routes/device_enrollments";
 import { handleListProductTypes, handleCreateProductType, handleUpdateProductType, handleDeleteProductType } from "./routes/product_types";
 import { handleListReleaseTypes, handleCreateReleaseType, handleUpdateReleaseType, handleDeleteReleaseType } from "./routes/release_types";
 import { handleListAuditLogs, handleListUserAudit } from "./routes/audit";
@@ -894,6 +900,26 @@ admin.delete(
   "/api/apps/:appId/device-groups/:groupId/members/:deviceId",
   requireAppRole("publisher"),
   handleRemoveDeviceGroupMember,
+);
+admin.get(
+  "/api/apps/:appId/device-enrollments",
+  requireAppRole("publisher"),
+  handleListDeviceEnrollments,
+);
+admin.post(
+  "/api/apps/:appId/device-enrollments",
+  requireAppRole("publisher"),
+  handleCreateDeviceEnrollment,
+);
+admin.post(
+  "/api/apps/:appId/device-enrollments/:enrollmentId/rebind",
+  requireAppRole("publisher"),
+  handleRebindDeviceEnrollment,
+);
+admin.post(
+  "/api/apps/:appId/device-enrollments/:enrollmentId/revoke",
+  requireAppRole("publisher"),
+  handleRevokeDeviceEnrollment,
 );
 
 admin.get("/api/apps/:appId/product-types", requireAppRole("viewer"), handleListProductTypes);

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -112,6 +112,11 @@ export const openApiDocument = docs.getOpenAPI31Document({
       description: "Per-app release channels.",
     },
     {
+      name: "Device enrollments",
+      description:
+        "Authenticated, revocable aliases that rebind rotating per-install ids for exact QA targeting.",
+    },
+    {
       name: "Product types",
       description: "Per-app artifact product families.",
     },

--- a/worker/src/openapi/settings.ts
+++ b/worker/src/openapi/settings.ts
@@ -110,7 +110,8 @@ export function registerSettingsRoutes(registry: OpenApiRegistry) {
         content: json(z.object({
           alias: z.string().min(1).max(80),
           label: z.string().max(120).optional(),
-          device_id: z.string().min(1).max(256),
+          device_id: z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
+          operation_id: z.string().min(1).max(128),
         })),
         required: true,
       },
@@ -133,7 +134,7 @@ export function registerSettingsRoutes(registry: OpenApiRegistry) {
       params: AppEnrollmentParams,
       body: {
         content: json(z.object({
-          device_id: z.string().min(1).max(256),
+          device_id: z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
           expected_revision: z.number().int().min(1),
           operation_id: z.string().min(1).max(128),
         })),

--- a/worker/src/openapi/settings.ts
+++ b/worker/src/openapi/settings.ts
@@ -21,6 +21,8 @@ const AppProductTypeParams = AppIdParam.merge(ProductTypeIdParam);
 const AppReleaseTypeParams = AppIdParam.merge(ReleaseTypeIdParam);
 const AppOperationParams = AppIdParam.merge(OperationIdParam);
 const AppMemberParams = AppIdParam.merge(AccountIdParam);
+const EnrollmentIdParam = z.object({ enrollmentId: z.string().min(1) });
+const AppEnrollmentParams = AppIdParam.merge(EnrollmentIdParam);
 
 function registerCollectionRoutes(
   registry: OpenApiRegistry,
@@ -83,6 +85,95 @@ function registerCollectionRoutes(
 }
 
 export function registerSettingsRoutes(registry: OpenApiRegistry) {
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/device-enrollments",
+    tags: ["Device enrollments"],
+    summary: "List test-device enrollments",
+    security: auth,
+    request: { params: AppIdParam },
+    responses: {
+      200: success("Enrollment list.", GenericObject),
+      403: error("Current principal cannot view device enrollments."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/device-enrollments",
+    tags: ["Device enrollments"],
+    summary: "Create a stable alias for a current per-install id",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      body: {
+        content: json(z.object({
+          alias: z.string().min(1).max(80),
+          label: z.string().max(120).optional(),
+          device_id: z.string().min(1).max(256),
+        })),
+        required: true,
+      },
+    },
+    responses: {
+      201: success("Enrollment created.", GenericObject),
+      400: error("Invalid enrollment request."),
+      403: error("Current principal cannot create device enrollments."),
+      409: error("Alias or installation is already enrolled."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/device-enrollments/{enrollmentId}/rebind",
+    tags: ["Device enrollments"],
+    summary: "Atomically replace a reinstalled device id in exact targeting",
+    security: auth,
+    request: {
+      params: AppEnrollmentParams,
+      body: {
+        content: json(z.object({
+          device_id: z.string().min(1).max(256),
+          expected_revision: z.number().int().min(1),
+          operation_id: z.string().min(1).max(128),
+        })),
+        required: true,
+      },
+    },
+    responses: {
+      200: success("Enrollment rebound with a durable operation receipt.", GenericObject),
+      400: error("Invalid rebind request."),
+      403: error("Current principal cannot rebind device enrollments."),
+      404: error("Enrollment was not found."),
+      409: error("Revision, status, operation id, or target installation conflicts."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/device-enrollments/{enrollmentId}/revoke",
+    tags: ["Device enrollments"],
+    summary: "Revoke an enrollment and remove its exact targeting",
+    security: auth,
+    request: {
+      params: AppEnrollmentParams,
+      body: {
+        content: json(z.object({
+          expected_revision: z.number().int().min(1),
+          operation_id: z.string().min(1).max(128),
+        })),
+        required: true,
+      },
+    },
+    responses: {
+      200: success("Enrollment revoked with a durable operation receipt.", GenericObject),
+      400: error("Invalid revoke request."),
+      403: error("Current principal cannot revoke device enrollments."),
+      404: error("Enrollment was not found."),
+      409: error("Revision, status, or operation id conflicts."),
+    },
+  });
+
   registerCollectionRoutes(
     registry,
     "Channels",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1044,6 +1044,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           alias: { type: "string", in: "body", required: true, description: "Stable app-scoped operator alias." },
           device_id: { type: "string", in: "body", required: true, description: "Current random per-install id." },
           label: { type: "string", in: "body", required: false, description: "Optional human-readable label." },
+          operation_id: { type: "string", in: "body", required: true, description: "Unique idempotency key for this exact create." },
         },
       },
       {

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1026,6 +1026,52 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "list-device-enrollments",
+        description:
+          "List authenticated, revocable test-device aliases and their current per-install ids. Requires app publisher; aliases are never exposed by public update APIs.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/device-enrollments" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+        },
+      },
+      {
+        name: "create-device-enrollment",
+        description:
+          "Adopt a current Hands per-install id under a stable operator alias. This does not change release scope or feature flags. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/device-enrollments" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          alias: { type: "string", in: "body", required: true, description: "Stable app-scoped operator alias." },
+          device_id: { type: "string", in: "body", required: true, description: "Current random per-install id." },
+          label: { type: "string", in: "body", required: false, description: "Optional human-readable label." },
+        },
+      },
+      {
+        name: "rebind-device-enrollment",
+        description:
+          "Atomically replace a reinstalled test device's old per-install id with a new id across every app device-group membership and feature-flag allow/deny reference. Requires exact revision and an idempotency operation id.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/device-enrollments/{enrollment_id}/rebind" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          enrollment_id: { type: "string", in: "path", required: true, description: "Enrollment UUID." },
+          device_id: { type: "string", in: "body", required: true, description: "New current per-install id." },
+          expected_revision: { type: "number", in: "body", required: true, description: "Current enrollment revision." },
+          operation_id: { type: "string", in: "body", required: true, description: "Unique idempotency key for this exact rebind." },
+        },
+      },
+      {
+        name: "revoke-device-enrollment",
+        description:
+          "Revoke a test-device alias and atomically remove its current per-install id from all app device groups and feature-flag allow/deny lists. Requires exact revision and an idempotency operation id.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/device-enrollments/{enrollment_id}/revoke" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          enrollment_id: { type: "string", in: "path", required: true, description: "Enrollment UUID." },
+          expected_revision: { type: "number", in: "body", required: true, description: "Current enrollment revision." },
+          operation_id: { type: "string", in: "body", required: true, description: "Unique idempotency key for this exact revoke." },
+        },
+      },
+      {
         name: "list-releases",
         description: "List an app's releases (id, status, channel, version, rollout). Requires app viewer.",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/releases" },

--- a/worker/src/routes/device_enrollments.ts
+++ b/worker/src/routes/device_enrollments.ts
@@ -64,8 +64,10 @@ function normalizeLabel(value: unknown): string | null {
 function normalizeDeviceId(value: unknown): string {
   const deviceId = String(value ?? "").trim();
   if (!deviceId) throw new Error("device_id required");
-  if (deviceId.length > 256) throw new Error("device_id too long (max 256 chars)");
-  return deviceId;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(deviceId)) {
+    throw new Error("device_id must be a Hands random per-install UUID");
+  }
+  return deviceId.toLowerCase();
 }
 
 function normalizeOperationId(value: unknown): string {
@@ -98,6 +100,17 @@ async function getOperation(db: D1Database, appId: string, operationId: string) 
     .first<DeviceEnrollmentOperationRow>();
 }
 
+async function requireAndroidApp(c: EnrollmentContext, appId: string): Promise<Response | null> {
+  const app = await c.env.DB.prepare("SELECT platform FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ platform: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+  if (app.platform !== "android") {
+    return c.json({ error: "device enrollments are only supported for Android apps" }, 400);
+  }
+  return null;
+}
+
 function operationMatches(
   operation: DeviceEnrollmentOperationRow,
   enrollmentId: string,
@@ -109,6 +122,20 @@ function operationMatches(
     operation.kind === kind &&
     operation.expected_revision === expectedRevision &&
     operation.to_device_id === toDeviceId;
+}
+
+async function createOperationMatches(
+  db: D1Database,
+  operation: DeviceEnrollmentOperationRow,
+  alias: string,
+  label: string | null,
+  deviceId: string,
+): Promise<boolean> {
+  if (operation.kind !== "create" || operation.from_device_id !== null ||
+      operation.to_device_id !== deviceId || operation.expected_revision !== null ||
+      operation.resulting_revision !== 1) return false;
+  const enrollment = await getEnrollment(db, operation.app_id, operation.enrollment_id);
+  return enrollment?.alias === alias && enrollment.label === label;
 }
 
 async function operationResponse(
@@ -173,6 +200,8 @@ function mapMutationError(message: string): { status: 400 | 409; error: string }
 
 export async function handleListDeviceEnrollments(c: EnrollmentContext) {
   const appId = c.req.param("appId") ?? "";
+  const platformError = await requireAndroidApp(c, appId);
+  if (platformError) return platformError;
   const { results: enrollments } = await c.env.DB.prepare(
     `${ENROLLMENT_SELECT} WHERE app_id = ?1 ORDER BY lower(alias), id`,
   ).bind(appId).all<DeviceEnrollmentRow>();
@@ -181,46 +210,73 @@ export async function handleListDeviceEnrollments(c: EnrollmentContext) {
 
 export async function handleCreateDeviceEnrollment(c: EnrollmentContext) {
   const appId = c.req.param("appId") ?? "";
+  const platformError = await requireAndroidApp(c, appId);
+  if (platformError) return platformError;
   const body = await c.req.json().catch(() => ({})) as {
     alias?: unknown;
     label?: unknown;
     device_id?: unknown;
+    operation_id?: unknown;
   };
   try {
     const alias = normalizeAlias(body.alias);
     const label = normalizeLabel(body.label);
     const deviceId = normalizeDeviceId(body.device_id);
+    const operationId = normalizeOperationId(body.operation_id);
+    const replay = await getOperation(c.env.DB, appId, operationId);
+    if (replay) {
+      if (!await createOperationMatches(c.env.DB, replay, alias, label, deviceId)) {
+        return c.json({ error: "operation_id already exists with different input" }, 409);
+      }
+      return operationResponse(c, replay.enrollment_id, replay, true);
+    }
     const enrollmentId = crypto.randomUUID();
-    const operationId = crypto.randomUUID();
     const actor = currentActor(c);
     const now = Date.now();
-    await c.env.DB.batch([
-      c.env.DB.prepare(
-        `INSERT INTO device_enrollments
+    try {
+      await c.env.DB.batch([
+        c.env.DB.prepare(
+          `INSERT INTO device_enrollments
            (id, app_id, alias, label, current_device_id, status, revision,
             created_by, updated_by, created_at, updated_at)
          VALUES (?1, ?2, ?3, ?4, ?5, 'active', 1, ?6, ?6, ?7, ?7)`,
-      ).bind(enrollmentId, appId, alias, label, deviceId, actor, now),
-      c.env.DB.prepare(
-        `INSERT INTO device_enrollment_operations
+        ).bind(enrollmentId, appId, alias, label, deviceId, actor, now),
+        c.env.DB.prepare(
+          `INSERT INTO device_enrollment_operations
            (id, app_id, enrollment_id, operation_id, kind, from_device_id,
             to_device_id, expected_revision, resulting_revision,
             migrated_group_memberships, migrated_feature_flags, actor, created_at)
          VALUES (?1, ?2, ?3, ?4, 'create', NULL, ?5, NULL, 1, 0, 0, ?6, ?7)`,
-      ).bind(crypto.randomUUID(), appId, enrollmentId, operationId, deviceId, actor, now),
-      c.env.DB.prepare(
-        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+        ).bind(crypto.randomUUID(), appId, enrollmentId, operationId, deviceId, actor, now),
+        c.env.DB.prepare(
+          `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
          VALUES (?1, ?2, 'device_enrollment.create', ?3, ?4, ?5)`,
-      ).bind(
-        crypto.randomUUID(),
-        appId,
-        actor,
-        JSON.stringify({ enrollment_id: enrollmentId, alias, label, device_id: deviceId, operation_id: operationId }),
-        now,
-      ),
-    ]);
+        ).bind(
+          crypto.randomUUID(),
+          appId,
+          actor,
+          JSON.stringify({ enrollment_id: enrollmentId, alias, label, device_id: deviceId, operation_id: operationId }),
+          now,
+        ),
+      ]);
+    } catch (error) {
+      const concurrentReplay = await getOperation(c.env.DB, appId, operationId);
+      if (concurrentReplay && await createOperationMatches(
+        c.env.DB,
+        concurrentReplay,
+        alias,
+        label,
+        deviceId,
+      )) {
+        return operationResponse(c, concurrentReplay.enrollment_id, concurrentReplay, true);
+      }
+      throw error;
+    }
     const enrollment = await getEnrollment(c.env.DB, appId, enrollmentId);
     const operation = await getOperation(c.env.DB, appId, operationId);
+    if (!enrollment || !operation) {
+      return c.json({ error: "device enrollment create receipt missing" }, 500);
+    }
     return c.json({ enrollment, operation, replayed: false }, 201);
   } catch (error) {
     const mapped = mapMutationError(error instanceof Error ? error.message : String(error));
@@ -238,6 +294,8 @@ export async function handleRevokeDeviceEnrollment(c: EnrollmentContext) {
 
 async function mutateEnrollment(c: EnrollmentContext, kind: "rebind" | "revoke") {
   const appId = c.req.param("appId") ?? "";
+  const platformError = await requireAndroidApp(c, appId);
+  if (platformError) return platformError;
   const enrollmentId = c.req.param("enrollmentId") ?? "";
   const body = await c.req.json().catch(() => ({})) as {
     device_id?: unknown;

--- a/worker/src/routes/device_enrollments.ts
+++ b/worker/src/routes/device_enrollments.ts
@@ -1,0 +1,413 @@
+import type { Context } from "hono";
+import { currentActor } from "../middleware/auth";
+
+type DeviceEnrollmentRow = {
+  id: string;
+  app_id: string;
+  alias: string;
+  label: string | null;
+  current_device_id: string | null;
+  status: "active" | "revoked";
+  revision: number;
+  created_by: string;
+  updated_by: string;
+  created_at: number;
+  updated_at: number;
+  last_rebound_at: number | null;
+  revoked_at: number | null;
+};
+
+type DeviceEnrollmentOperationRow = {
+  id: string;
+  app_id: string;
+  enrollment_id: string;
+  operation_id: string;
+  kind: "create" | "rebind" | "revoke";
+  from_device_id: string | null;
+  to_device_id: string | null;
+  expected_revision: number | null;
+  resulting_revision: number;
+  migrated_group_memberships: number;
+  migrated_feature_flags: number;
+  actor: string;
+  created_at: number;
+};
+
+type EnrollmentContext = Context<{ Bindings: Env }>;
+
+const ENROLLMENT_SELECT = `SELECT id, app_id, alias, label, current_device_id,
+       status, revision, created_by, updated_by, created_at, updated_at,
+       last_rebound_at, revoked_at
+  FROM device_enrollments`;
+
+const OPERATION_SELECT = `SELECT id, app_id, enrollment_id, operation_id, kind,
+       from_device_id, to_device_id, expected_revision, resulting_revision,
+       migrated_group_memberships, migrated_feature_flags, actor, created_at
+  FROM device_enrollment_operations`;
+
+function normalizeAlias(value: unknown): string {
+  const alias = String(value ?? "").trim();
+  if (!alias) throw new Error("alias required");
+  if (alias.length > 80) throw new Error("alias too long (max 80 chars)");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(alias)) {
+    throw new Error("alias must use letters, numbers, dot, underscore, or hyphen");
+  }
+  return alias;
+}
+
+function normalizeLabel(value: unknown): string | null {
+  const label = String(value ?? "").trim();
+  if (label.length > 120) throw new Error("label too long (max 120 chars)");
+  return label || null;
+}
+
+function normalizeDeviceId(value: unknown): string {
+  const deviceId = String(value ?? "").trim();
+  if (!deviceId) throw new Error("device_id required");
+  if (deviceId.length > 256) throw new Error("device_id too long (max 256 chars)");
+  return deviceId;
+}
+
+function normalizeOperationId(value: unknown): string {
+  const operationId = String(value ?? "").trim();
+  if (!operationId) throw new Error("operation_id required");
+  if (operationId.length > 128) throw new Error("operation_id too long (max 128 chars)");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(operationId)) {
+    throw new Error("operation_id contains unsupported characters");
+  }
+  return operationId;
+}
+
+function normalizeExpectedRevision(value: unknown): number {
+  const revision = Number(value);
+  if (!Number.isInteger(revision) || revision < 1) {
+    throw new Error("expected_revision must be a positive integer");
+  }
+  return revision;
+}
+
+async function getEnrollment(db: D1Database, appId: string, enrollmentId: string) {
+  return db.prepare(`${ENROLLMENT_SELECT} WHERE id = ?1 AND app_id = ?2`)
+    .bind(enrollmentId, appId)
+    .first<DeviceEnrollmentRow>();
+}
+
+async function getOperation(db: D1Database, appId: string, operationId: string) {
+  return db.prepare(`${OPERATION_SELECT} WHERE app_id = ?1 AND operation_id = ?2`)
+    .bind(appId, operationId)
+    .first<DeviceEnrollmentOperationRow>();
+}
+
+function operationMatches(
+  operation: DeviceEnrollmentOperationRow,
+  enrollmentId: string,
+  kind: "rebind" | "revoke",
+  expectedRevision: number,
+  toDeviceId: string | null,
+): boolean {
+  return operation.enrollment_id === enrollmentId &&
+    operation.kind === kind &&
+    operation.expected_revision === expectedRevision &&
+    operation.to_device_id === toDeviceId;
+}
+
+async function operationResponse(
+  c: EnrollmentContext,
+  enrollmentId: string,
+  operation: DeviceEnrollmentOperationRow,
+  replayed: boolean,
+) {
+  const enrollment = await getEnrollment(c.env.DB, operation.app_id, enrollmentId);
+  return c.json({ enrollment, operation, replayed });
+}
+
+function jsonArrayReplaceSql(column: "allow_device_ids" | "deny_device_ids"): string {
+  return `(SELECT COALESCE(json_group_array(next_value), '[]')
+    FROM (
+      SELECT next_value
+      FROM (
+        SELECT CASE WHEN value = ?1 THEN ?2 ELSE value END AS next_value,
+               MIN(CAST(key AS INTEGER)) AS first_position
+        FROM json_each(CASE WHEN json_valid(${column}) THEN ${column} ELSE '[]' END)
+        WHERE type = 'text'
+        GROUP BY next_value
+      )
+      ORDER BY first_position
+    ))`;
+}
+
+function jsonArrayRemoveSql(column: "allow_device_ids" | "deny_device_ids"): string {
+  return `(SELECT COALESCE(json_group_array(value), '[]')
+    FROM (
+      SELECT value, MIN(CAST(key AS INTEGER)) AS first_position
+      FROM json_each(CASE WHEN json_valid(${column}) THEN ${column} ELSE '[]' END)
+      WHERE type = 'text' AND value <> ?1
+      GROUP BY value
+      ORDER BY first_position
+    ))`;
+}
+
+function flagReferencesDeviceSql(devicePlaceholder = "?1"): string {
+  return `EXISTS (SELECT 1 FROM json_each(CASE WHEN json_valid(allow_device_ids) THEN allow_device_ids ELSE '[]' END) WHERE type = 'text' AND value = ${devicePlaceholder})
+      OR EXISTS (SELECT 1 FROM json_each(CASE WHEN json_valid(deny_device_ids) THEN deny_device_ids ELSE '[]' END) WHERE type = 'text' AND value = ${devicePlaceholder})`;
+}
+
+function mapMutationError(message: string): { status: 400 | 409; error: string } {
+  if (message.includes("device enrollment rebind precondition failed") ||
+      message.includes("device enrollment revoke precondition failed")) {
+    return { status: 409, error: "device enrollment revision/status changed; refresh and retry" };
+  }
+  if (message.includes("idx_device_enrollments_app_current_device") ||
+      message.includes("UNIQUE constraint failed: device_enrollments.app_id, device_enrollments.current_device_id")) {
+    return { status: 409, error: "device_id is already bound to another active enrollment" };
+  }
+  if (message.includes("idx_device_enrollments_app_alias") ||
+      message.includes("UNIQUE constraint failed: device_enrollments.app_id, device_enrollments.alias")) {
+    return { status: 409, error: "enrollment alias already exists" };
+  }
+  if (message.includes("device_enrollment_operations.app_id, device_enrollment_operations.operation_id")) {
+    return { status: 409, error: "operation_id already exists with different input" };
+  }
+  return { status: 400, error: message };
+}
+
+export async function handleListDeviceEnrollments(c: EnrollmentContext) {
+  const appId = c.req.param("appId") ?? "";
+  const { results: enrollments } = await c.env.DB.prepare(
+    `${ENROLLMENT_SELECT} WHERE app_id = ?1 ORDER BY lower(alias), id`,
+  ).bind(appId).all<DeviceEnrollmentRow>();
+  return c.json({ enrollments });
+}
+
+export async function handleCreateDeviceEnrollment(c: EnrollmentContext) {
+  const appId = c.req.param("appId") ?? "";
+  const body = await c.req.json().catch(() => ({})) as {
+    alias?: unknown;
+    label?: unknown;
+    device_id?: unknown;
+  };
+  try {
+    const alias = normalizeAlias(body.alias);
+    const label = normalizeLabel(body.label);
+    const deviceId = normalizeDeviceId(body.device_id);
+    const enrollmentId = crypto.randomUUID();
+    const operationId = crypto.randomUUID();
+    const actor = currentActor(c);
+    const now = Date.now();
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        `INSERT INTO device_enrollments
+           (id, app_id, alias, label, current_device_id, status, revision,
+            created_by, updated_by, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'active', 1, ?6, ?6, ?7, ?7)`,
+      ).bind(enrollmentId, appId, alias, label, deviceId, actor, now),
+      c.env.DB.prepare(
+        `INSERT INTO device_enrollment_operations
+           (id, app_id, enrollment_id, operation_id, kind, from_device_id,
+            to_device_id, expected_revision, resulting_revision,
+            migrated_group_memberships, migrated_feature_flags, actor, created_at)
+         VALUES (?1, ?2, ?3, ?4, 'create', NULL, ?5, NULL, 1, 0, 0, ?6, ?7)`,
+      ).bind(crypto.randomUUID(), appId, enrollmentId, operationId, deviceId, actor, now),
+      c.env.DB.prepare(
+        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+         VALUES (?1, ?2, 'device_enrollment.create', ?3, ?4, ?5)`,
+      ).bind(
+        crypto.randomUUID(),
+        appId,
+        actor,
+        JSON.stringify({ enrollment_id: enrollmentId, alias, label, device_id: deviceId, operation_id: operationId }),
+        now,
+      ),
+    ]);
+    const enrollment = await getEnrollment(c.env.DB, appId, enrollmentId);
+    const operation = await getOperation(c.env.DB, appId, operationId);
+    return c.json({ enrollment, operation, replayed: false }, 201);
+  } catch (error) {
+    const mapped = mapMutationError(error instanceof Error ? error.message : String(error));
+    return c.json({ error: mapped.error }, mapped.status);
+  }
+}
+
+export async function handleRebindDeviceEnrollment(c: EnrollmentContext) {
+  return mutateEnrollment(c, "rebind");
+}
+
+export async function handleRevokeDeviceEnrollment(c: EnrollmentContext) {
+  return mutateEnrollment(c, "revoke");
+}
+
+async function mutateEnrollment(c: EnrollmentContext, kind: "rebind" | "revoke") {
+  const appId = c.req.param("appId") ?? "";
+  const enrollmentId = c.req.param("enrollmentId") ?? "";
+  const body = await c.req.json().catch(() => ({})) as {
+    device_id?: unknown;
+    expected_revision?: unknown;
+    operation_id?: unknown;
+  };
+
+  let expectedRevision: number;
+  let operationId: string;
+  let toDeviceId: string | null = null;
+  try {
+    expectedRevision = normalizeExpectedRevision(body.expected_revision);
+    operationId = normalizeOperationId(body.operation_id);
+    if (kind === "rebind") toDeviceId = normalizeDeviceId(body.device_id);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+  }
+
+  const replay = await getOperation(c.env.DB, appId, operationId);
+  if (replay) {
+    if (!operationMatches(replay, enrollmentId, kind, expectedRevision, toDeviceId)) {
+      return c.json({ error: "operation_id already exists with different input" }, 409);
+    }
+    return operationResponse(c, enrollmentId, replay, true);
+  }
+
+  const enrollment = await getEnrollment(c.env.DB, appId, enrollmentId);
+  if (!enrollment) return c.json({ error: "device enrollment not found" }, 404);
+  if (enrollment.status !== "active" || !enrollment.current_device_id) {
+    return c.json({ error: "device enrollment is revoked" }, 409);
+  }
+  if (enrollment.revision !== expectedRevision) {
+    return c.json({ error: "stale expected_revision", current_revision: enrollment.revision }, 409);
+  }
+  if (kind === "rebind" && enrollment.current_device_id === toDeviceId) {
+    return c.json({ error: "device enrollment is already bound to device_id" }, 409);
+  }
+
+  const fromDeviceId = enrollment.current_device_id;
+  const resultingRevision = expectedRevision + 1;
+  const actor = currentActor(c);
+  const now = Date.now();
+  const operationDbId = crypto.randomUUID();
+  const operationInsert = c.env.DB.prepare(
+    `INSERT INTO device_enrollment_operations
+       (id, app_id, enrollment_id, operation_id, kind, from_device_id,
+        to_device_id, expected_revision, resulting_revision,
+        migrated_group_memberships, migrated_feature_flags, actor, created_at)
+     SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9,
+            (SELECT COUNT(*) FROM device_group_members m JOIN device_groups g ON g.id = m.group_id
+              WHERE g.app_id = ?2 AND m.device_id = ?6),
+            (SELECT COUNT(*) FROM feature_flags f WHERE f.app_id = ?2 AND (${flagReferencesDeviceSql("?6")})),
+            ?10, ?11`,
+  ).bind(
+    operationDbId,
+    appId,
+    enrollmentId,
+    operationId,
+    kind,
+    fromDeviceId,
+    toDeviceId,
+    expectedRevision,
+    resultingRevision,
+    actor,
+    now,
+  );
+
+  const statements: D1PreparedStatement[] = [operationInsert];
+  if (kind === "rebind") {
+    statements.push(
+      c.env.DB.prepare(
+        `INSERT INTO device_group_members (group_id, device_id, label, created_at)
+         SELECT m.group_id, ?1, m.label, m.created_at
+         FROM device_group_members m
+         JOIN device_groups g ON g.id = m.group_id
+         WHERE g.app_id = ?2 AND m.device_id = ?3
+         ON CONFLICT(group_id, device_id) DO UPDATE SET
+           label = COALESCE(excluded.label, device_group_members.label)`,
+      ).bind(toDeviceId, appId, fromDeviceId),
+    );
+  }
+  statements.push(
+    c.env.DB.prepare(
+      `UPDATE device_groups SET updated_at = ?1
+       WHERE app_id = ?2 AND id IN (
+         SELECT group_id FROM device_group_members WHERE device_id = ?3
+       )`,
+    ).bind(now, appId, fromDeviceId),
+    c.env.DB.prepare(
+      `DELETE FROM device_group_members
+       WHERE device_id = ?1 AND group_id IN (SELECT id FROM device_groups WHERE app_id = ?2)`,
+    ).bind(fromDeviceId, appId),
+  );
+
+  if (kind === "rebind") {
+    statements.push(
+      c.env.DB.prepare(
+        `UPDATE feature_flags
+         SET allow_device_ids = ${jsonArrayReplaceSql("allow_device_ids")},
+             deny_device_ids = ${jsonArrayReplaceSql("deny_device_ids")},
+             updated_at = ?3,
+             updated_by = ?4
+         WHERE app_id = ?5 AND (${flagReferencesDeviceSql()})`,
+      ).bind(fromDeviceId, toDeviceId, now, actor, appId),
+      c.env.DB.prepare(
+        `UPDATE device_enrollments
+         SET current_device_id = ?1, revision = ?2, updated_by = ?3,
+             updated_at = ?4, last_rebound_at = ?4
+         WHERE id = ?5 AND app_id = ?6`,
+      ).bind(toDeviceId, resultingRevision, actor, now, enrollmentId, appId),
+    );
+  } else {
+    statements.push(
+      c.env.DB.prepare(
+        `UPDATE feature_flags
+         SET allow_device_ids = ${jsonArrayRemoveSql("allow_device_ids")},
+             deny_device_ids = ${jsonArrayRemoveSql("deny_device_ids")},
+             updated_at = ?2,
+             updated_by = ?3
+         WHERE app_id = ?4 AND (${flagReferencesDeviceSql()})`,
+      ).bind(fromDeviceId, now, actor, appId),
+      c.env.DB.prepare(
+        `UPDATE device_enrollments
+         SET current_device_id = NULL, status = 'revoked', revision = ?1,
+             updated_by = ?2, updated_at = ?3, revoked_at = ?3
+         WHERE id = ?4 AND app_id = ?5`,
+      ).bind(resultingRevision, actor, now, enrollmentId, appId),
+    );
+  }
+
+  statements.push(
+    c.env.DB.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    ).bind(
+      crypto.randomUUID(),
+      appId,
+      `device_enrollment.${kind}`,
+      actor,
+      JSON.stringify({
+        enrollment_id: enrollmentId,
+        alias: enrollment.alias,
+        operation_id: operationId,
+        from_device_id: fromDeviceId,
+        to_device_id: toDeviceId,
+        expected_revision: expectedRevision,
+        resulting_revision: resultingRevision,
+      }),
+      now,
+    ),
+  );
+
+  try {
+    await c.env.DB.batch(statements);
+  } catch (error) {
+    const concurrentReplay = await getOperation(c.env.DB, appId, operationId);
+    if (concurrentReplay && operationMatches(
+      concurrentReplay,
+      enrollmentId,
+      kind,
+      expectedRevision,
+      toDeviceId,
+    )) {
+      return operationResponse(c, enrollmentId, concurrentReplay, true);
+    }
+    const mapped = mapMutationError(error instanceof Error ? error.message : String(error));
+    return c.json({ error: mapped.error }, mapped.status);
+  }
+
+  const operation = await getOperation(c.env.DB, appId, operationId);
+  if (!operation) return c.json({ error: "device enrollment operation receipt missing" }, 500);
+  return operationResponse(c, enrollmentId, operation, false);
+}

--- a/worker/src/routes/device_groups.ts
+++ b/worker/src/routes/device_groups.ts
@@ -69,12 +69,26 @@ export async function handleListDeviceGroups(c: Context<{ Bindings: Env }>) {
      ORDER BY lower(g.name), g.id`,
   ).bind(appId).all<DeviceGroupRow>();
   const { results: members } = await c.env.DB.prepare(
-    `SELECT m.group_id, m.device_id, m.label, m.created_at
+    `SELECT m.group_id, m.device_id, m.label, m.created_at,
+            e.id AS enrollment_id, e.alias AS enrollment_alias,
+            e.revision AS enrollment_revision
      FROM device_group_members m
      JOIN device_groups g ON g.id = m.group_id
+     LEFT JOIN device_enrollments e
+       ON e.app_id = g.app_id
+      AND e.current_device_id = m.device_id
+      AND e.status = 'active'
      WHERE g.app_id = ?1
      ORDER BY m.created_at, m.device_id`,
-  ).bind(appId).all<{ group_id: string; device_id: string; label: string | null; created_at: number }>();
+  ).bind(appId).all<{
+    group_id: string;
+    device_id: string;
+    label: string | null;
+    created_at: number;
+    enrollment_id: string | null;
+    enrollment_alias: string | null;
+    enrollment_revision: number | null;
+  }>();
   return c.json({
     groups: groups.map((group) => ({
       ...group,

--- a/worker/test/device_enrollments_migration.test.ts
+++ b/worker/test/device_enrollments_migration.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0055_device_enrollments.sql", import.meta.url),
+);
+
+describe("device-enrollment migration invariants", () => {
+  it("keeps remote-D1 guard trigger bodies on one physical line", () => {
+    const triggerLines = readFileSync(migrationPath, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("CREATE TRIGGER"));
+
+    expect(triggerLines).toHaveLength(2);
+    for (const line of triggerLines) {
+      expect(line).toContain(" BEGIN ");
+      expect(line).toMatch(/ END;$/);
+      expect(line.match(/\bEND;/g)).toHaveLength(1);
+    }
+  });
+
+  it("enforces app-scoped aliases, one live installation per app, and stale-operation guards", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec(`
+      CREATE TABLE apps (id TEXT PRIMARY KEY);
+      INSERT INTO apps (id) VALUES ('app-a'), ('app-b');
+    `);
+    db.exec(readFileSync(migrationPath, "utf8"));
+    db.exec(`
+      INSERT INTO device_enrollments
+        (id, app_id, alias, current_device_id, status, revision,
+         created_by, updated_by, created_at, updated_at)
+      VALUES
+        ('enroll-a', 'app-a', 'artin-tablet', 'install-old', 'active', 1,
+         'tester', 'tester', 1, 1),
+        ('enroll-b', 'app-b', 'artin-tablet', 'install-old', 'active', 1,
+         'tester', 'tester', 1, 1);
+    `);
+
+    expect(() => db.prepare(`
+      INSERT INTO device_enrollments
+        (id, app_id, alias, current_device_id, status, revision,
+         created_by, updated_by, created_at, updated_at)
+      VALUES ('dup-alias', 'app-a', 'ARTIN-TABLET', 'install-other', 'active', 1,
+              'tester', 'tester', 1, 1)
+    `).run()).toThrow();
+    expect(() => db.prepare(`
+      INSERT INTO device_enrollments
+        (id, app_id, alias, current_device_id, status, revision,
+         created_by, updated_by, created_at, updated_at)
+      VALUES ('dup-device', 'app-a', 'other-tablet', 'install-old', 'active', 1,
+              'tester', 'tester', 1, 1)
+    `).run()).toThrow();
+
+    const insertOperation = db.prepare(`
+      INSERT INTO device_enrollment_operations
+        (id, app_id, enrollment_id, operation_id, kind, from_device_id,
+         to_device_id, expected_revision, resulting_revision, actor, created_at)
+      VALUES (?, 'app-a', 'enroll-a', ?, ?, ?, ?, ?, ?, 'tester', 2)
+    `);
+    expect(() => insertOperation.run(
+      "op-valid",
+      "request-valid",
+      "rebind",
+      "install-old",
+      "install-new",
+      1,
+      2,
+    )).not.toThrow();
+    expect(() => insertOperation.run(
+      "op-stale",
+      "request-stale",
+      "rebind",
+      "install-old",
+      "install-third",
+      2,
+      3,
+    )).toThrow("device enrollment rebind precondition failed");
+    expect(() => insertOperation.run(
+      "op-wrong-device",
+      "request-wrong-device",
+      "revoke",
+      "install-new",
+      null,
+      1,
+      2,
+    )).toThrow("device enrollment revoke precondition failed");
+  });
+
+  it("cascades enrollment and immutable receipts with app deletion", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec("CREATE TABLE apps (id TEXT PRIMARY KEY); INSERT INTO apps (id) VALUES ('app-delete');");
+    db.exec(readFileSync(migrationPath, "utf8"));
+    db.exec(`
+      INSERT INTO device_enrollments
+        (id, app_id, alias, current_device_id, status, revision,
+         created_by, updated_by, created_at, updated_at)
+      VALUES ('enroll-delete', 'app-delete', 'device', 'install', 'active', 1,
+              'tester', 'tester', 1, 1);
+      INSERT INTO device_enrollment_operations
+        (id, app_id, enrollment_id, operation_id, kind, to_device_id,
+         resulting_revision, actor, created_at)
+      VALUES ('op-delete', 'app-delete', 'enroll-delete', 'create-delete',
+              'create', 'install', 1, 'tester', 1);
+    `);
+
+    expect(() => db.prepare("DELETE FROM apps WHERE id = 'app-delete'").run()).not.toThrow();
+    expect(db.prepare("SELECT COUNT(*) AS count FROM device_enrollments").get()).toEqual({ count: 0 });
+    expect(db.prepare("SELECT COUNT(*) AS count FROM device_enrollment_operations").get()).toEqual({ count: 0 });
+  });
+});

--- a/worker/test/device_enrollments_migration.test.ts
+++ b/worker/test/device_enrollments_migration.test.ts
@@ -34,9 +34,9 @@ describe("device-enrollment migration invariants", () => {
         (id, app_id, alias, current_device_id, status, revision,
          created_by, updated_by, created_at, updated_at)
       VALUES
-        ('enroll-a', 'app-a', 'artin-tablet', 'install-old', 'active', 1,
+        ('enroll-a', 'app-a', 'artin-tablet', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'active', 1,
          'tester', 'tester', 1, 1),
-        ('enroll-b', 'app-b', 'artin-tablet', 'install-old', 'active', 1,
+        ('enroll-b', 'app-b', 'artin-tablet', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'active', 1,
          'tester', 'tester', 1, 1);
     `);
 
@@ -51,7 +51,7 @@ describe("device-enrollment migration invariants", () => {
       INSERT INTO device_enrollments
         (id, app_id, alias, current_device_id, status, revision,
          created_by, updated_by, created_at, updated_at)
-      VALUES ('dup-device', 'app-a', 'other-tablet', 'install-old', 'active', 1,
+      VALUES ('dup-device', 'app-a', 'other-tablet', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'active', 1,
               'tester', 'tester', 1, 1)
     `).run()).toThrow();
 
@@ -65,8 +65,8 @@ describe("device-enrollment migration invariants", () => {
       "op-valid",
       "request-valid",
       "rebind",
-      "install-old",
-      "install-new",
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       1,
       2,
     )).not.toThrow();
@@ -74,8 +74,8 @@ describe("device-enrollment migration invariants", () => {
       "op-stale",
       "request-stale",
       "rebind",
-      "install-old",
-      "install-third",
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
       2,
       3,
     )).toThrow("device enrollment rebind precondition failed");
@@ -83,7 +83,7 @@ describe("device-enrollment migration invariants", () => {
       "op-wrong-device",
       "request-wrong-device",
       "revoke",
-      "install-new",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       null,
       1,
       2,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3464,6 +3464,9 @@ describe("quiver apps — default_channel_id", () => {
 
 describe("quiver releases — draft lifecycle", () => {
   let env: MockEnv;
+  const OLD_INSTALL_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const NEW_INSTALL_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const THIRD_INSTALL_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 
   async function seedReleaseBuild(buildId: string, versionCode: number) {
     const now = Date.now();
@@ -3561,14 +3564,14 @@ describe("quiver releases — draft lifecycle", () => {
   }
 
   function makeDeviceGroupContext(
-    params: { groupId?: string; deviceId?: string; enrollmentId?: string } = {},
+    params: { appId?: string; groupId?: string; deviceId?: string; enrollmentId?: string } = {},
     body: unknown = {},
   ) {
     return {
       env,
       req: {
         param: (name: string) => {
-          if (name === "appId") return "app-release";
+          if (name === "appId") return params.appId ?? "app-release";
           if (name === "groupId") return params.groupId ?? "";
           if (name === "deviceId") return params.deviceId ?? "";
           if (name === "enrollmentId") return params.enrollmentId ?? "";
@@ -4955,7 +4958,7 @@ describe("quiver releases — draft lifecycle", () => {
       name: "Artin test devices",
     })));
     await handleAddDeviceGroupMember(makeDeviceGroupContext({ groupId: group.id }, {
-      device_id: "install-old",
+      device_id: OLD_INSTALL_ID,
       label: "Huawei tablet",
     }));
     await env.DB.prepare(
@@ -4963,14 +4966,18 @@ describe("quiver releases — draft lifecycle", () => {
          (id, app_id, key, default_enabled, rollout_percent, allow_device_ids,
           deny_device_ids, allow_cohorts, platforms, updated_at, updated_by)
        VALUES ('ff-enrollment', 'app-release', 'delta_updates', 0, 0,
-               '["install-old","other","install-new"]',
-               '["blocked","install-old"]', '[]', '["android"]', ?1, 'tester')`,
-    ).bind(Date.now()).run();
+               ?1, ?2, '[]', '["android"]', ?3, 'tester')`,
+    ).bind(
+      JSON.stringify([OLD_INSTALL_ID, "other", NEW_INSTALL_ID]),
+      JSON.stringify(["blocked", OLD_INSTALL_ID]),
+      Date.now(),
+    ).run();
 
     const createdResponse = await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
       alias: "artin-huawei-tablet",
       label: "Artin Huawei tablet",
-      device_id: "install-old",
+      device_id: OLD_INSTALL_ID.toUpperCase(),
+      operation_id: "create-artin-1",
     }));
     expect(createdResponse.status).toBe(201);
     const created = await responseJson<any>(createdResponse);
@@ -4978,15 +4985,47 @@ describe("quiver releases — draft lifecycle", () => {
       replayed: false,
       enrollment: {
         alias: "artin-huawei-tablet",
-        current_device_id: "install-old",
+        current_device_id: OLD_INSTALL_ID,
         status: "active",
         revision: 1,
       },
-      operation: { kind: "create", resulting_revision: 1 },
+      operation: { operation_id: "create-artin-1", kind: "create", resulting_revision: 1 },
     });
 
+    const createReplay = await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "artin-huawei-tablet",
+      label: "Artin Huawei tablet",
+      device_id: OLD_INSTALL_ID,
+      operation_id: "create-artin-1",
+    }));
+    expect(createReplay.status).toBe(200);
+    await expect(responseJson<any>(createReplay)).resolves.toMatchObject({
+      replayed: true,
+      enrollment: { id: created.enrollment.id },
+      operation: { operation_id: "create-artin-1" },
+    });
+
+    const createReuse = await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "different-alias",
+      device_id: THIRD_INSTALL_ID,
+      operation_id: "create-artin-1",
+    }));
+    expect(createReuse.status).toBe(409);
+    const invalidDevice = await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "hardware-id",
+      device_id: "ANDROID_ID-123",
+      operation_id: "create-invalid-device",
+    }));
+    expect(invalidDevice.status).toBe(400);
+    const uppercaseDuplicate = await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "duplicate-case",
+      device_id: OLD_INSTALL_ID.toUpperCase(),
+      operation_id: "create-duplicate-case",
+    }));
+    expect(uppercaseDuplicate.status).toBe(409);
+
     const rebindBody = {
-      device_id: "install-new",
+      device_id: NEW_INSTALL_ID,
       expected_revision: 1,
       operation_id: "rebind-artin-1",
     };
@@ -4998,12 +5037,12 @@ describe("quiver releases — draft lifecycle", () => {
     const rebound = await responseJson<any>(reboundResponse);
     expect(rebound).toMatchObject({
       replayed: false,
-      enrollment: { current_device_id: "install-new", status: "active", revision: 2 },
+      enrollment: { current_device_id: NEW_INSTALL_ID, status: "active", revision: 2 },
       operation: {
         operation_id: "rebind-artin-1",
         kind: "rebind",
-        from_device_id: "install-old",
-        to_device_id: "install-new",
+        from_device_id: OLD_INSTALL_ID,
+        to_device_id: NEW_INSTALL_ID,
         expected_revision: 1,
         resulting_revision: 2,
         migrated_group_memberships: 1,
@@ -5014,17 +5053,17 @@ describe("quiver releases — draft lifecycle", () => {
     const memberships = await env.DB.prepare(
       "SELECT device_id, label FROM device_group_members WHERE group_id = ?1 ORDER BY device_id",
     ).bind(group.id).all();
-    expect(memberships.results).toEqual([{ device_id: "install-new", label: "Huawei tablet" }]);
+    expect(memberships.results).toEqual([{ device_id: NEW_INSTALL_ID, label: "Huawei tablet" }]);
     const flag = await env.DB.prepare(
       "SELECT allow_device_ids, deny_device_ids, platforms FROM feature_flags WHERE id = 'ff-enrollment'",
     ).first() as any;
-    expect(JSON.parse(flag.allow_device_ids)).toEqual(["install-new", "other"]);
-    expect(JSON.parse(flag.deny_device_ids)).toEqual(["blocked", "install-new"]);
+    expect(JSON.parse(flag.allow_device_ids)).toEqual([NEW_INSTALL_ID, "other"]);
+    expect(JSON.parse(flag.deny_device_ids)).toEqual(["blocked", NEW_INSTALL_ID]);
     expect(JSON.parse(flag.platforms)).toEqual(["android"]);
 
     const groupsAfterRebind = await responseJson<any>(await handleListDeviceGroups(makeDeviceGroupContext()));
     expect(groupsAfterRebind.groups[0].members[0]).toMatchObject({
-      device_id: "install-new",
+      device_id: NEW_INSTALL_ID,
       enrollment_id: created.enrollment.id,
       enrollment_alias: "artin-huawei-tablet",
       enrollment_revision: 2,
@@ -5041,7 +5080,7 @@ describe("quiver releases — draft lifecycle", () => {
     ).first()).resolves.toEqual({ count: 1 });
     const operationReuseResponse = await handleRebindDeviceEnrollment(makeDeviceGroupContext(
       { enrollmentId: created.enrollment.id },
-      { ...rebindBody, device_id: "install-third" },
+      { ...rebindBody, device_id: THIRD_INSTALL_ID },
     ));
     expect(operationReuseResponse.status).toBe(409);
     await expect(responseJson<any>(operationReuseResponse)).resolves.toMatchObject({
@@ -5050,7 +5089,7 @@ describe("quiver releases — draft lifecycle", () => {
 
     const staleResponse = await handleRebindDeviceEnrollment(makeDeviceGroupContext(
       { enrollmentId: created.enrollment.id },
-      { device_id: "install-third", expected_revision: 1, operation_id: "rebind-stale" },
+      { device_id: THIRD_INSTALL_ID, expected_revision: 1, operation_id: "rebind-stale" },
     ));
     expect(staleResponse.status).toBe(409);
     await expect(responseJson<any>(staleResponse)).resolves.toMatchObject({
@@ -5068,7 +5107,7 @@ describe("quiver releases — draft lifecycle", () => {
       enrollment: { current_device_id: null, status: "revoked", revision: 3 },
       operation: {
         kind: "revoke",
-        from_device_id: "install-new",
+        from_device_id: NEW_INSTALL_ID,
         to_device_id: null,
         migrated_group_memberships: 1,
         migrated_feature_flags: 1,
@@ -5092,6 +5131,140 @@ describe("quiver releases — draft lifecycle", () => {
 
     const list = await responseJson<any>(await handleListDeviceEnrollments(makeDeviceGroupContext()));
     expect(list.enrollments).toMatchObject([{ alias: "artin-huawei-tablet", status: "revoked", revision: 3 }]);
+  });
+
+  it("rejects every enrollment route for non-Android apps without creating rows or targeting", async () => {
+    const {
+      handleCreateDeviceEnrollment,
+      handleListDeviceEnrollments,
+      handleRebindDeviceEnrollment,
+      handleRevokeDeviceEnrollment,
+    } = await import("../src/routes/device_enrollments");
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?1, 'default', 'ios-app', 'iOS', 'ios', ?2)",
+    ).bind("app-ios", Date.now()).run();
+    await env.DB.prepare(
+      "INSERT INTO device_groups (id, app_id, name, created_at, updated_at) VALUES ('ios-group', 'app-ios', 'iOS devices', ?1, ?1)",
+    ).bind(Date.now()).run();
+    await env.DB.prepare(
+      "INSERT INTO device_group_members (group_id, device_id, created_at) VALUES ('ios-group', ?1, ?2)",
+    ).bind(OLD_INSTALL_ID, Date.now()).run();
+    await env.DB.prepare(
+      `INSERT INTO feature_flags
+         (id, app_id, key, default_enabled, rollout_percent, allow_device_ids,
+          deny_device_ids, allow_cohorts, platforms, updated_at, updated_by)
+       VALUES ('ios-flag', 'app-ios', 'test', 0, 0, ?1, '[]', '[]', '["ios"]', ?2, 'tester')`,
+    ).bind(JSON.stringify([OLD_INSTALL_ID]), Date.now()).run();
+
+    const create = await handleCreateDeviceEnrollment(makeDeviceGroupContext({ appId: "app-ios" }, {
+      alias: "ios-device",
+      device_id: OLD_INSTALL_ID,
+      operation_id: "create-ios",
+    }));
+    const list = await handleListDeviceEnrollments(makeDeviceGroupContext({ appId: "app-ios" }));
+    const rebind = await handleRebindDeviceEnrollment(makeDeviceGroupContext({
+      appId: "app-ios",
+      enrollmentId: "missing",
+    }, {
+      device_id: NEW_INSTALL_ID,
+      expected_revision: 1,
+      operation_id: "rebind-ios",
+    }));
+    const revoke = await handleRevokeDeviceEnrollment(makeDeviceGroupContext({
+      appId: "app-ios",
+      enrollmentId: "missing",
+    }, {
+      expected_revision: 1,
+      operation_id: "revoke-ios",
+    }));
+
+    for (const response of [create, list, rebind, revoke]) {
+      expect(response.status).toBe(400);
+      await expect(responseJson<any>(response)).resolves.toMatchObject({
+        error: "device enrollments are only supported for Android apps",
+      });
+    }
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM device_enrollments WHERE app_id = 'app-ios'",
+    ).first()).resolves.toEqual({ count: 0 });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM device_enrollment_operations WHERE app_id = 'app-ios'",
+    ).first()).resolves.toEqual({ count: 0 });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE app_id = 'app-ios' AND action LIKE 'device_enrollment.%'",
+    ).first()).resolves.toEqual({ count: 0 });
+    await expect(env.DB.prepare(
+      "SELECT device_id FROM device_group_members WHERE group_id = 'ios-group'",
+    ).all()).resolves.toMatchObject({ results: [{ device_id: OLD_INSTALL_ID }] });
+    const flag = await env.DB.prepare(
+      "SELECT allow_device_ids FROM feature_flags WHERE id = 'ios-flag'",
+    ).first() as { allow_device_ids: string } | null;
+    expect(JSON.parse(flag!.allow_device_ids)).toEqual([OLD_INSTALL_ID]);
+  });
+
+  it("rolls back operation, group, flag, enrollment and audit when the final target is already enrolled", async () => {
+    const {
+      handleCreateDeviceEnrollment,
+      handleRebindDeviceEnrollment,
+    } = await import("../src/routes/device_enrollments");
+    const {
+      handleAddDeviceGroupMember,
+      handleCreateDeviceGroup,
+    } = await import("../src/routes/device_groups");
+    const group = await responseJson<any>(await handleCreateDeviceGroup(makeDeviceGroupContext({}, {
+      name: "Rollback devices",
+    })));
+    await handleAddDeviceGroupMember(makeDeviceGroupContext({ groupId: group.id }, {
+      device_id: OLD_INSTALL_ID,
+      label: "old slot",
+    }));
+    await env.DB.prepare(
+      `INSERT INTO feature_flags
+         (id, app_id, key, default_enabled, rollout_percent, allow_device_ids,
+          deny_device_ids, allow_cohorts, platforms, updated_at, updated_by)
+       VALUES ('ff-rollback', 'app-release', 'rollback', 0, 0, ?1, '[]', '[]', '["android"]', ?2, 'tester')`,
+    ).bind(JSON.stringify([OLD_INSTALL_ID]), Date.now()).run();
+    const oldEnrollment = await responseJson<any>(await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "old-slot",
+      device_id: OLD_INSTALL_ID,
+      operation_id: "create-old-slot",
+    })));
+    await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "occupied-target",
+      device_id: NEW_INSTALL_ID,
+      operation_id: "create-occupied-target",
+    }));
+
+    const failed = await handleRebindDeviceEnrollment(makeDeviceGroupContext({
+      enrollmentId: oldEnrollment.enrollment.id,
+    }, {
+      device_id: NEW_INSTALL_ID,
+      expected_revision: 1,
+      operation_id: "rebind-late-unique-fail",
+    }));
+    expect(failed.status).toBe(409);
+    await expect(env.DB.prepare(
+      "SELECT current_device_id, revision, status FROM device_enrollments WHERE id = ?1",
+    ).bind(oldEnrollment.enrollment.id).first()).resolves.toEqual({
+      current_device_id: OLD_INSTALL_ID,
+      revision: 1,
+      status: "active",
+    });
+    await expect(env.DB.prepare(
+      "SELECT device_id, label FROM device_group_members WHERE group_id = ?1",
+    ).bind(group.id).all()).resolves.toMatchObject({
+      results: [{ device_id: OLD_INSTALL_ID, label: "old slot" }],
+    });
+    const flag = await env.DB.prepare(
+      "SELECT allow_device_ids FROM feature_flags WHERE id = 'ff-rollback'",
+    ).first() as { allow_device_ids: string } | null;
+    expect(JSON.parse(flag!.allow_device_ids)).toEqual([OLD_INSTALL_ID]);
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM device_enrollment_operations WHERE operation_id = 'rebind-late-unique-fail'",
+    ).first()).resolves.toEqual({ count: 0 });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'device_enrollment.rebind' AND payload LIKE '%rebind-late-unique-fail%'",
+    ).first()).resolves.toEqual({ count: 0 });
   });
 
   it("updates editable release metadata and replaces scopes", async () => {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -105,6 +105,9 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/feedback/{ticketId}/comments",
       "/api/app-permissions",
       "/api/apps/{appId}/client-key",
+      "/api/apps/{appId}/device-enrollments",
+      "/api/apps/{appId}/device-enrollments/{enrollmentId}/rebind",
+      "/api/apps/{appId}/device-enrollments/{enrollmentId}/revoke",
       "/api/apps/{appId}/analytics/versions",
       "/api/orgs/{orgId}/invites",
       "/api/orgs/{orgId}/webhooks/{webhookId}/deliveries",
@@ -314,6 +317,58 @@ function makeMockDb() {
       created_at INTEGER NOT NULL,
       PRIMARY KEY (group_id, device_id)
     );
+    CREATE TABLE device_enrollments (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      alias TEXT NOT NULL,
+      label TEXT,
+      current_device_id TEXT,
+      status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+      created_by TEXT NOT NULL,
+      updated_by TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      last_rebound_at INTEGER,
+      revoked_at INTEGER
+    );
+    CREATE UNIQUE INDEX idx_device_enrollments_app_alias
+      ON device_enrollments(app_id, alias COLLATE NOCASE);
+    CREATE UNIQUE INDEX idx_device_enrollments_app_current_device
+      ON device_enrollments(app_id, current_device_id)
+      WHERE status = 'active' AND current_device_id IS NOT NULL;
+    CREATE TABLE device_enrollment_operations (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+      enrollment_id TEXT NOT NULL REFERENCES device_enrollments(id) ON DELETE CASCADE,
+      operation_id TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK (kind IN ('create', 'rebind', 'revoke')),
+      from_device_id TEXT,
+      to_device_id TEXT,
+      expected_revision INTEGER,
+      resulting_revision INTEGER NOT NULL,
+      migrated_group_memberships INTEGER NOT NULL DEFAULT 0,
+      migrated_feature_flags INTEGER NOT NULL DEFAULT 0,
+      actor TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      UNIQUE (app_id, operation_id)
+    );
+    CREATE TRIGGER trg_device_enrollment_rebind_guard BEFORE INSERT ON device_enrollment_operations
+      WHEN NEW.kind = 'rebind' AND NOT EXISTS (
+        SELECT 1 FROM device_enrollments e
+        WHERE e.id = NEW.enrollment_id AND e.app_id = NEW.app_id
+          AND e.status = 'active' AND e.current_device_id = NEW.from_device_id
+          AND e.revision = NEW.expected_revision
+          AND NEW.resulting_revision = e.revision + 1
+      ) BEGIN SELECT RAISE(ABORT, 'device enrollment rebind precondition failed'); END;
+    CREATE TRIGGER trg_device_enrollment_revoke_guard BEFORE INSERT ON device_enrollment_operations
+      WHEN NEW.kind = 'revoke' AND NOT EXISTS (
+        SELECT 1 FROM device_enrollments e
+        WHERE e.id = NEW.enrollment_id AND e.app_id = NEW.app_id
+          AND e.status = 'active' AND e.current_device_id = NEW.from_device_id
+          AND e.revision = NEW.expected_revision
+          AND NEW.resulting_revision = e.revision + 1
+      ) BEGIN SELECT RAISE(ABORT, 'device enrollment revoke precondition failed'); END;
     CREATE TABLE release_metrics (
       release_id TEXT PRIMARY KEY,
       offered_count INTEGER NOT NULL DEFAULT 0,
@@ -3506,7 +3561,7 @@ describe("quiver releases — draft lifecycle", () => {
   }
 
   function makeDeviceGroupContext(
-    params: { groupId?: string; deviceId?: string } = {},
+    params: { groupId?: string; deviceId?: string; enrollmentId?: string } = {},
     body: unknown = {},
   ) {
     return {
@@ -3516,6 +3571,7 @@ describe("quiver releases — draft lifecycle", () => {
           if (name === "appId") return "app-release";
           if (name === "groupId") return params.groupId ?? "";
           if (name === "deviceId") return params.deviceId ?? "";
+          if (name === "enrollmentId") return params.enrollmentId ?? "";
           return "";
         },
         json: async () => body,
@@ -4880,6 +4936,162 @@ describe("quiver releases — draft lifecycle", () => {
     await expect(responseJson<any>(blockedDelete)).resolves.toMatchObject({
       error: "device group is used by a draft or active release",
     });
+  });
+
+  it("rebinds an enrolled test device across groups and feature flags atomically, idempotently, and revocably", async () => {
+    const {
+      handleCreateDeviceEnrollment,
+      handleListDeviceEnrollments,
+      handleRebindDeviceEnrollment,
+      handleRevokeDeviceEnrollment,
+    } = await import("../src/routes/device_enrollments");
+    const {
+      handleAddDeviceGroupMember,
+      handleCreateDeviceGroup,
+      handleListDeviceGroups,
+    } = await import("../src/routes/device_groups");
+
+    const group = await responseJson<any>(await handleCreateDeviceGroup(makeDeviceGroupContext({}, {
+      name: "Artin test devices",
+    })));
+    await handleAddDeviceGroupMember(makeDeviceGroupContext({ groupId: group.id }, {
+      device_id: "install-old",
+      label: "Huawei tablet",
+    }));
+    await env.DB.prepare(
+      `INSERT INTO feature_flags
+         (id, app_id, key, default_enabled, rollout_percent, allow_device_ids,
+          deny_device_ids, allow_cohorts, platforms, updated_at, updated_by)
+       VALUES ('ff-enrollment', 'app-release', 'delta_updates', 0, 0,
+               '["install-old","other","install-new"]',
+               '["blocked","install-old"]', '[]', '["android"]', ?1, 'tester')`,
+    ).bind(Date.now()).run();
+
+    const createdResponse = await handleCreateDeviceEnrollment(makeDeviceGroupContext({}, {
+      alias: "artin-huawei-tablet",
+      label: "Artin Huawei tablet",
+      device_id: "install-old",
+    }));
+    expect(createdResponse.status).toBe(201);
+    const created = await responseJson<any>(createdResponse);
+    expect(created).toMatchObject({
+      replayed: false,
+      enrollment: {
+        alias: "artin-huawei-tablet",
+        current_device_id: "install-old",
+        status: "active",
+        revision: 1,
+      },
+      operation: { kind: "create", resulting_revision: 1 },
+    });
+
+    const rebindBody = {
+      device_id: "install-new",
+      expected_revision: 1,
+      operation_id: "rebind-artin-1",
+    };
+    const reboundResponse = await handleRebindDeviceEnrollment(makeDeviceGroupContext(
+      { enrollmentId: created.enrollment.id },
+      rebindBody,
+    ));
+    expect(reboundResponse.status).toBe(200);
+    const rebound = await responseJson<any>(reboundResponse);
+    expect(rebound).toMatchObject({
+      replayed: false,
+      enrollment: { current_device_id: "install-new", status: "active", revision: 2 },
+      operation: {
+        operation_id: "rebind-artin-1",
+        kind: "rebind",
+        from_device_id: "install-old",
+        to_device_id: "install-new",
+        expected_revision: 1,
+        resulting_revision: 2,
+        migrated_group_memberships: 1,
+        migrated_feature_flags: 1,
+      },
+    });
+
+    const memberships = await env.DB.prepare(
+      "SELECT device_id, label FROM device_group_members WHERE group_id = ?1 ORDER BY device_id",
+    ).bind(group.id).all();
+    expect(memberships.results).toEqual([{ device_id: "install-new", label: "Huawei tablet" }]);
+    const flag = await env.DB.prepare(
+      "SELECT allow_device_ids, deny_device_ids, platforms FROM feature_flags WHERE id = 'ff-enrollment'",
+    ).first() as any;
+    expect(JSON.parse(flag.allow_device_ids)).toEqual(["install-new", "other"]);
+    expect(JSON.parse(flag.deny_device_ids)).toEqual(["blocked", "install-new"]);
+    expect(JSON.parse(flag.platforms)).toEqual(["android"]);
+
+    const groupsAfterRebind = await responseJson<any>(await handleListDeviceGroups(makeDeviceGroupContext()));
+    expect(groupsAfterRebind.groups[0].members[0]).toMatchObject({
+      device_id: "install-new",
+      enrollment_id: created.enrollment.id,
+      enrollment_alias: "artin-huawei-tablet",
+      enrollment_revision: 2,
+    });
+
+    const replayResponse = await handleRebindDeviceEnrollment(makeDeviceGroupContext(
+      { enrollmentId: created.enrollment.id },
+      rebindBody,
+    ));
+    expect(replayResponse.status).toBe(200);
+    await expect(responseJson<any>(replayResponse)).resolves.toMatchObject({ replayed: true });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM device_enrollment_operations WHERE operation_id = 'rebind-artin-1'",
+    ).first()).resolves.toEqual({ count: 1 });
+    const operationReuseResponse = await handleRebindDeviceEnrollment(makeDeviceGroupContext(
+      { enrollmentId: created.enrollment.id },
+      { ...rebindBody, device_id: "install-third" },
+    ));
+    expect(operationReuseResponse.status).toBe(409);
+    await expect(responseJson<any>(operationReuseResponse)).resolves.toMatchObject({
+      error: "operation_id already exists with different input",
+    });
+
+    const staleResponse = await handleRebindDeviceEnrollment(makeDeviceGroupContext(
+      { enrollmentId: created.enrollment.id },
+      { device_id: "install-third", expected_revision: 1, operation_id: "rebind-stale" },
+    ));
+    expect(staleResponse.status).toBe(409);
+    await expect(responseJson<any>(staleResponse)).resolves.toMatchObject({
+      error: "stale expected_revision",
+      current_revision: 2,
+    });
+
+    const revokeBody = { expected_revision: 2, operation_id: "revoke-artin-2" };
+    const revokeResponse = await handleRevokeDeviceEnrollment(makeDeviceGroupContext(
+      { enrollmentId: created.enrollment.id },
+      revokeBody,
+    ));
+    expect(revokeResponse.status).toBe(200);
+    await expect(responseJson<any>(revokeResponse)).resolves.toMatchObject({
+      enrollment: { current_device_id: null, status: "revoked", revision: 3 },
+      operation: {
+        kind: "revoke",
+        from_device_id: "install-new",
+        to_device_id: null,
+        migrated_group_memberships: 1,
+        migrated_feature_flags: 1,
+      },
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM device_group_members WHERE group_id = ?1",
+    ).bind(group.id).first()).resolves.toEqual({ count: 0 });
+    const flagAfterRevoke = await env.DB.prepare(
+      "SELECT allow_device_ids, deny_device_ids FROM feature_flags WHERE id = 'ff-enrollment'",
+    ).first() as any;
+    expect(JSON.parse(flagAfterRevoke.allow_device_ids)).toEqual(["other"]);
+    expect(JSON.parse(flagAfterRevoke.deny_device_ids)).toEqual(["blocked"]);
+
+    const revokeReplay = await handleRevokeDeviceEnrollment(makeDeviceGroupContext(
+      { enrollmentId: created.enrollment.id },
+      revokeBody,
+    ));
+    expect(revokeReplay.status).toBe(200);
+    await expect(responseJson<any>(revokeReplay)).resolves.toMatchObject({ replayed: true });
+
+    const list = await responseJson<any>(await handleListDeviceEnrollments(makeDeviceGroupContext()));
+    expect(list.enrollments).toMatchObject([{ alias: "artin-huawei-tablet", status: "revoked", revision: 3 }]);
   });
 
   it("updates editable release metadata and replaces scopes", async () => {
@@ -10326,6 +10538,22 @@ describe("Hands iOS simulator QA artifacts", () => {
       "delete-device-group": {
         method: "DELETE",
         path: "/api/apps/{app_id}/device-groups/{group_id}",
+      },
+      "list-device-enrollments": {
+        method: "GET",
+        path: "/api/apps/{app_id}/device-enrollments",
+      },
+      "create-device-enrollment": {
+        method: "POST",
+        path: "/api/apps/{app_id}/device-enrollments",
+      },
+      "rebind-device-enrollment": {
+        method: "POST",
+        path: "/api/apps/{app_id}/device-enrollments/{enrollment_id}/rebind",
+      },
+      "revoke-device-enrollment": {
+        method: "POST",
+        path: "/api/apps/{app_id}/device-enrollments/{enrollment_id}/revoke",
       },
       "list-ios-simulator-artifacts": {
         method: "GET",


### PR DESCRIPTION
## Outcome

Add an authenticated, app-scoped device-enrollment alias for physical QA devices while preserving the Android SDK's random per-install `device_id` contract.

A guarded rebind atomically replaces the old installation id across every app device-group membership and feature-flag allow/deny list. Revocation removes the current id from those targets. Public update resolution still accepts only the current raw per-install id; aliases remain private and no hardware identifier is introduced.

## Safety contract

- publisher-authenticated API, Console, CLI, OpenAPI, and Agent Login manifest
- exact `expected_revision` plus app-scoped `operation_id`
- immutable operation receipts and idempotent exact-input replay
- D1 trigger guard aborts stale/revoked batch before targeting mutation
- group and feature-flag migration are one D1 transaction
- active installation id unique per app enrollment
- additive migration; no automatic enrollment/backfill or production mutation
- existing direct device-group members remain compatible
- explicit uninstall/clear-data/Auto Backup/privacy documentation

## Validation

- full workspace build: PASS
- full workspace test: PASS
- Worker: 20 files / 264 tests PASS
- Admin typecheck/build: PASS; 30 tests PASS
- CLI build: PASS; 30 tests PASS
- migration trigger physical-line and SQLite invariant tests: PASS
- diff-check: PASS

First worktree build attempts preserved in the task receipt: dependencies/generated Worker bindings were initially absent; after lockfile install and `wrangler types --config wrangler.hands.jsonc`, source build passed. A Vitest invocation with the unsupported Jest flag `--runInBand` failed before loading tests; the repository-standard `vitest run` passed. Repository lint remains blocked by the pre-existing ESLint 9 missing `eslint.config.*` configuration.

No deploy, migration apply, live enrollment/rebind, release, feature-flag, SDK publish, or Mobile mutation is included.
