### PR TITLE
perf(feedback): collapse reporter detail D1 stages

### DIFF
--- a/worker/src/lib/deploy_tokens.ts
+++ b/worker/src/lib/deploy_tokens.ts
@@ -23,6 +23,7 @@ export type AppDeployToken = {
   last_used_at: number | null;
   revoked_at: number | null;
   reporter_integration_id: string | null;
+  reporter_integration_active: number | null;
 };
 
 export function isDeployTokenRole(value: unknown): value is DeployTokenRole {
@@ -99,9 +100,20 @@ export async function loadDeployToken(
     `SELECT dt.id, dt.app_id, a.slug AS app_slug, dt.name, dt.token_prefix,
             dt.app_role, dt.scopes_json, dt.created_by, dt.created_by_actor, dt.created_at,
             dt.expires_at, dt.last_used_at, dt.revoked_at,
-            dt.reporter_integration_id
+            dt.reporter_integration_id,
+            CASE
+              WHEN dt.reporter_integration_id IS NULL THEN NULL
+              WHEN ri.id IS NOT NULL THEN 1 ELSE 0
+            END AS reporter_integration_active
      FROM app_deploy_tokens dt
      JOIN apps a ON a.id = dt.app_id
+     -- Fold reporter-integration liveness into the authoritative token lookup.
+     -- Reporter auth can reject an archived integration without a second D1
+     -- round trip, while ordinary app tokens retain the same null sentinel.
+     LEFT JOIN app_reporter_integrations ri
+       ON ri.id = dt.reporter_integration_id
+      AND ri.app_id = dt.app_id
+      AND ri.archived_at IS NULL
      WHERE dt.token_hash = ?1
        AND dt.revoked_at IS NULL
        AND (dt.expires_at IS NULL OR dt.expires_at > ?2)

--- a/worker/src/lib/reporter_auth.ts
+++ b/worker/src/lib/reporter_auth.ts
@@ -55,6 +55,7 @@ export async function authenticateReporter(
   const grantValid = token.app_id === appId
     && token.app_role === null
     && token.reporter_integration_id !== null
+    && token.reporter_integration_active === 1
     && scopes !== null
     && scopes.length > 0
     && scopes.every(isFeedbackTokenPermission)
@@ -63,21 +64,11 @@ export async function authenticateReporter(
     return { ok: false, response: c.json({ error: "invalid reporter integration grant" }, 403) };
   }
 
-  const integration = await c.env.DB.prepare(
-    `SELECT id FROM app_reporter_integrations
-     WHERE id = ?1 AND app_id = ?2 AND archived_at IS NULL`,
-  )
-    .bind(token.reporter_integration_id, appId)
-    .first<{ id: string }>();
-  if (!integration) {
-    return { ok: false, response: c.json({ error: "invalid reporter integration grant" }, 403) };
-  }
-
   return {
     ok: true,
     principal: {
       appId,
-      integrationId: integration.id,
+      integrationId: token.reporter_integration_id!,
       reporterId,
       token,
     },
@@ -92,6 +83,7 @@ export function isFeedbackOnlyToken(
   return token.app_id === appId
     && token.app_role === null
     && token.reporter_integration_id !== null
+    && token.reporter_integration_active === 1
     && token.scopes !== null
     && token.scopes.length > 0
     && token.scopes.every(isFeedbackTokenPermission)

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -157,7 +157,8 @@ async function consumeRateLimit(
      VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7)
      ON CONFLICT(app_id, reporter_integration_id, reporter_hash,
                  audit_key_version, endpoint, window_started_at)
-     DO UPDATE SET request_count = request_count + 1, updated_at = excluded.updated_at`,
+     DO UPDATE SET request_count = request_count + 1, updated_at = excluded.updated_at
+     RETURNING request_count`,
   ).bind(
     principal.appId,
     principal.integrationId,
@@ -167,23 +168,16 @@ async function consumeRateLimit(
     windowStartedAt,
     now,
   );
-  await c.env.DB.batch([upsert(pseudonym.hash), upsert("integration-total")]);
-  const { results } = await c.env.DB.prepare(
-    `SELECT reporter_hash, request_count
-     FROM feedback_reporter_rate_windows
-     WHERE app_id = ?1 AND reporter_integration_id = ?2
-       AND reporter_hash IN (?3, 'integration-total')
-       AND audit_key_version = ?4 AND endpoint = ?5 AND window_started_at = ?6`,
-  ).bind(
-    principal.appId,
-    principal.integrationId,
-    pseudonym.hash,
-    pseudonym.version,
-    endpoint,
-    windowStartedAt,
-  ).all<{ reporter_hash: string; request_count: number }>();
-  const reporterCount = results.find((row) => row.reporter_hash === pseudonym.hash)?.request_count ?? 0;
-  const integrationCount = results.find((row) => row.reporter_hash === "integration-total")?.request_count ?? 0;
+  // RETURNING makes the atomic increment its own authoritative limit read;
+  // a separate SELECT would add latency and create another observable race.
+  const [reporterResult, integrationResult] = await c.env.DB.batch([
+    upsert(pseudonym.hash),
+    upsert("integration-total"),
+  ]);
+  const reporterCount = (reporterResult?.results[0] as { request_count?: number } | undefined)
+    ?.request_count ?? 0;
+  const integrationCount = (integrationResult?.results[0] as { request_count?: number } | undefined)
+    ?.request_count ?? 0;
   if (reporterCount > limit.reporter || integrationCount > limit.integration) {
     c.header("Retry-After", String(Math.max(1, Math.ceil((windowStartedAt + limit.windowMs - now) / 1000))));
     return { ok: false as const, response: c.json({ error: "reporter rate limit exceeded" }, 429) };
@@ -370,7 +364,11 @@ export async function handleListReporterFeedback(c: ReporterContext) {
   });
 }
 
-async function ownedTicket(c: ReporterContext, principal: ReporterPrincipal, ticketId: string) {
+function ownedTicketStatement(
+  c: ReporterContext,
+  principal: ReporterPrincipal,
+  ticketId: string,
+) {
   return c.env.DB.prepare(
     `SELECT t.id, t.kind, t.status, t.message, t.version_name, t.version_code,
             t.channel, t.created_at, t.updated_at, a.org_id,
@@ -390,19 +388,22 @@ async function ownedTicket(c: ReporterContext, principal: ReporterPrincipal, tic
       AND rr.ticket_id = t.id
      WHERE t.id = ?1 AND t.app_id = ?2
        AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4`,
-  ).bind(ticketId, principal.appId, principal.integrationId, principal.reporterId)
+  ).bind(ticketId, principal.appId, principal.integrationId, principal.reporterId);
+}
+
+async function ownedTicket(c: ReporterContext, principal: ReporterPrincipal, ticketId: string) {
+  return ownedTicketStatement(c, principal, ticketId)
     .first<Record<string, unknown> & { org_id: string | null }>();
 }
 
-async function markTicketRead(
+function markTicketReadStatement(
   c: ReporterContext,
   principal: ReporterPrincipal,
   ticketId: string,
-  latest: { id: string; reporter_sequence: number } | null,
-): Promise<void> {
-  if (!latest) return;
+  latest: { id: string; reporter_sequence: number },
+) {
   const now = Date.now();
-  await c.env.DB.prepare(
+  return c.env.DB.prepare(
     `INSERT INTO feedback_reporter_ticket_reads
      (app_id, reporter_integration_id, reporter_id, ticket_id,
       read_through_sequence, read_through_comment_id, updated_at)
@@ -424,42 +425,84 @@ async function markTicketRead(
     latest.reporter_sequence,
     latest.id,
     now,
-  ).run();
+  );
 }
 
 export async function handleGetReporterFeedback(c: ReporterContext) {
+  const startedAt = performance.now();
   const authorized = await authorize(c, "feedback:read", "detail");
   if (!authorized.ok) return authorized.response;
+  const authorizedAt = performance.now();
   const ticketId = fullUuid(c.req.param("ticketId"));
   if (!ticketId) return ticketNotFound(c);
-  const ticket = await ownedTicket(c, authorized.principal, ticketId);
-  if (!ticket) return ticketNotFound(c);
   const commentLimit = Math.min(100, Math.max(1, Number(c.req.query("comment_limit") ?? "50") || 50));
   const commentCursor = decodeCommentCursor(c.req.query("comment_cursor"));
   if (!commentCursor) return c.json({ error: "invalid comment cursor" }, 400);
   const commentStatement = commentCursor.mode === "sequence"
     ? c.env.DB.prepare(
-        `SELECT id, author_type, body, created_at, reporter_sequence
-         FROM feedback_comments
-         WHERE ticket_id = ?1 AND internal = 0 AND reporter_sequence > ?2
-         ORDER BY reporter_sequence ASC LIMIT ?3`,
-      ).bind(ticketId, commentCursor.sequence, commentLimit + 1)
+        `SELECT fc.id, fc.author_type, fc.body, fc.created_at, fc.reporter_sequence
+         FROM feedback_comments fc
+         JOIN feedback_tickets t ON t.id = fc.ticket_id
+         WHERE fc.ticket_id = ?1 AND t.app_id = ?2
+           AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4
+           AND fc.internal = 0 AND fc.reporter_sequence > ?5
+         ORDER BY fc.reporter_sequence ASC LIMIT ?6`,
+      ).bind(
+        ticketId,
+        authorized.principal.appId,
+        authorized.principal.integrationId,
+        authorized.principal.reporterId,
+        commentCursor.sequence,
+        commentLimit + 1,
+      )
     : c.env.DB.prepare(
-        `SELECT id, author_type, body, created_at, reporter_sequence
-         FROM feedback_comments
-         WHERE ticket_id = ?1 AND internal = 0
-           AND (created_at > ?2 OR (created_at = ?2 AND id > ?3))
-         ORDER BY created_at ASC, id ASC LIMIT ?4`,
-      ).bind(ticketId, commentCursor.createdAt, commentCursor.id, commentLimit + 1);
-  const [{ results: comments }, { results: attachments }] = await Promise.all([
-    commentStatement.all<Record<string, unknown>>(),
+        `SELECT fc.id, fc.author_type, fc.body, fc.created_at, fc.reporter_sequence
+         FROM feedback_comments fc
+         JOIN feedback_tickets t ON t.id = fc.ticket_id
+         WHERE fc.ticket_id = ?1 AND t.app_id = ?2
+           AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4
+           AND fc.internal = 0
+           AND (fc.created_at > ?5 OR (fc.created_at = ?5 AND fc.id > ?6))
+         ORDER BY fc.created_at ASC, fc.id ASC LIMIT ?7`,
+      ).bind(
+        ticketId,
+        authorized.principal.appId,
+        authorized.principal.integrationId,
+        authorized.principal.reporterId,
+        commentCursor.createdAt,
+        commentCursor.id,
+        commentLimit + 1,
+      );
+  const attachmentStatement =
     c.env.DB.prepare(
-      `SELECT id, filename, content_type, size_bytes, created_at
-       FROM feedback_attachments
-       WHERE ticket_id = ?1 AND origin IN ('submission', 'reporter') AND visibility = 'reporter'
-       ORDER BY created_at, id`,
-    ).bind(ticketId).all(),
+      `SELECT fa.id, fa.filename, fa.content_type, fa.size_bytes, fa.created_at
+       FROM feedback_attachments fa
+       JOIN feedback_tickets t ON t.id = fa.ticket_id
+       WHERE fa.ticket_id = ?1 AND t.app_id = ?2
+         AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4
+         AND fa.origin IN ('submission', 'reporter') AND fa.visibility = 'reporter'
+       ORDER BY fa.created_at, fa.id`,
+    ).bind(
+      ticketId,
+      authorized.principal.appId,
+      authorized.principal.integrationId,
+      authorized.principal.reporterId,
+    );
+  // One consistent, owner-constrained read phase. Comments and attachments
+  // repeat the principal predicates so even the internal batch never reads a
+  // different reporter's payload while establishing ticket ownership.
+  const [ticketResult, commentResult, attachmentResult] = await c.env.DB.batch([
+    ownedTicketStatement(c, authorized.principal, ticketId),
+    commentStatement,
+    attachmentStatement,
   ]);
+  const ticket = ticketResult?.results[0] as
+    | (Record<string, unknown> & { org_id: string | null })
+    | undefined;
+  if (!ticket) return ticketNotFound(c);
+  const comments = (commentResult?.results ?? []) as Record<string, unknown>[];
+  const attachments = (attachmentResult?.results ?? []) as Record<string, unknown>[];
+  const readAt = performance.now();
   const commentPage = comments.slice(0, commentLimit);
   // A legacy (created_at, id)-ordered page is not necessarily contiguous in
   // reporter_sequence, so a single high-water receipt cannot represent it
@@ -472,12 +515,27 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
         && typeof comment.id === "string"
       ) as { id: string; reporter_sequence: number } | undefined
     : undefined;
