### PR TITLE
Android: persist update install transactions

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -53,13 +53,45 @@ val checker = UpdateChecker(
     installedVersionCode = BuildConfig.VERSION_CODE.toLong(),
     channel = "main",
     arch = "arm64-v8a",
+    // Explicit host-selected locale; the SDK never guesses the system locale.
+    languageTag = "zh-CN",
+    eventListener = HandsUpdateEventListener { event ->
+        // Persist in the host's diagnostics/feedback log if desired.
+        hostUpdateLog.append(event)
+    },
 )
 
-val result = checker.checkAndInstall()
-if (!result.update_available) {
-    // Already current.
+// Idempotent command: starts a check only from idle/failed/stale/installed,
+// waits during active work, and reopens the same verified APK when ready.
+val status = checker.install()
+when (status.state) {
+    HandsUpdateState.DOWNLOADING -> showDownloading()
+    HandsUpdateState.READY_TO_INSTALL,
+    HandsUpdateState.INSTALLER_OPENED -> showInstallEnabled()
+    HandsUpdateState.INSTALLED -> showDone()
+    else -> render(status)
 }
 ```
+
+Call `checker.status()` whenever the update page or process resumes. It
+reconciles the persisted transaction against PackageManager, DownloadManager,
+and the SDK-owned APK file. `checker.reopenPendingInstaller()` opens the same
+verified file without another network request. Missing/unsafe files, target
+drift, exact version mismatch, hash mismatch (when the server supplied one), or
+signer/package mismatch fail closed as `stale`/`failed` with a stable
+`errorCode`.
+
+The persisted transaction is bound to package, Hands origin, app slug,
+channel, product, platform, and architecture. It stores target/build/asset
+identity, DownloadManager id, and an app-scoped path; it never stores the signed
+download URL or an auth secret. Structured `HandsUpdateEvent` records cover
+check, patch download/apply/validation/fallback, full download, content URI,
+installer open/reopen, resume state changes, failures, and cleanup so hosts can
+include the chain in Hands feedback rather than relying on Logcat alone.
+
+`languageTag` is an explicit BCP-47 tag. Valid values are sent as both
+`X-Hands-Lang` and `Accept-Language`; missing or malformed values send neither
+header, and unsupported values retain the server's English fallback.
 
 The SDK calls:
 

--- a/clients/android/docs/integration.md
+++ b/clients/android/docs/integration.md
@@ -48,11 +48,12 @@ R2 URL that expires in `expires_in` seconds.
 
 | File | Purpose |
 |---|---|
-| `UpdateChecker.kt`            | Public API — high-level "check + download + install" entry point |
+| `UpdateChecker.kt`            | Public API — persistent status, idempotent check/install, and installer reopen |
+| `HandsUpdateTransaction.kt`   | Stable states/status/events and authority-bound transaction persistence |
 | `HandsClient.kt`              | Internal HTTP client (OkHttp + kotlinx.serialization) |
 | `models/Version.kt`           | Wire-model for `/public/v2/apps/:slug/updates/check` response |
 | `models/App.kt`               | Same, app metadata |
-| `installer/ApkInstaller.kt`   | DownloadManager + Intent.ACTION_INSTALL_PACKAGE |
+| `installer/ApkInstaller.kt`   | DownloadManager query/enqueue + read-only FileProvider installer launch |
 | `MainActivity.kt.example`     | Reference Activity wiring UpdateChecker |
 
 ## Permission
@@ -64,8 +65,25 @@ Add to `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
 ```
 
-For Android 8+, you also need a FileProvider for `ACTION_VIEW` flows (not used
-here — we use `ACTION_INSTALL_PACKAGE` directly via DownloadManager).
+The SDK AAR contributes a non-exported `${applicationId}.hands.fileprovider`
+with read-only cache and app-scoped external Downloads roots. Do not add a
+world-readable APK path. The full and delta flows both launch the package
+installer through this provider with read access only.
+
+## Resume-safe host flow
+
+Create one `UpdateChecker` for the same package/origin/app/channel authority and
+pass the app-selected BCP-47 language tag explicitly. On page/lifecycle resume,
+call `status()` and map every `HandsUpdateState` value. Keep `Install` enabled
+for `ready_to_install` and `installer_opened`; calling `install()` or
+`reopenPendingInstaller()` reopens the same verified APK and never downloads it
+again. Show download progress only for `downloading`, and start a new check only
+from `idle`, `failed`, `stale`, or `installed`.
+
+`installed` is reported only after PackageManager's installed version reaches
+the exact target. A user returning from the system installer without accepting
+installation therefore remains able to press Install again instead of becoming
+stuck in a host-owned "Installing" snapshot.
 
 ## Required dependencies
 

--- a/clients/android/src/androidTest/kotlin/build/hands/update/UpdateTransactionPlatformTest.kt
+++ b/clients/android/src/androidTest/kotlin/build/hands/update/UpdateTransactionPlatformTest.kt
@@ -1,0 +1,73 @@
+package build.hands.update
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UpdateTransactionPlatformTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun transactionRoundTripsInPrivatePreferencesAndSeparatesAuthorities() {
+        val first = authority("main")
+        val second = authority("preview")
+        val firstStore = UpdateTransactionStore(context, first)
+        val secondStore = UpdateTransactionStore(context, second)
+        firstStore.clear()
+        secondStore.clear()
+
+        try {
+            val record = record(first).copy(
+                state = HandsUpdateState.DOWNLOADING,
+                targetVersionCode = 1000011,
+                downloadId = 42,
+                localFilePath = context.getExternalFilesDir("Download")
+                    ?.resolve("quiver-raft-1000011.apk")
+                    ?.absolutePath,
+            )
+            firstStore.write(record)
+
+            assertEquals(record, firstStore.read())
+            assertNull(secondStore.read())
+        } finally {
+            firstStore.clear()
+            secondStore.clear()
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun storeRejectsRecordFromAnotherAuthority() {
+        val store = UpdateTransactionStore(context, authority("main"))
+        try {
+            store.write(record(authority("preview")))
+        } finally {
+            store.clear()
+        }
+    }
+
+    private fun authority(channel: String) = UpdateAuthority(
+        packageName = context.packageName,
+        baseUrl = "https://hands.example.test",
+        appSlug = "raft-android",
+        channel = channel,
+        productType = "android-apk",
+        platform = "android",
+        arch = "arm64-v8a",
+    )
+
+    private fun record(authority: UpdateAuthority) = UpdateTransactionRecord(
+        packageName = authority.packageName,
+        baseUrl = authority.canonicalBaseUrl,
+        appSlug = authority.appSlug,
+        channel = authority.channel,
+        productType = authority.productType,
+        platform = authority.platform,
+        arch = authority.arch,
+        state = HandsUpdateState.CHECKING,
+    )
+}

--- a/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.security.MessageDigest
 
 /** Stable states exposed to host applications and cross-platform bridges. */
@@ -72,6 +74,136 @@ data class HandsUpdateEvent(
 /** The listener must return quickly; events are emitted on the calling thread. */
 fun interface HandsUpdateEventListener {
     fun onEvent(event: HandsUpdateEvent)
+}
+
+internal class AuthorityTransactionGate(private val mutex: Mutex) {
+    suspend fun <T> run(block: suspend () -> T): T = mutex.withLock { block() }
+}
+
+internal enum class DurableInstallerLaunchResult {
+    READY_PERSIST_FAILED,
+    LAUNCH_FAILED,
+    OPENED,
+    OPENED_WITH_READY_AUTHORITY,
+}
+
+/** Persist READY before the installer side effect; OPENED persistence is best-effort afterward. */
+internal fun launchWithDurableInstallerAuthority(
+    persistReady: () -> Unit,
+    launchInstaller: () -> Unit,
+    persistOpened: () -> Unit,
+): DurableInstallerLaunchResult {
+    try {
+        persistReady()
+    } catch (_: Throwable) {
+        return DurableInstallerLaunchResult.READY_PERSIST_FAILED
+    }
+    try {
+        launchInstaller()
+    } catch (_: Throwable) {
+        return DurableInstallerLaunchResult.LAUNCH_FAILED
+    }
+    return try {
+        persistOpened()
+        DurableInstallerLaunchResult.OPENED
+    } catch (_: Throwable) {
+        // The READY record remains the durable authority for a safe reopen.
+        DurableInstallerLaunchResult.OPENED_WITH_READY_AUTHORITY
+    }
+}
+
+internal data class ExactCleanupResult(
+    val downloadAbsent: Boolean,
+    val fileAbsent: Boolean,
+) {
+    val succeeded: Boolean get() = downloadAbsent && fileAbsent
+}
+
+internal data class ExactCleanupTransition(
+    val state: HandsUpdateState,
+    val errorCode: String?,
+    val retryable: Boolean,
+    val clearLocalAuthority: Boolean,
+)
+
+internal fun exactCleanupTransition(
+    cleanup: ExactCleanupResult,
+    successState: HandsUpdateState,
+    successErrorCode: String?,
+    successRetryable: Boolean,
+): ExactCleanupTransition = if (cleanup.succeeded) {
+    ExactCleanupTransition(
+        state = successState,
+        errorCode = successErrorCode,
+        retryable = successRetryable,
+        clearLocalAuthority = true,
+    )
+} else {
+    ExactCleanupTransition(
+        state = HandsUpdateState.FAILED,
+        errorCode = "cleanup_failed",
+        retryable = true,
+        clearLocalAuthority = false,
+    )
+}
+
+internal fun performExactCleanup(
+    downloadId: Long?,
+    localFilePath: String?,
+    removeDownload: (Long) -> Boolean,
+    isOwnedFile: (String) -> Boolean,
+    fileExists: (String) -> Boolean,
+    deleteFile: (String) -> Boolean,
+): ExactCleanupResult {
+    val downloadAbsent = downloadId == null || try {
+        removeDownload(downloadId)
+    } catch (_: Throwable) {
+        false
+    }
+    val fileAbsent = when {
+        localFilePath == null -> true
+        !isOwnedFile(localFilePath) -> false
+        !fileExists(localFilePath) -> true
+        else -> try {
+            deleteFile(localFilePath) && !fileExists(localFilePath)
+        } catch (_: Throwable) {
+            false
+        }
+    }
+    return ExactCleanupResult(downloadAbsent, fileAbsent)
+}
+
+internal enum class PendingInstallerOfferAction {
+    REOPEN_CURRENT,
+    REPLACE_CURRENT,
+    WITHDRAW_CURRENT,
+}
+
+internal fun pendingInstallerOfferAction(
+    persistedTargetVersionCode: Long?,
+    offeredTargetVersionCode: Long?,
+): PendingInstallerOfferAction = when {
+    offeredTargetVersionCode == null -> PendingInstallerOfferAction.WITHDRAW_CURRENT
+    offeredTargetVersionCode == persistedTargetVersionCode ->
+        PendingInstallerOfferAction.REOPEN_CURRENT
+    else -> PendingInstallerOfferAction.REPLACE_CURRENT
+}
+
+internal inline fun <T> reconcilePendingInstallerOffer(
+    persistedTargetVersionCode: Long?,
+    offeredTargetVersionCode: Long?,
+    reopenCurrent: () -> T,
+    replaceCurrent: () -> T,
+    withdrawCurrent: () -> T,
+): T = when (
+    pendingInstallerOfferAction(
+        persistedTargetVersionCode = persistedTargetVersionCode,
+        offeredTargetVersionCode = offeredTargetVersionCode,
+    )
+) {
+    PendingInstallerOfferAction.REOPEN_CURRENT -> reopenCurrent()
+    PendingInstallerOfferAction.REPLACE_CURRENT -> replaceCurrent()
+    PendingInstallerOfferAction.WITHDRAW_CURRENT -> withdrawCurrent()
 }
 
 @Serializable

--- a/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
@@ -1,0 +1,216 @@
+package build.hands.update
+
+import android.content.Context
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+
+/** Stable states exposed to host applications and cross-platform bridges. */
+@Serializable
+enum class HandsUpdateState(val wireValue: String) {
+    @SerialName("idle")
+    IDLE("idle"),
+
+    @SerialName("checking")
+    CHECKING("checking"),
+
+    @SerialName("patching")
+    PATCHING("patching"),
+
+    @SerialName("downloading")
+    DOWNLOADING("downloading"),
+
+    @SerialName("ready_to_install")
+    READY_TO_INSTALL("ready_to_install"),
+
+    @SerialName("installer_opened")
+    INSTALLER_OPENED("installer_opened"),
+
+    @SerialName("failed")
+    FAILED("failed"),
+
+    @SerialName("stale")
+    STALE("stale"),
+
+    @SerialName("installed")
+    INSTALLED("installed"),
+}
+
+/**
+ * Immutable, secret-free view of the SDK's persisted update transaction.
+ *
+ * [targetVersionCode] is null only while the first update check is in flight.
+ * Signed download URLs are deliberately never exposed or persisted here.
+ */
+@Serializable
+data class HandsUpdateStatus(
+    val state: HandsUpdateState,
+    val targetVersionCode: Long? = null,
+    val installedVersionCode: Long? = null,
+    val retryable: Boolean = false,
+    val errorCode: String? = null,
+    val targetBuildId: String? = null,
+    val assetSha256: String? = null,
+    val requestedLanguageTag: String? = null,
+    val resolvedLanguageTag: String? = null,
+    val updatedAt: Long? = null,
+)
+
+/** Structured update events that hosts can include in their own diagnostics. */
+@Serializable
+data class HandsUpdateEvent(
+    val name: String,
+    val state: HandsUpdateState,
+    val targetVersionCode: Long? = null,
+    val errorCode: String? = null,
+    val requestedLanguageTag: String? = null,
+    val resolvedLanguageTag: String? = null,
+    val timestamp: Long = System.currentTimeMillis(),
+)
+
+/** The listener must return quickly; events are emitted on the calling thread. */
+fun interface HandsUpdateEventListener {
+    fun onEvent(event: HandsUpdateEvent)
+}
+
+@Serializable
+internal data class UpdateTransactionRecord(
+    val schemaVersion: Int = TRANSACTION_SCHEMA_VERSION,
+    val packageName: String,
+    val baseUrl: String,
+    val appSlug: String,
+    val channel: String,
+    val productType: String,
+    val platform: String,
+    val arch: String? = null,
+    val state: HandsUpdateState,
+    val installedVersionCodeAtStart: Long? = null,
+    val targetVersionCode: Long? = null,
+    val targetBuildId: String? = null,
+    val assetSizeBytes: Long? = null,
+    val assetSha256: String? = null,
+    val assetSignature: String? = null,
+    val filetype: String? = null,
+    val downloadId: Long? = null,
+    val localFilePath: String? = null,
+    val retryable: Boolean = false,
+    val errorCode: String? = null,
+    val requestedLanguageTag: String? = null,
+    val resolvedLanguageTag: String? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+) {
+    fun status(installedVersionCode: Long?): HandsUpdateStatus = HandsUpdateStatus(
+        state = state,
+        targetVersionCode = targetVersionCode,
+        installedVersionCode = installedVersionCode,
+        retryable = retryable,
+        errorCode = errorCode,
+        targetBuildId = targetBuildId,
+        assetSha256 = assetSha256,
+        requestedLanguageTag = requestedLanguageTag,
+        resolvedLanguageTag = resolvedLanguageTag,
+        updatedAt = updatedAt,
+    )
+}
+
+internal data class UpdateAuthority(
+    val packageName: String,
+    val baseUrl: String,
+    val appSlug: String,
+    val channel: String,
+    val productType: String,
+    val platform: String,
+    val arch: String?,
+) {
+    val canonicalBaseUrl: String = baseUrl.trimEnd('/')
+
+    fun matches(record: UpdateTransactionRecord): Boolean =
+        record.schemaVersion == TRANSACTION_SCHEMA_VERSION &&
+            record.packageName == packageName &&
+            record.baseUrl == canonicalBaseUrl &&
+            record.appSlug == appSlug &&
+            record.channel == channel &&
+            record.productType == productType &&
+            record.platform == platform &&
+            record.arch == arch
+
+    fun storageKey(): String {
+        val canonical = listOf(
+            packageName,
+            canonicalBaseUrl,
+            appSlug,
+            channel,
+            productType,
+            platform,
+            arch.orEmpty(),
+        ).joinToString("\n")
+        val bytes = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray())
+        return "transaction_" + bytes.joinToString("") { "%02x".format(it) }
+    }
+}
+
+internal class UpdateTransactionStore(
+    context: Context,
+    private val authority: UpdateAuthority,
+    private val json: Json = Json { ignoreUnknownKeys = false },
+) {
+    private val preferences = context.getSharedPreferences(TRANSACTION_PREFERENCES, Context.MODE_PRIVATE)
+    private val key = authority.storageKey()
+
+    @Synchronized
+    fun read(): UpdateTransactionRecord? {
+        val encoded = preferences.getString(key, null) ?: return null
+        val decoded = try {
+            json.decodeFromString(UpdateTransactionRecord.serializer(), encoded)
+        } catch (_: Exception) {
+            preferences.edit().remove(key).apply()
+            return null
+        }
+        if (!authority.matches(decoded)) {
+            preferences.edit().remove(key).apply()
+            return null
+        }
+        return decoded
+    }
+
+    @Synchronized
+    fun write(record: UpdateTransactionRecord) {
+        require(authority.matches(record)) { "update transaction authority mismatch" }
+        preferences.edit()
+            .putString(key, json.encodeToString(UpdateTransactionRecord.serializer(), record))
+            .apply()
+    }
+
+    @Synchronized
+    fun clear() {
+        preferences.edit().remove(key).apply()
+    }
+}
+
+internal fun normalizedLanguageTag(languageTag: String?): String? {
+    val value = languageTag?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    if (value.length > 64) return null
+    if (!value.matches(Regex("^[A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*$"))) return null
+    return value
+}
+
+internal fun resolveLanguageTag(
+    requestedLanguageTag: String?,
+    releaseNotes: Map<String, String>?,
+): String? {
+    val entries = releaseNotes.orEmpty().filterValues { it.isNotBlank() }.keys
+    if (entries.isEmpty()) return null
+    val requested = normalizedLanguageTag(requestedLanguageTag)?.lowercase().orEmpty()
+    entries.firstOrNull { it.lowercase() == requested }?.let { return it }
+    val prefix = requested.substringBefore('-').takeIf { it.isNotBlank() }
+    if (prefix != null) {
+        entries.firstOrNull { it.lowercase().substringBefore('-') == prefix }?.let { return it }
+    }
+    return entries.firstOrNull { it.lowercase().substringBefore('-') == "en" }
+        ?: entries.first()
+}
+
+private const val TRANSACTION_SCHEMA_VERSION = 1
+private const val TRANSACTION_PREFERENCES = "hands_update_transactions_v1"

--- a/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
@@ -178,14 +178,15 @@ internal class UpdateTransactionStore(
     @Synchronized
     fun write(record: UpdateTransactionRecord) {
         require(authority.matches(record)) { "update transaction authority mismatch" }
-        preferences.edit()
+        val committed = preferences.edit()
             .putString(key, json.encodeToString(UpdateTransactionRecord.serializer(), record))
-            .apply()
+            .commit()
+        check(committed) { "unable to durably persist update transaction" }
     }
 
     @Synchronized
     fun clear() {
-        preferences.edit().remove(key).apply()
+        preferences.edit().remove(key).commit()
     }
 }
 

--- a/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
@@ -240,6 +240,30 @@ internal fun installerLaunchFailureTransition() = ExactCleanupTransition(
     clearLocalAuthority = false,
 )
 
+internal enum class PreparedDownloadRecoveryAction {
+    NO_MATCH,
+    RECOVER_ONE,
+    KEEP_UNCERTAIN,
+}
+
+internal data class PreparedDownloadRecovery(
+    val action: PreparedDownloadRecoveryAction,
+    val downloadId: Long? = null,
+)
+
+internal fun preparedDownloadRecovery(
+    readable: Boolean,
+    matchingDownloadIds: List<Long>,
+): PreparedDownloadRecovery = when {
+    !readable -> PreparedDownloadRecovery(PreparedDownloadRecoveryAction.KEEP_UNCERTAIN)
+    matchingDownloadIds.isEmpty() -> PreparedDownloadRecovery(PreparedDownloadRecoveryAction.NO_MATCH)
+    matchingDownloadIds.distinct().size == 1 -> PreparedDownloadRecovery(
+        PreparedDownloadRecoveryAction.RECOVER_ONE,
+        matchingDownloadIds.first(),
+    )
+    else -> PreparedDownloadRecovery(PreparedDownloadRecoveryAction.KEEP_UNCERTAIN)
+}
+
 @Serializable
 internal data class UpdateTransactionRecord(
     val schemaVersion: Int = TRANSACTION_SCHEMA_VERSION,
@@ -258,6 +282,7 @@ internal data class UpdateTransactionRecord(
     val assetSha256: String? = null,
     val assetSignature: String? = null,
     val filetype: String? = null,
+    val downloadRequestId: String? = null,
     val downloadId: Long? = null,
     val localFilePath: String? = null,
     val retryable: Boolean = false,

--- a/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsUpdateTransaction.kt
@@ -173,6 +173,22 @@ internal fun performExactCleanup(
     return ExactCleanupResult(downloadAbsent, fileAbsent)
 }
 
+internal data class PendingInstallerTargetIdentity(
+    val versionCode: Long?,
+    val buildId: String?,
+    val sha256: String?,
+    val sizeBytes: Long?,
+    val filetype: String?,
+    val signature: String?,
+) {
+    fun normalized(): PendingInstallerTargetIdentity = copy(
+        buildId = buildId?.trim()?.ifEmpty { null },
+        sha256 = sha256?.trim()?.lowercase()?.ifEmpty { null },
+        filetype = filetype?.trim()?.lowercase()?.ifEmpty { null },
+        signature = signature?.trim()?.ifEmpty { null },
+    )
+}
+
 internal enum class PendingInstallerOfferAction {
     REOPEN_CURRENT,
     REPLACE_CURRENT,
@@ -180,31 +196,49 @@ internal enum class PendingInstallerOfferAction {
 }
 
 internal fun pendingInstallerOfferAction(
-    persistedTargetVersionCode: Long?,
-    offeredTargetVersionCode: Long?,
+    persistedTarget: PendingInstallerTargetIdentity,
+    offeredTarget: PendingInstallerTargetIdentity?,
 ): PendingInstallerOfferAction = when {
-    offeredTargetVersionCode == null -> PendingInstallerOfferAction.WITHDRAW_CURRENT
-    offeredTargetVersionCode == persistedTargetVersionCode ->
+    offeredTarget == null -> PendingInstallerOfferAction.WITHDRAW_CURRENT
+    offeredTarget.normalized() == persistedTarget.normalized() ->
         PendingInstallerOfferAction.REOPEN_CURRENT
     else -> PendingInstallerOfferAction.REPLACE_CURRENT
 }
 
 internal inline fun <T> reconcilePendingInstallerOffer(
-    persistedTargetVersionCode: Long?,
-    offeredTargetVersionCode: Long?,
+    persistedTarget: PendingInstallerTargetIdentity,
+    offeredTarget: PendingInstallerTargetIdentity?,
     reopenCurrent: () -> T,
     replaceCurrent: () -> T,
     withdrawCurrent: () -> T,
 ): T = when (
     pendingInstallerOfferAction(
-        persistedTargetVersionCode = persistedTargetVersionCode,
-        offeredTargetVersionCode = offeredTargetVersionCode,
+        persistedTarget = persistedTarget,
+        offeredTarget = offeredTarget,
     )
 ) {
     PendingInstallerOfferAction.REOPEN_CURRENT -> reopenCurrent()
     PendingInstallerOfferAction.REPLACE_CURRENT -> replaceCurrent()
     PendingInstallerOfferAction.WITHDRAW_CURRENT -> withdrawCurrent()
 }
+
+internal fun shouldCleanupRestartableAuthority(
+    state: HandsUpdateState,
+    downloadId: Long?,
+    localFilePath: String?,
+): Boolean = state in setOf(
+    HandsUpdateState.IDLE,
+    HandsUpdateState.FAILED,
+    HandsUpdateState.STALE,
+    HandsUpdateState.INSTALLED,
+) && (downloadId != null || localFilePath != null)
+
+internal fun installerLaunchFailureTransition() = ExactCleanupTransition(
+    state = HandsUpdateState.READY_TO_INSTALL,
+    errorCode = "installer_open_failed",
+    retryable = true,
+    clearLocalAuthority = false,
+)
 
 @Serializable
 internal data class UpdateTransactionRecord(

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -521,7 +521,6 @@ class UpdateChecker(
             downloadUrl = asset.download_url,
             fileName = fileName,
             title = "${response.app.slug} v${latest.version}",
-            requestId = downloadRequestId,
         )
         val downloading = prepared.copy(
             state = HandsUpdateState.DOWNLOADING,
@@ -578,6 +577,10 @@ class UpdateChecker(
     private fun reconcileTransaction(): HandsUpdateStatus {
         val installed = installedVersionCodeNow()
         val record = transactionStore.read() ?: return idleStatus(installed)
+        if (record.downloadRequestId != null && record.downloadId == null &&
+            record.localFilePath != null) {
+            return reconcilePreparedDownload(record, installed)
+        }
         if (record.state == HandsUpdateState.INSTALLED) return record.status(installed)
         val target = record.targetVersionCode
         if (target != null && installed != null && installed >= target) {
@@ -605,11 +608,6 @@ class UpdateChecker(
                 installed = installed,
             )
         }
-        if (record.downloadRequestId != null && record.downloadId == null &&
-            record.localFilePath != null) {
-            return reconcilePreparedDownload(record, installed)
-        }
-
         return when (record.state) {
             HandsUpdateState.CHECKING -> {
                 if (isExpired(record, CHECK_TIMEOUT_MS)) {
@@ -724,8 +722,7 @@ class UpdateChecker(
         installed: Long?,
     ): HandsUpdateStatus {
         val destination = record.localFilePath?.let(::File) ?: return record.status(installed)
-        val requestId = record.downloadRequestId ?: return record.status(installed)
-        val scan = installer.scanPreparedDownload(requestId, destination)
+        val scan = installer.scanDownloadsForDestination(destination)
         val recovery = preparedDownloadRecovery(scan.readable, scan.matchingDownloadIds)
         return when (recovery.action) {
             PreparedDownloadRecoveryAction.NO_MATCH -> cleanupTransition(
@@ -751,7 +748,7 @@ class UpdateChecker(
                     requestedLanguageTag = recovered.requestedLanguageTag,
                     resolvedLanguageTag = recovered.resolvedLanguageTag,
                 )
-                recovered.status(installed)
+                reconcileTransaction()
             }
             PreparedDownloadRecoveryAction.KEEP_UNCERTAIN -> {
                 val error = if (scan.readable) {

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -204,12 +204,19 @@ class UpdateChecker(
         try {
             installer.installDownloadedApk(requireNotNull(file))
         } catch (_: Exception) {
-            return transition(
-                record,
-                HandsUpdateState.FAILED,
-                errorCode = "installer_open_failed",
-                retryable = true,
-            ).status(installedVersionCodeNow())
+            val failure = installerLaunchFailureTransition()
+            return try {
+                transition(
+                    record,
+                    failure.state,
+                    errorCode = failure.errorCode,
+                    retryable = failure.retryable,
+                    clearLocalAuthority = failure.clearLocalAuthority,
+                ).status(installedVersionCodeNow())
+            } catch (_: Exception) {
+                // The existing READY/OPENED record remains the durable locator.
+                record.status(installedVersionCodeNow())
+            }
         }
         emit(
             "content_uri_ready",
@@ -251,7 +258,11 @@ class UpdateChecker(
     private suspend fun checkAndInstallUnlocked(languageTag: String?): UpdateCheckResponse {
         val requestedLanguage = normalizedLanguageTag(languageTag)
         var prior = transactionStore.read()
-        if (prior?.errorCode == CLEANUP_FAILED) {
+        if (prior != null && shouldCleanupRestartableAuthority(
+            state = prior.state,
+            downloadId = prior.downloadId,
+            localFilePath = prior.localFilePath,
+        )) {
             requireCleanup(prior)
             prior = transition(
                 prior,
@@ -333,8 +344,8 @@ class UpdateChecker(
                 HandsUpdateState.READY_TO_INSTALL,
                 HandsUpdateState.INSTALLER_OPENED,
                 -> reconcilePendingInstallerOffer(
-                    persistedTargetVersionCode = current.targetVersionCode,
-                    offeredTargetVersionCode = null,
+                    persistedTarget = current.pendingInstallerIdentity(),
+                    offeredTarget = null,
                     reopenCurrent = { error("withdrawn offer cannot reopen current target") },
                     replaceCurrent = { error("withdrawn offer cannot replace current target") },
                     withdrawCurrent = {
@@ -381,8 +392,15 @@ class UpdateChecker(
         val existing = transactionStore.read()
         if (existing != null) {
             reconcilePendingInstallerOffer(
-                persistedTargetVersionCode = existing.targetVersionCode,
-                offeredTargetVersionCode = latest.version_code,
+                persistedTarget = existing.pendingInstallerIdentity(),
+                offeredTarget = PendingInstallerTargetIdentity(
+                    versionCode = latest.version_code,
+                    buildId = latest.build_id,
+                    sha256 = asset.sha256 ?: response.patch?.target_sha256,
+                    sizeBytes = asset.size_bytes,
+                    filetype = asset.filetype,
+                    signature = asset.signature,
+                ),
                 reopenCurrent = {
                     when (reconcileTransaction().state) {
                         HandsUpdateState.READY_TO_INSTALL,
@@ -629,6 +647,8 @@ class UpdateChecker(
             DownloadState.PENDING,
             DownloadState.RUNNING,
             DownloadState.PAUSED,
+            DownloadState.READ_UNAVAILABLE,
+            DownloadState.UNKNOWN,
             -> record.status(installed)
 
             DownloadState.SUCCESSFUL -> {
@@ -692,6 +712,15 @@ class UpdateChecker(
         filetype = asset.filetype,
         requestedLanguageTag = requestedLanguageTag,
         resolvedLanguageTag = resolvedLanguageTag,
+    )
+
+    private fun UpdateTransactionRecord.pendingInstallerIdentity() = PendingInstallerTargetIdentity(
+        versionCode = targetVersionCode,
+        buildId = targetBuildId,
+        sha256 = assetSha256,
+        sizeBytes = assetSizeBytes,
+        filetype = filetype,
+        signature = assetSignature,
     )
 
     private fun newRecord(

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -258,6 +258,15 @@ class UpdateChecker(
     private suspend fun checkAndInstallUnlocked(languageTag: String?): UpdateCheckResponse {
         val requestedLanguage = normalizedLanguageTag(languageTag)
         var prior = transactionStore.read()
+        if (prior?.downloadRequestId != null && prior.downloadId == null &&
+            prior.localFilePath != null) {
+            val recovered = reconcileTransaction()
+            prior = transactionStore.read()
+            if (recovered.state == HandsUpdateState.CHECKING &&
+                prior?.downloadRequestId != null && prior.downloadId == null) {
+                throw IllegalStateException("prepared download authority is not yet recoverable")
+            }
+        }
         if (prior != null && shouldCleanupRestartableAuthority(
             state = prior.state,
             downloadId = prior.downloadId,
@@ -324,7 +333,8 @@ class UpdateChecker(
                 installUpdate(response, requestedLanguage, resolvedLanguage)
             } catch (exception: Exception) {
                 transactionStore.read()?.takeIf {
-                    it.state == HandsUpdateState.CHECKING || it.state == HandsUpdateState.PATCHING
+                    (it.state == HandsUpdateState.CHECKING || it.state == HandsUpdateState.PATCHING) &&
+                        it.downloadRequestId == null
                 }?.let {
                     transition(it, HandsUpdateState.FAILED, "update_start_failed", true)
                 }
@@ -497,15 +507,25 @@ class UpdateChecker(
             )
         }
 
+        val downloadRequestId = java.util.UUID.randomUUID().toString()
+        val fileName = "hands-update-$downloadRequestId.apk"
+        val plannedDestination = installer.downloadDestination(fileName)
+        val prepared = baseRecord.copy(
+            state = HandsUpdateState.CHECKING,
+            downloadRequestId = downloadRequestId,
+            localFilePath = plannedDestination.absolutePath,
+            updatedAt = System.currentTimeMillis(),
+        )
+        transactionStore.write(prepared)
         val enqueued = installer.enqueueDownload(
             downloadUrl = asset.download_url,
-            fileName = "quiver-${appSlug}-${latest.version_code}.apk",
+            fileName = fileName,
             title = "${response.app.slug} v${latest.version}",
+            requestId = downloadRequestId,
         )
-        val downloading = baseRecord.copy(
+        val downloading = prepared.copy(
             state = HandsUpdateState.DOWNLOADING,
             downloadId = enqueued.id,
-            localFilePath = enqueued.destination.absolutePath,
             updatedAt = System.currentTimeMillis(),
         )
         try {
@@ -584,6 +604,10 @@ class UpdateChecker(
                 retryable = true,
                 installed = installed,
             )
+        }
+        if (record.downloadRequestId != null && record.downloadId == null &&
+            record.localFilePath != null) {
+            return reconcilePreparedDownload(record, installed)
         }
 
         return when (record.state) {
@@ -695,6 +719,56 @@ class UpdateChecker(
         }
     }
 
+    private fun reconcilePreparedDownload(
+        record: UpdateTransactionRecord,
+        installed: Long?,
+    ): HandsUpdateStatus {
+        val destination = record.localFilePath?.let(::File) ?: return record.status(installed)
+        val requestId = record.downloadRequestId ?: return record.status(installed)
+        val scan = installer.scanPreparedDownload(requestId, destination)
+        val recovery = preparedDownloadRecovery(scan.readable, scan.matchingDownloadIds)
+        return when (recovery.action) {
+            PreparedDownloadRecoveryAction.NO_MATCH -> cleanupTransition(
+                record,
+                HandsUpdateState.STALE,
+                errorCode = "download_not_enqueued",
+                retryable = true,
+                installed = installed,
+            )
+            PreparedDownloadRecoveryAction.RECOVER_ONE -> {
+                val recovered = record.copy(
+                    state = HandsUpdateState.DOWNLOADING,
+                    downloadId = requireNotNull(recovery.downloadId),
+                    errorCode = null,
+                    retryable = false,
+                    updatedAt = System.currentTimeMillis(),
+                )
+                transactionStore.write(recovered)
+                emit(
+                    "download_authority_recovered",
+                    recovered.state,
+                    recovered.targetVersionCode,
+                    requestedLanguageTag = recovered.requestedLanguageTag,
+                    resolvedLanguageTag = recovered.resolvedLanguageTag,
+                )
+                recovered.status(installed)
+            }
+            PreparedDownloadRecoveryAction.KEEP_UNCERTAIN -> {
+                val error = if (scan.readable) {
+                    "download_recovery_ambiguous"
+                } else {
+                    "download_recovery_unavailable"
+                }
+                val uncertain = if (record.errorCode == error && record.retryable) record else record.copy(
+                    errorCode = error,
+                    retryable = true,
+                    updatedAt = System.currentTimeMillis(),
+                ).also(transactionStore::write)
+                uncertain.status(installed)
+            }
+        }
+    }
+
     private fun recordForOffer(
         latest: LatestUpdate,
         asset: UpdateAsset,
@@ -763,6 +837,7 @@ class UpdateChecker(
     ): UpdateTransactionRecord {
         val next = record.copy(
             state = state,
+            downloadRequestId = if (clearLocalAuthority) null else record.downloadRequestId,
             downloadId = if (clearLocalAuthority) null else record.downloadId,
             localFilePath = if (clearLocalAuthority) null else record.localFilePath,
             errorCode = errorCode,

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.security.MessageDigest
@@ -127,7 +126,9 @@ class UpdateChecker(
         platform = platform,
         arch = arch,
     )
-    private val commandMutex = commandMutexes.computeIfAbsent(authority.storageKey()) { Mutex() }
+    private val commandGate = AuthorityTransactionGate(
+        commandMutexes.computeIfAbsent(authority.storageKey()) { Mutex() }
+    )
     private val transactionStore = UpdateTransactionStore(context, authority)
     private val effectiveDeltaUpdater: DeltaUpdater by lazy {
         deltaUpdater ?: DeltaUpdater(
@@ -143,24 +144,21 @@ class UpdateChecker(
     }
 
     /** Reconcile the persisted transaction with PackageManager, DownloadManager and disk. */
-    suspend fun status(): HandsUpdateStatus = withContext(Dispatchers.IO) {
-        reconcileTransaction()
+    suspend fun status(): HandsUpdateStatus = commandGate.run {
+        withContext(Dispatchers.IO) { reconcileTransaction() }
     }
 
     /**
      * Idempotent install command for host UIs.
      *
-     * A verified local APK is reopened, an active patch/download is left alone,
-     * and only idle/failed/stale/installed transactions start a new check.
+     * An active patch/download is left alone. A verified local APK is first
+     * reconciled against a fresh authoritative offer: only the same target is
+     * reopened, while a withdrawn or changed target is cleaned up fail-closed.
      */
     suspend fun install(languageTag: String? = this.languageTag): HandsUpdateStatus {
-        return commandMutex.withLock {
+        return commandGate.run {
             val current = withContext(Dispatchers.IO) { reconcileTransaction() }
             when (current.state) {
-                HandsUpdateState.READY_TO_INSTALL,
-                HandsUpdateState.INSTALLER_OPENED,
-                -> withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
-
                 HandsUpdateState.CHECKING,
                 HandsUpdateState.PATCHING,
                 HandsUpdateState.DOWNLOADING,
@@ -179,7 +177,7 @@ class UpdateChecker(
     }
 
     /** Reopen the same verified APK without checking or downloading again. */
-    suspend fun reopenPendingInstaller(): HandsUpdateStatus = commandMutex.withLock {
+    suspend fun reopenPendingInstaller(): HandsUpdateStatus = commandGate.run {
         withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
     }
 
@@ -195,33 +193,46 @@ class UpdateChecker(
         val file = record.localFilePath?.let(::File)
         val validationError = validateLocalApk(record, file)
         if (validationError != null) {
-            cleanup(record)
-            return transition(
+            return cleanupTransition(
                 record,
                 HandsUpdateState.STALE,
                 errorCode = validationError,
                 retryable = true,
-                clearLocalAuthority = true,
-            ).status(installedVersionCodeNow())
-        }
-        return try {
-            installer.installDownloadedApk(requireNotNull(file))
-            emit(
-                "content_uri_ready",
-                HandsUpdateState.READY_TO_INSTALL,
-                record.targetVersionCode,
-                requestedLanguageTag = record.requestedLanguageTag,
-                resolvedLanguageTag = record.resolvedLanguageTag,
+                installed = installedVersionCodeNow(),
             )
-            transition(record, HandsUpdateState.INSTALLER_OPENED)
-                .status(installedVersionCodeNow())
+        }
+        try {
+            installer.installDownloadedApk(requireNotNull(file))
         } catch (_: Exception) {
-            transition(
+            return transition(
                 record,
                 HandsUpdateState.FAILED,
                 errorCode = "installer_open_failed",
                 retryable = true,
             ).status(installedVersionCodeNow())
+        }
+        emit(
+            "content_uri_ready",
+            HandsUpdateState.READY_TO_INSTALL,
+            record.targetVersionCode,
+            requestedLanguageTag = record.requestedLanguageTag,
+            resolvedLanguageTag = record.resolvedLanguageTag,
+        )
+        return try {
+            transition(record, HandsUpdateState.INSTALLER_OPENED)
+                .status(installedVersionCodeNow())
+        } catch (_: Exception) {
+            // The external installer is already open. Preserve the last
+            // durable READY/OPENED authority instead of inventing a redownload.
+            emit(
+                "transaction_persist_failed",
+                record.state,
+                record.targetVersionCode,
+                errorCode = "opened_persist_failed",
+                requestedLanguageTag = record.requestedLanguageTag,
+                resolvedLanguageTag = record.resolvedLanguageTag,
+            )
+            record.status(installedVersionCodeNow())
         }
     }
 
@@ -235,11 +246,20 @@ class UpdateChecker(
      *         caller can display a "you are up to date" message.
      */
     suspend fun checkAndInstall(languageTag: String? = this.languageTag): UpdateCheckResponse =
-        commandMutex.withLock { checkAndInstallUnlocked(languageTag) }
+        commandGate.run { checkAndInstallUnlocked(languageTag) }
 
     private suspend fun checkAndInstallUnlocked(languageTag: String?): UpdateCheckResponse {
         val requestedLanguage = normalizedLanguageTag(languageTag)
-        val prior = transactionStore.read()
+        var prior = transactionStore.read()
+        if (prior?.errorCode == CLEANUP_FAILED) {
+            requireCleanup(prior)
+            prior = transition(
+                prior,
+                HandsUpdateState.STALE,
+                retryable = true,
+                clearLocalAuthority = true,
+            )
+        }
         if (prior == null || prior.state in RESTARTABLE_STATES) {
             transactionStore.write(
                 newRecord(
@@ -287,7 +307,8 @@ class UpdateChecker(
             requestedLanguageTag = requestedLanguage,
             resolvedLanguageTag = resolvedLanguage,
         )
-        if (response.requireUpdate() != null) {
+        val offeredUpdate = response.requireUpdate()
+        if (offeredUpdate != null) {
             try {
                 installUpdate(response, requestedLanguage, resolvedLanguage)
             } catch (exception: Exception) {
@@ -306,8 +327,30 @@ class UpdateChecker(
                 )
                 throw exception
             }
-        } else if (transactionStore.read()?.state == HandsUpdateState.CHECKING) {
-            transactionStore.clear()
+        } else {
+            val current = transactionStore.read()
+            when (current?.state) {
+                HandsUpdateState.READY_TO_INSTALL,
+                HandsUpdateState.INSTALLER_OPENED,
+                -> reconcilePendingInstallerOffer(
+                    persistedTargetVersionCode = current.targetVersionCode,
+                    offeredTargetVersionCode = null,
+                    reopenCurrent = { error("withdrawn offer cannot reopen current target") },
+                    replaceCurrent = { error("withdrawn offer cannot replace current target") },
+                    withdrawCurrent = {
+                        cleanupTransition(
+                            current,
+                            HandsUpdateState.STALE,
+                            errorCode = "offer_withdrawn",
+                            retryable = true,
+                            installed = installedVersionCodeNow(),
+                        )
+                    },
+                )
+
+                HandsUpdateState.CHECKING -> transactionStore.clear()
+                else -> Unit
+            }
         }
         return response
     }
@@ -336,29 +379,39 @@ class UpdateChecker(
     ) {
         val (latest, asset) = response.requireUpdate() ?: return
         val existing = transactionStore.read()
-        if (existing?.targetVersionCode == latest.version_code) {
-            when (reconcileTransaction().state) {
-                HandsUpdateState.READY_TO_INSTALL,
-                HandsUpdateState.INSTALLER_OPENED,
-                -> {
-                    withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
-                    return
-                }
+        if (existing != null) {
+            reconcilePendingInstallerOffer(
+                persistedTargetVersionCode = existing.targetVersionCode,
+                offeredTargetVersionCode = latest.version_code,
+                reopenCurrent = {
+                    when (reconcileTransaction().state) {
+                        HandsUpdateState.READY_TO_INSTALL,
+                        HandsUpdateState.INSTALLER_OPENED,
+                        -> {
+                            withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
+                            return
+                        }
 
-                HandsUpdateState.PATCHING,
-                HandsUpdateState.DOWNLOADING,
-                -> return
+                        HandsUpdateState.PATCHING,
+                        HandsUpdateState.DOWNLOADING,
+                        -> return
 
-                else -> cleanup(existing)
-            }
-        } else if (existing != null && existing.state != HandsUpdateState.CHECKING) {
-            cleanup(existing)
-            transition(
-                existing,
-                HandsUpdateState.STALE,
-                errorCode = "target_changed",
-                retryable = true,
-                clearLocalAuthority = true,
+                        else -> requireCleanup(existing)
+                    }
+                },
+                replaceCurrent = {
+                    if (existing.state != HandsUpdateState.CHECKING) {
+                        requireCleanup(existing)
+                        transition(
+                            existing,
+                            HandsUpdateState.STALE,
+                            errorCode = "target_changed",
+                            retryable = true,
+                            clearLocalAuthority = true,
+                        )
+                    }
+                },
+                withdrawCurrent = { error("installUpdate requires an offered target") },
             )
         }
 
@@ -384,21 +437,37 @@ class UpdateChecker(
                 requestedLanguageTag = requestedLanguageTag,
                 resolvedLanguageTag = resolvedLanguageTag,
             )
+            var durableReady: UpdateTransactionRecord? = null
             val applied = withContext(Dispatchers.IO) {
                 effectiveDeltaUpdater.tryApplyAndInstall(
                     patch,
                     asset,
                     latest,
                     appSlug,
-                ) { apk, sha256 ->
-                    val opened = baseRecord.copy(
-                        state = HandsUpdateState.INSTALLER_OPENED,
-                        assetSha256 = sha256,
-                        localFilePath = apk.absolutePath,
-                        updatedAt = System.currentTimeMillis(),
-                    )
-                    transactionStore.write(opened)
-                }
+                    persistReadyToInstall = { apk, sha256 ->
+                        val ready = baseRecord.copy(
+                            state = HandsUpdateState.READY_TO_INSTALL,
+                            assetSha256 = sha256,
+                            localFilePath = apk.absolutePath,
+                            updatedAt = System.currentTimeMillis(),
+                        )
+                        transactionStore.write(ready)
+                        durableReady = ready
+                        emit(
+                            "state_changed",
+                            HandsUpdateState.READY_TO_INSTALL,
+                            ready.targetVersionCode,
+                            requestedLanguageTag = ready.requestedLanguageTag,
+                            resolvedLanguageTag = ready.resolvedLanguageTag,
+                        )
+                    },
+                    persistInstallerOpened = {
+                        transition(
+                            requireNotNull(durableReady) { "READY authority missing" },
+                            HandsUpdateState.INSTALLER_OPENED,
+                        )
+                    },
+                )
             }
             if (applied) return
             emit(
@@ -424,11 +493,21 @@ class UpdateChecker(
         try {
             transactionStore.write(downloading)
         } catch (exception: Exception) {
-            installer.removeDownload(enqueued.id)
-            try {
-                if (enqueued.destination.exists()) enqueued.destination.delete()
-            } catch (_: Exception) {
-                // DownloadManager removal remains the primary cleanup path.
+            val cleanup = cleanup(downloading)
+            if (!cleanup.succeeded) {
+                try {
+                    transactionStore.write(
+                        downloading.copy(
+                            state = HandsUpdateState.FAILED,
+                            errorCode = CLEANUP_FAILED,
+                            retryable = true,
+                            updatedAt = System.currentTimeMillis(),
+                        )
+                    )
+                } catch (_: Exception) {
+                    // Storage is unavailable. We already attempted exact DM
+                    // removal and file deletion before allowing this to escape.
+                }
             }
             throw exception
         }
@@ -441,9 +520,11 @@ class UpdateChecker(
         )
         val receiver = installer.createDownloadCompletionReceiver(enqueued.id) {
             scope.launch {
-                val completed = status()
-                if (completed.state == HandsUpdateState.READY_TO_INSTALL) {
-                    reopenPendingInstaller()
+                commandGate.run {
+                    val completed = withContext(Dispatchers.IO) { reconcileTransaction() }
+                    if (completed.state == HandsUpdateState.READY_TO_INSTALL) {
+                        withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
+                    }
                 }
             }
         }
@@ -462,23 +543,29 @@ class UpdateChecker(
         if (record.state == HandsUpdateState.INSTALLED) return record.status(installed)
         val target = record.targetVersionCode
         if (target != null && installed != null && installed >= target) {
-            cleanup(record)
-            return transition(
+            return cleanupTransition(
                 record,
                 HandsUpdateState.INSTALLED,
                 retryable = false,
-                clearLocalAuthority = true,
-            ).status(installed)
+                installed = installed,
+            )
         }
         if (target != null && installed != null && installed < (record.installedVersionCodeAtStart ?: 0)) {
-            cleanup(record)
-            return transition(
+            return cleanupTransition(
                 record,
                 HandsUpdateState.STALE,
                 errorCode = "installed_version_regressed",
                 retryable = true,
-                clearLocalAuthority = true,
-            ).status(installed)
+                installed = installed,
+            )
+        }
+        if (record.errorCode == CLEANUP_FAILED) {
+            return cleanupTransition(
+                record,
+                HandsUpdateState.STALE,
+                retryable = true,
+                installed = installed,
+            )
         }
 
         return when (record.state) {
@@ -493,14 +580,13 @@ class UpdateChecker(
 
             HandsUpdateState.PATCHING -> {
                 if (isExpired(record, PATCH_TIMEOUT_MS)) {
-                    cleanup(record)
-                    transition(
+                    cleanupTransition(
                         record,
                         HandsUpdateState.STALE,
-                        "patch_interrupted",
-                        true,
-                        clearLocalAuthority = true,
-                    ).status(installed)
+                        errorCode = "patch_interrupted",
+                        retryable = true,
+                        installed = installed,
+                    )
                 } else {
                     record.status(installed)
                 }
@@ -514,14 +600,13 @@ class UpdateChecker(
                 if (error == null) {
                     record.status(installed)
                 } else {
-                    cleanup(record)
-                    transition(
+                    cleanupTransition(
                         record,
                         HandsUpdateState.STALE,
-                        error,
-                        true,
-                        clearLocalAuthority = true,
-                    ).status(installed)
+                        errorCode = error,
+                        retryable = true,
+                        installed = installed,
+                    )
                 }
             }
 
@@ -533,13 +618,13 @@ class UpdateChecker(
         record: UpdateTransactionRecord,
         installed: Long?,
     ): HandsUpdateStatus {
-        val downloadId = record.downloadId ?: return transition(
+        val downloadId = record.downloadId ?: return cleanupTransition(
             record,
             HandsUpdateState.STALE,
-            "download_id_missing",
-            true,
-            clearLocalAuthority = true,
-        ).status(installed)
+            errorCode = "download_id_missing",
+            retryable = true,
+            installed = installed,
+        )
         return when (installer.queryDownload(downloadId).state) {
             DownloadState.PENDING,
             DownloadState.RUNNING,
@@ -558,37 +643,34 @@ class UpdateChecker(
                     )
                     transition(record, HandsUpdateState.READY_TO_INSTALL).status(installed)
                 } else {
-                    cleanup(record)
-                    transition(
+                    cleanupTransition(
                         record,
                         HandsUpdateState.STALE,
-                        error,
-                        true,
-                        clearLocalAuthority = true,
-                    ).status(installed)
+                        errorCode = error,
+                        retryable = true,
+                        installed = installed,
+                    )
                 }
             }
 
             DownloadState.FAILED -> {
-                cleanup(record)
-                transition(
+                cleanupTransition(
                     record,
                     HandsUpdateState.FAILED,
-                    "download_failed",
-                    true,
-                    clearLocalAuthority = true,
-                ).status(installed)
+                    errorCode = "download_failed",
+                    retryable = true,
+                    installed = installed,
+                )
             }
 
             DownloadState.MISSING -> {
-                cleanup(record)
-                transition(
+                cleanupTransition(
                     record,
                     HandsUpdateState.STALE,
-                    "download_missing",
-                    true,
-                    clearLocalAuthority = true,
-                ).status(installed)
+                    errorCode = "download_missing",
+                    retryable = true,
+                    installed = installed,
+                )
             }
         }
     }
@@ -672,23 +754,60 @@ class UpdateChecker(
         return next
     }
 
-    private fun cleanup(record: UpdateTransactionRecord) {
-        record.downloadId?.let(installer::removeDownload)
-        val file = record.localFilePath?.let(::File)
-        if (file != null && isSdkOwnedFile(file)) {
-            try {
-                if (file.exists()) file.delete()
-            } catch (_: Exception) {
-                // Best-effort cleanup. Authority is still cleared fail-closed.
-            }
-        }
+    private fun cleanup(record: UpdateTransactionRecord): ExactCleanupResult {
+        val result = performExactCleanup(
+            downloadId = record.downloadId,
+            localFilePath = record.localFilePath,
+            removeDownload = installer::removeDownload,
+            isOwnedFile = { isSdkOwnedFile(File(it)) },
+            fileExists = { File(it).exists() },
+            deleteFile = { File(it).delete() },
+        )
         emit(
-            "cleanup",
+            if (result.succeeded) "cleanup" else CLEANUP_FAILED,
             record.state,
             record.targetVersionCode,
+            errorCode = if (result.succeeded) null else CLEANUP_FAILED,
             requestedLanguageTag = record.requestedLanguageTag,
             resolvedLanguageTag = record.resolvedLanguageTag,
         )
+        return result
+    }
+
+    private fun cleanupTransition(
+        record: UpdateTransactionRecord,
+        successState: HandsUpdateState,
+        errorCode: String? = null,
+        retryable: Boolean,
+        installed: Long?,
+    ): HandsUpdateStatus {
+        val cleanup = cleanup(record)
+        val outcome = exactCleanupTransition(
+            cleanup = cleanup,
+            successState = successState,
+            successErrorCode = errorCode,
+            successRetryable = retryable,
+        )
+        val next = transition(
+            record,
+            outcome.state,
+            errorCode = outcome.errorCode,
+            retryable = outcome.retryable,
+            clearLocalAuthority = outcome.clearLocalAuthority,
+        )
+        return next.status(installed)
+    }
+
+    private fun requireCleanup(record: UpdateTransactionRecord) {
+        if (cleanup(record).succeeded) return
+        transition(
+            record,
+            HandsUpdateState.FAILED,
+            errorCode = CLEANUP_FAILED,
+            retryable = true,
+            clearLocalAuthority = false,
+        )
+        throw IllegalStateException("unable to remove previous SDK update authority")
     }
 
     private fun validateLocalApk(record: UpdateTransactionRecord, file: File?): String? {
@@ -852,5 +971,6 @@ class UpdateChecker(
         )
         const val CHECK_TIMEOUT_MS = 2 * 60 * 1000L
         const val PATCH_TIMEOUT_MS = 30 * 60 * 1000L
+        const val CLEANUP_FAILED = "cleanup_failed"
     }
 }

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -4,16 +4,27 @@ import android.app.DownloadManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.Build
 import build.hands.update.installer.ApkInstaller
+import build.hands.update.installer.DownloadState
 import build.hands.update.internal.DeltaUpdater
 import build.hands.update.internal.HandsClient
+import build.hands.update.models.LatestUpdate
+import build.hands.update.models.Patch
+import build.hands.update.models.UpdateAsset
 import build.hands.update.models.UpdateCheckResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 
 internal const val DOWNLOAD_COMPLETED_SENDER_PERMISSION =
     "android.permission.SEND_DOWNLOAD_COMPLETED_INTENTS"
@@ -84,8 +95,8 @@ internal fun registerDownloadReceiverForSdk(
  *  2. The server resolves scope/rollout, compares version_code, and picks
  *     one APK asset for this device.
  *  3. If `update_available` is true, queues a download via DownloadManager.
- *  4. Registers a [BroadcastReceiver] that fires ACTION_INSTALL_PACKAGE
- *     when the download finishes.
+ *  4. Persists the transaction and registers a [BroadcastReceiver] that
+ *     reconciles the completed download before opening the package installer.
  *  5. If no update is available, returns silently.
  */
 class UpdateChecker(
@@ -102,39 +113,184 @@ class UpdateChecker(
     private val deviceId: String? = null,
     /** Master switch for client-side delta (incremental) update apply. */
     private val deltaApplyEnabled: Boolean = true,
-    private val deltaUpdater: DeltaUpdater = DeltaUpdater(
-        context = context,
-        installedVersionCode = installedVersionCode,
-        httpClient = HandsClient.defaultClient(),
-        installer = installer,
-        deltaApplyEnabled = deltaApplyEnabled,
-    ),
+    private val languageTag: String? = null,
+    private val eventListener: HandsUpdateEventListener = HandsUpdateEventListener {},
+    private val deltaUpdater: DeltaUpdater? = null,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val authority = UpdateAuthority(
+        packageName = context.packageName,
+        baseUrl = baseUrl,
+        appSlug = appSlug,
+        channel = channel,
+        productType = productType,
+        platform = platform,
+        arch = arch,
+    )
+    private val commandMutex = commandMutexes.computeIfAbsent(authority.storageKey()) { Mutex() }
+    private val transactionStore = UpdateTransactionStore(context, authority)
+    private val effectiveDeltaUpdater: DeltaUpdater by lazy {
+        deltaUpdater ?: DeltaUpdater(
+            context = context,
+            installedVersionCode = installedVersionCode,
+            httpClient = HandsClient.defaultClient(),
+            installer = installer,
+            deltaApplyEnabled = deltaApplyEnabled,
+            eventSink = { name, errorCode ->
+                emit(name, HandsUpdateState.PATCHING, errorCode = errorCode)
+            },
+        )
+    }
+
+    /** Reconcile the persisted transaction with PackageManager, DownloadManager and disk. */
+    suspend fun status(): HandsUpdateStatus = withContext(Dispatchers.IO) {
+        reconcileTransaction()
+    }
+
+    /**
+     * Idempotent install command for host UIs.
+     *
+     * A verified local APK is reopened, an active patch/download is left alone,
+     * and only idle/failed/stale/installed transactions start a new check.
+     */
+    suspend fun install(languageTag: String? = this.languageTag): HandsUpdateStatus {
+        return commandMutex.withLock {
+            val current = withContext(Dispatchers.IO) { reconcileTransaction() }
+            when (current.state) {
+                HandsUpdateState.READY_TO_INSTALL,
+                HandsUpdateState.INSTALLER_OPENED,
+                -> withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
+
+                HandsUpdateState.CHECKING,
+                HandsUpdateState.PATCHING,
+                HandsUpdateState.DOWNLOADING,
+                -> current
+
+                else -> {
+                    try {
+                        checkAndInstallUnlocked(languageTag)
+                    } catch (_: Exception) {
+                        // The command records the precise failure boundary.
+                    }
+                    withContext(Dispatchers.IO) { reconcileTransaction() }
+                }
+            }
+        }
+    }
+
+    /** Reopen the same verified APK without checking or downloading again. */
+    suspend fun reopenPendingInstaller(): HandsUpdateStatus = commandMutex.withLock {
+        withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
+    }
+
+    private fun reopenPendingInstallerUnlocked(): HandsUpdateStatus {
+        val current = reconcileTransaction()
+        if (
+            current.state != HandsUpdateState.READY_TO_INSTALL &&
+            current.state != HandsUpdateState.INSTALLER_OPENED
+        ) {
+            return current
+        }
+        val record = transactionStore.read() ?: return idleStatus()
+        val file = record.localFilePath?.let(::File)
+        val validationError = validateLocalApk(record, file)
+        if (validationError != null) {
+            cleanup(record)
+            return transition(
+                record,
+                HandsUpdateState.STALE,
+                errorCode = validationError,
+                retryable = true,
+                clearLocalAuthority = true,
+            ).status(installedVersionCodeNow())
+        }
+        return try {
+            installer.installDownloadedApk(requireNotNull(file))
+            emit(
+                "content_uri_ready",
+                HandsUpdateState.READY_TO_INSTALL,
+                record.targetVersionCode,
+                requestedLanguageTag = record.requestedLanguageTag,
+                resolvedLanguageTag = record.resolvedLanguageTag,
+            )
+            transition(record, HandsUpdateState.INSTALLER_OPENED)
+                .status(installedVersionCodeNow())
+        } catch (_: Exception) {
+            transition(
+                record,
+                HandsUpdateState.FAILED,
+                errorCode = "installer_open_failed",
+                retryable = true,
+            ).status(installedVersionCodeNow())
+        }
+    }
 
     /**
      * Check for an update; if newer, download and trigger install.
      *
-     * The call to [ApkInstaller.downloadAndInstall] registers a sticky
-     * BroadcastReceiver scoped to [context] (typically Application).
-     * For shorter-lived receivers, use [checkForUpdate] and manage
-     * installation yourself.
+     * Full downloads are persisted and reconciled through DownloadManager,
+     * PackageManager, and the exact SDK-owned file before installation.
      *
      * @return UpdateCheckResponse (always, even when no update) so the
      *         caller can display a "you are up to date" message.
      */
-    suspend fun checkAndInstall(): UpdateCheckResponse {
-        val response = client.checkForUpdate(
-            slug = appSlug,
-            channel = channel,
-            currentVersionCode = installedVersionCode,
-            productType = productType,
-            platform = platform,
-            arch = arch,
-            deviceId = deviceId ?: HandsDeviceId.get(context),
+    suspend fun checkAndInstall(languageTag: String? = this.languageTag): UpdateCheckResponse =
+        commandMutex.withLock { checkAndInstallUnlocked(languageTag) }
+
+    private suspend fun checkAndInstallUnlocked(languageTag: String?): UpdateCheckResponse {
+        val requestedLanguage = normalizedLanguageTag(languageTag)
+        val prior = transactionStore.read()
+        if (prior == null || prior.state in RESTARTABLE_STATES) {
+            transactionStore.write(
+                newRecord(
+                    state = HandsUpdateState.CHECKING,
+                    requestedLanguageTag = requestedLanguage,
+                )
+            )
+        }
+        emit(
+            "check_started",
+            HandsUpdateState.CHECKING,
+            requestedLanguageTag = requestedLanguage,
+        )
+        val response = try {
+            client.checkForUpdate(
+                slug = appSlug,
+                channel = channel,
+                currentVersionCode = installedVersionCode,
+                productType = productType,
+                platform = platform,
+                arch = arch,
+                deviceId = deviceId ?: HandsDeviceId.get(context),
+                languageTag = requestedLanguage,
+            )
+        } catch (exception: Exception) {
+            transactionStore.read()?.takeIf { it.state == HandsUpdateState.CHECKING }?.let {
+                transition(it, HandsUpdateState.FAILED, "check_failed", true)
+            }
+            emit(
+                "check_failed",
+                HandsUpdateState.FAILED,
+                errorCode = "check_failed",
+                requestedLanguageTag = requestedLanguage,
+            )
+            throw exception
+        }
+        val resolvedLanguage = resolveLanguageTag(
+            requestedLanguage,
+            response.latest?.release_notes,
+        )
+        emit(
+            "check_completed",
+            HandsUpdateState.CHECKING,
+            targetVersionCode = response.latest?.version_code,
+            requestedLanguageTag = requestedLanguage,
+            resolvedLanguageTag = resolvedLanguage,
         )
         if (response.requireUpdate() != null) {
-            installUpdate(response)
+            installUpdate(response, requestedLanguage, resolvedLanguage)
+        } else if (transactionStore.read()?.state == HandsUpdateState.CHECKING) {
+            transactionStore.clear()
         }
         return response
     }
@@ -156,8 +312,46 @@ class UpdateChecker(
         }
     }
 
-    private suspend fun installUpdate(response: UpdateCheckResponse) {
+    private suspend fun installUpdate(
+        response: UpdateCheckResponse,
+        requestedLanguageTag: String?,
+        resolvedLanguageTag: String?,
+    ) {
         val (latest, asset) = response.requireUpdate() ?: return
+        val existing = transactionStore.read()
+        if (existing?.targetVersionCode == latest.version_code) {
+            when (reconcileTransaction().state) {
+                HandsUpdateState.READY_TO_INSTALL,
+                HandsUpdateState.INSTALLER_OPENED,
+                -> {
+                    withContext(Dispatchers.IO) { reopenPendingInstallerUnlocked() }
+                    return
+                }
+
+                HandsUpdateState.PATCHING,
+                HandsUpdateState.DOWNLOADING,
+                -> return
+
+                else -> cleanup(existing)
+            }
+        } else if (existing != null && existing.state != HandsUpdateState.CHECKING) {
+            cleanup(existing)
+            transition(
+                existing,
+                HandsUpdateState.STALE,
+                errorCode = "target_changed",
+                retryable = true,
+                clearLocalAuthority = true,
+            )
+        }
+
+        val baseRecord = recordForOffer(
+            latest = latest,
+            asset = asset,
+            patch = response.patch,
+            requestedLanguageTag = requestedLanguageTag,
+            resolvedLanguageTag = resolvedLanguageTag,
+        )
 
         // Prefer the incremental (delta) path when the server offered a patch.
         // DeltaUpdater does blocking IO + a CPU-heavy patch apply and never
@@ -165,18 +359,67 @@ class UpdateChecker(
         // fall through to the unchanged full-APK download below.
         val patch = response.patch
         if (patch != null) {
+            transactionStore.write(baseRecord.copy(state = HandsUpdateState.PATCHING))
+            emit(
+                "patch_started",
+                HandsUpdateState.PATCHING,
+                latest.version_code,
+                requestedLanguageTag = requestedLanguageTag,
+                resolvedLanguageTag = resolvedLanguageTag,
+            )
             val applied = withContext(Dispatchers.IO) {
-                deltaUpdater.tryApplyAndInstall(patch, asset, latest, appSlug)
+                effectiveDeltaUpdater.tryApplyAndInstall(
+                    patch,
+                    asset,
+                    latest,
+                    appSlug,
+                ) { apk, sha256 ->
+                    val opened = baseRecord.copy(
+                        state = HandsUpdateState.INSTALLER_OPENED,
+                        assetSha256 = sha256,
+                        localFilePath = apk.absolutePath,
+                        updatedAt = System.currentTimeMillis(),
+                    )
+                    transactionStore.write(opened)
+                }
             }
             if (applied) return
+            emit(
+                "full_download_fallback",
+                HandsUpdateState.DOWNLOADING,
+                latest.version_code,
+                requestedLanguageTag = requestedLanguageTag,
+                resolvedLanguageTag = resolvedLanguageTag,
+            )
         }
 
-        val downloadId = installer.downloadAndInstall(
+        val enqueued = installer.enqueueDownload(
             downloadUrl = asset.download_url,
             fileName = "quiver-${appSlug}-${latest.version_code}.apk",
             title = "${response.app.slug} v${latest.version}",
         )
-        val receiver = installer.createInstallReceiver(downloadId)
+        val downloading = baseRecord.copy(
+            state = HandsUpdateState.DOWNLOADING,
+            downloadId = enqueued.id,
+            localFilePath = enqueued.destination.absolutePath,
+            updatedAt = System.currentTimeMillis(),
+        )
+        transactionStore.write(downloading)
+        emit(
+            "full_download_started",
+            HandsUpdateState.DOWNLOADING,
+            latest.version_code,
+            requestedLanguageTag = requestedLanguageTag,
+            resolvedLanguageTag = resolvedLanguageTag,
+        )
+        val receiver = installer.createDownloadCompletionReceiver(enqueued.id) {
+            scope.launch {
+                val completed = status()
+                if (completed.state == HandsUpdateState.READY_TO_INSTALL) {
+                    reopenPendingInstaller()
+                }
+            }
+        }
         // Register on Application context so the receiver survives Activity death.
         if (context is android.app.Application) {
             context.registerDownloadReceiver(
@@ -184,5 +427,403 @@ class UpdateChecker(
                 IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
             )
         }
+    }
+
+    private fun reconcileTransaction(): HandsUpdateStatus {
+        val installed = installedVersionCodeNow()
+        val record = transactionStore.read() ?: return idleStatus(installed)
+        if (record.state == HandsUpdateState.INSTALLED) return record.status(installed)
+        val target = record.targetVersionCode
+        if (target != null && installed != null && installed >= target) {
+            cleanup(record)
+            return transition(
+                record,
+                HandsUpdateState.INSTALLED,
+                retryable = false,
+                clearLocalAuthority = true,
+            ).status(installed)
+        }
+        if (target != null && installed != null && installed < (record.installedVersionCodeAtStart ?: 0)) {
+            cleanup(record)
+            return transition(
+                record,
+                HandsUpdateState.STALE,
+                errorCode = "installed_version_regressed",
+                retryable = true,
+                clearLocalAuthority = true,
+            ).status(installed)
+        }
+
+        return when (record.state) {
+            HandsUpdateState.CHECKING -> {
+                if (isExpired(record, CHECK_TIMEOUT_MS)) {
+                    transition(record, HandsUpdateState.STALE, "check_interrupted", true)
+                        .status(installed)
+                } else {
+                    record.status(installed)
+                }
+            }
+
+            HandsUpdateState.PATCHING -> {
+                if (isExpired(record, PATCH_TIMEOUT_MS)) {
+                    cleanup(record)
+                    transition(
+                        record,
+                        HandsUpdateState.STALE,
+                        "patch_interrupted",
+                        true,
+                        clearLocalAuthority = true,
+                    ).status(installed)
+                } else {
+                    record.status(installed)
+                }
+            }
+
+            HandsUpdateState.DOWNLOADING -> reconcileDownload(record, installed)
+            HandsUpdateState.READY_TO_INSTALL,
+            HandsUpdateState.INSTALLER_OPENED,
+            -> {
+                val error = validateLocalApk(record, record.localFilePath?.let(::File))
+                if (error == null) {
+                    record.status(installed)
+                } else {
+                    cleanup(record)
+                    transition(
+                        record,
+                        HandsUpdateState.STALE,
+                        error,
+                        true,
+                        clearLocalAuthority = true,
+                    ).status(installed)
+                }
+            }
+
+            else -> record.status(installed)
+        }
+    }
+
+    private fun reconcileDownload(
+        record: UpdateTransactionRecord,
+        installed: Long?,
+    ): HandsUpdateStatus {
+        val downloadId = record.downloadId ?: return transition(
+            record,
+            HandsUpdateState.STALE,
+            "download_id_missing",
+            true,
+            clearLocalAuthority = true,
+        ).status(installed)
+        return when (installer.queryDownload(downloadId).state) {
+            DownloadState.PENDING,
+            DownloadState.RUNNING,
+            DownloadState.PAUSED,
+            -> record.status(installed)
+
+            DownloadState.SUCCESSFUL -> {
+                val error = validateLocalApk(record, record.localFilePath?.let(::File))
+                if (error == null) {
+                    emit(
+                        "full_download_completed",
+                        HandsUpdateState.READY_TO_INSTALL,
+                        record.targetVersionCode,
+                        requestedLanguageTag = record.requestedLanguageTag,
+                        resolvedLanguageTag = record.resolvedLanguageTag,
+                    )
+                    transition(record, HandsUpdateState.READY_TO_INSTALL).status(installed)
+                } else {
+                    cleanup(record)
+                    transition(
+                        record,
+                        HandsUpdateState.STALE,
+                        error,
+                        true,
+                        clearLocalAuthority = true,
+                    ).status(installed)
+                }
+            }
+
+            DownloadState.FAILED -> {
+                cleanup(record)
+                transition(
+                    record,
+                    HandsUpdateState.FAILED,
+                    "download_failed",
+                    true,
+                    clearLocalAuthority = true,
+                ).status(installed)
+            }
+
+            DownloadState.MISSING -> {
+                cleanup(record)
+                transition(
+                    record,
+                    HandsUpdateState.STALE,
+                    "download_missing",
+                    true,
+                    clearLocalAuthority = true,
+                ).status(installed)
+            }
+        }
+    }
+
+    private fun recordForOffer(
+        latest: LatestUpdate,
+        asset: UpdateAsset,
+        patch: Patch?,
+        requestedLanguageTag: String?,
+        resolvedLanguageTag: String?,
+    ): UpdateTransactionRecord = newRecord(
+        state = HandsUpdateState.CHECKING,
+        installedVersionCodeAtStart = installedVersionCodeNow() ?: installedVersionCode,
+        targetVersionCode = latest.version_code,
+        targetBuildId = latest.build_id,
+        assetSizeBytes = asset.size_bytes,
+        assetSha256 = asset.sha256 ?: patch?.target_sha256,
+        assetSignature = asset.signature,
+        filetype = asset.filetype,
+        requestedLanguageTag = requestedLanguageTag,
+        resolvedLanguageTag = resolvedLanguageTag,
+    )
+
+    private fun newRecord(
+        state: HandsUpdateState,
+        installedVersionCodeAtStart: Long? = null,
+        targetVersionCode: Long? = null,
+        targetBuildId: String? = null,
+        assetSizeBytes: Long? = null,
+        assetSha256: String? = null,
+        assetSignature: String? = null,
+        filetype: String? = null,
+        requestedLanguageTag: String? = null,
+        resolvedLanguageTag: String? = null,
+    ): UpdateTransactionRecord = UpdateTransactionRecord(
+        packageName = authority.packageName,
+        baseUrl = authority.canonicalBaseUrl,
+        appSlug = authority.appSlug,
+        channel = authority.channel,
+        productType = authority.productType,
+        platform = authority.platform,
+        arch = authority.arch,
+        state = state,
+        installedVersionCodeAtStart = installedVersionCodeAtStart,
+        targetVersionCode = targetVersionCode,
+        targetBuildId = targetBuildId,
+        assetSizeBytes = assetSizeBytes,
+        assetSha256 = assetSha256,
+        assetSignature = assetSignature,
+        filetype = filetype,
+        requestedLanguageTag = requestedLanguageTag,
+        resolvedLanguageTag = resolvedLanguageTag,
+    )
+
+    private fun transition(
+        record: UpdateTransactionRecord,
+        state: HandsUpdateState,
+        errorCode: String? = null,
+        retryable: Boolean = record.retryable,
+        clearLocalAuthority: Boolean = false,
+    ): UpdateTransactionRecord {
+        val next = record.copy(
+            state = state,
+            downloadId = if (clearLocalAuthority) null else record.downloadId,
+            localFilePath = if (clearLocalAuthority) null else record.localFilePath,
+            errorCode = errorCode,
+            retryable = retryable,
+            updatedAt = System.currentTimeMillis(),
+        )
+        transactionStore.write(next)
+        if (record.state != next.state || record.errorCode != next.errorCode) {
+            emit(
+                "state_changed",
+                state,
+                next.targetVersionCode,
+                errorCode,
+                next.requestedLanguageTag,
+                next.resolvedLanguageTag,
+            )
+        }
+        return next
+    }
+
+    private fun cleanup(record: UpdateTransactionRecord) {
+        record.downloadId?.let(installer::removeDownload)
+        val file = record.localFilePath?.let(::File)
+        if (file != null && isSdkOwnedFile(file)) {
+            try {
+                if (file.exists()) file.delete()
+            } catch (_: Exception) {
+                // Best-effort cleanup. Authority is still cleared fail-closed.
+            }
+        }
+        emit(
+            "cleanup",
+            record.state,
+            record.targetVersionCode,
+            requestedLanguageTag = record.requestedLanguageTag,
+            resolvedLanguageTag = record.resolvedLanguageTag,
+        )
+    }
+
+    private fun validateLocalApk(record: UpdateTransactionRecord, file: File?): String? {
+        if (file == null || !isSdkOwnedFile(file) || !file.isFile) return "apk_missing"
+        if (record.filetype != null && record.filetype.lowercase() != "apk") return "filetype_mismatch"
+        if (record.assetSizeBytes != null && file.length() != record.assetSizeBytes) {
+            return "size_mismatch"
+        }
+        val expectedSha = record.assetSha256?.lowercase()
+        if (expectedSha != null && !constantTimeEquals(sha256Hex(file), expectedSha)) {
+            return "sha256_mismatch"
+        }
+        return validatePackageIdentity(file, record.targetVersionCode)
+    }
+
+    private fun isSdkOwnedFile(file: File): Boolean {
+        val candidate = try {
+            file.canonicalFile
+        } catch (_: Exception) {
+            return false
+        }
+        val roots = listOfNotNull(
+            context.cacheDir,
+            context.getExternalFilesDir(android.os.Environment.DIRECTORY_DOWNLOADS),
+        ).mapNotNull {
+            try {
+                it.canonicalFile
+            } catch (_: Exception) {
+                null
+            }
+        }
+        return candidate.name.endsWith(".apk", ignoreCase = true) && roots.any { root ->
+            candidate.path.startsWith(root.path + File.separator)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun validatePackageIdentity(file: File, targetVersionCode: Long?): String? {
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            PackageManager.GET_SIGNATURES
+        }
+        val archive = context.packageManager.getPackageArchiveInfo(file.path, flags)
+            ?: return "invalid_apk"
+        archive.applicationInfo?.apply {
+            sourceDir = file.path
+            publicSourceDir = file.path
+        }
+        if (archive.packageName != context.packageName) return "package_mismatch"
+        val archiveVersion = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            archive.longVersionCode
+        } else {
+            archive.versionCode.toLong()
+        }
+        if (targetVersionCode == null || archiveVersion != targetVersionCode) {
+            return "target_version_mismatch"
+        }
+        val installed = try {
+            context.packageManager.getPackageInfo(context.packageName, flags)
+        } catch (_: Exception) {
+            return "installed_package_missing"
+        }
+        val archiveCertificates = signingCertificates(archive) ?: return "signer_mismatch"
+        val installedCertificates = signingCertificates(installed) ?: return "signer_mismatch"
+        if (archiveCertificates != installedCertificates) {
+            return "signer_mismatch"
+        }
+        return null
+    }
+
+    @Suppress("DEPRECATION")
+    private fun signingCertificates(info: PackageInfo): Set<String>? {
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signingInfo = info.signingInfo ?: return null
+            if (signingInfo.hasMultipleSigners()) {
+                signingInfo.apkContentsSigners
+            } else {
+                signingInfo.signingCertificateHistory
+            }
+        } else {
+            info.signatures
+        }
+        return signatures?.map { bytesToHex(it.toByteArray()) }?.toSet()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun installedVersionCodeNow(): Long? = try {
+        val info = context.packageManager.getPackageInfo(context.packageName, 0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun idleStatus(installed: Long? = installedVersionCodeNow()) = HandsUpdateStatus(
+        state = HandsUpdateState.IDLE,
+        installedVersionCode = installed,
+    )
+
+    private fun isExpired(record: UpdateTransactionRecord, timeoutMs: Long): Boolean =
+        System.currentTimeMillis() - record.updatedAt > timeoutMs
+
+    private fun sha256Hex(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(8192)
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                digest.update(buffer, 0, count)
+            }
+        }
+        return bytesToHex(digest.digest())
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String =
+        bytes.joinToString("") { "%02x".format(it) }
+
+    private fun constantTimeEquals(left: String, right: String): Boolean {
+        if (left.length != right.length) return false
+        var difference = 0
+        left.indices.forEach { difference = difference or (left[it].code xor right[it].code) }
+        return difference == 0
+    }
+
+    private fun emit(
+        name: String,
+        state: HandsUpdateState,
+        targetVersionCode: Long? = null,
+        errorCode: String? = null,
+        requestedLanguageTag: String? = null,
+        resolvedLanguageTag: String? = null,
+    ) {
+        try {
+            eventListener.onEvent(
+                HandsUpdateEvent(
+                    name = name,
+                    state = state,
+                    targetVersionCode = targetVersionCode,
+                    errorCode = errorCode,
+                    requestedLanguageTag = requestedLanguageTag,
+                    resolvedLanguageTag = resolvedLanguageTag,
+                )
+            )
+        } catch (_: Throwable) {
+            // Host diagnostics must never break delivery.
+        }
+    }
+
+    private companion object {
+        val commandMutexes = ConcurrentHashMap<String, Mutex>()
+        val RESTARTABLE_STATES = setOf(
+            HandsUpdateState.IDLE,
+            HandsUpdateState.FAILED,
+            HandsUpdateState.STALE,
+            HandsUpdateState.INSTALLED,
+        )
+        const val CHECK_TIMEOUT_MS = 2 * 60 * 1000L
+        const val PATCH_TIMEOUT_MS = 30 * 60 * 1000L
     }
 }

--- a/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/UpdateChecker.kt
@@ -288,7 +288,24 @@ class UpdateChecker(
             resolvedLanguageTag = resolvedLanguage,
         )
         if (response.requireUpdate() != null) {
-            installUpdate(response, requestedLanguage, resolvedLanguage)
+            try {
+                installUpdate(response, requestedLanguage, resolvedLanguage)
+            } catch (exception: Exception) {
+                transactionStore.read()?.takeIf {
+                    it.state == HandsUpdateState.CHECKING || it.state == HandsUpdateState.PATCHING
+                }?.let {
+                    transition(it, HandsUpdateState.FAILED, "update_start_failed", true)
+                }
+                emit(
+                    "update_start_failed",
+                    HandsUpdateState.FAILED,
+                    targetVersionCode = response.latest?.version_code,
+                    errorCode = "update_start_failed",
+                    requestedLanguageTag = requestedLanguage,
+                    resolvedLanguageTag = resolvedLanguage,
+                )
+                throw exception
+            }
         } else if (transactionStore.read()?.state == HandsUpdateState.CHECKING) {
             transactionStore.clear()
         }
@@ -404,7 +421,17 @@ class UpdateChecker(
             localFilePath = enqueued.destination.absolutePath,
             updatedAt = System.currentTimeMillis(),
         )
-        transactionStore.write(downloading)
+        try {
+            transactionStore.write(downloading)
+        } catch (exception: Exception) {
+            installer.removeDownload(enqueued.id)
+            try {
+                if (enqueued.destination.exists()) enqueued.destination.delete()
+            } catch (_: Exception) {
+                // DownloadManager removal remains the primary cleanup path.
+            }
+            throw exception
+        }
         emit(
             "full_download_started",
             HandsUpdateState.DOWNLOADING,

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -207,12 +207,14 @@ class ApkInstaller(private val context: Context) {
         }
     }
 
-    internal fun removeDownload(downloadId: Long) {
-        val dm = ContextCompat.getSystemService(context, DownloadManager::class.java) ?: return
-        try {
+    internal fun removeDownload(downloadId: Long): Boolean {
+        val dm = ContextCompat.getSystemService(context, DownloadManager::class.java)
+            ?: return queryDownload(downloadId).state == DownloadState.MISSING
+        return try {
             dm.remove(downloadId)
+            queryDownload(downloadId).state == DownloadState.MISSING
         } catch (_: Exception) {
-            // Best-effort cleanup; the app-scoped file is removed separately.
+            false
         }
     }
 

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -19,6 +19,8 @@ internal enum class DownloadState {
     SUCCESSFUL,
     FAILED,
     MISSING,
+    READ_UNAVAILABLE,
+    UNKNOWN,
 }
 
 internal data class ApkDownloadStatus(
@@ -27,6 +29,23 @@ internal data class ApkDownloadStatus(
     val downloadedBytes: Long? = null,
     val totalBytes: Long? = null,
 )
+
+internal fun downloadStateFromRawStatus(rawStatus: Int): DownloadState = when (rawStatus) {
+    DownloadManager.STATUS_PENDING -> DownloadState.PENDING
+    DownloadManager.STATUS_RUNNING -> DownloadState.RUNNING
+    DownloadManager.STATUS_PAUSED -> DownloadState.PAUSED
+    DownloadManager.STATUS_SUCCESSFUL -> DownloadState.SUCCESSFUL
+    DownloadManager.STATUS_FAILED -> DownloadState.FAILED
+    else -> DownloadState.UNKNOWN
+}
+
+internal inline fun readDownloadStatus(
+    read: () -> ApkDownloadStatus?,
+): ApkDownloadStatus = try {
+    read() ?: ApkDownloadStatus(DownloadState.READ_UNAVAILABLE)
+} catch (_: Exception) {
+    ApkDownloadStatus(DownloadState.READ_UNAVAILABLE)
+}
 
 data class EnqueuedApkDownload(
     val id: Long,
@@ -181,29 +200,25 @@ class ApkInstaller(private val context: Context) {
 
     internal fun queryDownload(downloadId: Long): ApkDownloadStatus {
         val dm = ContextCompat.getSystemService(context, DownloadManager::class.java)
-            ?: return ApkDownloadStatus(DownloadState.MISSING)
-        val cursor = try {
-            dm.query(DownloadManager.Query().setFilterById(downloadId))
-        } catch (_: Exception) {
-            return ApkDownloadStatus(DownloadState.MISSING)
-        } ?: return ApkDownloadStatus(DownloadState.MISSING)
-        cursor.use {
-            if (!it.moveToFirst()) return ApkDownloadStatus(DownloadState.MISSING)
-            val rawStatus = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
-            val reason = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
-            val downloaded = it.getLong(
-                it.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
-            )
-            val total = it.getLong(it.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
-            val state = when (rawStatus) {
-                DownloadManager.STATUS_PENDING -> DownloadState.PENDING
-                DownloadManager.STATUS_RUNNING -> DownloadState.RUNNING
-                DownloadManager.STATUS_PAUSED -> DownloadState.PAUSED
-                DownloadManager.STATUS_SUCCESSFUL -> DownloadState.SUCCESSFUL
-                DownloadManager.STATUS_FAILED -> DownloadState.FAILED
-                else -> DownloadState.MISSING
+            ?: return ApkDownloadStatus(DownloadState.READ_UNAVAILABLE)
+        return readDownloadStatus {
+            val cursor = dm.query(DownloadManager.Query().setFilterById(downloadId))
+                ?: return@readDownloadStatus null
+            cursor.use {
+                if (!it.moveToFirst()) return@readDownloadStatus ApkDownloadStatus(DownloadState.MISSING)
+                val rawStatus = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+                val reason = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+                val downloaded = it.getLong(
+                    it.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+                )
+                val total = it.getLong(it.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
+                ApkDownloadStatus(
+                    downloadStateFromRawStatus(rawStatus),
+                    reason,
+                    downloaded,
+                    total,
+                )
             }
-            return ApkDownloadStatus(state, reason, downloaded, total)
         }
     }
 

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -47,6 +47,40 @@ internal inline fun readDownloadStatus(
     ApkDownloadStatus(DownloadState.READ_UNAVAILABLE)
 }
 
+internal data class DownloadDestinationScan(
+    val readable: Boolean,
+    val matchingDownloadIds: List<Long> = emptyList(),
+)
+
+internal fun localDownloadUriMatchesDestination(
+    localUri: String?,
+    destination: File,
+): Boolean {
+    val parsed = try {
+        URI(localUri ?: return false)
+    } catch (_: Exception) {
+        return false
+    }
+    if (!parsed.scheme.equals("file", ignoreCase = true)) return false
+    return try {
+        File(parsed).canonicalFile == destination.canonicalFile
+    } catch (_: Exception) {
+        false
+    }
+}
+
+internal inline fun readDownloadDestinationScan(
+    read: () -> List<Long>?,
+): DownloadDestinationScan = try {
+    val ids = read() ?: return DownloadDestinationScan(readable = false)
+    DownloadDestinationScan(readable = true, matchingDownloadIds = ids.distinct())
+} catch (_: Exception) {
+    DownloadDestinationScan(readable = false)
+}
+
+internal fun preparedDownloadDescription(requestId: String): String =
+    "Hands update request $requestId"
+
 data class EnqueuedApkDownload(
     val id: Long,
     val destination: File,
@@ -155,6 +189,7 @@ class ApkInstaller(private val context: Context) {
         downloadUrl: String,
         fileName: String = "quiver-update.apk",
         title: String = "App update",
+        requestId: String? = null,
     ): EnqueuedApkDownload {
         val destination = downloadDestination(fileName)
         if (destination.exists() && !destination.delete()) {
@@ -166,7 +201,7 @@ class ApkInstaller(private val context: Context) {
 
         val request = DownloadManager.Request(Uri.parse(downloadUrl))
             .setTitle(title)
-            .setDescription("Downloading latest version…")
+            .setDescription(requestId?.let(::preparedDownloadDescription) ?: "Downloading latest version…")
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
             .setAllowedOverMetered(true)
             .setAllowedOverRoaming(true)
@@ -218,6 +253,33 @@ class ApkInstaller(private val context: Context) {
                     downloaded,
                     total,
                 )
+            }
+        }
+    }
+
+    internal fun scanPreparedDownload(
+        requestId: String,
+        destination: File,
+    ): DownloadDestinationScan {
+        val dm = ContextCompat.getSystemService(context, DownloadManager::class.java)
+            ?: return DownloadDestinationScan(readable = false)
+        return readDownloadDestinationScan {
+            val cursor = dm.query(DownloadManager.Query()) ?: return@readDownloadDestinationScan null
+            cursor.use {
+                val ids = mutableListOf<Long>()
+                val idColumn = it.getColumnIndexOrThrow(DownloadManager.COLUMN_ID)
+                val uriColumn = it.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI)
+                val descriptionColumn = it.getColumnIndexOrThrow(DownloadManager.COLUMN_DESCRIPTION)
+                val expectedDescription = preparedDownloadDescription(requestId)
+                while (it.moveToNext()) {
+                    if (it.getString(descriptionColumn) != expectedDescription) continue
+                    val localUri = it.getString(uriColumn)
+                    if (localUri != null && !localDownloadUriMatchesDestination(localUri, destination)) {
+                        return@readDownloadDestinationScan null
+                    }
+                    ids += it.getLong(idColumn)
+                }
+                ids
             }
         }
     }

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -12,6 +12,27 @@ import androidx.core.content.FileProvider
 import java.io.File
 import java.net.URI
 
+internal enum class DownloadState {
+    PENDING,
+    RUNNING,
+    PAUSED,
+    SUCCESSFUL,
+    FAILED,
+    MISSING,
+}
+
+internal data class ApkDownloadStatus(
+    val state: DownloadState,
+    val reason: Int? = null,
+    val downloadedBytes: Long? = null,
+    val totalBytes: Long? = null,
+)
+
+data class EnqueuedApkDownload(
+    val id: Long,
+    val destination: File,
+)
+
 internal enum class DownloadInstallResult {
     IGNORED,
     UNAVAILABLE_OR_UNSAFE_URI,
@@ -111,11 +132,16 @@ internal fun triggerApkInstall(ctx: Context, apkUri: Uri) {
  */
 class ApkInstaller(private val context: Context) {
 
-    fun downloadAndInstall(
+    fun enqueueDownload(
         downloadUrl: String,
         fileName: String = "quiver-update.apk",
         title: String = "App update",
-    ): Long {
+    ): EnqueuedApkDownload {
+        val destination = downloadDestination(fileName)
+        if (destination.exists() && !destination.delete()) {
+            throw IllegalStateException("unable to replace previous SDK update file")
+        }
+
         val dm = ContextCompat.getSystemService(context, DownloadManager::class.java)
             ?: throw IllegalStateException("DownloadManager not available")
 
@@ -135,7 +161,67 @@ class ApkInstaller(private val context: Context) {
             fileName,
         )
 
-        return dm.enqueue(request)
+        return EnqueuedApkDownload(dm.enqueue(request), destination)
+    }
+
+    fun downloadAndInstall(
+        downloadUrl: String,
+        fileName: String = "quiver-update.apk",
+        title: String = "App update",
+    ): Long = enqueueDownload(downloadUrl, fileName, title).id
+
+    fun downloadDestination(fileName: String): File {
+        require(fileName.matches(Regex("^[A-Za-z0-9._-]+\\.apk$"))) {
+            "unsafe APK file name"
+        }
+        val directory = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+            ?: throw IllegalStateException("app-scoped Downloads directory unavailable")
+        return File(directory, fileName)
+    }
+
+    internal fun queryDownload(downloadId: Long): ApkDownloadStatus {
+        val dm = ContextCompat.getSystemService(context, DownloadManager::class.java)
+            ?: return ApkDownloadStatus(DownloadState.MISSING)
+        val cursor = try {
+            dm.query(DownloadManager.Query().setFilterById(downloadId))
+        } catch (_: Exception) {
+            return ApkDownloadStatus(DownloadState.MISSING)
+        } ?: return ApkDownloadStatus(DownloadState.MISSING)
+        cursor.use {
+            if (!it.moveToFirst()) return ApkDownloadStatus(DownloadState.MISSING)
+            val rawStatus = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+            val reason = it.getInt(it.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+            val downloaded = it.getLong(
+                it.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+            )
+            val total = it.getLong(it.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
+            val state = when (rawStatus) {
+                DownloadManager.STATUS_PENDING -> DownloadState.PENDING
+                DownloadManager.STATUS_RUNNING -> DownloadState.RUNNING
+                DownloadManager.STATUS_PAUSED -> DownloadState.PAUSED
+                DownloadManager.STATUS_SUCCESSFUL -> DownloadState.SUCCESSFUL
+                DownloadManager.STATUS_FAILED -> DownloadState.FAILED
+                else -> DownloadState.MISSING
+            }
+            return ApkDownloadStatus(state, reason, downloaded, total)
+        }
+    }
+
+    internal fun removeDownload(downloadId: Long) {
+        val dm = ContextCompat.getSystemService(context, DownloadManager::class.java) ?: return
+        try {
+            dm.remove(downloadId)
+        } catch (_: Exception) {
+            // Best-effort cleanup; the app-scoped file is removed separately.
+        }
+    }
+
+    /** Reopens the exact SDK-owned APK file through the SDK FileProvider. */
+    fun installDownloadedApk(file: File): String {
+        val authority = "${context.packageName}.hands.fileprovider"
+        val apkUri = FileProvider.getUriForFile(context, authority, file)
+        triggerApkInstall(context, apkUri)
+        return apkUri.toString()
     }
 
     /**
@@ -181,6 +267,27 @@ class ApkInstaller(private val context: Context) {
     }
 
     /**
+     * Completion signal for the persistent transaction controller. It does not
+     * trust or launch the returned URI; the controller reconciles and verifies
+     * the exact SDK-owned destination before opening the installer.
+     */
+    fun createDownloadCompletionReceiver(
+        downloadId: Long,
+        onComplete: () -> Unit,
+    ): BroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context?, intent: Intent?) {
+            val completedId = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L)
+                ?: -1L
+            if (completedId != downloadId) return
+            try {
+                onComplete()
+            } catch (exception: Exception) {
+                Log.e(TAG, "Unable to reconcile the completed APK download", exception)
+            }
+        }
+    }
+
+    /**
      * Trigger the system install prompt for an APK that already lives on disk
      * (e.g. one reconstructed locally by the delta updater), rather than one
      * fetched via DownloadManager.
@@ -191,9 +298,7 @@ class ApkInstaller(private val context: Context) {
      * so no world-readable storage is needed.
      */
     fun installLocalApk(file: File) {
-        val authority = "${context.packageName}.hands.fileprovider"
-        val apkUri = FileProvider.getUriForFile(context, authority, file)
-        triggerApkInstall(context, apkUri)
+        installDownloadedApk(file)
     }
 
     private companion object {

--- a/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/installer/ApkInstaller.kt
@@ -78,8 +78,15 @@ internal inline fun readDownloadDestinationScan(
     DownloadDestinationScan(readable = false)
 }
 
-internal fun preparedDownloadDescription(requestId: String): String =
-    "Hands update request $requestId"
+internal fun matchingDownloadIdsForDestination(
+    rows: List<Pair<Long, String?>>,
+    destination: File,
+): List<Long>? {
+    if (rows.any { (_, localUri) -> localUri == null }) return null
+    return rows.filter { (_, localUri) ->
+        localDownloadUriMatchesDestination(localUri, destination)
+    }.map { (id) -> id }
+}
 
 data class EnqueuedApkDownload(
     val id: Long,
@@ -189,7 +196,6 @@ class ApkInstaller(private val context: Context) {
         downloadUrl: String,
         fileName: String = "quiver-update.apk",
         title: String = "App update",
-        requestId: String? = null,
     ): EnqueuedApkDownload {
         val destination = downloadDestination(fileName)
         if (destination.exists() && !destination.delete()) {
@@ -201,7 +207,7 @@ class ApkInstaller(private val context: Context) {
 
         val request = DownloadManager.Request(Uri.parse(downloadUrl))
             .setTitle(title)
-            .setDescription(requestId?.let(::preparedDownloadDescription) ?: "Downloading latest version…")
+            .setDescription("Downloading latest version…")
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
             .setAllowedOverMetered(true)
             .setAllowedOverRoaming(true)
@@ -257,29 +263,19 @@ class ApkInstaller(private val context: Context) {
         }
     }
 
-    internal fun scanPreparedDownload(
-        requestId: String,
-        destination: File,
-    ): DownloadDestinationScan {
+    internal fun scanDownloadsForDestination(destination: File): DownloadDestinationScan {
         val dm = ContextCompat.getSystemService(context, DownloadManager::class.java)
             ?: return DownloadDestinationScan(readable = false)
         return readDownloadDestinationScan {
             val cursor = dm.query(DownloadManager.Query()) ?: return@readDownloadDestinationScan null
             cursor.use {
-                val ids = mutableListOf<Long>()
                 val idColumn = it.getColumnIndexOrThrow(DownloadManager.COLUMN_ID)
                 val uriColumn = it.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_URI)
-                val descriptionColumn = it.getColumnIndexOrThrow(DownloadManager.COLUMN_DESCRIPTION)
-                val expectedDescription = preparedDownloadDescription(requestId)
+                val rows = mutableListOf<Pair<Long, String?>>()
                 while (it.moveToNext()) {
-                    if (it.getString(descriptionColumn) != expectedDescription) continue
-                    val localUri = it.getString(uriColumn)
-                    if (localUri != null && !localDownloadUriMatchesDestination(localUri, destination)) {
-                        return@readDownloadDestinationScan null
-                    }
-                    ids += it.getLong(idColumn)
+                    rows += it.getLong(idColumn) to it.getString(uriColumn)
                 }
-                ids
+                matchingDownloadIdsForDestination(rows, destination)
             }
         }
     }

--- a/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
@@ -52,6 +52,7 @@ class DeltaUpdater(
     private val httpClient: OkHttpClient,
     private val installer: ApkInstaller,
     private val deltaApplyEnabled: Boolean = true,
+    private val eventSink: (name: String, errorCode: String?) -> Unit = { _, _ -> },
 ) {
 
     /**
@@ -67,12 +68,15 @@ class DeltaUpdater(
         asset: UpdateAsset,
         latest: LatestUpdate,
         appSlug: String,
+        onInstallerOpened: (apk: File, sha256: String) -> Unit = { _, _ -> },
     ): Boolean {
         if (!deltaEnabled()) {
+            emit("patch_fallback", "flag_off")
             log("delta_fallback reason=flag_off")
             return false
         }
         if (!validateOffer(patch)) {
+            emit("patch_fallback", "offer_invalid")
             log("delta_fallback reason=validate")
             return false
         }
@@ -93,8 +97,11 @@ class DeltaUpdater(
         try {
             // 1. Download the patch bytes into a private temp file.
             try {
+                emit("patch_download_started")
                 downloadTo(patch.download_url, patchFile)
+                emit("patch_download_completed")
             } catch (e: Throwable) {
+                emit("patch_fallback", "patch_download_failed")
                 log("delta_fallback reason=download err=${e.message}")
                 return false
             }
@@ -104,6 +111,7 @@ class DeltaUpdater(
             val deltaStream: InputStream = try {
                 openDeltaStream(patchFile, isGzipped(patch.algorithm))
             } catch (e: Throwable) {
+                emit("patch_fallback", "patch_gunzip_failed")
                 log("delta_fallback reason=gunzip err=${e.message}")
                 return false
             }
@@ -111,6 +119,7 @@ class DeltaUpdater(
             // 3. Apply the patch onto the base APK. A mid-stream gunzip fault or
             //    any patch error surfaces here as `apply`.
             try {
+                emit("patch_apply_started")
                 deltaStream.use { stream ->
                     reconstructed.outputStream().buffered().use { out ->
                         // Use cacheDir as the applier's scratch dir explicitly
@@ -119,7 +128,9 @@ class DeltaUpdater(
                             .applyDelta(baseFile, stream, out)
                     }
                 }
+                emit("patch_apply_completed")
             } catch (e: Throwable) {
+                emit("patch_fallback", "patch_apply_failed")
                 log("delta_fallback reason=apply err=${e.message}")
                 return false
             }
@@ -127,6 +138,7 @@ class DeltaUpdater(
             // 4a. Content integrity: sha256 must equal the offered target.
             val actualSha = sha256Hex(reconstructed)
             if (!constantTimeEquals(actualSha, expectedSha.lowercase())) {
+                emit("patch_fallback", "sha256_mismatch")
                 log("delta_fallback reason=sha_mismatch")
                 return false
             }
@@ -134,17 +146,28 @@ class DeltaUpdater(
             // 4b/4c. Package identity, version, and signer-cert equality.
             val reason = verifyReconstructedApk(reconstructed)
             if (reason != null) {
+                emit("patch_fallback", reason)
                 log("delta_fallback reason=$reason")
                 return false
             }
+            emit("patch_validation_completed")
 
             // 5. Install the verified reconstructed APK.
             installer.installLocalApk(reconstructed)
             installed = true
+            try {
+                onInstallerOpened(reconstructed, actualSha)
+            } catch (_: Throwable) {
+                // The installer is already open. A host/store callback failure
+                // must never start a duplicate full-APK download.
+                emit("transaction_persist_failed", "transaction_persist_failed")
+            }
+            emit("installer_opened")
             log("delta_applied bytes_saved=${asset.size_bytes - patch.size_bytes}")
             return true
         } catch (e: Throwable) {
             // Belt-and-suspenders: nothing above should escape, but never throw.
+            emit("patch_fallback", "patch_apply_failed")
             log("delta_fallback reason=apply err=${e.message}")
             return false
         } finally {
@@ -288,6 +311,14 @@ class DeltaUpdater(
 
     private fun log(message: String) {
         Log.i(TAG, message)
+    }
+
+    private fun emit(name: String, errorCode: String? = null) {
+        try {
+            eventSink(name, errorCode)
+        } catch (_: Throwable) {
+            // Host diagnostics must never break update delivery.
+        }
     }
 
     companion object {

--- a/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/internal/DeltaUpdater.kt
@@ -9,6 +9,8 @@ import build.hands.update.installer.ApkInstaller
 import build.hands.update.models.LatestUpdate
 import build.hands.update.models.Patch
 import build.hands.update.models.UpdateAsset
+import build.hands.update.DurableInstallerLaunchResult
+import build.hands.update.launchWithDurableInstallerAuthority
 import com.google.archivepatcher.applier.FileByFileV1DeltaApplier
 import com.google.archivepatcher.shared.DefaultDeflater
 import com.google.archivepatcher.shared.IDeflater
@@ -68,7 +70,8 @@ class DeltaUpdater(
         asset: UpdateAsset,
         latest: LatestUpdate,
         appSlug: String,
-        onInstallerOpened: (apk: File, sha256: String) -> Unit = { _, _ -> },
+        persistReadyToInstall: (apk: File, sha256: String) -> Unit = { _, _ -> },
+        persistInstallerOpened: () -> Unit = {},
     ): Boolean {
         if (!deltaEnabled()) {
             emit("patch_fallback", "flag_off")
@@ -152,15 +155,29 @@ class DeltaUpdater(
             }
             emit("patch_validation_completed")
 
-            // 5. Install the verified reconstructed APK.
-            installer.installLocalApk(reconstructed)
-            installed = true
-            try {
-                onInstallerOpened(reconstructed, actualSha)
-            } catch (_: Throwable) {
-                // The installer is already open. A host/store callback failure
-                // must never start a duplicate full-APK download.
-                emit("transaction_persist_failed", "transaction_persist_failed")
+            // 5. Persist exact file authority before opening the external
+            // installer. If the post-launch OPENED commit fails, READY remains
+            // durable and the host can safely reopen the same verified APK.
+            when (launchWithDurableInstallerAuthority(
+                persistReady = { persistReadyToInstall(reconstructed, actualSha) },
+                launchInstaller = { installer.installLocalApk(reconstructed) },
+                persistOpened = persistInstallerOpened,
+            )) {
+                DurableInstallerLaunchResult.READY_PERSIST_FAILED -> {
+                    emit("transaction_persist_failed", "ready_persist_failed")
+                    return false
+                }
+                DurableInstallerLaunchResult.LAUNCH_FAILED -> {
+                    emit("patch_fallback", "installer_open_failed")
+                    return false
+                }
+                DurableInstallerLaunchResult.OPENED_WITH_READY_AUTHORITY -> {
+                    installed = true
+                    emit("transaction_persist_failed", "opened_persist_failed")
+                }
+                DurableInstallerLaunchResult.OPENED -> {
+                    installed = true
+                }
             }
             emit("installer_opened")
             log("delta_applied bytes_saved=${asset.size_bytes - patch.size_bytes}")

--- a/clients/android/src/main/kotlin/build/hands/update/internal/HandsClient.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/internal/HandsClient.kt
@@ -1,5 +1,6 @@
 package build.hands.update.internal
 
+import build.hands.update.normalizedLanguageTag
 import build.hands.update.models.UpdateCheckResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -37,6 +38,7 @@ class HandsClient(
         arch: String? = null,
         filetype: String = "apk",
         deviceId: String? = null,
+        languageTag: String? = null,
     ): UpdateCheckResponse = withContext(Dispatchers.IO) {
         val urlBuilder = baseUrl.trimEnd('/').toHttpUrl().newBuilder()
             .addPathSegments("public/v2/apps")
@@ -57,6 +59,12 @@ class HandsClient(
         if (!deviceId.isNullOrBlank()) {
             // Stable per-install id; the server uses it to bucket staged rollouts.
             requestBuilder.header("X-Hands-Device-Id", deviceId)
+        }
+        normalizedLanguageTag(languageTag)?.let { normalized ->
+            // Locale is explicit caller intent. The SDK never guesses the
+            // device/system locale, and malformed values are not put on wire.
+            requestBuilder.header("X-Hands-Lang", normalized)
+            requestBuilder.header("Accept-Language", normalized)
         }
         val request = requestBuilder.build()
 

--- a/clients/android/src/main/kotlin/build/hands/update/models/Version.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/models/Version.kt
@@ -38,6 +38,7 @@ data class LatestUpdate(
     val version: String,
     val version_code: Long,
     val changelog: String? = null,
+    val release_notes: Map<String, String>? = null,
     val force_update: Boolean = false,
     val released_at: Long,
 )
@@ -50,6 +51,8 @@ data class UpdateAsset(
     val filetype: String,
     val size_bytes: Long,
     val signature: String? = null,
+    /** Optional future-compatible full APK digest; absent on older servers. */
+    val sha256: String? = null,
     val download_url: String,
 )
 

--- a/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
@@ -1,0 +1,87 @@
+package build.hands.update
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HandsUpdateTransactionTest {
+    @Test
+    fun `wire states are stable lower-case constants`() {
+        assertEquals(
+            listOf(
+                "idle",
+                "checking",
+                "patching",
+                "downloading",
+                "ready_to_install",
+                "installer_opened",
+                "failed",
+                "stale",
+                "installed",
+            ),
+            HandsUpdateState.entries.map { it.wireValue },
+        )
+    }
+
+    @Test
+    fun `locale resolution matches exact then language prefix and English fallback`() {
+        val notes = linkedMapOf(
+            "en" to "English",
+            "zh-CN" to "中文",
+            "ja" to "日本語",
+        )
+
+        assertEquals("zh-CN", resolveLanguageTag("zh-CN", notes))
+        assertEquals("ja", resolveLanguageTag("ja-JP", notes))
+        assertEquals("en", resolveLanguageTag(null, notes))
+        assertEquals("en", resolveLanguageTag("de-DE", notes))
+    }
+
+    @Test
+    fun `malformed locale is omitted instead of entering an HTTP header`() {
+        assertEquals("zh-CN", normalizedLanguageTag(" zh-CN "))
+        assertNull(normalizedLanguageTag(null))
+        assertNull(normalizedLanguageTag(""))
+        assertNull(normalizedLanguageTag("zh_CN"))
+        assertNull(normalizedLanguageTag("en\r\nX-Injected: yes"))
+    }
+
+    @Test
+    fun `public status serializes stable state and host telemetry fields`() {
+        val status = HandsUpdateStatus(
+            state = HandsUpdateState.READY_TO_INSTALL,
+            targetVersionCode = 1000011,
+            installedVersionCode = 1000010,
+            retryable = false,
+            targetBuildId = "build-11",
+            assetSha256 = "a".repeat(64),
+            requestedLanguageTag = "zh-CN",
+            resolvedLanguageTag = "zh-CN",
+            updatedAt = 1234,
+        )
+
+        val encoded = Json.encodeToString(status)
+        assertTrue(encoded.contains("\"state\":\"ready_to_install\""))
+        assertEquals(status, Json.decodeFromString<HandsUpdateStatus>(encoded))
+    }
+
+    @Test
+    fun `authority storage keys separate channel and app identities`() {
+        fun authority(app: String, channel: String) = UpdateAuthority(
+            packageName = "build.raft.app.alpha",
+            baseUrl = "https://hands.example.test/",
+            appSlug = app,
+            channel = channel,
+            productType = "android-apk",
+            platform = "android",
+            arch = null,
+        )
+
+        assertEquals(authority("raft", "main").storageKey(), authority("raft", "main").storageKey())
+        assertTrue(authority("raft", "main").storageKey() != authority("raft", "alpha").storageKey())
+        assertTrue(authority("raft", "main").storageKey() != authority("other", "main").storageKey())
+    }
+}

--- a/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
@@ -352,4 +352,27 @@ class HandsUpdateTransactionTest {
             localFilePath = null,
         ))
     }
+
+    @Test
+    fun `prepared download crash windows recover zero one and uncertain ledger states`() {
+        assertEquals(
+            PreparedDownloadRecoveryAction.NO_MATCH,
+            preparedDownloadRecovery(readable = true, matchingDownloadIds = emptyList()).action,
+        )
+        assertEquals(
+            PreparedDownloadRecovery(
+                action = PreparedDownloadRecoveryAction.RECOVER_ONE,
+                downloadId = 42,
+            ),
+            preparedDownloadRecovery(readable = true, matchingDownloadIds = listOf(42)),
+        )
+        assertEquals(
+            PreparedDownloadRecoveryAction.KEEP_UNCERTAIN,
+            preparedDownloadRecovery(readable = true, matchingDownloadIds = listOf(42, 43)).action,
+        )
+        assertEquals(
+            PreparedDownloadRecoveryAction.KEEP_UNCERTAIN,
+            preparedDownloadRecovery(readable = false, matchingDownloadIds = emptyList()).action,
+        )
+    }
 }

--- a/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
@@ -14,6 +14,22 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HandsUpdateTransactionTest {
+    private fun target(
+        versionCode: Long = 1000011,
+        buildId: String = "build-11",
+        sha256: String = "a".repeat(64),
+        sizeBytes: Long = 42,
+        filetype: String = "apk",
+        signature: String = "signature-11",
+    ) = PendingInstallerTargetIdentity(
+        versionCode = versionCode,
+        buildId = buildId,
+        sha256 = sha256,
+        sizeBytes = sizeBytes,
+        filetype = filetype,
+        signature = signature,
+    )
+
     @Test
     fun `wire states are stable lower-case constants`() {
         assertEquals(
@@ -229,22 +245,40 @@ class HandsUpdateTransactionTest {
         assertEquals(
             PendingInstallerOfferAction.REOPEN_CURRENT,
             pendingInstallerOfferAction(
-                persistedTargetVersionCode = 1000011,
-                offeredTargetVersionCode = 1000011,
+                persistedTarget = target(sha256 = "A".repeat(64), filetype = "APK"),
+                offeredTarget = target(),
             ),
         )
         assertEquals(
             PendingInstallerOfferAction.REPLACE_CURRENT,
             pendingInstallerOfferAction(
-                persistedTargetVersionCode = 1000011,
-                offeredTargetVersionCode = 1000012,
+                persistedTarget = target(),
+                offeredTarget = target(versionCode = 1000012, buildId = "build-12"),
             ),
         )
         assertEquals(
             PendingInstallerOfferAction.WITHDRAW_CURRENT,
             pendingInstallerOfferAction(
-                persistedTargetVersionCode = 1000011,
-                offeredTargetVersionCode = null,
+                persistedTarget = target(),
+                offeredTarget = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `same version with different build or SHA never reopens stale APK`() {
+        assertEquals(
+            PendingInstallerOfferAction.REPLACE_CURRENT,
+            pendingInstallerOfferAction(
+                persistedTarget = target(buildId = "build-A"),
+                offeredTarget = target(buildId = "build-B"),
+            ),
+        )
+        assertEquals(
+            PendingInstallerOfferAction.REPLACE_CURRENT,
+            pendingInstallerOfferAction(
+                persistedTarget = target(sha256 = "a".repeat(64)),
+                offeredTarget = target(sha256 = "b".repeat(64)),
             ),
         )
     }
@@ -254,8 +288,8 @@ class HandsUpdateTransactionTest {
         val effects = mutableListOf<String>()
 
         reconcilePendingInstallerOffer(
-            persistedTargetVersionCode = 1000011,
-            offeredTargetVersionCode = 1000012,
+            persistedTarget = target(),
+            offeredTarget = target(versionCode = 1000012, buildId = "build-12"),
             reopenCurrent = { effects += "reopen-A" },
             replaceCurrent = {
                 effects += "cleanup-A"
@@ -272,13 +306,50 @@ class HandsUpdateTransactionTest {
         val effects = mutableListOf<String>()
 
         reconcilePendingInstallerOffer(
-            persistedTargetVersionCode = 1000011,
-            offeredTargetVersionCode = null,
+            persistedTarget = target(),
+            offeredTarget = null,
             reopenCurrent = { effects += "reopen-A" },
             replaceCurrent = { effects += "start-other" },
             withdrawCurrent = { effects += "cleanup-A" },
         )
 
         assertEquals(listOf("cleanup-A"), effects)
+    }
+
+    @Test
+    fun `installer launch failure retains READY locator and same-offer retry reopens it`() {
+        val failure = installerLaunchFailureTransition()
+        assertEquals(HandsUpdateState.READY_TO_INSTALL, failure.state)
+        assertEquals("installer_open_failed", failure.errorCode)
+        assertTrue(failure.retryable)
+        assertTrue(!failure.clearLocalAuthority)
+        assertTrue(!shouldCleanupRestartableAuthority(
+            state = failure.state,
+            downloadId = 42,
+            localFilePath = "/owned/update.apk",
+        ))
+        assertEquals(
+            PendingInstallerOfferAction.REOPEN_CURRENT,
+            pendingInstallerOfferAction(target(), target()),
+        )
+    }
+
+    @Test
+    fun `restartable records with any locator require exact cleanup before a new check`() {
+        assertTrue(shouldCleanupRestartableAuthority(
+            state = HandsUpdateState.FAILED,
+            downloadId = 42,
+            localFilePath = null,
+        ))
+        assertTrue(shouldCleanupRestartableAuthority(
+            state = HandsUpdateState.STALE,
+            downloadId = null,
+            localFilePath = "/owned/update.apk",
+        ))
+        assertTrue(!shouldCleanupRestartableAuthority(
+            state = HandsUpdateState.FAILED,
+            downloadId = null,
+            localFilePath = null,
+        ))
     }
 }

--- a/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsUpdateTransactionTest.kt
@@ -2,6 +2,12 @@ package build.hands.update
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -83,5 +89,196 @@ class HandsUpdateTransactionTest {
         assertEquals(authority("raft", "main").storageKey(), authority("raft", "main").storageKey())
         assertTrue(authority("raft", "main").storageKey() != authority("raft", "alpha").storageKey())
         assertTrue(authority("raft", "main").storageKey() != authority("other", "main").storageKey())
+    }
+
+    @Test
+    fun `installer never opens when READY authority commit fails`() {
+        var launched = false
+        var openedPersisted = false
+
+        val result = launchWithDurableInstallerAuthority(
+            persistReady = { error("disk full") },
+            launchInstaller = { launched = true },
+            persistOpened = { openedPersisted = true },
+        )
+
+        assertEquals(DurableInstallerLaunchResult.READY_PERSIST_FAILED, result)
+        assertTrue(!launched)
+        assertTrue(!openedPersisted)
+    }
+
+    @Test
+    fun `OPENED commit failure retains the durable READY authority`() {
+        val order = mutableListOf<String>()
+
+        val result = launchWithDurableInstallerAuthority(
+            persistReady = { order += "ready" },
+            launchInstaller = { order += "launch" },
+            persistOpened = {
+                order += "opened"
+                error("commit failed")
+            },
+        )
+
+        assertEquals(DurableInstallerLaunchResult.OPENED_WITH_READY_AUTHORITY, result)
+        assertEquals(listOf("ready", "launch", "opened"), order)
+    }
+
+    @Test
+    fun `same authority gate prevents stale reconcile from overtaking a command`() = runBlocking {
+        val gate = AuthorityTransactionGate(Mutex())
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val order = mutableListOf<String>()
+
+        val first = async {
+            gate.run {
+                order += "command-start"
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+                order += "command-opened"
+            }
+        }
+        firstEntered.await()
+        val staleStatus = async {
+            gate.run { order += "status-reconcile" }
+        }
+        yield()
+        assertEquals(listOf("command-start"), order)
+        releaseFirst.complete(Unit)
+        awaitAll(first, staleStatus)
+        assertEquals(listOf("command-start", "command-opened", "status-reconcile"), order)
+    }
+
+    @Test
+    fun `cleanup delete false retains authority and a later retry proves absence`() {
+        var exists = true
+        var deleteAttempts = 0
+        val first = performExactCleanup(
+            downloadId = 42,
+            localFilePath = "/owned/update.apk",
+            removeDownload = { true },
+            isOwnedFile = { true },
+            fileExists = { exists },
+            deleteFile = {
+                deleteAttempts += 1
+                false
+            },
+        )
+        assertTrue(!first.succeeded)
+        assertTrue(exists)
+
+        val second = performExactCleanup(
+            downloadId = 42,
+            localFilePath = "/owned/update.apk",
+            removeDownload = { true },
+            isOwnedFile = { true },
+            fileExists = { exists },
+            deleteFile = {
+                deleteAttempts += 1
+                exists = false
+                true
+            },
+        )
+        assertTrue(second.succeeded)
+        assertTrue(!exists)
+        assertEquals(2, deleteAttempts)
+    }
+
+    @Test
+    fun `cleanup delete exception is a stable failure rather than false absence`() {
+        val result = performExactCleanup(
+            downloadId = null,
+            localFilePath = "/owned/update.apk",
+            removeDownload = { true },
+            isOwnedFile = { true },
+            fileExists = { true },
+            deleteFile = { error("filesystem busy") },
+        )
+
+        assertTrue(!result.succeeded)
+        assertTrue(!result.fileAbsent)
+    }
+
+    @Test
+    fun `cleanup failure transition preserves exact download and file authority`() {
+        val failed = exactCleanupTransition(
+            cleanup = ExactCleanupResult(downloadAbsent = true, fileAbsent = false),
+            successState = HandsUpdateState.STALE,
+            successErrorCode = "target_changed",
+            successRetryable = true,
+        )
+        assertEquals(HandsUpdateState.FAILED, failed.state)
+        assertEquals("cleanup_failed", failed.errorCode)
+        assertTrue(failed.retryable)
+        assertTrue(!failed.clearLocalAuthority)
+
+        val succeeded = exactCleanupTransition(
+            cleanup = ExactCleanupResult(downloadAbsent = true, fileAbsent = true),
+            successState = HandsUpdateState.STALE,
+            successErrorCode = "target_changed",
+            successRetryable = true,
+        )
+        assertEquals(HandsUpdateState.STALE, succeeded.state)
+        assertEquals("target_changed", succeeded.errorCode)
+        assertTrue(succeeded.clearLocalAuthority)
+    }
+
+    @Test
+    fun `ready target only reopens for the same fresh authoritative offer`() {
+        assertEquals(
+            PendingInstallerOfferAction.REOPEN_CURRENT,
+            pendingInstallerOfferAction(
+                persistedTargetVersionCode = 1000011,
+                offeredTargetVersionCode = 1000011,
+            ),
+        )
+        assertEquals(
+            PendingInstallerOfferAction.REPLACE_CURRENT,
+            pendingInstallerOfferAction(
+                persistedTargetVersionCode = 1000011,
+                offeredTargetVersionCode = 1000012,
+            ),
+        )
+        assertEquals(
+            PendingInstallerOfferAction.WITHDRAW_CURRENT,
+            pendingInstallerOfferAction(
+                persistedTargetVersionCode = 1000011,
+                offeredTargetVersionCode = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `ready A with offer B cleans A then starts B without reopening A`() {
+        val effects = mutableListOf<String>()
+
+        reconcilePendingInstallerOffer(
+            persistedTargetVersionCode = 1000011,
+            offeredTargetVersionCode = 1000012,
+            reopenCurrent = { effects += "reopen-A" },
+            replaceCurrent = {
+                effects += "cleanup-A"
+                effects += "start-B"
+            },
+            withdrawCurrent = { effects += "withdraw-A" },
+        )
+
+        assertEquals(listOf("cleanup-A", "start-B"), effects)
+    }
+
+    @Test
+    fun `ready A with cancelled offer cleans A without reopen or replacement`() {
+        val effects = mutableListOf<String>()
+
+        reconcilePendingInstallerOffer(
+            persistedTargetVersionCode = 1000011,
+            offeredTargetVersionCode = null,
+            reopenCurrent = { effects += "reopen-A" },
+            replaceCurrent = { effects += "start-other" },
+            withdrawCurrent = { effects += "cleanup-A" },
+        )
+
+        assertEquals(listOf("cleanup-A"), effects)
     }
 }

--- a/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
@@ -11,6 +11,36 @@ import java.io.File
 
 class ApkInstallerTest {
     @Test
+    fun `DownloadManager read exception cannot prove absence and later active read recovers`() {
+        var reads = 0
+        val first = readDownloadStatus {
+            reads += 1
+            throw IllegalStateException("binder unavailable")
+        }
+        val second = readDownloadStatus {
+            reads += 1
+            ApkDownloadStatus(DownloadState.RUNNING, downloadedBytes = 10, totalBytes = 100)
+        }
+
+        assertEquals(DownloadState.READ_UNAVAILABLE, first.state)
+        assertEquals(DownloadState.RUNNING, second.state)
+        assertEquals(2, reads)
+    }
+
+    @Test
+    fun `null cursor and unknown status cannot prove DownloadManager absence`() {
+        assertEquals(
+            DownloadState.READ_UNAVAILABLE,
+            readDownloadStatus { null }.state,
+        )
+        assertEquals(DownloadState.UNKNOWN, downloadStateFromRawStatus(Int.MAX_VALUE))
+        assertEquals(
+            DownloadState.MISSING,
+            readDownloadStatus { ApkDownloadStatus(DownloadState.MISSING) }.state,
+        )
+    }
+
+    @Test
     fun `DownloadManager file URI converts through FileProvider before installer launch`() {
         val expectedContentUri =
             "content://build.raft.app.alpha.hands.fileprovider/hands_downloads/update.apk"

--- a/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
@@ -41,18 +41,28 @@ class ApkInstallerTest {
     }
 
     @Test
-    fun `prepared request marker and exact destination bind crash recovery`() {
+    fun `exact planned destination binds crash recovery without user-visible markers`() {
         val destination = File("/owned/hands-update-request.apk")
-        assertEquals(
-            "Hands update request request-42",
-            preparedDownloadDescription("request-42"),
-        )
         assertTrue(localDownloadUriMatchesDestination(destination.toURI().toString(), destination))
         assertFalse(localDownloadUriMatchesDestination(
             File("/owned/other.apk").toURI().toString(),
             destination,
         ))
         assertFalse(localDownloadUriMatchesDestination("content://downloads/42", destination))
+        assertEquals(
+            listOf(42L),
+            matchingDownloadIdsForDestination(
+                listOf(
+                    41L to File("/owned/other.apk").toURI().toString(),
+                    42L to destination.toURI().toString(),
+                ),
+                destination,
+            ),
+        )
+        assertNull(matchingDownloadIdsForDestination(
+            listOf(41L to null, 42L to destination.toURI().toString()),
+            destination,
+        ))
     }
 
     @Test

--- a/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/installer/ApkInstallerTest.kt
@@ -41,6 +41,31 @@ class ApkInstallerTest {
     }
 
     @Test
+    fun `prepared request marker and exact destination bind crash recovery`() {
+        val destination = File("/owned/hands-update-request.apk")
+        assertEquals(
+            "Hands update request request-42",
+            preparedDownloadDescription("request-42"),
+        )
+        assertTrue(localDownloadUriMatchesDestination(destination.toURI().toString(), destination))
+        assertFalse(localDownloadUriMatchesDestination(
+            File("/owned/other.apk").toURI().toString(),
+            destination,
+        ))
+        assertFalse(localDownloadUriMatchesDestination("content://downloads/42", destination))
+    }
+
+    @Test
+    fun `prepared ledger read failure remains uncertain and never becomes zero matches`() {
+        assertFalse(readDownloadDestinationScan { null }.readable)
+        assertFalse(readDownloadDestinationScan { error("binder unavailable") }.readable)
+        assertEquals(
+            DownloadDestinationScan(readable = true, matchingDownloadIds = emptyList()),
+            readDownloadDestinationScan { emptyList() },
+        )
+    }
+
+    @Test
     fun `DownloadManager file URI converts through FileProvider before installer launch`() {
         val expectedContentUri =
             "content://build.raft.app.alpha.hands.fileprovider/hands_downloads/update.apk"

--- a/clients/android/src/test/kotlin/build/hands/update/internal/HandsClientTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/internal/HandsClientTest.kt
@@ -1,0 +1,83 @@
+package build.hands.update.internal
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HandsClientTest {
+    @Test
+    fun `explicit Chinese locale is sent through both supported headers`() = runBlocking {
+        val request = execute("zh-CN")
+
+        assertEquals("zh-CN", request.header("X-Hands-Lang"))
+        assertEquals("zh-CN", request.header("Accept-Language"))
+    }
+
+    @Test
+    fun `explicit Japanese locale is sent unchanged`() = runBlocking {
+        val request = execute("ja")
+
+        assertEquals("ja", request.header("X-Hands-Lang"))
+        assertEquals("ja", request.header("Accept-Language"))
+    }
+
+    @Test
+    fun `missing or malformed locale omits locale headers`() = runBlocking {
+        listOf<String?>(null, "", "unsupported_locale").forEach { languageTag ->
+            val request = execute(languageTag)
+            assertNull(request.header("X-Hands-Lang"))
+            assertNull(request.header("Accept-Language"))
+        }
+    }
+
+    @Test
+    fun `well formed unsupported locale reaches server for English fallback`() = runBlocking {
+        val request = execute("de-DE")
+
+        assertEquals("de-DE", request.header("X-Hands-Lang"))
+        assertEquals("de-DE", request.header("Accept-Language"))
+    }
+
+    private suspend fun execute(languageTag: String?): Request {
+        var captured: Request? = null
+        val client = OkHttpClient.Builder()
+            .addInterceptor(Interceptor { chain ->
+                captured = chain.request()
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(NO_UPDATE.toResponseBody("application/json".toMediaType()))
+                    .build()
+            })
+            .build()
+        HandsClient("https://hands.example.test", client).checkForUpdate(
+            slug = "raft-android",
+            currentVersionCode = 1000010,
+            languageTag = languageTag,
+        )
+        return requireNotNull(captured)
+    }
+
+    private companion object {
+        const val NO_UPDATE = """
+            {
+              "update_available": false,
+              "app": {"slug": "raft-android", "platform": "android"},
+              "channel": "main",
+              "current_version_code": 1000010,
+              "latest_version_code": 1000010,
+              "checked_at": 1
+            }
+        """
+    }
+}

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -62,11 +62,39 @@ val checker = UpdateChecker(
     installedVersionCode = BuildConfig.VERSION_CODE.toLong(),
     channel = BuildConfig.HANDS_CHANNEL,
     arch = Build.SUPPORTED_ABIS.firstOrNull(),
+    // Pass the app-selected locale; the SDK never guesses system locale.
+    languageTag = currentAppLanguageTag,
+    eventListener = HandsUpdateEventListener(updateDiagnostics::append),
 )
 
-// suspending; returns the response even when no update is available
-val response = checker.checkAndInstall()
+// Idempotent: checks only from a restartable state, waits for active work,
+// and reopens the same verified APK after returning from the system installer.
+val status = checker.install()
 ```
+
+Call `checker.status()` on update-page/lifecycle resume and map the stable
+lower-case states: `idle`, `checking`, `patching`, `downloading`,
+`ready_to_install`, `installer_opened`, `failed`, `stale`, and `installed`.
+`installed` is reached only after PackageManager observes the exact target
+version. If the user returns without accepting the system installer, the state
+remains installable; `reopenPendingInstaller()` reopens the same APK without a
+duplicate download.
+
+The SDK persists a package/origin/app/channel/product/platform/architecture
+bound transaction containing target/build/asset identity, DownloadManager id,
+and the expected app-scoped file. It deliberately does not persist signed
+download URLs or auth material. Resume reconciliation checks installed version,
+DownloadManager, path ownership, file size, SHA-256 when supplied, exact APK
+package/target version, and signing certificates. Missing, changed, or unsafe
+inputs fail closed as `stale`/`failed` with a stable `errorCode`.
+
+`HandsUpdateEventListener` receives structured check, delta download/apply/
+validation/fallback, full-download, content-URI, installer, reconciliation,
+failure, and cleanup events for inclusion in host feedback diagnostics; Logcat
+is not the only telemetry path. Valid explicit BCP-47 `languageTag` values are
+sent as `X-Hands-Lang` and `Accept-Language`. Missing/malformed values send
+neither header, while unsupported languages retain the server's English
+fallback. Events/status include requested and resolved language tags.
 
 The SDK sends a stable per-install id (`X-Hands-Device-Id`, from
 `HandsDeviceId`; the server still accepts the legacy `X-Quiver-Device-Id`) so
@@ -75,7 +103,8 @@ the server can bucket the device for **staged rollouts**
 devices, and each device keeps its bucket as you raise the percentage.
 
 To check without installing (e.g. to render your own "update available" UI),
-call `HandsClient(baseUrl).checkForUpdate(...)` and act on the result.
+call `HandsClient(baseUrl).checkForUpdate(..., languageTag = ...)` and act on
+the result.
 
 ## Feedback
 


### PR DESCRIPTION
## Summary

- persist a versioned update transaction bound to package + Hands origin/app/channel/product/platform/arch, without persisting signed URLs or auth material
- expose stable `HandsUpdateState`, `HandsUpdateStatus`, `UpdateChecker.status()`, idempotent `install()`, and `reopenPendingInstaller()`
- reconcile installed version, DownloadManager, SDK-owned file, exact size/SHA when available, APK package/target version/signers; fail closed on missing/drifted/unsafe state
- expose structured host-capturable update events for check, patch download/apply/validation/fallback, full download, content URI, installer, state changes, failures, and cleanup
- accept explicit BCP-47 `languageTag`, send `X-Hands-Lang` and `Accept-Language`, and expose requested/resolved locale without guessing system locale
- add JVM request/state/serialization tests and API31 private-preferences authority tests; update Android SDK docs

## Validation

- `ANDROID_HOME=/home/exedev/android-sdk gradle 8.13 clean testReleaseUnitTest assembleRelease assembleDebugAndroidTest` — PASS (99 tasks)
- JVM: 30 tests PASS, including zh-CN/ja/missing/malformed/well-formed unsupported locale and stable wire states
- QNC2 native identity script — PASS
- release AAR SHA-256: `bb72b563fc85dc7202468d6b47e6e7d456e06d31abbd539e923849d5070ae37a`
- debug androidTest APK SHA-256: `a9d968b4882c0271cdc975ecf25351054758e13ca7fe5c64d7ba12655f61b520`
- `git diff --check` — PASS

Preserved red: the first Gradle invocation omitted `ANDROID_HOME` and stopped during project configuration before source compilation; the corrected pinned SDK/toolchain run above passed cleanly.

## Boundaries

Source/review only. No SDK version bump/tag/publish, Mobile merge, Alpha, Hands mutation, or runtime/device action is authorized by this PR.
