### PR TITLE
fix(feedback): separate staff notes from replies

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1708,10 +1708,15 @@ export const updateFeedbackTicket = (
     },
   );
 
-export const addFeedbackComment = (appId: string, ticketId: string, body: string) =>
+export const addFeedbackComment = (
+  appId: string,
+  ticketId: string,
+  body: string,
+  internal: boolean,
+) =>
   request<{ id: string }>(`/api/apps/${appId}/feedback/${ticketId}/comments`, {
     method: "POST",
-    body: JSON.stringify({ body }),
+    body: JSON.stringify({ body, internal }),
     admin: true,
   });
 

--- a/admin/src/lib/feedbackComments.test.ts
+++ b/admin/src/lib/feedbackComments.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { addFeedbackComment } from "./api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("feedback staff comment visibility", () => {
+  it("sends an explicit internal flag for notes and reporter-visible replies", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({ id: "comment-1" }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await addFeedbackComment("app-1", "ticket-1", "private context", true);
+    await addFeedbackComment("app-1", "ticket-1", "customer update", false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      body: "private context",
+      internal: true,
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      body: "customer update",
+      internal: false,
+    });
+  });
+});

--- a/admin/src/lib/feedbackMessages.test.ts
+++ b/admin/src/lib/feedbackMessages.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEEDBACK_MESSAGES,
+  FEEDBACK_MESSAGE_KEYS,
+  feedbackMessage,
+} from "./feedbackMessages";
+
+describe("feedback staff visibility messages", () => {
+  it("keeps English and Simplified Chinese keys complete", () => {
+    for (const locale of ["en", "zh-CN"] as const) {
+      expect(Object.keys(FEEDBACK_MESSAGES[locale]).sort()).toEqual(
+        [...FEEDBACK_MESSAGE_KEYS].sort(),
+      );
+    }
+  });
+
+  it("selects Chinese aliases and falls back to English", () => {
+    expect(feedbackMessage("sendToReporter", ["zh-Hans-CN"])).toBe("发送给用户");
+    expect(feedbackMessage("sendToReporter", ["fr-FR"])).toBe("Send to reporter");
+  });
+});

--- a/admin/src/lib/feedbackMessages.ts
+++ b/admin/src/lib/feedbackMessages.ts
@@ -1,0 +1,35 @@
+export const FEEDBACK_MESSAGE_KEYS = [
+  "internalNote",
+  "visibleToReporter",
+  "addInternalNote",
+  "sendToReporter",
+] as const;
+
+export type FeedbackMessageKey = typeof FEEDBACK_MESSAGE_KEYS[number];
+
+export const FEEDBACK_MESSAGES: Record<"en" | "zh-CN", Record<FeedbackMessageKey, string>> = {
+  en: {
+    internalNote: "Internal note",
+    visibleToReporter: "Visible to reporter",
+    addInternalNote: "Add internal note",
+    sendToReporter: "Send to reporter",
+  },
+  "zh-CN": {
+    internalNote: "内部备注",
+    visibleToReporter: "用户可见",
+    addInternalNote: "添加内部备注",
+    sendToReporter: "发送给用户",
+  },
+};
+
+export function feedbackMessage(
+  key: FeedbackMessageKey,
+  languages: readonly string[] = typeof navigator === "undefined"
+    ? ["en"]
+    : navigator.languages,
+): string {
+  const locale = languages.some((language) => language.toLowerCase().startsWith("zh"))
+    ? "zh-CN"
+    : "en";
+  return FEEDBACK_MESSAGES[locale][key] ?? FEEDBACK_MESSAGES.en[key];
+}

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -18,6 +18,7 @@ import {
   getFeedbackAttachmentText,
   updateFeedbackTicket,
 } from "../lib/api";
+import { feedbackMessage } from "../lib/feedbackMessages";
 import { useToast } from "../components/Toast";
 import { FeedbackTrends } from "../components/FeedbackTrends";
 import { Button, Input, Select, SelectTrigger, SelectValue, SelectIcon, SelectContent, SelectItem, Tooltip, TooltipTrigger, TooltipContent, EmptyState, EmptyStateTitle, Skeleton } from "raft-ui";