-  await auditRead(c, authorized.principal, authorized.pseudonym, "detail", { ticketId });
-  await markTicketRead(c, authorized.principal, ticketId, readWatermark ?? null);
-  const [totalUnread, refreshedTicket] = await Promise.all([
-    unreadTotal(c, authorized.principal),
-    ownedTicket(c, authorized.principal, ticketId),
-  ]);
+  const receiptStatements = [
+    auditReadStatement(c, authorized.principal, authorized.pseudonym, "detail", { ticketId }),
+    ...(readWatermark
+      ? [markTicketReadStatement(c, authorized.principal, ticketId, readWatermark)]
+      : []),
+    unreadTotalStatement(c, authorized.principal),
+    ownedTicketStatement(c, authorized.principal, ticketId),
+  ];
+  // D1 batch ordering makes the receipt visible to the unread/refreshed-ticket
+  // reads in the same round trip. A comment committed after the page snapshot
+  // remains unread and is deliberately not advanced by this receipt.
+  const receiptResults = await c.env.DB.batch(receiptStatements);
+  const unreadIndex = readWatermark ? 2 : 1;
+  const unreadRow = receiptResults[unreadIndex]?.results[0] as
+    | { unread_total?: number }
+    | undefined;
+  const totalUnread = Math.max(0, unreadRow?.unread_total ?? 0);
+  const refreshedTicket = receiptResults[unreadIndex + 1]?.results[0] as
+    | (Record<string, unknown> & { org_id: string | null })
+    | undefined;
+  const committedAt = performance.now();
   const { org_id: _orgId, ...safeTicket } = refreshedTicket ?? ticket;
   const lastComment = commentPage.at(-1);
   const nextCommentCursor = comments.length > commentLimit && lastComment
