### PR TITLE
fix(feedback): align ticket visuals with Raft tasks

### DIFF
--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -153,13 +153,9 @@ function StatusBadge({ status }: { status: FeedbackTicketSummary["status"] }) {
           : "statusOpen",
   );
   const variant =
-    status === "open"
-      ? "warning"
-      : status === "in_progress"
-        ? "information"
-        : status === "resolved"
-          ? "success"
-          : "muted";
+    status === "open" || status === "in_progress"
+      ? "information"
+      : "success";
   return (
     <Badge
       appearance="solid"

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -152,20 +152,22 @@ function StatusBadge({ status }: { status: FeedbackTicketSummary["status"] }) {
           ? "statusClosed"
           : "statusOpen",
   );
-  if (status === "in_progress")
-    return (
-      <Badge variant="information" uppercase={false}>
-        {label}
-      </Badge>
-    );
-  if (status === "resolved")
-    return (
-      <Badge variant="success" uppercase={false}>
-        {label}
-      </Badge>
-    );
+  const variant =
+    status === "open"
+      ? "warning"
+      : status === "in_progress"
+        ? "information"
+        : status === "resolved"
+          ? "success"
+          : "muted";
   return (
-    <Badge appearance="outline" uppercase={false}>
+    <Badge
+      appearance="solid"
+      variant={variant}
+      uppercase={false}
+      className="hands-feedback-status"
+      data-feedback-status={status}
+    >
       {label}
     </Badge>
   );

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -185,6 +185,37 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(await screen.findByText(ticket.message)).toBeTruthy();
   });
 
