### PR TITLE
fix(feedback): separate hover from selection

### DIFF
--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -174,10 +174,10 @@ describe("FeedbackProvider", () => {
       /article\[data-author="staff"\][^}]*justify-self:\s*start/,
     );
     expect(css).toMatch(
-      /\.hands-feedback-ticket-row:hover\s*\{[^}]*box-shadow:\s*2px 2px 0 var\(--hf-border-strong\)[^}]*outline:\s*2px solid var\(--hf-border-strong\)/,
+      /\.hands-feedback-ticket-row:hover,\s*\.hands-feedback-ticket-row:focus-visible\s*\{[^}]*background:\s*var\(--hf-surface\)/,
     );
     expect(css).not.toMatch(
-      /\.hands-feedback-ticket-row:hover\s*\{[^}]*var\(--color-brutal-pink/,
+      /\.hands-feedback-ticket-row:hover\s*\{[^}]*(?:outline|box-shadow)/,
     );
     expect(css).toMatch(
       /\.hands-feedback-ticket-row:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--hf-border-strong\)/,

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -146,13 +146,6 @@
 .hands-feedback-ticket-row:focus-visible {
   background: var(--hf-surface);
 }
-.hands-feedback-ticket-row:hover {
-  box-shadow: 2px 2px 0 var(--hf-border-strong);
-  outline: 2px solid var(--hf-border-strong);
-  outline-offset: -2px;
-  position: relative;
-  z-index: 1;
-}
 .hands-feedback-ticket-row:focus-visible {
   outline: 2px solid var(--hf-border-strong);
   outline-offset: -2px;


### PR DESCRIPTION
## Summary

- keep pointer hover lightweight with the existing shallow surface tint only
- preserve an ink keyboard focus ring
- remove the heavy ink outline/shadow from hover because the current single-panel list-to-detail navigation has no persistent selected row
- retain Active filter semantics, task-aligned status colors, and pink unread attention from the prior merge
- update the CSS contract to reject selection chrome on hover

## Validation

- pnpm --filter @botiverse/hands-feedback-react test (32/32)
- pnpm --filter @botiverse/hands-feedback-react typecheck
- pnpm --filter @botiverse/hands-feedback-react build
- git diff --check