@@ -556,7 +557,8 @@ export function FeedbackTicketPage({
   });
 
   const addComment = useMutation({
-    mutationFn: () => addFeedbackComment(appId, ticketId, comment.trim()),
+    mutationFn: (internal: boolean) =>
+      addFeedbackComment(appId, ticketId, comment.trim(), internal),
     onSuccess: () => {
       setComment("");
       invalidate();
@@ -849,8 +851,13 @@ export function FeedbackTicketPage({
             <ul className="space-y-2 text-sm">
               {detail.data!.comments.map((cm) => (
                 <li key={cm.id} className="rounded-sm border border-slate-200 p-2">
-                  <div className="text-xs text-slate-500">
-                    {cm.author_actor} · {new Date(cm.created_at).toLocaleString()}
+                  <div className="flex items-center justify-between gap-2 text-xs text-slate-500">
+                    <span>{cm.author_actor} · {new Date(cm.created_at).toLocaleString()}</span>
+                    <span className="rounded-sm border border-slate-300 px-1.5 py-0.5 font-medium">
+                      {cm.internal
+                        ? feedbackMessage("internalNote")
+                        : feedbackMessage("visibleToReporter")}
+                    </span>
                   </div>
                   <div className="whitespace-pre-wrap">{cm.body}</div>
                 </li>
@@ -863,16 +870,23 @@ export function FeedbackTicketPage({
                 value={comment}
                 onChange={(e) => setComment(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && comment.trim()) addComment.mutate();
+                  if (e.key === "Enter" && comment.trim()) addComment.mutate(true);
                 }}
               />
+              <Button
+                className="text-sm"
+                disabled={addComment.isPending || !comment.trim()}
+                onClick={() => addComment.mutate(true)}
+              >
+                {feedbackMessage("addInternalNote")}
+              </Button>
               <Button
                 variant="primary"
                 className="text-sm"
                 disabled={addComment.isPending || !comment.trim()}
-                onClick={() => addComment.mutate()}
+                onClick={() => addComment.mutate(false)}
               >
-                Send
+                {feedbackMessage("sendToReporter")}
               </Button>
             </div>
           </div>

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -162,6 +162,15 @@ describe("FeedbackProvider", () => {
     expect(css).toMatch(
       /\.hands-feedback-conversation[^}]*align-content:\s*start/,
     );
+    expect(css).toMatch(
+      /\.hands-feedback-conversation article\s*\{[^}]*max-width:\s*min\(42rem, 88%\)[^}]*width:\s*fit-content/,
+    );
+    expect(css).toMatch(
+      /article\[data-author="reporter"\][^}]*justify-self:\s*end/,
+    );
+    expect(css).toMatch(
+      /article\[data-author="staff"\][^}]*justify-self:\s*start/,
+    );
     expect(css).not.toMatch(/display:\s*none[^}]*hands-feedback-conversation/);
   });
 

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -159,6 +159,9 @@ describe("FeedbackProvider", () => {
     expect(css).toMatch(
       /\.hands-feedback-conversation[^}]*flex:\s*1[^}]*overflow-y:\s*auto/,
     );
+    expect(css).toMatch(
+      /\.hands-feedback-conversation[^}]*align-content:\s*start/,
+    );
     expect(css).not.toMatch(/display:\s*none[^}]*hands-feedback-conversation/);
   });
 

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -225,6 +225,7 @@
   margin-bottom: 8px;
 }
 .hands-feedback-conversation {
+  align-content: start;
   display: grid;
   flex: 1;
   gap: 10px;

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -237,10 +237,15 @@
 }
 .hands-feedback-conversation article[data-author="reporter"] {
   background: var(--hf-surface);
-  margin-left: min(48px, 8vw);
+  justify-self: end;
 }
 .hands-feedback-conversation article[data-author="staff"] {
-  margin-right: min(48px, 8vw);
+  justify-self: start;
+}
+.hands-feedback-conversation article {
+  max-width: min(42rem, 88%);
+  overflow-wrap: anywhere;
+  width: fit-content;
 }
 .hands-feedback-comment-meta {
   display: flex;

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -36,10 +36,10 @@ function timingDuration(start: number, end: number): string {
 }
 
 function setServerTiming(
-  c: Context<{ Bindings: Env }>,
+  c: unknown,
   value: string,
 ): void {
-  const header = (c as Context<{ Bindings: Env }> & {
+  const header = (c as {
     header?: (name: string, value: string) => void;
   }).header;
   header?.call(c, "Server-Timing", value);
@@ -2179,10 +2179,19 @@ async function loadFeedbackMutationSnapshot(
 }
 
 export async function handleAddFeedbackComment(c: AdminContext) {
+  const startedAt = performance.now();
   const appId = c.req.param("appId") ?? "";
-  const resolved = await resolveTicketId(c.env.DB, appId, c.req.param("ticketId"));
-  if ("error" in resolved) return ticketResolveError(c, resolved);
-  const ticketId = resolved.id;
+  const rawTicketId = (c.req.param("ticketId") ?? "").trim();
+  let ticketId: string;
+  if (UUID_RE.test(rawTicketId)) {
+    // The mutation snapshot below is the authoritative existence/ownership
+    // check, so a full UUID does not need a redundant preliminary SELECT.
+    ticketId = rawTicketId.toLowerCase();
+  } else {
+    const resolved = await resolveTicketId(c.env.DB, appId, rawTicketId);
+    if ("error" in resolved) return ticketResolveError(c, resolved);
+    ticketId = resolved.id;
+  }
   const body = (await c.req.json().catch(() => ({}))) as {
     body?: string;
     internal?: boolean;
@@ -2207,6 +2216,7 @@ export async function handleAddFeedbackComment(c: AdminContext) {
       reporter_active: number;
     }>();
   if (!ticket) return c.json({ error: "ticket not found" }, 404);
+  const preflightAt = performance.now();
   const now = Date.now();
   const id = crypto.randomUUID();
   const statements = [
@@ -2248,6 +2258,11 @@ export async function handleAddFeedbackComment(c: AdminContext) {
     }));
   }
   await c.env.DB.batch(statements);
+  const committedAt = performance.now();
+  setServerTiming(c, [
+    `hands_comment_preflight;dur=${timingDuration(startedAt, preflightAt)}`,
+    `hands_comment_commit;dur=${timingDuration(preflightAt, committedAt)}`,
+  ].join(", "));
   return c.json({ id, ticket_id: ticketId, created_at: now }, 201);
 }
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -1442,6 +1442,9 @@ describe("quiver route handlers — SQL smoke", () => {
       env as any,
     );
     expect(memberComment.status).toBe(201);
+    expect(memberComment.headers.get("server-timing")).toMatch(
+      /^hands_comment_preflight;dur=\d+\.\d, hands_comment_commit;dur=\d+\.\d$/,
+    );
 
     const ticket = (await env.DB
       .prepare("SELECT status FROM feedback_tickets WHERE id = ?")


### PR DESCRIPTION
## Summary

- make Enter and the ordinary admin action create an internal staff note
- require the explicit `Send to reporter` action for reporter-visible replies
- label existing comments as internal or reporter-visible
- localize the new visibility controls in English and Simplified Chinese
- keep reporter conversation rows content-sized instead of stretching each reply to fill the viewport
- skip the redundant ticket lookup for full UUID admin comments and expose fixed-name comment preflight/commit durations

The Worker API contract is unchanged: `internal: true` remains staff-only and `internal: false` remains reporter-visible. CLI/agent callers retain their existing explicit choice; only the Hands Admin composer changes its default.

## Validation

- Worker: 260/260 tests; generated Hands bindings + build/typecheck
- Admin: 33/33 tests; typecheck; production build
- Feedback React: 31/31 tests; typecheck; build
- `git diff --check`

The repository lint command remains unavailable under the existing ESLint 9/no `eslint.config.*` baseline; no lint configuration or rule was changed.
