### PR TITLE
perf(feedback): remove reporter comment preflight read

### DIFF
--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -667,11 +667,18 @@ async function reconcileReporterR2Keys(env: Env, keys: string[], now: number) {
 }
 
 export async function handleAddReporterComment(c: ReporterContext) {
+  const startedAt = performance.now();
   const authorized = await authorize(c, "feedback:comment", "comment");
   if (!authorized.ok) return authorized.response;
+  const authorizedAt = performance.now();
   const ticketId = fullUuid(c.req.param("ticketId"));
   if (!ticketId) return ticketNotFound(c);
-  const ticket = await ownedTicket(c, authorized.principal, ticketId);
+  const [ticketResult] = await c.env.DB.batch([
+    ownedTicketStatement(c, authorized.principal, ticketId),
+  ]);
+  const ticket = ticketResult?.results[0] as
+    | (Record<string, unknown> & { org_id: string | null })
+    | undefined;
   if (!ticket) return ticketNotFound(c);
   const input = await parseReporterCommentInput(c);
   if (!input) return c.json({ error: "invalid reporter comment" }, 400);
@@ -694,14 +701,6 @@ export async function handleAddReporterComment(c: ReporterContext) {
        AND reporter_id = ?3 AND submission_id = ?4`,
   ).bind(ticketId, authorized.principal.integrationId, authorized.principal.reporterId, submissionId)
     .first<{ id: string; submission_fingerprint: string; created_at: number }>();
-  const prior = await existingComment();
-  if (prior) {
-    if (prior.submission_fingerprint !== fingerprint) {
-      return c.json({ error: "submission_id already used with a different body" }, 409);
-    }
-    return c.json({ id: prior.id, ticket_id: ticketId, created_at: prior.created_at, idempotent_replay: true });
-  }
-
   const now = Date.now();
   const commentId = crypto.randomUUID();
   const eventId = crypto.randomUUID();
@@ -728,6 +727,16 @@ export async function handleAddReporterComment(c: ReporterContext) {
     audit_key_version: authorized.pseudonym.version,
   });
   const uploadedKeys: string[] = [];
+  const preflightAt = performance.now();
+  const setCommentTiming = (committedAt: number) => {
+    const respondedAt = performance.now();
+    c.header("Server-Timing", [
+      `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
+      `hands_preflight;dur=${timingDuration(authorizedAt, preflightAt)}`,
+      `hands_commit;dur=${timingDuration(preflightAt, committedAt)}`,
+      `hands_postcommit;dur=${timingDuration(committedAt, respondedAt)}`,
+    ].join(", "));
+  };
   try {
     if (attachmentRows.length > 0) {
       await c.env.DB.batch(attachmentRows.map((attachment) => c.env.DB.prepare(
@@ -869,6 +878,8 @@ export async function handleAddReporterComment(c: ReporterContext) {
     const concurrent = await existingComment();
     await reconcileReporterR2Keys(c.env, uploadedKeys, now);
     if (concurrent) {
+      const committedAt = performance.now();
+      setCommentTiming(committedAt);
       if (concurrent.submission_fingerprint !== fingerprint) {
         return c.json({ error: "submission_id already used with a different body" }, 409);
       }
@@ -876,6 +887,8 @@ export async function handleAddReporterComment(c: ReporterContext) {
     }
     throw error;
   }
+  const committedAt = performance.now();
+  setCommentTiming(committedAt);
   return c.json({ id: commentId, ticket_id: ticketId, created_at: now, idempotent_replay: false }, 201);
 }
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -479,6 +479,9 @@ function makeMockDb() {
     );
     CREATE UNIQUE INDEX idx_feedback_comments_reporter_sequence
       ON feedback_comments(reporter_sequence);
+    CREATE UNIQUE INDEX idx_feedback_comments_reporter_submission
+      ON feedback_comments(ticket_id, reporter_integration_id, reporter_id, submission_id)
+      WHERE author_type = 'reporter';
     CREATE TABLE feedback_comment_sequence_state (
       singleton INTEGER PRIMARY KEY,
       high_water INTEGER NOT NULL
@@ -11157,6 +11160,37 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect(raceBody.ticket).toMatchObject({ unread: true, unread_count: 1 });
     expect(raceBody.unread_total).toBe(1);
     await handleGetReporterFeedback(context("detail", credentialA.token, ticketA));
+
+    const stageTicket = "abababab-1111-4111-8111-abababababab";
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+       VALUES (?1, 'app-ios', 'feedback', 'open', 'Four-stage comment', '{}',
+               ?2, ?3, ?4, ?4)`,
+    ).bind(stageTicket, reporterId, integrationA, now).run();
+    const commentBatch = env.DB.batch.bind(env.DB);
+    let commentBatchStages = 0;
+    env.DB.batch = async (statements: unknown[]) => {
+      commentBatchStages += 1;
+      return commentBatch(statements);
+    };
+    const stagedComment = await handleAddReporterComment(context(
+      "comment",
+      credentialA.token,
+      stageTicket,
+      {
+        body: "four stage comment",
+        submission_id: "abababab-abab-4bab-8bab-abababababab",
+      },
+    ));
+    env.DB.batch = commentBatch;
+    expect(stagedComment.status).toBe(201);
+    expect(commentBatchStages).toBe(4);
+    expect(stagedComment.headers.get("server-timing")).toMatch(
+      /^hands_auth;dur=\d+\.\d, hands_preflight;dur=\d+\.\d, hands_commit;dur=\d+\.\d, hands_postcommit;dur=\d+\.\d$/,
+    );
+    await env.DB.prepare("DELETE FROM feedback_tickets WHERE id = ?1").bind(stageTicket).run();
 
     const emojiSubmission = "12121212-1212-4212-8212-121212121212";
     expect((await handleAddReporterComment(context(


### PR DESCRIPTION
## Summary

- remove the happy-path reporter-comment idempotency SELECT and rely on the existing production unique constraint plus bounded conflict reconciliation
- keep ticket ownership as a fail-fast phase, then commit the comment/audit/event/delivery projection atomically
- expose the existing fixed-name safe `Server-Timing` phases for reporter comments
- bring the executable route fixture in line with the production reporter-submission unique index

The no-attachment reporter comment path now uses four D1 stages (token lookup, rate limit, owned ticket, atomic commit). Exact replays and conflicting payloads still reconcile to 200/409, and attachment losers retain the existing R2 cleanup path.

## Validation

- worker tests: 260/260
- focused route test with exact four-stage, timing, concurrent 200/201, conflicting 409, audit/event, and attachment cleanup teeth
- worker TypeScript build
- `git diff --check`

## Notes

No schema, migration, credential, route, or public response-body change. Timing values use existing fixed metric names only.
