### PR TITLE
fix(feedback): clarify active tickets and unread

### DIFF
--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -299,7 +299,7 @@ export function FeedbackInbox({
           >
             {value === "all"
               ? message("all")
-              : message(value === "open" ? "statusOpen" : "statusResolved")}
+              : message(value === "open" ? "active" : "statusResolved")}
           </Button>
         ))}
       </div>

--- a/packages/feedback-react/src/locale.ts
+++ b/packages/feedback-react/src/locale.ts
@@ -5,6 +5,7 @@ import type {
 } from "./types.js";
 
 export type FeedbackMessageKey =
+  | "active"
   | "all"
   | "attachmentTooLarge"
   | "attachmentTooMany"
@@ -70,6 +71,7 @@ export type FeedbackMessageValues = Record<string, string | number>;
 
 const messages: Record<FeedbackLocale, FeedbackMessages> = {
   en: {
+    active: "Active",
     all: "All",
     attachmentTooLarge: "{name} is larger than 10 MB.",
     attachmentTooMany: "Choose no more than {count} screenshots.",
@@ -132,6 +134,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     you: "You",
   },
   "zh-CN": {
+    active: "活跃",
     all: "全部",
     attachmentTooLarge: "{name} 超过 10 MB。",
     attachmentTooMany: "最多选择 {count} 张截图。",

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -209,6 +209,7 @@ describe("FeedbackWorkspace browser behavior", () => {
     );
 
     await screen.findByText("Ticket open");
+    expect(screen.getByRole("button", { name: "Active" })).toBeTruthy();
     expect(
       Array.from(
         container.querySelectorAll<HTMLElement>("[data-feedback-status]"),
@@ -245,7 +246,7 @@ describe("FeedbackWorkspace browser behavior", () => {
     const row = await screen.findByRole("button", {
       name: /A reporter-visible ticket/,
     });
-    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    fireEvent.click(screen.getByRole("button", { name: "Active" }));
     const listScroll = document.querySelector<HTMLElement>(
       "[data-feedback-list-scroll]",
     )!;
@@ -256,7 +257,9 @@ describe("FeedbackWorkspace browser behavior", () => {
     await waitFor(() => expect(document.activeElement).toBe(row));
     expect(listScroll.scrollTop).toBe(91);
     expect(
-      screen.getByRole("button", { name: "Open" }).getAttribute("aria-pressed"),
+      screen
+        .getByRole("button", { name: "Active" })
+        .getAttribute("aria-pressed"),
     ).toBe("true");
     expect(row.getAttribute("data-unread")).toBeNull();
   });

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -51,6 +51,8 @@ describe("FeedbackProvider", () => {
     expect(
       resolveFeedbackLocaleFromPreferences(["fr-FR", "zh-CN", "en-US"]),
     ).toBe("zh-CN");
+    expect(feedbackMessage("en", "active")).toBe("Active");
+    expect(feedbackMessage("zh-CN", "active")).toBe("活跃");
     expect(
       feedbackMessage(
         "en",
@@ -192,6 +194,12 @@ describe("FeedbackProvider", () => {
         ),
       );
     }
+    expect(css).toMatch(
+      /\.hands-feedback-unread-dot[^}]*var\(--color-brutal-pink/,
+    );
+    expect(css).not.toMatch(
+      /\.hands-feedback-unread-dot[^}]*var\(--danger/,
+    );
     expect(css).not.toMatch(/display:\s*none[^}]*hands-feedback-conversation/);
   });
 

--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -174,7 +174,10 @@ describe("FeedbackProvider", () => {
       /article\[data-author="staff"\][^}]*justify-self:\s*start/,
     );
     expect(css).toMatch(
-      /\.hands-feedback-ticket-row:hover\s*\{[^}]*outline:\s*2px solid var\(--color-brutal-pink/,
+      /\.hands-feedback-ticket-row:hover\s*\{[^}]*box-shadow:\s*2px 2px 0 var\(--hf-border-strong\)[^}]*outline:\s*2px solid var\(--hf-border-strong\)/,
+    );
+    expect(css).not.toMatch(
+      /\.hands-feedback-ticket-row:hover\s*\{[^}]*var\(--color-brutal-pink/,
     );
     expect(css).toMatch(
       /\.hands-feedback-ticket-row:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--hf-border-strong\)/,

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -147,8 +147,11 @@
   background: var(--hf-surface);
 }
 .hands-feedback-ticket-row:hover {
-  outline: 2px solid var(--color-brutal-pink, var(--hf-border-strong));
+  box-shadow: 2px 2px 0 var(--hf-border-strong);
+  outline: 2px solid var(--hf-border-strong);
   outline-offset: -2px;
+  position: relative;
+  z-index: 1;
 }
 .hands-feedback-ticket-row:focus-visible {
   outline: 2px solid var(--hf-border-strong);

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -193,7 +193,7 @@
   background-color: var(--color-brutal-lime, #a3e635) !important;
 }
 .hands-feedback-unread-dot {
-  background: var(--danger, #e11d48);
+  background: var(--color-brutal-pink, var(--primary, #ec4899));
   border: 1px solid var(--hf-border-strong);
   border-radius: 50%;
   height: 9px;


### PR DESCRIPTION
## Summary

- rename the combined open/in-progress filter from Open to Active while preserving exact row status labels
- add complete English and Simplified Chinese copy for the new filter label
- use the Raft pink attention token for authoritative unread indicators instead of the destructive/error token
- use the raft-ui card selection treatment for pointer rows: ink outline, shallow tint, and offset shadow; keyboard focus remains ink
- update behavior and CSS contract coverage for filter semantics, localization, unread color, and row interaction

## Validation

- pnpm --filter @botiverse/hands-feedback-react test (32/32)
- pnpm --filter @botiverse/hands-feedback-react typecheck
- pnpm --filter @botiverse/hands-feedback-react build
- git diff --check
