### PR TITLE
fix(feedback): surface newly created tickets in inbox

### DIFF
--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -177,6 +177,8 @@ export type FeedbackInboxProps = {
   pageSize?: number;
   hidden?: boolean;
   readTicketId?: string | null;
+  /** Newly-created authoritative ticket to expose without waiting for a list refetch. */
+  upsertTicket?: FeedbackTicketSummary | null;
 };
 
 export function FeedbackInbox({
@@ -185,6 +187,7 @@ export function FeedbackInbox({
   pageSize = 20,
   hidden = false,
   readTicketId,
+  upsertTicket,
 }: FeedbackInboxProps) {
   const { formatDate, message, reportUnread, transport } = useHandsFeedback();
   const safeError = useSafeError();
@@ -254,6 +257,14 @@ export function FeedbackInbox({
       ),
     );
   }, [readTicketId]);
+
+  useEffect(() => {
+    if (!upsertTicket) return;
+    setTickets((current) => [
+      upsertTicket,
+      ...current.filter((ticket) => ticket.id !== upsertTicket.id),
+    ]);
+  }, [upsertTicket]);
 
   const visibleTickets = tickets.filter(
     (ticket) =>
@@ -901,7 +912,7 @@ type PendingAttachment = {
 
 export type NewFeedbackProps = {
   onCancel(): void;
-  onCreated(ticketId: string): void;
+  onCreated(ticketId: string, detail?: FeedbackTicketDetail): void;
 };
 
 export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
@@ -982,7 +993,7 @@ export function NewFeedback({ onCancel, onCreated }: NewFeedbackProps) {
       reportUnread({ total: result.unreadTotal, source: "create" });
       createSubmission.current = null;
       setAnnouncement(copy("feedbackCreated"));
-      onCreated(result.ticket.id);
+      onCreated(result.ticket.id, result);
     } catch (cause) {
       if (!controller.signal.aborted) {
         const safe = safeError(cause);
@@ -1186,6 +1197,8 @@ export function FeedbackWorkspace({
   const route = controlledRoute ?? internalRoute;
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [readTicketId, setReadTicketId] = useState<string | null>(null);
+  const [createdTicket, setCreatedTicket] =
+    useState<FeedbackTicketSummary | null>(null);
   const originTicket = useRef<string | null>(initialTicketId ?? null);
   const pendingInboxFocus = useRef<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -1243,6 +1256,7 @@ export function FeedbackWorkspace({
       <FeedbackInbox
         hidden={route.view !== "inbox"}
         readTicketId={readTicketId}
+        upsertTicket={createdTicket}
         onNewFeedback={() => navigate({ view: "new" })}
         onSelectTicket={(ticketId) => {
           originTicket.current = ticketId;
@@ -1252,7 +1266,8 @@ export function FeedbackWorkspace({
       {route.view === "new" && (
         <NewFeedback
           onCancel={() => navigate({ view: "inbox" })}
-          onCreated={(ticketId) => {
+          onCreated={(ticketId, detail) => {
+            if (detail) setCreatedTicket(detail.ticket);
             originTicket.current = ticketId;
             navigate({ view: "ticket", ticketId });
           }}

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -419,6 +419,34 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(calls[0]![0].attachments[0]).toBe(file);
   });
 
+  it("shows a created ticket in the mounted inbox without a refresh or list refetch", async () => {
+    const adapter = transport();
+    adapter.listTickets = vi.fn(async () => ({
+      tickets: [],
+      nextCursor: null,
+      unreadTotal: 0,
+    }));
+    render(
+      <FeedbackProvider transport={adapter}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    expect(await screen.findByText("No feedback yet")).toBeTruthy();
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "New feedback" })[0]!,
+    );
+    fireEvent.change(screen.getByLabelText("What would you like us to know?"), {
+      target: { value: "A newly-created ticket" },
+    });
+    fireEvent.click(screen.getByText("Submit feedback"));
+    expect(await screen.findByText("Thanks")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(await screen.findByText(ticket.message)).toBeTruthy();
+    expect(adapter.listTickets).toHaveBeenCalledTimes(1);
+  });
+
   it("prevents duplicate create submission and lets the reporter cancel an in-flight upload", async () => {
     const adapter = transport();
     let uploadSignal: AbortSignal | undefined;


### PR DESCRIPTION
## Summary

- pass the authoritative created ticket from the composer into the workspace
- upsert that ticket into the already-mounted inbox state
- preserve direct `FeedbackInbox` / `NewFeedback` consumer compatibility with optional props

## Why

The inbox remains mounted while the workspace navigates to the create and detail views. Previously a successful create only changed the route, so returning to the inbox displayed its pre-create state until a page refresh.

## Verification

- `pnpm --filter @botiverse/hands-feedback-react test` (31/31)
- `pnpm --filter @botiverse/hands-feedback-react typecheck`
- `pnpm --filter @botiverse/hands-feedback-react build`
- regression: create from an empty inbox, return from detail, new ticket is visible while `listTickets` remains called exactly once
