### PR TITLE
feat(feedback): add signed reporter sessions

### DIFF
--- a/docs/feedback-conversations-contract.md
+++ b/docs/feedback-conversations-contract.md
@@ -150,9 +150,36 @@ cannot be physically deleted.
 
 ## Reporter API
 
-All routes use an explicit `Authorization: Bearer <app-token>` header and
-`X-Hands-Reporter-Id: <opaque-id>`. Cookies and role sessions never satisfy
-these routes.
+All routes use an explicit `Authorization: Bearer <app-token-or-short-session>`
+header and `X-Hands-Reporter-Id: <opaque-id>`. Cookies and role sessions never
+satisfy these routes. Short sessions are disabled by default and remain
+server-only.
+
+### Mint a short reporter session (disabled by default)
+
+```http
+POST /api/apps/{appId}/reporter-feedback/session
+Authorization: Bearer <role-free integration-bound deploy token>
+X-Hands-Reporter-Id: <opaque-id>
+Content-Type: application/json
+
+{ "scopes": ["feedback:read", "feedback:comment"] }
+```
+
+Minting performs the current authoritative token/revocation/expiry/app/
+integration/scope checks, then applies both source-token+integration and
+audit-HMAC reporter quotas. A `201` returns a fixed-format authenticated token
+with a 30-second lifetime plus the exact integration id required in the
+caller's cache key. The closed claims bind protocol, issuer, audience,
+app, integration, exact reporter id, source token id, canonical scopes,
+timestamps, nonce, and key version. The mint response is private/no-store.
+
+Reporter handlers verify the session locally before any D1 operation and assert
+the route app and reporter header match the claims. They then use the claim
+integration/reporter values as the exact existing D1 ownership inputs. Normal
+key rotation accepts only N and N-1; emergency removal rejects the removed
+version immediately. When disabled, mint returns `404`, session-looking bearer
+bytes are not treated as deploy tokens, and no session timing names are emitted.
 
 ### List tickets
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -371,6 +371,36 @@ each file must be GIF, JPEG, PNG, or WebP and at most 10 MiB. Original submissio
 attachments and reporter-comment attachments are served with private/no-store,
 safe-disposition, and no-sniff headers.
 
+#### Optional short-lived server session (disabled by default)
+
+When Hands enables reporter sessions for a server integration, the trusted
+proxy can exchange its deploy token for a 30-second session:
+
+```http
+POST /api/apps/:appId/reporter-feedback/session
+Authorization: Bearer qvdt_...
+X-Hands-Reporter-Id: <stable opaque value>
+Content-Type: application/json
+
+{ "scopes": ["feedback:read", "feedback:comment"] }
+```
+
+The mint still performs the full deploy-token, app, active-integration, and
+scope checks. A successful `201` returns `session_token`, epoch-seconds
+`expires_at`, exact `reporter_integration_id`, and the canonical granted
+`scopes`. The integration id is a required component of the proxy's session
+cache key. Keep the session on the
+trusted proxy: do not persist it, log it, or return it to a browser. The same
+reporter routes accept the session as their bearer and still require the exact
+same `X-Hands-Reporter-Id`; app/reporter mismatches fail before ticket access.
+The reporter header selects a reporter under the deploy token's existing
+integration authority; it is not independent reporter authentication.
+
+Minting is fail-closed rate limited by source token, integration, and an
+audit-HMAC reporter pseudonym. Responses use `Cache-Control: private, no-store`.
+When the feature is disabled the mint route returns `404` and reporter routes
+retain their deploy-token-only behavior.
+
 Reporter comment and status webhooks carry a stable logical event id in both
 the signed JSON body and `X-Hands-Event-Id`. Each subscription delivery also
 has a stable `X-Hands-Delivery-Id`. Retries reuse the exact same body,

--- a/migrations/sql/0055_feedback_reporter_sessions.sql
+++ b/migrations/sql/0055_feedback_reporter_sessions.sql
@@ -1,0 +1,25 @@
+-- Short-lived reporter-session mint quotas. Session signing keys and session
+-- bytes never enter D1; this table stores only opaque ids and audit-HMAC
+-- pseudonyms needed to bound full-auth mint amplification.
+CREATE TABLE feedback_reporter_session_mint_rate_windows (
+  app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  reporter_integration_id TEXT NOT NULL
+    REFERENCES app_reporter_integrations(id) ON DELETE CASCADE,
+  deploy_token_id TEXT NOT NULL REFERENCES app_deploy_tokens(id) ON DELETE CASCADE,
+  reporter_hash TEXT NOT NULL,
+  audit_key_version TEXT NOT NULL,
+  window_started_at INTEGER NOT NULL,
+  request_count INTEGER NOT NULL DEFAULT 0 CHECK (request_count >= 0),
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (
+    app_id,
+    reporter_integration_id,
+    deploy_token_id,
+    reporter_hash,
+    audit_key_version,
+    window_started_at
+  )
+);
+
+CREATE INDEX idx_feedback_reporter_session_mint_rate_updated
+  ON feedback_reporter_session_mint_rate_windows(updated_at);

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -32,6 +32,12 @@ declare global {
     RAFT_ALLOWED_SERVER_SLUGS?: string;
     FEEDBACK_AUDIT_HMAC_KEY?: string;
     FEEDBACK_AUDIT_KEY_VERSION?: string;
+    /** Disabled unless exactly "true"; reporter sessions remain server-only. */
+    FEEDBACK_REPORTER_SESSION_ENABLED?: string;
+    /** Active version in FEEDBACK_REPORTER_SESSION_KEYS. */
+    FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION?: string;
+    /** Secret JSON object containing one or two base64url HMAC keys by version. */
+    FEEDBACK_REPORTER_SESSION_KEYS?: string;
   }
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -112,6 +112,7 @@ import {
   handleListReporterFeedback,
   cleanupReporterFeedbackData,
 } from "./routes/reporter_feedback";
