### PR TITLE
perf(feedback): collapse reporter D1 round trips

### DIFF
--- a/worker/src/lib/deploy_tokens.ts
+++ b/worker/src/lib/deploy_tokens.ts
@@ -95,7 +95,7 @@ export async function loadDeployToken(
   if (!token?.startsWith(`${TOKEN_PREFIX}_`)) return null;
   const tokenHash = await hashDeployToken(token);
   const now = Date.now();
-  const row = await env.DB.prepare(
+  const lookup = env.DB.prepare(
     `SELECT dt.id, dt.app_id, a.slug AS app_slug, dt.name, dt.token_prefix,
             dt.app_role, dt.scopes_json, dt.created_by, dt.created_by_actor, dt.created_at,
             dt.expires_at, dt.last_used_at, dt.revoked_at,
@@ -107,16 +107,18 @@ export async function loadDeployToken(
        AND (dt.expires_at IS NULL OR dt.expires_at > ?2)
      LIMIT 1`,
   )
-    .bind(tokenHash, now)
-    .first<Omit<AppDeployToken, "scopes"> & { scopes_json: string | null }>();
+    .bind(tokenHash, now);
+  const touch = env.DB.prepare(
+    `UPDATE app_deploy_tokens SET last_used_at = ?1
+     WHERE token_hash = ?2 AND revoked_at IS NULL
+       AND (expires_at IS NULL OR expires_at > ?1)`,
+  ).bind(now, tokenHash);
+  const [lookupResult] = await env.DB.batch([lookup, touch]);
+  const row = lookupResult?.results[0] as
+    | (Omit<AppDeployToken, "scopes"> & { scopes_json: string | null })
+    | undefined;
 
   if (!row) return null;
-
-  await env.DB.prepare(
-    "UPDATE app_deploy_tokens SET last_used_at = ?1 WHERE id = ?2",
-  )
-    .bind(now, row.id)
-    .run();
   let scopes: AppPermission[] | null = null;
   if (row.scopes_json !== null) {
     try {

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -31,6 +31,20 @@ const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
 const TICKET_KINDS = ["feedback", "bug", "crash"] as const;
 const SUBMISSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function timingDuration(start: number, end: number): string {
+  return Math.max(0, end - start).toFixed(1);
+}
+
+function setServerTiming(
+  c: Context<{ Bindings: Env }>,
+  value: string,
+): void {
+  const header = (c as Context<{ Bindings: Env }> & {
+    header?: (name: string, value: string) => void;
+  }).header;
+  header?.call(c, "Server-Timing", value);
+}
+
 type FeedbackApp = {
   id: string;
   org_id: string | null;
@@ -108,6 +122,7 @@ export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: En
 }
 
 export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) {
+  const startedAt = performance.now();
   const slug = c.req.param("slug");
   if (!slug) return c.json({ error: "slug required" }, 400);
   const app = await c.env.DB.prepare(
@@ -198,42 +213,52 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       return c.json({ error: "trusted reporter identity requires feedback:write permission for this app" }, 401);
     }
     const integration = await c.env.DB.prepare(
-      `SELECT id FROM app_reporter_integrations
-       WHERE id = ?1 AND app_id = ?2 AND archived_at IS NULL`,
-    ).bind(deployToken.reporter_integration_id, app.id).first<{ id: string }>();
+      `SELECT ri.id,
+              EXISTS (
+                SELECT 1 FROM app_reporter_routes route
+                WHERE route.app_id = ri.app_id
+                  AND route.reporter_integration_id = ri.id
+                  AND route.reporter_id = ?3
+              ) AS route_exists
+       FROM app_reporter_integrations ri
+       WHERE ri.id = ?1 AND ri.app_id = ?2 AND ri.archived_at IS NULL`,
+    ).bind(deployToken.reporter_integration_id, app.id, reporterId)
+      .first<{ id: string; route_exists: number }>();
     if (!integration) {
       return c.json({ error: "trusted reporter identity requires an active reporter integration" }, 401);
     }
     reporterIntegrationId = deployToken.reporter_integration_id;
-    const route = await c.env.DB.prepare(
-      `SELECT 1 AS ok FROM app_reporter_routes
-       WHERE app_id = ?1 AND reporter_integration_id = ?2 AND reporter_id = ?3`,
-    ).bind(app.id, reporterIntegrationId, reporterId).first<{ ok: number }>();
-    if (!route) {
+    if (integration.route_exists !== 1) {
       return c.json({ error: "route_required" }, 409);
     }
     rateLimitHashInput = `feedback:${app.id}:integration:${reporterIntegrationId}:reporter:${reporterId}`;
     rateLimitPerHour = TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR;
   }
+  const authorizedAt = performance.now();
   const clientIpHash = await sha256Hex(rateLimitHashInput);
   const oneHourAgo = Date.now() - 3600_000;
   // A cheap indexed lookup happens before attachment hashing/R2 HEAD work.
   // Only a known idempotency key may bypass the rate-limit count so a lost
   // response remains recoverable; a new key is rejected before expensive
   // attachment processing once the subject is over quota.
-  const existingSubmission = submissionId
-    ? await findFeedbackSubmission(c.env.DB, app.id, submissionId, reporterIntegrationId)
-    : null;
+  const existingPromise = submissionId
+    ? findFeedbackSubmission(c.env.DB, app.id, submissionId, reporterIntegrationId)
+    : Promise.resolve(null);
+  const recentPromise = c.env.DB.prepare(
+    `SELECT COUNT(*) AS count, MIN(created_at) AS oldest_created_at FROM feedback_tickets
+     WHERE app_id = ?1 AND client_ip_hash = ?2 AND created_at > ?3`,
+  )
+    .bind(app.id, clientIpHash, oneHourAgo)
+    .first<{ count: number; oldest_created_at: number | null }>();
+  const [existingSubmission, recent] = await Promise.all([
+    existingPromise,
+    recentPromise,
+  ]);
+  const preflightAt = performance.now();
   if (existingSubmission && existingSubmission.reporter_id !== (reporterId || null)) {
     return c.json({ error: "submission_id already used by a different reporter" }, 409);
   }
   if (!existingSubmission) {
-    const recent = await c.env.DB.prepare(
-      `SELECT COUNT(*) AS count, MIN(created_at) AS oldest_created_at FROM feedback_tickets
-       WHERE app_id = ?1 AND client_ip_hash = ?2 AND created_at > ?3`,
-    )
-      .bind(app.id, clientIpHash, oneHourAgo)
-      .first<{ count: number; oldest_created_at: number | null }>();
     if ((recent?.count ?? 0) >= rateLimitPerHour) {
       const retryAfter = Math.max(
         1,
@@ -546,7 +571,11 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       .map((attachment) => c.env.APK_BUCKET.delete(attachment.r2Key)),
   );
   try {
-    await c.env.DB.batch(statements);
+    const results = await c.env.DB.batch(statements);
+    if ((results[0]?.meta.changes ?? 0) !== 1) {
+      await cleanupInlineUploads();
+      return c.json({ error: "route_required" }, 409);
+    }
   } catch (error) {
     if (submissionId && submissionFingerprint) {
       const existing = await findFeedbackSubmission(
@@ -569,14 +598,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     await cleanupInlineUploads();
     throw error;
   }
-  const committedTicket = await c.env.DB.prepare(
-    "SELECT 1 AS ok FROM feedback_tickets WHERE app_id = ?1 AND id = ?2",
-  ).bind(app.id, ticketId).first<{ ok: number }>();
-  if (!committedTicket) {
-    await cleanupInlineUploads();
-    return c.json({ error: "route_required" }, 409);
-  }
-
+  const committedAt = performance.now();
   // Crash tickets: symbolicate in the background (retrace / native / OHOS / dSYM
   // lanes) and record the result on the ticket's symbolicated_stack /
   // symbolication_status fields. See dispatchSymbolication.
@@ -674,7 +696,55 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     });
   }
 
-  return feedbackSubmitResponse(c, app, ticketId, 201, false);
+  const respondedAt = performance.now();
+  setServerTiming(c, [
+    `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
+    `hands_preflight;dur=${timingDuration(authorizedAt, preflightAt)}`,
+    `hands_commit;dur=${timingDuration(preflightAt, committedAt)}`,
+    `hands_postcommit;dur=${timingDuration(committedAt, respondedAt)}`,
+  ].join(", "));
+  return feedbackNewSubmitResponse(c, app, {
+    ticketId,
+    status: "open",
+    versionName: meta("version_name"),
+    versionCode,
+    attachmentNames: attachmentRows.map((attachment) => attachment.filename),
+  });
+}
+
+function feedbackNewSubmitResponse(
+  c: Context<{ Bindings: Env }>,
+  app: FeedbackApp,
+  input: {
+    ticketId: string;
+    status: string;
+    versionName: string | null;
+    versionCode: number | null;
+    attachmentNames: string[];
+  },
+) {
+  const versionLabel = input.versionName
+    ? input.versionCode != null
+      ? `${input.versionName} (${input.versionCode})`
+      : input.versionName
+    : input.versionCode != null
+      ? String(input.versionCode)
+      : null;
+  const referenceLine = [app.slug, versionLabel, `ticket ${input.ticketId}`]
+    .filter(Boolean)
+    .join(" · ");
+  const reference = input.attachmentNames.length
+    ? `${referenceLine}\nattachments:\n${input.attachmentNames.join("\n")}`
+    : referenceLine;
+  return c.json({
+    id: input.ticketId,
+    status: input.status,
+    attachments: input.attachmentNames.length,
+    attachment_names: input.attachmentNames,
+    reference,
+    ticket_url: `${dashboardOrigin(c.env)}/apps/${app.id}/feedback/${input.ticketId}`,
+    idempotent_replay: false,
+  }, 201);
 }
 
 async function findFeedbackSubmission(

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -24,6 +24,10 @@ type ReporterEnv = Env & {
 
 type Endpoint = "list" | "detail" | "attachment" | "comment";
 
+function timingDuration(start: number, end: number): string {
+  return Math.max(0, end - start).toFixed(1);
+}
+
 const LIMITS: Record<Endpoint, { reporter: number; integration: number; windowMs: number }> = {
   list: { reporter: 60, integration: 600, windowMs: 60_000 },
   detail: { reporter: 120, integration: 1_200, windowMs: 60_000 },
@@ -194,10 +198,20 @@ async function auditRead(
   endpoint: Endpoint,
   input?: { ticketId?: string; attachmentId?: string; everyTime?: boolean },
 ) {
+  await auditReadStatement(c, principal, pseudonym, endpoint, input).run();
+}
+
+function auditReadStatement(
+  c: ReporterContext,
+  principal: ReporterPrincipal,
+  pseudonym: { hash: string; version: string },
+  endpoint: Endpoint,
+  input?: { ticketId?: string; attachmentId?: string; everyTime?: boolean },
+) {
   const now = Date.now();
   const id = crypto.randomUUID();
   if (input?.everyTime) {
-    await c.env.DB.prepare(
+    return c.env.DB.prepare(
       `INSERT INTO feedback_reporter_access_audits
        (id, app_id, reporter_integration_id, reporter_hash, audit_key_version,
         endpoint, ticket_id, attachment_id, throttle_window_started_at, created_at)
@@ -212,11 +226,10 @@ async function auditRead(
       input.ticketId ?? null,
       input.attachmentId ?? null,
       now,
-    ).run();
-    return;
+    );
   }
   const throttleWindow = Math.floor(now / (10 * 60_000)) * (10 * 60_000);
-  await c.env.DB.prepare(
+  return c.env.DB.prepare(
     `INSERT OR IGNORE INTO feedback_reporter_access_audits
      (id, app_id, reporter_integration_id, reporter_hash, audit_key_version,
       endpoint, ticket_id, attachment_id, throttle_window_started_at, created_at)
@@ -232,7 +245,7 @@ async function auditRead(
     input?.attachmentId ?? null,
     throttleWindow,
     now,
-  ).run();
+  );
 }
 
 function ticketNotFound(c: ReporterContext) {
@@ -270,11 +283,11 @@ const unreadCountSql = `(SELECT COUNT(*) FROM feedback_comments unread_comment
       OR unread_comment.reporter_sequence > rr.read_through_sequence
     ))`;
 
-async function unreadTotal(
+function unreadTotalStatement(
   c: ReporterContext,
   principal: ReporterPrincipal,
-): Promise<number> {
-  const row = await c.env.DB.prepare(
+) {
+  return c.env.DB.prepare(
     `SELECT COUNT(*) AS unread_total FROM feedback_tickets t
      LEFT JOIN feedback_reporter_ticket_reads rr
        ON rr.app_id = t.app_id
@@ -283,20 +296,28 @@ async function unreadTotal(
       AND rr.ticket_id = t.id
      WHERE t.app_id = ?1 AND t.reporter_integration_id = ?2
        AND t.reporter_id = ?3 AND ${unreadCountSql} > 0`,
-  ).bind(principal.appId, principal.integrationId, principal.reporterId)
+  ).bind(principal.appId, principal.integrationId, principal.reporterId);
+}
+
+async function unreadTotal(
+  c: ReporterContext,
+  principal: ReporterPrincipal,
+): Promise<number> {
+  const row = await unreadTotalStatement(c, principal)
     .first<{ unread_total: number }>();
   return Math.max(0, row?.unread_total ?? 0);
 }
 
 export async function handleListReporterFeedback(c: ReporterContext) {
+  const startedAt = performance.now();
   const authorized = await authorize(c, "feedback:read", "list");
   if (!authorized.ok) return authorized.response;
+  const authorizedAt = performance.now();
   const limit = Math.min(50, Math.max(1, Number(c.req.query("limit") ?? "20") || 20));
   const decodedCursor = decodeCursor(c.req.query("cursor"));
   if (!decodedCursor) return c.json({ error: "invalid cursor" }, 400);
   const [cursorCreatedAt, cursorId] = decodedCursor;
-  const [{ results }, totalUnread] = await Promise.all([
-    c.env.DB.prepare(
+  const ticketStatement = c.env.DB.prepare(
     `SELECT t.id, t.kind, t.status, t.message, t.version_name, t.version_code,
             t.channel, t.created_at, t.updated_at,
             (SELECT COUNT(*) FROM feedback_attachments fa
@@ -323,15 +344,25 @@ export async function handleListReporterFeedback(c: ReporterContext) {
     cursorCreatedAt,
     cursorId,
     limit + 1,
-  ).all<Record<string, unknown>>(),
-    unreadTotal(c, authorized.principal),
+  );
+  const [ticketResult, unreadResult] = await c.env.DB.batch([
+    ticketStatement,
+    unreadTotalStatement(c, authorized.principal),
+    auditReadStatement(c, authorized.principal, authorized.pseudonym, "list"),
   ]);
+  const results = (ticketResult?.results ?? []) as Record<string, unknown>[];
+  const unreadRow = unreadResult?.results[0] as { unread_total?: number } | undefined;
+  const totalUnread = Math.max(0, unreadRow?.unread_total ?? 0);
+  const queriedAt = performance.now();
   const page = results.slice(0, limit);
   const last = page.at(-1);
   const nextCursor = results.length > limit && last
     ? encodeCursor(last.created_at, last.id)
     : null;
-  await auditRead(c, authorized.principal, authorized.pseudonym, "list");
+  c.header("Server-Timing", [
+    `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
+    `hands_list;dur=${timingDuration(authorizedAt, queriedAt)}`,
+  ].join(", "));
   return c.json({
     tickets: page.map(ticketDto),
     next_cursor: nextCursor,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -812,8 +812,11 @@ function makeMockDb() {
           const info = stmt.run(...expanded);
           return { success: true, meta: { changes: info.changes } };
         };
+        const batchSync = () => stmt.reader
+          ? { results: stmt.all(...expanded), success: true }
+          : runSync();
         return {
-          _runSync: runSync,
+          _runSync: batchSync,
           run: async () => runSync(),
           all: async () => {
             const rows = stmt.all(...expanded);
@@ -9090,7 +9093,7 @@ describe("quiver public API v2 — scope resolution", () => {
       ...dbBeforeRace,
       prepare(sql: string) {
         const prepared = prepareBeforeRace(sql);
-        if (!sql.includes("SELECT 1 AS ok FROM app_reporter_routes")) return prepared;
+        if (!sql.includes("FROM app_reporter_integrations ri")) return prepared;
         return {
           ...prepared,
           bind(...params: unknown[]) {
@@ -9142,7 +9145,15 @@ describe("quiver public API v2 — scope resolution", () => {
       "SELECT COUNT(*) AS count FROM feedback_submission_events WHERE app_id = 'app-scope' AND reporter_id = ?1",
     ).bind("g".repeat(64)).first() as any).count).toBe(0);
 
-    for (let index = 0; index < 100; index += 1) expect((await submit(reporterA)).status).toBe(201);
+    for (let index = 0; index < 100; index += 1) {
+      const response = await submit(reporterA);
+      expect(response.status).toBe(201);
+      if (index === 0) {
+        expect(response.headers.get("server-timing")).toMatch(
+          /^hands_auth;dur=\d+\.\d, hands_preflight;dur=\d+\.\d, hands_commit;dur=\d+\.\d, hands_postcommit;dur=\d+\.\d$/,
+        );
+      }
+    }
     const limited = await submit(reporterA);
     expect(limited.status).toBe(429);
     expect(Number(limited.headers.get("retry-after"))).toBeGreaterThan(0);
@@ -10830,6 +10841,9 @@ describe("Hands iOS simulator QA artifacts", () => {
 
     const listA = await handleListReporterFeedback(context("list", credentialA.token));
     expect(listA.status).toBe(200);
+    expect(listA.headers.get("server-timing")).toMatch(
+      /^hands_auth;dur=\d+\.\d, hands_list;dur=\d+\.\d$/,
+    );
     const listABody = await listA.json() as any;
     expect(listABody.tickets.map((ticket: any) => ticket.id)).toEqual([ticketA]);
     expect(listABody.tickets[0]).toMatchObject({


### PR DESCRIPTION
## Summary

- batch deploy-token lookup and `last_used_at` touch into one D1 request
- combine trusted-reporter integration and route preflight
- run idempotency and rate-limit lookups concurrently
- use the create batch result as the route-race fence and build the new-ticket receipt from committed input, removing three post-commit reads
- batch reporter list, authoritative unread total, and access audit
- return safe `Server-Timing` phase durations for create and list

## Contract preservation

- invalid/expired/revoked tokens remain fail-closed and are not touched
- route disappearance still prevents ticket/event/delivery writes
- ambiguous idempotent commits still reconcile to the original ticket
- rate limits, reporter isolation, authoritative unread, and durable read audit remain unchanged
- timing headers contain only fixed phase names and durations

## Verification

- Worker full suite: 260/260
- focused route suite after final timing change: 171/171
- Worker build/typecheck
- `git diff --check`

The repository's existing `worker` lint script is currently non-runnable with ESLint 9 because no `eslint.config.*` exists; no lint rule was bypassed or changed here.