@@ -485,6 +543,13 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
       ? encodeCursor(lastComment.created_at, lastComment.id)
       : encodeCommentSequenceCursor(lastComment.reporter_sequence, lastComment.id)
     : null;
+  const respondedAt = performance.now();
+  c.header("Server-Timing", [
+    `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
+    `hands_preflight;dur=${timingDuration(authorizedAt, readAt)}`,
+    `hands_commit;dur=${timingDuration(readAt, committedAt)}`,
+    `hands_postcommit;dur=${timingDuration(committedAt, respondedAt)}`,
+  ].join(", "));
   return c.json({
     ticket: ticketDto(safeTicket),
     comments: commentPage.map(({ reporter_sequence: _sequence, ...comment }) => comment),

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -10861,6 +10861,37 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect((await handleListReporterFeedback(context("list", credentialA.token, undefined, undefined, ""))).status).toBe(400);
     expect((await handleListReporterFeedback(context("list", null))).status).toBe(401);
 
+    const rateReporter = "rate_limit_reporter_123456789";
+    const firstRateRequest = await handleListReporterFeedback(context(
+      "list",
+      credentialA.token,
+      undefined,
+      undefined,
+      rateReporter,
+    ));
+    expect(firstRateRequest.status).toBe(200);
+    const { computeReporterAuditHash: reporterAuditHash } =
+      await import("../src/lib/reporter_audit");
+    const rateReporterHash = await reporterAuditHash({
+      key: env.FEEDBACK_AUDIT_HMAC_KEY,
+      appId: "app-ios",
+      integrationId: integrationA,
+      reporterId: rateReporter,
+    });
+    await env.DB.prepare(
+      `UPDATE feedback_reporter_rate_windows SET request_count = 59
+       WHERE app_id = 'app-ios' AND reporter_integration_id = ?1
+         AND reporter_hash = ?2 AND endpoint = 'list'`,
+    ).bind(integrationA, rateReporterHash).run();
+    expect((await handleListReporterFeedback(context(
+      "list", credentialA.token, undefined, undefined, rateReporter,
+    ))).status).toBe(200);
+    const rateLimited = await handleListReporterFeedback(context(
+      "list", credentialA.token, undefined, undefined, rateReporter,
+    ));
+    expect(rateLimited.status).toBe(429);
+    expect(Number(rateLimited.headers.get("retry-after"))).toBeGreaterThan(0);
+
     const submissionId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
     const makeComment = () => handleAddReporterComment(context(
       "comment",
@@ -10934,10 +10965,21 @@ describe("Hands iOS simulator QA artifacts", () => {
          VALUES (?1, ?2, 'system', 'system', ?1, 0, ?3)`,
       ).bind(id, ticketA, now + 100).run();
     }
