### PR TITLE
chore(android-sdk): prepare 0.12.3 release

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.12.2"
+        default: "0.12.3"
   push:
     tags:
       - "android-sdk-v*"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.2")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.3")
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.12.2")
+    implementation("build.hands:hands-android-sdk:0.12.3")
 }
 ```
 
@@ -126,7 +126,7 @@ to catch that.
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.2`). That publishes to
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.3`). That publishes to
 GitHub Packages (`build.hands:hands-android-sdk:<version>`, including the
 `native-symbols` classifier) and, on the first
 request, builds the same version on JitPack

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.12.2"
+        const val SDK_VERSION = "0.12.3"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.2")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.3")
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.12.2")
+    implementation("build.hands:hands-android-sdk:0.12.3")
 }
 ```
 


### PR DESCRIPTION
## Summary

Prepare the already-reviewed and landed Android SDK update-transaction work for an immutable `0.12.3` release.

This release-prep commit changes only four version-bearing surfaces from `0.12.2` to `0.12.3`:

- publish workflow default
- GitHub Packages/JitPack documentation and tag example
- `HandsFeedback.SDK_VERSION`
- public Android SDK documentation

## Exact source

- Head: `085e3e8abd512c0e82107ffdc254bfa407947df5`
- Parent/base: `1b47f196277f418efbb692da65a74eb8d8797579`
- Tree: `6542ecd38d1e223d8e75e612c027cdb828590b04`
- Stable patch-id: `9da31e63189f3c38026caca2ceeee6ebb3d7bb28`
- Scope: 4 paths, +7/-7
- DCO: `Signed-off-by: Quinn Rafferty <cc-quiver-owner@mail.build>`

## Validation

- Clean isolated-cache sequential release gate: `BUILD SUCCESSFUL`, 47 actionable tasks
- JVM: 47/47; QNC2 native record identity: PASS
- Release AAR: `f13ef3be645957eb934604f3061603fc8261f3d85f6228d29483117a8e10426a`
- Native symbols ZIP: `17060be3d0a8c8a6ed5eb06b8f7bd7752dcca167f18aa0e4f0d5a16a1553ab32`
- AndroidTest APK assembly: PASS, SHA `beeb327689a00184588e4476df58b8875f15c0d6a39f9d29e55c9719b86b2c72`
- Generated POM: `build.hands:hands-android-sdk:0.12.3`
- AAR readback: `HandsFeedback.SDK_VERSION=0.12.3`, no `0.12.2`, expected update/transaction/provider classes and three JNI ABIs present
- Native-symbol manifest readback: version `0.12.3`, exact source head, exactly arm64-v8a/armeabi-v7a/x86_64
- `git diff --check`: PASS; worktree clean

## Preserved failed attempts

- The first clean build using the shared Gradle home failed before project configuration on a missing Kotlin-DSL `metadata.bin` cache file.
- The first isolated all-in-one invocation passed unit/QNC2/release/androidTest work but failed `packageReleaseNativeSymbols` because debug and release native outputs were generated concurrently, yielding multiple ABI candidates. Sequential clean release/symbol packaging followed by AndroidTest assembly passed without source changes.

This PR does not itself publish a tag/package or authorize Mobile/Alpha/Hands/runtime changes.