+  it("maps every reporter ticket status to the Raft task palette", async () => {
+    const adapter = transport();
+    adapter.listTickets = vi.fn(async () => ({
+      tickets: (["open", "in_progress", "resolved", "closed"] as const).map(
+        (status, index) => ({
+          ...ticket,
+          id: `ticket-${status}`,
+          message: `Ticket ${status}`,
+          status,
+          unread: false,
+          unreadCount: 0,
+          updatedAt: index + 10,
+        }),
+      ),
+      nextCursor: null,
+      unreadTotal: 0,
+    }));
+    const { container } = render(
+      <FeedbackProvider transport={adapter} theme="brutal">
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    await screen.findByText("Ticket open");
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>("[data-feedback-status]"),
+      ).map((badge) => badge.dataset.feedbackStatus),
+    ).toEqual(["open", "in_progress", "resolved", "closed"]);
+  });
+
   it("does not re-notify when list and detail return the same authoritative total", async () => {
     const adapter = transport();
     adapter.getTicket = vi.fn(async () => ({

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -171,6 +171,27 @@ describe("FeedbackProvider", () => {
     expect(css).toMatch(
       /article\[data-author="staff"\][^}]*justify-self:\s*start/,
     );
+    expect(css).toMatch(
+      /\.hands-feedback-ticket-row:hover\s*\{[^}]*outline:\s*none/,
+    );
+    expect(css).toMatch(
+      /\.hands-feedback-ticket-row:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--hf-border-strong\)/,
+    );
+    expect(css).not.toMatch(
+      /\.hands-feedback-ticket-row:(?:hover|focus-visible)[^{]*\{[^}]*var\(--hf-accent\)/,
+    );
+    for (const [status, token] of [
+      ["open", "orange"],
+      ["in_progress", "cyan"],
+      ["resolved", "lime"],
+      ["closed", "stone"],
+    ] as const) {
+      expect(css).toMatch(
+        new RegExp(
+          `\\.hands-feedback-status\\[data-feedback-status="${status}"\\][^}]*var\\(--color-brutal-${token}`,
+        ),
+      );
+    }
     expect(css).not.toMatch(/display:\s*none[^}]*hands-feedback-conversation/);
   });
 

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -172,7 +172,7 @@ describe("FeedbackProvider", () => {
       /article\[data-author="staff"\][^}]*justify-self:\s*start/,
     );
     expect(css).toMatch(
-      /\.hands-feedback-ticket-row:hover\s*\{[^}]*outline:\s*none/,
+      /\.hands-feedback-ticket-row:hover\s*\{[^}]*outline:\s*2px solid var\(--color-brutal-pink/,
     );
     expect(css).toMatch(
       /\.hands-feedback-ticket-row:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--hf-border-strong\)/,
@@ -181,10 +181,10 @@ describe("FeedbackProvider", () => {
       /\.hands-feedback-ticket-row:(?:hover|focus-visible)[^{]*\{[^}]*var\(--hf-accent\)/,
     );
     for (const [status, token] of [
-      ["open", "orange"],
+      ["open", "cyan"],
       ["in_progress", "cyan"],
       ["resolved", "lime"],
-      ["closed", "stone"],
+      ["closed", "lime"],
     ] as const) {
       expect(css).toMatch(
         new RegExp(

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -145,7 +145,12 @@
 .hands-feedback-ticket-row:hover,
 .hands-feedback-ticket-row:focus-visible {
   background: var(--hf-surface);
-  outline: 2px solid var(--hf-accent);
+}
+.hands-feedback-ticket-row:hover {
+  outline: none;
+}
+.hands-feedback-ticket-row:focus-visible {
+  outline: 2px solid var(--hf-border-strong);
   outline-offset: -2px;
 }
 .hands-feedback-ticket-row[data-unread="true"] .hands-feedback-ticket-title {
@@ -173,6 +178,21 @@
   display: flex;
   flex: none;
   gap: 8px;
+}
+.hands-feedback-status[data-feedback-status="open"] {
+  background-color: var(--color-brutal-orange, #ffb02e) !important;
+}
+.hands-feedback-status[data-feedback-status="in_progress"] {
+  background-color: var(--color-brutal-cyan, #22d3ee) !important;
+}
+.hands-feedback-status[data-feedback-status="resolved"] {
+  background-color: var(--color-brutal-lime, #a3e635) !important;
+}
+.hands-feedback-status[data-feedback-status="closed"] {
+  background-color: var(--color-brutal-stone, #d6d3d1) !important;
+}
+.hands-feedback-status {
+  color: var(--hf-text) !important;
 }
 .hands-feedback-unread-dot {
   background: var(--danger, #e11d48);

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -147,7 +147,8 @@
   background: var(--hf-surface);
 }
 .hands-feedback-ticket-row:hover {
-  outline: none;
+  outline: 2px solid var(--color-brutal-pink, var(--hf-border-strong));
+  outline-offset: -2px;
 }
 .hands-feedback-ticket-row:focus-visible {
   outline: 2px solid var(--hf-border-strong);
@@ -180,7 +181,7 @@
   gap: 8px;
 }
 .hands-feedback-status[data-feedback-status="open"] {
-  background-color: var(--color-brutal-orange, #ffb02e) !important;
+  background-color: var(--color-brutal-cyan, #22d3ee) !important;
 }
 .hands-feedback-status[data-feedback-status="in_progress"] {
   background-color: var(--color-brutal-cyan, #22d3ee) !important;
@@ -189,10 +190,7 @@
   background-color: var(--color-brutal-lime, #a3e635) !important;
 }
 .hands-feedback-status[data-feedback-status="closed"] {
-  background-color: var(--color-brutal-stone, #d6d3d1) !important;
-}
-.hands-feedback-status {
-  color: var(--hf-text) !important;
+  background-color: var(--color-brutal-lime, #a3e635) !important;
 }
 .hands-feedback-unread-dot {
   background: var(--danger, #e11d48);


### PR DESCRIPTION
## Summary

- map reporter ticket states to the established Raft task semantics: open/in progress use the active cyan token; resolved/closed use the completed lime token
- keep all status labels localized while using solid semantic badges
- replace the blue row outline with Raft interaction colors: pink for pointer hover/selection and ink for keyboard focus
- let raft-ui own badge foreground contrast instead of overriding it from the host foreground token
- add DOM and package CSS contract coverage for all four statuses and the interaction treatment

## Validation

- pnpm --filter @botiverse/hands-feedback-react test (32/32)
- pnpm --filter @botiverse/hands-feedback-react typecheck
- pnpm --filter @botiverse/hands-feedback-react build
- git diff --check