+    const detailBatch = env.DB.batch.bind(env.DB);
+    let detailBatchStages = 0;
+    env.DB.batch = async (statements: unknown[]) => {
+      detailBatchStages += 1;
+      return detailBatch(statements);
+    };
     const page1 = await handleGetReporterFeedback(context(
       "detail", credentialA.token, ticketA, undefined, reporterId,
       { comment_limit: "2" },
     ));
+    env.DB.batch = detailBatch;
+    expect(detailBatchStages).toBe(4);
+    expect(page1.headers.get("server-timing")).toMatch(
+      /^hands_auth;dur=\d+\.\d, hands_preflight;dur=\d+\.\d, hands_commit;dur=\d+\.\d, hands_postcommit;dur=\d+\.\d$/,
+    );
     const page1Body = await page1.json() as any;
     expect(page1Body.ticket).toMatchObject({ unread: true, unread_count: 2 });
     expect(page1Body.unread_total).toBe(1);
@@ -11083,32 +11125,33 @@ describe("Hands iOS simulator QA artifacts", () => {
 
     const raceCommentId = "10101010-1010-4010-8010-101010101010";
     const originalPrepare = env.DB.prepare.bind(env.DB);
+    const raceOriginalBatch = env.DB.batch.bind(env.DB);
     let injectRace = true;
+    let raceReadPrepared = false;
     env.DB.prepare = (sql: string) => {
       const statement = originalPrepare(sql);
-      if (!sql.includes("SELECT id, author_type, body, created_at")) return statement;
-      const originalBind = statement.bind.bind(statement);
-      statement.bind = (...params: unknown[]) => {
-        const bound = originalBind(...params);
-        const originalAll = bound.all.bind(bound);
-        bound.all = async () => {
-          const snapshot = await originalAll();
-          if (injectRace) {
-            injectRace = false;
-            await originalPrepare(
-              `INSERT INTO feedback_comments
-               (id, ticket_id, author_actor, author_type, body, internal, created_at)
-               VALUES (?1, ?2, 'staff:test', 'staff', 'raced after snapshot', 0, ?3)`,
-            ).bind(raceCommentId, ticketA, now + 200).run();
-          }
-          return snapshot;
-        };
-        return bound;
-      };
+      if (
+        sql.includes("FROM feedback_comments fc")
+        && sql.includes("fc.reporter_sequence")
+      ) raceReadPrepared = true;
       return statement;
+    };
+    env.DB.batch = async (statements: unknown[]) => {
+      const snapshot = await raceOriginalBatch(statements);
+      if (injectRace && raceReadPrepared) {
+        injectRace = false;
+        raceReadPrepared = false;
+        await originalPrepare(
+          `INSERT INTO feedback_comments
+           (id, ticket_id, author_actor, author_type, body, internal, created_at)
+           VALUES (?1, ?2, 'staff:test', 'staff', 'raced after snapshot', 0, ?3)`,
+        ).bind(raceCommentId, ticketA, now + 200).run();
+      }
+      return snapshot;
     };
     const raceDetail = await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
     env.DB.prepare = originalPrepare;
+    env.DB.batch = raceOriginalBatch;
     const raceBody = await raceDetail.json() as any;
     expect(raceBody.comments.some((comment: any) => comment.id === raceCommentId)).toBe(false);
     expect(raceBody.ticket).toMatchObject({ unread: true, unread_count: 1 });


### PR DESCRIPTION
## Summary

- fold active reporter-integration validation into the deploy-token lookup
- use the rate-window upsert's `RETURNING request_count` result instead of a follow-up SELECT
- batch the owner-constrained ticket/comment/attachment snapshot and the ordered audit/read-receipt/unread refresh
- emit the existing fixed-name safe `Server-Timing` phases on reporter detail responses

The reporter detail path now completes in four D1 batch stages (token lookup, rate limit, detail snapshot, receipt/readback) while preserving cross-reporter isolation and the rule that a comment committed after the page snapshot remains unread.

## Validation

- worker tests: 260/260
- focused reporter route test, including exact 4-stage tooth, rate-limit boundary, timing header, cursor/read-receipt race, replay, and isolation
- worker TypeScript build
- `git diff --check`

## Notes

No schema, migration, credential, route, or public response-body change. Timing values expose durations under existing fixed metric names only.