+import { handleMintReporterSession } from "./routes/reporter_sessions";
 import {
   handleBindReporterRouteSubject,
   handleBindReporterWebhook,
@@ -568,6 +569,7 @@ app.post("/public/v2/apps/:slug/metrics", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/sessions", handleSessionEvent);
 app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
 app.get("/api/apps/:appId/reporter-feedback", handleListReporterFeedback);
+app.post("/api/apps/:appId/reporter-feedback/session", handleMintReporterSession);
 app.put("/api/apps/:appId/reporter-feedback/route-subject", handleBindReporterRouteSubject);
 app.get("/api/apps/:appId/reporter-feedback/:ticketId", handleGetReporterFeedback);
 app.post("/api/apps/:appId/reporter-feedback/:ticketId/comments", handleAddReporterComment);

--- a/worker/src/lib/reporter_auth.ts
+++ b/worker/src/lib/reporter_auth.ts
@@ -4,6 +4,10 @@ import {
   type FeedbackTokenPermission,
 } from "./app_permissions";
 import { loadDeployToken, type AppDeployToken } from "./deploy_tokens";
+import {
+  isReporterSessionToken,
+  verifyReporterSession,
+} from "./reporter_sessions";
 
 export const REPORTER_ID_PATTERN = /^[A-Za-z0-9_-]{16,200}$/;
 
@@ -11,12 +15,13 @@ export type ReporterPrincipal = {
   appId: string;
   integrationId: string;
   reporterId: string;
-  token: AppDeployToken;
+  authMode: "deploy_token" | "session";
+  sessionVerifyDurationMs: number | null;
 };
 
 type ReporterContext = Context<{ Bindings: Env }>;
 
-function bearerValue(c: ReporterContext): string | null {
+export function reporterBearerValue(c: ReporterContext): string | null {
   const authorization = c.req.header("authorization") ?? "";
   if (!authorization.startsWith("Bearer ")) return null;
   const value = authorization.slice("Bearer ".length).trim();
@@ -42,9 +47,44 @@ export async function authenticateReporter(
     };
   }
 
-  const bearer = bearerValue(c);
+  const bearer = reporterBearerValue(c);
   if (!bearer) {
     return { ok: false, response: c.json({ error: "invalid or missing bearer token" }, 401) };
+  }
+  if (isReporterSessionToken(bearer)) {
+    const verifyStartedAt = performance.now();
+    const verified = await verifyReporterSession(c.env, bearer);
+    const sessionVerifyDurationMs = Math.max(0, performance.now() - verifyStartedAt);
+    if (!verified.ok) {
+      return {
+        ok: false,
+        response: c.json(
+          { error: verified.reason === "unavailable" ? "reporter session is not configured" : "invalid or missing bearer token" },
+          verified.reason === "unavailable" ? 503 : 401,
+        ),
+      };
+    }
+    const claims = verified.claims;
+    // Bind verified claims to the route and caller header before any D1 rate,
+    // ownership, or data query. Downstream owner predicates remain defense in
+    // depth, not the primary session boundary.
+    if (
+      claims.app_id !== appId
+      || claims.reporter_id !== reporterId
+      || !claims.scopes.includes(required)
+    ) {
+      return { ok: false, response: c.json({ error: "invalid reporter session grant" }, 403) };
+    }
+    return {
+      ok: true,
+      principal: {
+        appId: claims.app_id,
+        integrationId: claims.reporter_integration_id,
+        reporterId: claims.reporter_id,
+        authMode: "session",
+        sessionVerifyDurationMs,
+      },
+    };
   }
   const token = await loadDeployToken(c.env, bearer);
   if (!token) {
@@ -70,7 +110,8 @@ export async function authenticateReporter(
       appId,
       integrationId: token.reporter_integration_id!,
       reporterId,
-      token,
+      authMode: "deploy_token",
+      sessionVerifyDurationMs: null,
     },
   };
 }

--- a/worker/src/lib/reporter_sessions.ts
+++ b/worker/src/lib/reporter_sessions.ts
@@ -1,0 +1,321 @@
+import type { FeedbackTokenPermission } from "./app_permissions";
+
+const SESSION_PREFIX = "hrps_v1_";
+const SESSION_ALGORITHM = "HS256";
+const SESSION_TYPE = "hands-reporter-session+jwt";
+const SESSION_ISSUER = "hands";
+const SESSION_AUDIENCE = "hands-reporter-feedback";
+const SESSION_PROTOCOL_VERSION = 1;
+const SESSION_TTL_SECONDS = 30;
+const SESSION_MAX_LIFETIME_SECONDS = 60;
+const SESSION_CLOCK_SKEW_SECONDS = 5;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const KEY_VERSION_RE = /^[A-Za-z0-9._-]{1,64}$/;
+const JTI_RE = /^[A-Za-z0-9_-]{22,128}$/;
+const MAX_SESSION_BYTES = 4096;
+const REPORTER_SESSION_SCOPES = ["feedback:comment", "feedback:read"] as const;
+
+function isReporterSessionScope(value: unknown): value is FeedbackTokenPermission {
+  return typeof value === "string"
+    && (REPORTER_SESSION_SCOPES as readonly string[]).includes(value);
+}
+
+export type ReporterSessionEnv = Env & {
+  FEEDBACK_REPORTER_SESSION_ENABLED?: string;
+  FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION?: string;
+  FEEDBACK_REPORTER_SESSION_KEYS?: string;
+};
+
+export type ReporterSessionClaims = {
+  v: 1;
+  iss: typeof SESSION_ISSUER;
+  aud: typeof SESSION_AUDIENCE;
+  app_id: string;
+  reporter_integration_id: string;
+  reporter_id: string;
+  token_id: string;
+  scopes: FeedbackTokenPermission[];
+  iat: number;
+  nbf: number;
+  exp: number;
+  jti: string;
+  key_version: string;
+};
+
+type SessionHeader = {
+  alg: typeof SESSION_ALGORITHM;
+  kid: string;
+  typ: typeof SESSION_TYPE;
+};
+
+type SessionKeyring = {
+  activeVersion: string;
+  keys: Map<string, Uint8Array>;
+};
+
+export type VerifyReporterSessionResult =
+  | { ok: true; claims: ReporterSessionClaims }
+  | { ok: false; reason: "invalid" | "unavailable" };
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+function base64UrlDecode(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+function encodeJson(value: unknown): string {
+  return base64UrlEncode(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function decodeJson(value: string): unknown {
+  const bytes = base64UrlDecode(value);
+  if (!bytes) return null;
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(bytes));
+  } catch {
+    return null;
+  }
+}
+
+function canonicalHeader(keyVersion: string): SessionHeader {
+  return { alg: SESSION_ALGORITHM, kid: keyVersion, typ: SESSION_TYPE };
+}
+
+function canonicalClaims(claims: ReporterSessionClaims): ReporterSessionClaims {
+  return {
+    v: SESSION_PROTOCOL_VERSION,
+    iss: SESSION_ISSUER,
+    aud: SESSION_AUDIENCE,
+    app_id: claims.app_id,
+    reporter_integration_id: claims.reporter_integration_id,
+    reporter_id: claims.reporter_id,
+    token_id: claims.token_id,
+    scopes: claims.scopes,
+    iat: claims.iat,
+    nbf: claims.nbf,
+    exp: claims.exp,
+    jti: claims.jti,
+    key_version: claims.key_version,
+  };
+}
+
+function exactCanonicalJson(encoded: string, value: unknown): boolean {
+  return encodeJson(value) === encoded;
+}
+
+function parseKeyring(env: ReporterSessionEnv): SessionKeyring | null {
+  const activeVersion = env.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION?.trim() ?? "";
+  if (!KEY_VERSION_RE.test(activeVersion)) return null;
+  try {
+    const parsed = JSON.parse(env.FEEDBACK_REPORTER_SESSION_KEYS ?? "") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    if (entries.length < 1 || entries.length > 2) return null;
+    const keys = new Map<string, Uint8Array>();
+    for (const [version, encoded] of entries) {
+      if (!KEY_VERSION_RE.test(version) || typeof encoded !== "string") return null;
+      const key = base64UrlDecode(encoded);
+      if (!key || key.byteLength < 32 || key.byteLength > 64) return null;
+      keys.set(version, key);
+    }
+    if (!keys.has(activeVersion)) return null;
+    return { activeVersion, keys };
+  } catch {
+    return null;
+  }
+}
+
+async function sign(key: Uint8Array, input: string): Promise<Uint8Array> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    key,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, new TextEncoder().encode(input)));
+}
+
+async function verify(key: Uint8Array, input: string, signature: Uint8Array): Promise<boolean> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    key,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  return crypto.subtle.verify("HMAC", cryptoKey, signature, new TextEncoder().encode(input));
+}
+
+function canonicalScopes(value: unknown): FeedbackTokenPermission[] | null {
+  if (!Array.isArray(value) || value.length === 0 || !value.every(isReporterSessionScope)) {
+    return null;
+  }
+  const scopes = [...new Set(value)].sort() as FeedbackTokenPermission[];
+  if (scopes.length !== value.length || scopes.some((scope, index) => scope !== value[index])) return null;
+  return scopes;
+}
+
+function parseClaims(value: unknown): ReporterSessionClaims | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const expectedKeys = [
+    "v", "iss", "aud", "app_id", "reporter_integration_id", "reporter_id",
+    "token_id", "scopes", "iat", "nbf", "exp", "jti", "key_version",
+  ];
+  if (Object.keys(record).length !== expectedKeys.length || expectedKeys.some((key) => !(key in record))) {
+    return null;
+  }
+  const scopes = canonicalScopes(record.scopes);
+  if (
+    record.v !== SESSION_PROTOCOL_VERSION
+    || record.iss !== SESSION_ISSUER
+    || record.aud !== SESSION_AUDIENCE
+    || typeof record.app_id !== "string"
+    || !UUID_RE.test(record.app_id)
+    || typeof record.reporter_integration_id !== "string"
+    || !UUID_RE.test(record.reporter_integration_id)
+    || typeof record.reporter_id !== "string"
+    || !/^[A-Za-z0-9_-]{16,200}$/.test(record.reporter_id)
+    || typeof record.token_id !== "string"
+    || !UUID_RE.test(record.token_id)
+    || !scopes
+    || !Number.isSafeInteger(record.iat)
+    || (record.iat as number) < 0
+    || !Number.isSafeInteger(record.nbf)
+    || (record.nbf as number) < 0
+    || !Number.isSafeInteger(record.exp)
+    || (record.exp as number) < 0
+    || typeof record.jti !== "string"
+    || !JTI_RE.test(record.jti)
+    || typeof record.key_version !== "string"
+    || !KEY_VERSION_RE.test(record.key_version)
+  ) return null;
+  return canonicalClaims({ ...record, scopes } as ReporterSessionClaims);
+}
+
+export function reporterSessionEnabled(env: ReporterSessionEnv): boolean {
+  return env.FEEDBACK_REPORTER_SESSION_ENABLED === "true";
+}
+
+export function isReporterSessionToken(value: string): boolean {
+  return value.startsWith(SESSION_PREFIX);
+}
+
+export function normalizeRequestedReporterSessionScopes(value: unknown): FeedbackTokenPermission[] | null {
+  if (!Array.isArray(value) || value.length === 0 || !value.every(isReporterSessionScope)) {
+    return null;
+  }
+  return [...new Set(value)].sort() as FeedbackTokenPermission[];
+}
+
+export async function mintReporterSession(
+  env: ReporterSessionEnv,
+  input: {
+    appId: string;
+    integrationId: string;
+    reporterId: string;
+    tokenId: string;
+    scopes: FeedbackTokenPermission[];
+    nowSeconds?: number;
+  },
+): Promise<{ token: string; claims: ReporterSessionClaims } | null> {
+  const keyring = parseKeyring(env);
+  if (!keyring || !reporterSessionEnabled(env)) return null;
+  const now = input.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const scopes = normalizeRequestedReporterSessionScopes(input.scopes);
+  if (
+    !UUID_RE.test(input.appId)
+    || !UUID_RE.test(input.integrationId)
+    || !UUID_RE.test(input.tokenId)
+    || !/^[A-Za-z0-9_-]{16,200}$/.test(input.reporterId)
+    || !scopes
+    || !Number.isSafeInteger(now)
+    || now < 0
+  ) return null;
+  const nonce = new Uint8Array(16);
+  crypto.getRandomValues(nonce);
+  const claims = canonicalClaims({
+    v: SESSION_PROTOCOL_VERSION,
+    iss: SESSION_ISSUER,
+    aud: SESSION_AUDIENCE,
+    app_id: input.appId,
+    reporter_integration_id: input.integrationId,
+    reporter_id: input.reporterId,
+    token_id: input.tokenId,
+    scopes,
+    iat: now,
+    nbf: now,
+    exp: now + SESSION_TTL_SECONDS,
+    jti: base64UrlEncode(nonce),
+    key_version: keyring.activeVersion,
+  });
+  const encodedHeader = encodeJson(canonicalHeader(keyring.activeVersion));
+  const encodedClaims = encodeJson(claims);
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signature = await sign(keyring.keys.get(keyring.activeVersion)!, signingInput);
+  return { token: `${SESSION_PREFIX}${signingInput}.${base64UrlEncode(signature)}`, claims };
+}
+
+export async function verifyReporterSession(
+  env: ReporterSessionEnv,
+  token: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<VerifyReporterSessionResult> {
+  if (!reporterSessionEnabled(env)) return { ok: false, reason: "invalid" };
+  const keyring = parseKeyring(env);
+  if (!keyring) return { ok: false, reason: "unavailable" };
+  if (!isReporterSessionToken(token) || token.length > MAX_SESSION_BYTES) {
+    return { ok: false, reason: "invalid" };
+  }
+  const compact = token.slice(SESSION_PREFIX.length);
+  const parts = compact.split(".");
+  if (parts.length !== 3) return { ok: false, reason: "invalid" };
+  const encodedHeader = parts[0]!;
+  const encodedClaims = parts[1]!;
+  const encodedSignature = parts[2]!;
+  const headerValue = decodeJson(encodedHeader);
+  if (!headerValue || typeof headerValue !== "object" || Array.isArray(headerValue)) {
+    return { ok: false, reason: "invalid" };
+  }
+  const header = headerValue as Record<string, unknown>;
+  if (
+    Object.keys(header).length !== 3
+    || header.alg !== SESSION_ALGORITHM
+    || header.typ !== SESSION_TYPE
+    || typeof header.kid !== "string"
+    || !KEY_VERSION_RE.test(header.kid)
+    || !exactCanonicalJson(encodedHeader, canonicalHeader(header.kid))
+  ) return { ok: false, reason: "invalid" };
+  const key = keyring.keys.get(header.kid);
+  if (!key) return { ok: false, reason: "invalid" };
+  const signature = base64UrlDecode(encodedSignature);
+  if (!signature || signature.byteLength !== 32) return { ok: false, reason: "invalid" };
+  if (!await verify(key, `${encodedHeader}.${encodedClaims}`, signature)) {
+    return { ok: false, reason: "invalid" };
+  }
+  const claims = parseClaims(decodeJson(encodedClaims));
+  if (
+    !claims
+    || claims.key_version !== header.kid
+    || !exactCanonicalJson(encodedClaims, canonicalClaims(claims))
+    || claims.nbf < claims.iat
+    || claims.exp <= claims.nbf
+    || claims.exp - claims.iat > SESSION_MAX_LIFETIME_SECONDS
+    || claims.iat > nowSeconds + SESSION_CLOCK_SKEW_SECONDS
+    || claims.nbf > nowSeconds + SESSION_CLOCK_SKEW_SECONDS
+    || claims.exp <= nowSeconds - SESSION_CLOCK_SKEW_SECONDS
+  ) return { ok: false, reason: "invalid" };
+  return { ok: true, claims };
+}

--- a/worker/src/openapi/feedback.ts
+++ b/worker/src/openapi/feedback.ts
@@ -40,6 +40,18 @@ const ReporterCommentInput = z.object({
   submission_id: z.string().uuid(),
 }).openapi("ReporterFeedbackCommentInput");
 
+const ReporterSessionInput = z.object({
+  scopes: z.array(z.enum(["feedback:read", "feedback:comment"]))
+    .min(1),
+}).strict().openapi("ReporterSessionInput");
+
+const ReporterSessionOutput = z.object({
+  session_token: z.string(),
+  expires_at: z.number().int(),
+  reporter_integration_id: z.string().uuid(),
+  scopes: z.array(z.string()),
+}).openapi("ReporterSessionOutput");
+
 const ReporterRouteInput = z.object({
   route_subject: z.string().regex(/^rfr_v1_[A-Za-z0-9_-]+$/).max(160),
 }).strict().openapi("ReporterRouteSubjectInput");
@@ -50,6 +62,29 @@ const ReporterWebhookParams = AppIdParam.extend({
 });
 
 export function registerFeedbackRoutes(registry: OpenApiRegistry) {
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/reporter-feedback/session",
+    tags: ["Reporter Feedback"],
+    summary: "Mint a short-lived server-only reporter session",
+    description: "Disabled by default. Requires an active feedback-only deploy token; callers must keep the returned session on a trusted server.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      headers: ReporterHeaders,
+      body: { content: json(ReporterSessionInput), required: true },
+    },
+    responses: {
+      201: success("Short-lived reporter session; never expose it to a browser.", ReporterSessionOutput),
+      400: error("Malformed reporter id, app id, or scope set."),
+      401: error("Missing or invalid deploy token."),
+      403: error("Deploy token is not an active reporter integration grant for every requested scope."),
+      404: error("Reporter sessions are disabled."),
+      429: error("Reporter session mint rate limit exceeded."),
+      503: error("Reporter session signing or audit configuration is unavailable."),
+    },
+  });
+
   register(registry, {
     method: "put",
     path: "/api/apps/{appId}/reporter-feedback/route-subject",

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -28,6 +28,12 @@ function timingDuration(start: number, end: number): string {
   return Math.max(0, end - start).toFixed(1);
 }
 
+function sessionVerifyTiming(principal: ReporterPrincipal): string[] {
+  return principal.sessionVerifyDurationMs === null
+    ? []
+    : [`hands_session_verify;dur=${principal.sessionVerifyDurationMs.toFixed(1)}`];
+}
+
 const LIMITS: Record<Endpoint, { reporter: number; integration: number; windowMs: number }> = {
   list: { reporter: 60, integration: 600, windowMs: 60_000 },
   detail: { reporter: 120, integration: 1_200, windowMs: 60_000 },
@@ -354,6 +360,7 @@ export async function handleListReporterFeedback(c: ReporterContext) {
     ? encodeCursor(last.created_at, last.id)
     : null;
   c.header("Server-Timing", [
+    ...sessionVerifyTiming(authorized.principal),
     `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
     `hands_list;dur=${timingDuration(authorizedAt, queriedAt)}`,
   ].join(", "));
@@ -545,6 +552,7 @@ export async function handleGetReporterFeedback(c: ReporterContext) {
     : null;
   const respondedAt = performance.now();
   c.header("Server-Timing", [
+    ...sessionVerifyTiming(authorized.principal),
     `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
     `hands_preflight;dur=${timingDuration(authorizedAt, readAt)}`,
     `hands_commit;dur=${timingDuration(readAt, committedAt)}`,
@@ -731,6 +739,7 @@ export async function handleAddReporterComment(c: ReporterContext) {
   const setCommentTiming = (committedAt: number) => {
     const respondedAt = performance.now();
     c.header("Server-Timing", [
+      ...sessionVerifyTiming(authorized.principal),
       `hands_auth;dur=${timingDuration(startedAt, authorizedAt)}`,
       `hands_preflight;dur=${timingDuration(authorizedAt, preflightAt)}`,
       `hands_commit;dur=${timingDuration(preflightAt, committedAt)}`,
@@ -921,13 +930,16 @@ export async function handleDownloadReporterAttachment(c: ReporterContext) {
   const object = await c.env.APK_BUCKET.get(row.r2_key);
   if (!object) return ticketNotFound(c);
   const filename = safeFilename(row.filename);
+  const headers = new Headers({
+    "content-type": row.content_type ?? "application/octet-stream",
+    "content-disposition": `attachment; filename="${filename}"`,
+    "x-content-type-options": "nosniff",
+    "cache-control": "private, no-store",
+  });
+  const verifyTiming = sessionVerifyTiming(authorized.principal)[0];
+  if (verifyTiming) headers.set("Server-Timing", verifyTiming);
   return new Response(object.body, {
-    headers: {
-      "content-type": row.content_type ?? "application/octet-stream",
-      "content-disposition": `attachment; filename="${filename}"`,
-      "x-content-type-options": "nosniff",
-      "cache-control": "private, no-store",
-    },
+    headers,
   });
 }
 
@@ -965,6 +977,9 @@ export async function cleanupReporterFeedbackData(env: Env, now = Date.now()) {
   await env.DB.batch([
     env.DB.prepare(
       "DELETE FROM feedback_reporter_rate_windows WHERE updated_at < ?1",
+    ).bind(now - 24 * 60 * 60_000),
+    env.DB.prepare(
+      "DELETE FROM feedback_reporter_session_mint_rate_windows WHERE updated_at < ?1",
     ).bind(now - 24 * 60 * 60_000),
     env.DB.prepare(
       "DELETE FROM feedback_reporter_access_audits WHERE created_at < ?1",

--- a/worker/src/routes/reporter_sessions.ts
+++ b/worker/src/routes/reporter_sessions.ts
@@ -1,0 +1,153 @@
+import type { Context } from "hono";
+import { isFeedbackTokenPermission } from "../lib/app_permissions";
+import { loadDeployToken } from "../lib/deploy_tokens";
+import { computeReporterAuditHash } from "../lib/reporter_audit";
+import { REPORTER_ID_PATTERN, reporterBearerValue } from "../lib/reporter_auth";
+import {
+  mintReporterSession,
+  normalizeRequestedReporterSessionScopes,
+  reporterSessionEnabled,
+} from "../lib/reporter_sessions";
+
+type ReporterSessionContext = Context<{ Bindings: Env }>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const MINT_WINDOW_MS = 60_000;
+const MINT_REPORTER_LIMIT = 30;
+const MINT_INTEGRATION_LIMIT = 300;
+
+function timingDuration(start: number, end: number): string {
+  return Math.max(0, end - start).toFixed(1);
+}
+
+async function consumeMintQuota(
+  c: ReporterSessionContext,
+  input: {
+    appId: string;
+    integrationId: string;
+    tokenId: string;
+    reporterHash: string;
+    auditKeyVersion: string;
+  },
+) {
+  const now = Date.now();
+  const windowStartedAt = Math.floor(now / MINT_WINDOW_MS) * MINT_WINDOW_MS;
+  const upsert = (bucket: string) => c.env.DB.prepare(
+    `INSERT INTO feedback_reporter_session_mint_rate_windows
+     (app_id, reporter_integration_id, deploy_token_id, reporter_hash,
+      audit_key_version, window_started_at, request_count, updated_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7)
+     ON CONFLICT(app_id, reporter_integration_id, deploy_token_id,
+                 reporter_hash, audit_key_version, window_started_at)
+     DO UPDATE SET request_count = request_count + 1, updated_at = excluded.updated_at
+     RETURNING request_count`,
+  ).bind(
+    input.appId,
+    input.integrationId,
+    input.tokenId,
+    bucket,
+    input.auditKeyVersion,
+    windowStartedAt,
+    now,
+  );
+  const [reporterResult, integrationResult] = await c.env.DB.batch([
+    upsert(input.reporterHash),
+    upsert("integration-total"),
+  ]);
+  const reporterCount = (reporterResult?.results[0] as { request_count?: number } | undefined)
+    ?.request_count ?? 0;
+  const integrationCount = (integrationResult?.results[0] as { request_count?: number } | undefined)
+    ?.request_count ?? 0;
+  if (reporterCount > MINT_REPORTER_LIMIT || integrationCount > MINT_INTEGRATION_LIMIT) {
+    c.header(
+      "Retry-After",
+      String(Math.max(1, Math.ceil((windowStartedAt + MINT_WINDOW_MS - now) / 1000))),
+    );
+    return false;
+  }
+  return true;
+}
+
+export async function handleMintReporterSession(c: ReporterSessionContext) {
+  // Disabled is indistinguishable from an absent route and retains the current
+  // deploy-token-only behavior without new timing names.
+  if (!reporterSessionEnabled(c.env)) return c.json({ error: "not found" }, 404);
+  const startedAt = performance.now();
+  const appId = (c.req.param("appId") ?? "").trim();
+  const reporterId = (c.req.header("X-Hands-Reporter-Id") ?? "").trim();
+  if (!UUID_RE.test(appId) || !REPORTER_ID_PATTERN.test(reporterId)) {
+    return c.json({ error: "invalid reporter session request" }, 400);
+  }
+  const bearer = reporterBearerValue(c);
+  if (!bearer) return c.json({ error: "invalid or missing bearer token" }, 401);
+  const contentLength = Number(c.req.header("content-length") ?? "0");
+  if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > 1024) {
+    return c.json({ error: "invalid reporter session request" }, 400);
+  }
+  const token = await loadDeployToken(c.env, bearer);
+  if (!token) return c.json({ error: "invalid or missing bearer token" }, 401);
+  let body: unknown;
+  try {
+    const rawBody = await c.req.text();
+    if (new TextEncoder().encode(rawBody).byteLength > 1024) {
+      return c.json({ error: "invalid reporter session request" }, 400);
+    }
+    body = JSON.parse(rawBody);
+  } catch {
+    return c.json({ error: "invalid reporter session request" }, 400);
+  }
+  const bodyRecord = body && typeof body === "object" && !Array.isArray(body)
+    ? body as Record<string, unknown>
+    : null;
+  if (!bodyRecord || Object.keys(bodyRecord).length !== 1 || !("scopes" in bodyRecord)) {
+    return c.json({ error: "invalid reporter session request" }, 400);
+  }
+  const requestedScopes = normalizeRequestedReporterSessionScopes(bodyRecord.scopes);
+  if (!requestedScopes) return c.json({ error: "invalid reporter session request" }, 400);
+  const tokenScopes = token.scopes;
+  const grantValid = token.app_id === appId
+    && token.app_role === null
+    && token.reporter_integration_id !== null
+    && token.reporter_integration_active === 1
+    && tokenScopes !== null
+    && tokenScopes.length > 0
+    && tokenScopes.every(isFeedbackTokenPermission)
+    && requestedScopes.every((scope) => tokenScopes.includes(scope));
+  if (!grantValid) return c.json({ error: "invalid reporter integration grant" }, 403);
+  const auditKey = c.env.FEEDBACK_AUDIT_HMAC_KEY;
+  const auditKeyVersion = c.env.FEEDBACK_AUDIT_KEY_VERSION?.trim();
+  if (!auditKey || !auditKeyVersion) {
+    return c.json({ error: "reporter session is not configured" }, 503);
+  }
+  const reporterHash = await computeReporterAuditHash({
+    key: auditKey,
+    appId,
+    integrationId: token.reporter_integration_id!,
+    reporterId,
+  });
+  if (!reporterHash) return c.json({ error: "reporter session is not configured" }, 503);
+  if (!await consumeMintQuota(c, {
+    appId,
+    integrationId: token.reporter_integration_id!,
+    tokenId: token.id,
+    reporterHash,
+    auditKeyVersion,
+  })) return c.json({ error: "reporter session mint rate limit exceeded" }, 429);
+  const minted = await mintReporterSession(c.env, {
+    appId,
+    integrationId: token.reporter_integration_id!,
+    reporterId,
+    tokenId: token.id,
+    scopes: requestedScopes,
+  });
+  if (!minted) return c.json({ error: "reporter session is not configured" }, 503);
+  const completedAt = performance.now();
+  c.header("Cache-Control", "private, no-store");
+  c.header("Server-Timing", `hands_session_mint;dur=${timingDuration(startedAt, completedAt)}`);
+  return c.json({
+    session_token: minted.token,
+    expires_at: minted.claims.exp,
+    reporter_integration_id: minted.claims.reporter_integration_id,
+    scopes: minted.claims.scopes,
+  }, 201);
+}

--- a/worker/test/feedback_reporter_sessions_migration.test.ts
+++ b/worker/test/feedback_reporter_sessions_migration.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0055_feedback_reporter_sessions.sql", import.meta.url),
+);
+
+function makeDb() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE apps (id TEXT PRIMARY KEY);
+    CREATE TABLE app_reporter_integrations (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE
+    );
+    CREATE TABLE app_deploy_tokens (
+      id TEXT PRIMARY KEY,
+      app_id TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE
+    );
+    INSERT INTO apps (id) VALUES ('app-a');
+    INSERT INTO app_reporter_integrations (id, app_id) VALUES ('integration-a', 'app-a');
+    INSERT INTO app_deploy_tokens (id, app_id) VALUES ('token-a', 'app-a');
+  `);
+  db.exec(readFileSync(migrationPath, "utf8"));
+  return db;
+}
+
+describe("feedback reporter sessions migration", () => {
+  it("isolates source-token, integration, reporter, key-version, and window buckets", () => {
+    const db = makeDb();
+    const insert = db.prepare(`
+      INSERT INTO feedback_reporter_session_mint_rate_windows
+        (app_id, reporter_integration_id, deploy_token_id, reporter_hash,
+         audit_key_version, window_started_at, request_count, updated_at)
+      VALUES ('app-a', 'integration-a', 'token-a', ?, ?, ?, 1, 1)
+    `);
+    insert.run("reporter-hash-a", "audit-v1", 0);
+    expect(() => insert.run("reporter-hash-a", "audit-v1", 0)).toThrow();
+    expect(() => insert.run("reporter-hash-b", "audit-v1", 0)).not.toThrow();
+    expect(() => insert.run("reporter-hash-a", "audit-v2", 0)).not.toThrow();
+    expect(() => insert.run("reporter-hash-a", "audit-v1", 60_000)).not.toThrow();
+    expect(() => db.prepare(`
+      INSERT INTO feedback_reporter_session_mint_rate_windows
+        (app_id, reporter_integration_id, deploy_token_id, reporter_hash,
+         audit_key_version, window_started_at, request_count, updated_at)
+      VALUES ('app-a', 'integration-a', 'token-a', 'negative', 'audit-v1', 0, -1, 1)
+    `).run()).toThrow();
+  });
+
+  it("cascades quota state when its token is deleted", () => {
+    const db = makeDb();
+    db.prepare(`
+      INSERT INTO feedback_reporter_session_mint_rate_windows
+        (app_id, reporter_integration_id, deploy_token_id, reporter_hash,
+         audit_key_version, window_started_at, request_count, updated_at)
+      VALUES ('app-a', 'integration-a', 'token-a', 'reporter-hash', 'audit-v1', 0, 1, 1)
+    `).run();
+    db.prepare("DELETE FROM app_deploy_tokens WHERE id = 'token-a'").run();
+    expect(db.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_session_mint_rate_windows",
+    ).get()).toEqual({ count: 0 });
+  });
+});

--- a/worker/test/reporter_sessions.test.ts
+++ b/worker/test/reporter_sessions.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  mintReporterSession,
+  verifyReporterSession,
+} from "../src/lib/reporter_sessions";
+
+const APP_ID = "11111111-1111-4111-8111-111111111111";
+const INTEGRATION_ID = "22222222-2222-4222-8222-222222222222";
+const TOKEN_ID = "33333333-3333-4333-8333-333333333333";
+const REPORTER_ID = "reporter_session_test_123456789";
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+function encodedJson(value: unknown): string {
+  return base64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function env(active = "n", entries: Record<string, Uint8Array> = {
+  n: new Uint8Array(32).fill(1),
+}) {
+  return {
+    FEEDBACK_REPORTER_SESSION_ENABLED: "true",
+    FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION: active,
+    FEEDBACK_REPORTER_SESSION_KEYS: JSON.stringify(Object.fromEntries(
+      Object.entries(entries).map(([version, key]) => [version, base64Url(key)]),
+    )),
+  } as Env;
+}
+
+async function signMalformed(
+  key: Uint8Array,
+  header: Record<string, unknown>,
+  claims: Record<string, unknown>,
+) {
+  const encodedHeader = encodedJson(header);
+  const encodedClaims = encodedJson(claims);
+  const input = `${encodedHeader}.${encodedClaims}`;
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw", key, { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const signature = new Uint8Array(
+    await crypto.subtle.sign("HMAC", cryptoKey, new TextEncoder().encode(input)),
+  );
+  return `hrps_v1_${input}.${base64Url(signature)}`;
+}
+
+describe("reporter sessions", () => {
+  it("mints a fixed 30-second closed-claim token and verifies canonical scopes", async () => {
+    const minted = await mintReporterSession(env(), {
+      appId: APP_ID,
+      integrationId: INTEGRATION_ID,
+      reporterId: REPORTER_ID,
+      tokenId: TOKEN_ID,
+      scopes: ["feedback:read", "feedback:comment"],
+      nowSeconds: 1_700_000_000,
+    });
+    expect(minted).not.toBeNull();
+    expect(minted!.token).toMatch(/^hrps_v1_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(minted!.claims).toMatchObject({
+      app_id: APP_ID,
+      reporter_integration_id: INTEGRATION_ID,
+      reporter_id: REPORTER_ID,
+      token_id: TOKEN_ID,
+      scopes: ["feedback:comment", "feedback:read"],
+      iat: 1_700_000_000,
+      nbf: 1_700_000_000,
+      exp: 1_700_000_030,
+      key_version: "n",
+    });
+    await expect(verifyReporterSession(env(), minted!.token, 1_700_000_010)).resolves.toEqual({
+      ok: true,
+      claims: minted!.claims,
+    });
+    await expect(verifyReporterSession(env(), minted!.token, 1_700_000_036)).resolves.toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+  });
+
+  it("fails closed when disabled or key configuration is missing", async () => {
+    const disabled = { ...env(), FEEDBACK_REPORTER_SESSION_ENABLED: "false" } as Env;
+    await expect(mintReporterSession(disabled, {
+      appId: APP_ID,
+      integrationId: INTEGRATION_ID,
+      reporterId: REPORTER_ID,
+      tokenId: TOKEN_ID,
+      scopes: ["feedback:read"],
+    })).resolves.toBeNull();
+    await expect(verifyReporterSession(disabled, "hrps_v1_bad", 1)).resolves.toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+    await expect(verifyReporterSession({
+      FEEDBACK_REPORTER_SESSION_ENABLED: "true",
+    } as Env, "hrps_v1_bad", 1)).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+  });
+
+  it("accepts N and N-1 during rotation, mints with N only, and rejects retired keys", async () => {
+    const oldKey = new Uint8Array(32).fill(7);
+    const newKey = new Uint8Array(32).fill(8);
+    const oldEnv = env("n", { n: oldKey });
+    const old = await mintReporterSession(oldEnv, {
+      appId: APP_ID,
+      integrationId: INTEGRATION_ID,
+      reporterId: REPORTER_ID,
+      tokenId: TOKEN_ID,
+      scopes: ["feedback:read"],
+      nowSeconds: 2_000,
+    });
+    const overlap = env("n1", { n1: newKey, n: oldKey });
+    await expect(verifyReporterSession(overlap, old!.token, 2_010)).resolves.toMatchObject({ ok: true });
+    const fresh = await mintReporterSession(overlap, {
+      appId: APP_ID,
+      integrationId: INTEGRATION_ID,
+      reporterId: REPORTER_ID,
+      tokenId: TOKEN_ID,
+      scopes: ["feedback:read"],
+      nowSeconds: 2_010,
+    });
+    expect(fresh!.claims.key_version).toBe("n1");
+    await expect(verifyReporterSession(env("n1", { n1: newKey }), old!.token, 2_010))
+      .resolves.toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("rejects validly signed unknown claims, wrong algorithm, audience, and oversized lifetime", async () => {
+    const key = new Uint8Array(32).fill(1);
+    const header = { alg: "HS256", kid: "n", typ: "hands-reporter-session+jwt" };
+    const claims = {
+      v: 1,
+      iss: "hands",
+      aud: "hands-reporter-feedback",
+      app_id: APP_ID,
+      reporter_integration_id: INTEGRATION_ID,
+      reporter_id: REPORTER_ID,
+      token_id: TOKEN_ID,
+      scopes: ["feedback:read"],
+      iat: 1_000,
+      nbf: 1_000,
+      exp: 1_030,
+      jti: "A".repeat(22),
+      key_version: "n",
+    };
+    for (const [changedHeader, changedClaims] of [
+      [{ ...header }, { ...claims, extra: "unknown" }],
+      [{ ...header, alg: "HS512" }, { ...claims }],
+      [{ ...header }, { ...claims, aud: "wrong" }],
+      [{ ...header }, { ...claims, exp: 1_061 }],
+    ] as Array<[Record<string, unknown>, Record<string, unknown>]>) {
+      const token = await signMalformed(key, changedHeader, changedClaims);
+      await expect(verifyReporterSession(env(), token, 1_010)).resolves.toEqual({
+        ok: false,
+        reason: "invalid",
+      });
+    }
+  });
+
+  it("rejects tampering, non-canonical claims, unknown key versions, and oversized tokens", async () => {
+    const minted = await mintReporterSession(env(), {
+      appId: APP_ID,
+      integrationId: INTEGRATION_ID,
+      reporterId: REPORTER_ID,
+      tokenId: TOKEN_ID,
+      scopes: ["feedback:read"],
+      nowSeconds: 1_000,
+    });
+    const tampered = `${minted!.token.slice(0, -1)}${minted!.token.endsWith("A") ? "B" : "A"}`;
+    await expect(verifyReporterSession(env(), tampered, 1_010)).resolves.toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+    const wrongKey = { ...env(), FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION: "missing" } as Env;
+    await expect(verifyReporterSession(wrongKey, minted!.token, 1_010)).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+    await expect(verifyReporterSession(env(), `hrps_v1_${"A".repeat(5_000)}`, 1_010)).resolves.toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -103,6 +103,7 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/qa-artifacts/ios-simulator/{assetId}/download",
       "/api/apps/{appId}/releases/{releaseId}/publish",
       "/api/apps/{appId}/feedback/{ticketId}/comments",
+      "/api/apps/{appId}/reporter-feedback/session",
       "/api/app-permissions",
       "/api/apps/{appId}/client-key",
       "/api/apps/{appId}/analytics/versions",
@@ -742,6 +743,18 @@ function makeMockDb() {
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (app_id, reporter_integration_id, reporter_hash,
                    audit_key_version, endpoint, window_started_at)
+    );
+    CREATE TABLE feedback_reporter_session_mint_rate_windows (
+      app_id TEXT NOT NULL,
+      reporter_integration_id TEXT NOT NULL,
+      deploy_token_id TEXT NOT NULL,
+      reporter_hash TEXT NOT NULL,
+      audit_key_version TEXT NOT NULL,
+      window_started_at INTEGER NOT NULL,
+      request_count INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (app_id, reporter_integration_id, deploy_token_id,
+                   reporter_hash, audit_key_version, window_started_at)
     );
     CREATE TABLE feedback_reporter_access_audits (
       id TEXT PRIMARY KEY,
@@ -10749,6 +10762,201 @@ describe("Hands iOS simulator QA artifacts", () => {
     await env.DB.prepare(
       "UPDATE app_reporter_integrations SET archived_at = NULL WHERE id = ?1",
     ).bind(integrationId).run();
+  });
+
+  it("mints disabled-by-default reporter sessions and removes deploy-token D1 auth from hot routes", async () => {
+    const { env } = makeEnv() as any;
+    env.FEEDBACK_AUDIT_HMAC_KEY = "test-audit-key-with-enough-entropy";
+    env.FEEDBACK_AUDIT_KEY_VERSION = "test-v1";
+    const keyBytes = new Uint8Array(32).fill(19);
+    let keyBinary = "";
+    for (const byte of keyBytes) keyBinary += String.fromCharCode(byte);
+    const key = btoa(keyBinary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+    const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
+    const { handleMintReporterSession } = await import("../src/routes/reporter_sessions");
+    const {
+      handleAddReporterComment,
+      handleGetReporterFeedback,
+      handleListReporterFeedback,
+    } = await import("../src/routes/reporter_feedback");
+    const appId = "10101010-1010-4010-8010-101010101010";
+    const integrationId = "20202020-2020-4020-8020-202020202020";
+    const tokenId = "30303030-3030-4030-8030-303030303030";
+    const ticketId = "40404040-4040-4040-8040-404040404040";
+    const reporterId = "signed_session_reporter_123456789";
+    const credential = generateDeployToken();
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO apps (id, org_id, slug, name, platform, created_at)
+       VALUES (?1, 'default', 'signed-session-app', 'Signed session app', 'web', ?2)`,
+    ).bind(appId, now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_reporter_integrations
+       (id, app_id, name, created_at, updated_at)
+       VALUES (?1, ?2, 'Signed session', ?3, ?3)`,
+    ).bind(integrationId, appId, now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+        created_by_actor, created_at, reporter_integration_id)
+       VALUES (?1, ?2, 'signed-session', ?3, ?4, NULL,
+               '["feedback:read","feedback:comment"]', 'test', ?5, ?6)`,
+    ).bind(tokenId, appId, credential.token_prefix, await hashDeployToken(credential.token), now, integrationId).run();
+    await env.DB.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+       VALUES (?1, ?2, 'feedback', 'open', 'Session ticket', '{}', ?3, ?4, ?5, ?5)`,
+    ).bind(ticketId, appId, reporterId, integrationId, now).run();
+
+    const context = (input: {
+      app?: string;
+      reporter?: string;
+      bearer?: string;
+      ticket?: string;
+      body?: unknown;
+      query?: Record<string, string>;
+    }) => {
+      const responseHeaders = new Headers();
+      return {
+        env,
+        header: (name: string, value: string) => responseHeaders.set(name, value),
+        req: {
+          param: (name: string) => name === "appId"
+            ? input.app ?? appId
+            : name === "ticketId"
+              ? input.ticket
+              : undefined,
+          header: (name: string) => name === "X-Hands-Reporter-Id"
+            ? input.reporter ?? reporterId
+            : name.toLowerCase() === "authorization" && input.bearer
+              ? `Bearer ${input.bearer}`
+              : undefined,
+          query: (name: string) => input.query?.[name],
+          json: async () => input.body,
+          text: async () => JSON.stringify(input.body),
+          formData: async () => new FormData(),
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), {
+          status,
+          headers: responseHeaders,
+        }),
+      } as any;
+    };
+
+    const disabledMint = await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:read", "feedback:comment"] },
+    }));
+    expect(disabledMint.status).toBe(404);
+    expect(disabledMint.headers.get("server-timing")).toBeNull();
+
+    env.FEEDBACK_REPORTER_SESSION_ENABLED = "true";
+    env.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION = "test-n";
+    env.FEEDBACK_REPORTER_SESSION_KEYS = JSON.stringify({ "test-n": key });
+    const mint = await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:read", "feedback:comment"] },
+    }));
+    expect(mint.status).toBe(201);
+    expect(mint.headers.get("cache-control")).toBe("private, no-store");
+    expect(mint.headers.get("server-timing")).toMatch(/^hands_session_mint;dur=\d+\.\d$/);
+    const mintBody = await mint.json() as any;
+    expect(mintBody.reporter_integration_id).toBe(integrationId);
+    const session = mintBody.session_token as string;
+    expect(session).toMatch(/^hrps_v1_/);
+
+    const originalBatch = env.DB.batch.bind(env.DB);
+    let batchStages = 0;
+    env.DB.batch = async (statements: unknown[]) => {
+      batchStages += 1;
+      return originalBatch(statements);
+    };
+    const list = await handleListReporterFeedback(context({ bearer: session }));
+    env.DB.batch = originalBatch;
+    expect(list.status).toBe(200);
+    expect(batchStages).toBe(2);
+    expect((await list.json() as any).tickets.map((ticket: any) => ticket.id)).toEqual([ticketId]);
+    expect(list.headers.get("server-timing")).toMatch(
+      /^hands_session_verify;dur=\d+\.\d, hands_auth;dur=\d+\.\d, hands_list;dur=\d+\.\d$/,
+    );
+
+    const detail = await handleGetReporterFeedback(context({ bearer: session, ticket: ticketId }));
+    expect(detail.status).toBe(200);
+    expect((await detail.json() as any).ticket.id).toBe(ticketId);
+    const comment = await handleAddReporterComment(context({
+      bearer: session,
+      ticket: ticketId,
+      body: {
+        body: "signed session comment",
+        submission_id: "50505050-5050-4050-8050-505050505050",
+      },
+    }));
+    expect(comment.status).toBe(201);
+    expect(comment.headers.get("server-timing")).toMatch(/^hands_session_verify;/);
+
+    expect((await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:write"] },
+    }))).status).toBe(400);
+    expect((await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:read"], extra: true },
+    }))).status).toBe(400);
+    expect((await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:read"], padding: "x".repeat(2_000) },
+    }))).status).toBe(400);
+    // The reporter header selects an opaque reporter under the deploy token's
+    // existing integration authority; it is not separately authenticated.
+    expect((await handleMintReporterSession(context({
+      bearer: credential.token,
+      reporter: "another_reporter_header_123456789",
+      body: { scopes: ["feedback:read"] },
+    }))).status).toBe(201);
+
+    let mismatchBatches = 0;
+    env.DB.batch = async (statements: unknown[]) => {
+      mismatchBatches += 1;
+      return originalBatch(statements);
+    };
+    expect((await handleListReporterFeedback(context({
+      app: "60606060-6060-4060-8060-606060606060",
+      bearer: session,
+    }))).status).toBe(403);
+    expect((await handleListReporterFeedback(context({
+      reporter: "different_reporter_123456789",
+      bearer: session,
+    }))).status).toBe(403);
+    env.DB.batch = originalBatch;
+    expect(mismatchBatches).toBe(0);
+
+    await env.DB.prepare(
+      `UPDATE feedback_reporter_session_mint_rate_windows SET request_count = 30
+       WHERE app_id = ?1 AND reporter_integration_id = ?2
+         AND reporter_hash <> 'integration-total'`,
+    ).bind(appId, integrationId).run();
+    const limited = await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:read"] },
+    }));
+    expect(limited.status).toBe(429);
+    expect(Number(limited.headers.get("retry-after"))).toBeGreaterThan(0);
+
+    await env.DB.prepare("UPDATE app_deploy_tokens SET revoked_at = ?1 WHERE id = ?2")
+      .bind(Date.now(), tokenId).run();
+    expect((await handleMintReporterSession(context({
+      bearer: credential.token,
+      body: { scopes: ["feedback:read"] },
+    }))).status).toBe(401);
+    // Already-issued sessions deliberately retain bounded validity after source
+    // revocation; no D1 auth lookup is reintroduced on the hot path.
+    expect((await handleListReporterFeedback(context({ bearer: session }))).status).toBe(200);
+
+    env.FEEDBACK_REPORTER_SESSION_ENABLED = "false";
+    const disabledUse = await handleListReporterFeedback(context({ bearer: session }));
+    expect(disabledUse.status).toBe(401);
+    expect(disabledUse.headers.get("server-timing")).toBeNull();
   });
 
   it("reporter feedback bearer routes isolate integrations and converge comment replay", async () => {


### PR DESCRIPTION
## Problem

Reporter feedback list, detail, attachment, and comment requests currently perform a deploy-token D1 lookup on every call. That stateful round trip dominates the public network cost even though the caller and exact reporter grant usually remain unchanged across a short conversation burst.

## Changes

- Add a disabled-by-default server-only mint route for 30-second signed reporter sessions.
- Use a closed canonical claim set, fixed HS256 algorithm, explicit token prefix, bounded size/lifetime/skew, N/N-1 key rotation, and local verification before any D1 access.
- Bind every session to the exact app, reporter integration, reporter id, source token id, and canonical read/comment scopes.
- Keep existing reporter ownership, D1 rate windows, audit, read-receipt, attachment, and idempotency behavior unchanged.
- Add source-token/integration and audit-HMAC per-reporter mint quotas with bounded `Retry-After`.
- Add a migration for pseudonymous mint quota windows, fixed-name safe timing values, OpenAPI coverage, and public/contract documentation.
- Preserve exact deploy-token behavior when the feature flag is off; session-looking bytes never fall back to deploy-token auth.

## Follow-up

- Keep the runtime flag and signing-key bindings unset until the calling server implements a server-only single-flight cache and staging proves expiry, revocation bounds, rollback, and cold/warm p50/p95.
- Edge rate limiting is intentionally not part of this change. Existing D1 rate windows remain authoritative.

## Testing

- `pnpm -w build`
- `pnpm -w test` (all workspace tests; Worker 268/268)
- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-worker test`
- `git diff --check HEAD^ HEAD`
- Worker lint command is currently unavailable on main because the repository has no ESLint v9 flat config; this change does not alter lint configuration.
