### PR TITLE
fix(android-sdk): support 16 KB page devices

### DIFF
--- a/.github/workflows/android-sdk-check.yml
+++ b/.github/workflows/android-sdk-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "clients/android/**"
+      - "scripts/verify_android_elf_alignment.py"
+      - "scripts/test_verify_android_elf_alignment.py"
       - ".github/workflows/android-sdk-check.yml"
 
 jobs:
@@ -15,11 +17,24 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
+      - uses: android-actions/setup-android@v3
+      - name: Install pinned Android NDK
+        run: sdkmanager "ndk;26.3.11579264"
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "8.10.2"
       - name: Assemble release AAR and run unit tests
-        run: gradle -p clients/android assembleRelease testReleaseUnitTest
+        run: gradle -p clients/android assembleRelease testReleaseUnitTest packageReleaseNativeSymbols
+      - name: Verify 16 KB ELF alignment
+        run: |
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_verify_android_elf_alignment.py
+          AAR="$(find clients/android/build/outputs/aar -type f -name '*-release.aar' -print -quit)"
+          SYMBOLS="$(find clients/android/build/outputs/native-symbols -type f -name '*-native-symbols.zip' -print -quit)"
+          test -n "${AAR}" && test -n "${SYMBOLS}"
+          python3 scripts/verify_android_elf_alignment.py \
+            --archive "${AAR}"
+          python3 scripts/verify_android_elf_alignment.py \
+            --archive "${SYMBOLS}"
 
   api31-instrumentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-sdk-check.yml
+++ b/.github/workflows/android-sdk-check.yml
@@ -6,7 +6,11 @@ on:
       - "clients/android/**"
       - "scripts/verify_android_elf_alignment.py"
       - "scripts/test_verify_android_elf_alignment.py"
+      - "scripts/package_android_native_symbols.sh"
+      - "scripts/test_android_publication_gate.sh"
       - ".github/workflows/android-sdk-check.yml"
+      - ".github/workflows/publish-android-sdk.yml"
+      - "jitpack.yml"
 
 jobs:
   assemble:
@@ -23,18 +27,10 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: "8.10.2"
-      - name: Assemble release AAR and run unit tests
-        run: gradle -p clients/android assembleRelease testReleaseUnitTest packageReleaseNativeSymbols
-      - name: Verify 16 KB ELF alignment
-        run: |
-          PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_verify_android_elf_alignment.py
-          AAR="$(find clients/android/build/outputs/aar -type f -name '*-release.aar' -print -quit)"
-          SYMBOLS="$(find clients/android/build/outputs/native-symbols -type f -name '*-native-symbols.zip' -print -quit)"
-          test -n "${AAR}" && test -n "${SYMBOLS}"
-          python3 scripts/verify_android_elf_alignment.py \
-            --archive "${AAR}"
-          python3 scripts/verify_android_elf_alignment.py \
-            --archive "${SYMBOLS}"
+      - name: Build SDK and run central publication gate
+        run: gradle -p clients/android testReleaseUnitTest verifyReleaseElfAlignment -PVERSION_NAME=0.12.4
+      - name: Verify local and remote publication task graphs
+        run: scripts/test_android_publication_gate.sh
 
   api31-instrumentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "SDK version to publish, for example 0.1.0"
         required: true
-        default: "0.12.3"
+        default: "0.12.4"
   push:
     tags:
       - "android-sdk-v*"
@@ -47,6 +47,17 @@ jobs:
 
       - name: Build SDK and unstripped native symbols
         run: gradle -p clients/android assembleRelease packageReleaseNativeSymbols -PVERSION_NAME=${{ steps.version.outputs.value }}
+
+      - name: Verify 16 KB ELF alignment
+        run: |
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_verify_android_elf_alignment.py
+          AAR="$(find clients/android/build/outputs/aar -type f -name '*-release.aar' -print -quit)"
+          SYMBOLS="$(find clients/android/build/outputs/native-symbols -type f -name '*-native-symbols.zip' -print -quit)"
+          test -n "${AAR}" && test -n "${SYMBOLS}"
+          python3 scripts/verify_android_elf_alignment.py \
+            --archive "${AAR}"
+          python3 scripts/verify_android_elf_alignment.py \
+            --archive "${SYMBOLS}"
 
       - name: Upload native symbols as workflow evidence
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -38,11 +38,13 @@ jobs:
       - name: Resolve version
         id: version
         shell: bash
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION="${GITHUB_REF_NAME#android-sdk-v}"
           else
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="${INPUT_VERSION}"
           fi
           [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || {
             echo "Invalid Android SDK semantic version: ${VERSION}" >&2

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -40,24 +40,23 @@ jobs:
         shell: bash
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            echo "value=${GITHUB_REF_NAME#android-sdk-v}" >> "$GITHUB_OUTPUT"
+            VERSION="${GITHUB_REF_NAME#android-sdk-v}"
           else
-            echo "value=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            VERSION="${{ github.event.inputs.version }}"
           fi
+          [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || {
+            echo "Invalid Android SDK semantic version: ${VERSION}" >&2
+            exit 1
+          }
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build SDK and unstripped native symbols
-        run: gradle -p clients/android assembleRelease packageReleaseNativeSymbols -PVERSION_NAME=${{ steps.version.outputs.value }}
+      - name: Build SDK and run central publication gate
+        run: gradle -p clients/android testReleaseUnitTest verifyReleaseElfAlignment -PVERSION_NAME=${{ steps.version.outputs.value }}
 
-      - name: Verify 16 KB ELF alignment
-        run: |
-          PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_verify_android_elf_alignment.py
-          AAR="$(find clients/android/build/outputs/aar -type f -name '*-release.aar' -print -quit)"
-          SYMBOLS="$(find clients/android/build/outputs/native-symbols -type f -name '*-native-symbols.zip' -print -quit)"
-          test -n "${AAR}" && test -n "${SYMBOLS}"
-          python3 scripts/verify_android_elf_alignment.py \
-            --archive "${AAR}"
-          python3 scripts/verify_android_elf_alignment.py \
-            --archive "${SYMBOLS}"
+      - name: Verify local and remote publication task graphs
+        env:
+          HANDS_ANDROID_SDK_TEST_VERSION: ${{ steps.version.outputs.value }}
+        run: scripts/test_android_publication_gate.sh
 
       - name: Upload native symbols as workflow evidence
         uses: actions/upload-artifact@v4

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.3")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.4")
 }
 ```
 
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.12.3")
+    implementation("build.hands:hands-android-sdk:0.12.4")
 }
 ```
 
@@ -118,6 +118,10 @@ before uploading the zip to Hands (`hands builds publish-android --symbols`);
 treat a missing or mismatched classifier as a release blocker. Published since
 `0.11.1`.
 
+Since `0.12.4`, the 64-bit crash library uses 16 KB-compatible ELF `PT_LOAD`
+alignment. CI checks both the packaged AAR and the matching unstripped symbols
+archive so a 4 KB-only native binary cannot be published silently.
+
 The classifier is also served by JitPack, but **AAR and classifier must come
 from the same channel**: JitPack rebuilds from source, so its Build IDs differ
 from the GitHub Packages build of the same tag. Never mix a JitPack AAR with a
@@ -126,7 +130,7 @@ to catch that.
 
 ## Release
 
-Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.3`). That publishes to
+Push a tag `android-sdk-v<version>` (e.g. `android-sdk-v0.12.4`). That publishes to
 GitHub Packages (`build.hands:hands-android-sdk:<version>`, including the
 `native-symbols` classifier) and, on the first
 request, builds the same version on JitPack

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+
 plugins {
     id("com.android.library") version "8.7.3"
     id("org.jetbrains.kotlin.android") version "2.0.21"
@@ -6,16 +9,27 @@ plugins {
 }
 
 group = "build.hands"
-version = providers.gradleProperty("VERSION_NAME").orElse("0.1.0-SNAPSHOT").get()
+val requestedVersion = providers.gradleProperty("VERSION_NAME")
+val sdkVersion = requestedVersion.orElse("0.1.0-SNAPSHOT").get()
+if (!Regex("[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?").matches(sdkVersion)) {
+    throw GradleException("VERSION_NAME must be a semantic SDK version: $sdkVersion")
+}
+version = sdkVersion
 
 val nativeSymbolsZip = layout.buildDirectory.file(
     "outputs/native-symbols/hands-android-sdk-${project.version}-native-symbols.zip"
 )
+val releaseAar = layout.buildDirectory.file(
+    "outputs/aar/hands-android-sdk-release.aar"
+)
+val verifyAndroidElfScript = rootProject.file("../../scripts/verify_android_elf_alignment.py")
+val testAndroidElfScript = rootProject.file("../../scripts/test_verify_android_elf_alignment.py")
 
 val packageReleaseNativeSymbols by tasks.registering(Exec::class) {
     dependsOn("externalNativeBuildRelease")
     inputs.file(rootProject.file("../../scripts/package_android_native_symbols.sh"))
     outputs.file(nativeSymbolsZip)
+    outputs.upToDateWhen { false }
     commandLine(
         "bash",
         rootProject.file("../../scripts/package_android_native_symbols.sh"),
@@ -38,6 +52,50 @@ val testNativeRecordIdentity by tasks.registering(Exec::class) {
     commandLine("bash", file("src/test/scripts/test_qnc2_record_identity.sh"))
 }
 
+val testAndroidElfVerifier by tasks.registering(Exec::class) {
+    group = "verification"
+    description = "Runs deterministic unit tests for the Android ELF verifier."
+    inputs.files(verifyAndroidElfScript, testAndroidElfScript)
+    environment("PYTHONDONTWRITEBYTECODE", "1")
+    commandLine("python3", testAndroidElfScript)
+}
+
+val verifyReleaseAarElfAlignment by tasks.registering(Exec::class) {
+    group = "verification"
+    description = "Verifies every 64-bit ELF packaged in the release AAR."
+    dependsOn("assembleRelease")
+    inputs.files(verifyAndroidElfScript, releaseAar)
+    commandLine("python3", verifyAndroidElfScript, "--archive", releaseAar.get().asFile)
+}
+
+val verifyReleaseNativeSymbolsElfAlignment by tasks.registering(Exec::class) {
+    group = "verification"
+    description = "Verifies every 64-bit ELF packaged in the native-symbols archive."
+    dependsOn(packageReleaseNativeSymbols)
+    inputs.files(verifyAndroidElfScript, nativeSymbolsZip)
+    commandLine("python3", verifyAndroidElfScript, "--archive", nativeSymbolsZip.get().asFile)
+}
+
+val verifyReleaseElfAlignment by tasks.registering {
+    group = "verification"
+    description = "Publication gate for release AAR and native-symbols 16 KB ELF alignment."
+    dependsOn(
+        testAndroidElfVerifier,
+        verifyReleaseAarElfAlignment,
+        verifyReleaseNativeSymbolsElfAlignment,
+    )
+}
+
+val validatePublicationVersion by tasks.registering {
+    group = "verification"
+    description = "Refuses Maven publication without one explicit SDK version source."
+    doLast {
+        if (!requestedVersion.isPresent) {
+            throw GradleException("Refusing Maven publication without -PVERSION_NAME")
+        }
+    }
+}
+
 android {
     namespace = "build.hands.update"
     compileSdk = 34
@@ -45,6 +103,7 @@ android {
     defaultConfig {
         minSdk = 24
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "HANDS_SDK_VERSION", "\"$sdkVersion\"")
         consumerProguardFiles("consumer-rules.pro")
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
@@ -63,6 +122,9 @@ android {
         singleVariant("release") {
             withSourcesJar()
         }
+    }
+    buildFeatures {
+        buildConfig = true
     }
 }
 
@@ -87,6 +149,14 @@ dependencies {
 
 tasks.matching { it.name == "testReleaseUnitTest" }.configureEach {
     dependsOn(testNativeRecordIdentity)
+}
+
+tasks.withType<PublishToMavenLocal>().configureEach {
+    dependsOn(validatePublicationVersion, verifyReleaseElfAlignment)
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    dependsOn(validatePublicationVersion, verifyReleaseElfAlignment)
 }
 
 afterEvaluate {

--- a/clients/android/src/main/cpp/CMakeLists.txt
+++ b/clients/android/src/main/cpp/CMakeLists.txt
@@ -3,4 +3,7 @@ project(handscrash C)
 
 add_library(handscrash SHARED hands_native_crash.c hands_record_file.c)
 target_compile_options(handscrash PRIVATE -Wall -Wextra -Werror -fvisibility=hidden)
+# NDK r26 defaults to 4 KB PT_LOAD alignment. Keep the supported r26 toolchain
+# while emitting one binary that can load on both 4 KB and 16 KB Android.
+target_link_options(handscrash PRIVATE "-Wl,-z,max-page-size=16384")
 # JNIEXPORT carries default visibility, so the entry point stays exported.

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -248,9 +248,9 @@ class HandsFeedback(
     }
 
     companion object {
-        /** Quiver Android SDK version — reported in feedback/crash environment
-         *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.12.4"
+        /** Hands Android SDK version reported in feedback/crash metadata. */
+        @JvmField
+        val SDK_VERSION = BuildConfig.HANDS_SDK_VERSION
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -250,7 +250,7 @@ class HandsFeedback(
     companion object {
         /** Quiver Android SDK version — reported in feedback/crash environment
          *  metadata. Keep in sync with the SDK's published version. */
-        const val SDK_VERSION = "0.12.3"
+        const val SDK_VERSION = "0.12.4"
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsFeedback.kt
@@ -249,8 +249,7 @@ class HandsFeedback(
 
     companion object {
         /** Hands Android SDK version reported in feedback/crash metadata. */
-        @JvmField
-        val SDK_VERSION = BuildConfig.HANDS_SDK_VERSION
+        const val SDK_VERSION = BuildConfig.HANDS_SDK_VERSION
 
         /** Server-enforced: at most 9 attachments per ticket. */
         const val MAX_ATTACHMENTS = 9

--- a/clients/android/src/test/kotlin/build/hands/update/HandsFeedbackVersionTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsFeedbackVersionTest.kt
@@ -1,0 +1,11 @@
+package build.hands.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HandsFeedbackVersionTest {
+    @Test
+    fun feedbackMetadataUsesPublicationVersion() {
+        assertEquals(BuildConfig.HANDS_SDK_VERSION, HandsFeedback.SDK_VERSION)
+    }
+}

--- a/clients/android/src/test/kotlin/build/hands/update/HandsFeedbackVersionTest.kt
+++ b/clients/android/src/test/kotlin/build/hands/update/HandsFeedbackVersionTest.kt
@@ -3,9 +3,27 @@ package build.hands.update
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@Target(AnnotationTarget.CLASS)
+private annotation class SdkVersionCompileTimeMarker(val value: String)
+
+@SdkVersionCompileTimeMarker(HandsFeedback.SDK_VERSION)
+private class SdkVersionCompileTimeConsumer
+
 class HandsFeedbackVersionTest {
     @Test
     fun feedbackMetadataUsesPublicationVersion() {
         assertEquals(BuildConfig.HANDS_SDK_VERSION, HandsFeedback.SDK_VERSION)
+    }
+
+    @Test
+    fun sdkVersionRemainsACompileTimeConstant() {
+        val marker = requireNotNull(
+            SdkVersionCompileTimeConsumer::class.java
+                .getAnnotation(SdkVersionCompileTimeMarker::class.java),
+        )
+        assertEquals(
+            BuildConfig.HANDS_SDK_VERSION,
+            marker.value,
+        )
     }
 }

--- a/docs/public/android-sdk.md
+++ b/docs/public/android-sdk.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.botiverse:hands:android-sdk-v0.12.3")
+    implementation("com.github.botiverse:hands:android-sdk-v0.12.4")
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation("build.hands:hands-android-sdk:0.12.3")
+    implementation("build.hands:hands-android-sdk:0.12.4")
 }
 ```
 
@@ -95,6 +95,10 @@ is not the only telemetry path. Valid explicit BCP-47 `languageTag` values are
 sent as `X-Hands-Lang` and `Accept-Language`. Missing/malformed values send
 neither header, while unsupported languages retain the server's English
 fallback. Events/status include requested and resolved language tags.
+
+The `0.12.4` and newer AARs use 16 KB-compatible ELF `PT_LOAD` alignment for
+the 64-bit native crash library. Publication verifies the AAR and its matching
+unstripped native-symbols archive before either artifact is released.
 
 The SDK sends a stable per-install id (`X-Hands-Device-Id`, from
 `HandsDeviceId`; the server still accepts the legacy `X-Quiver-Device-Id`) so

--- a/docs/sdk-parity/android.md
+++ b/docs/sdk-parity/android.md
@@ -4,9 +4,12 @@ Source: `clients/android` (all Kotlin read 2026-07-09). minSdk 24, hand-rolled
 (okhttp 4.12, kotlinx-serialization/coroutines) — no third-party crash SDK.
 Native lib `handscrash` (CMake, arm64-v8a/armeabi-v7a/x86_64).
 
-**Version drift (P1.6):** Gradle `0.1.0-SNAPSHOT` default vs README `0.4.0`
-vs `HandsFeedback.SDK_VERSION = 0.9.0` (the value actually reported in
-ticket metadata).
+**Version contract:** release publication requires one explicit
+`-PVERSION_NAME`. The Maven coordinate, native-symbols filename/manifest, and
+`HandsFeedback` runtime metadata all consume that same Gradle value through
+`BuildConfig.HANDS_SDK_VERSION`. Android SDK 0.12.4 adds a central Gradle gate
+that verifies both the AAR and native-symbols archive before any local, JitPack,
+or GitHub Packages publication task may write.
 
 ## Present
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -13,4 +13,4 @@ before_install:
   - sdk install gradle 8.10.2 < /dev/null
   - sdk default gradle 8.10.2 < /dev/null
 install:
-  - cd clients/android && gradle --no-daemon -PVERSION_NAME=$VERSION publishToMavenLocal
+  - cd clients/android && SDK_VERSION="${VERSION#android-sdk-v}" && gradle --no-daemon -PVERSION_NAME="$SDK_VERSION" publishToMavenLocal

--- a/scripts/package_android_native_symbols.sh
+++ b/scripts/package_android_native_symbols.sh
@@ -36,7 +36,8 @@ done
 [ -n "$BUILD_DIR" ] || die "--build-dir is required"
 [ -n "$OUTPUT" ] || die "--output is required"
 [ -n "$SDK_VERSION" ] || die "--sdk-version is required"
-[ -d "$BUILD_DIR/intermediates/cxx" ] || die "missing release CMake intermediates under $BUILD_DIR"
+RELEASE_CXX_DIR="$BUILD_DIR/intermediates/cxx/RelWithDebInfo"
+[ -d "$RELEASE_CXX_DIR" ] || die "missing release CMake intermediates under $BUILD_DIR"
 
 find_readelf() {
   local candidate
@@ -82,7 +83,7 @@ while IFS= read -r so; do
   sha="$(sha256sum "$so" | awk '{print $1}')"
   printf '%s\t%s\t%s\n' "$arch" "$build_id" "$sha" >> "$MANIFEST_ROWS"
   count=$((count + 1))
-done < <(find "$BUILD_DIR/intermediates/cxx" -type f -path '*/obj/*/libhandscrash.so' | sort)
+done < <(find "$RELEASE_CXX_DIR" -type f -path '*/obj/*/libhandscrash.so' | sort)
 
 [ "$count" -eq 3 ] || die "expected 3 SDK ABIs, found $count"
 for required_arch in arm64-v8a armeabi-v7a x86_64; do
@@ -121,6 +122,8 @@ PY
 mkdir -p "$(dirname "$OUTPUT")"
 OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
 rm -f "$OUTPUT"
+# Keep workflow evidence and the later Maven classifier byte-identical.
+find "$STAGE" -exec touch -t 198001010000 {} +
 (
   cd "$STAGE"
   zip -X -qr "$OUTPUT" manifest.json arm64-v8a armeabi-v7a x86_64

--- a/scripts/test_android_publication_gate.sh
+++ b/scripts/test_android_publication_gate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GRADLE_BIN="${GRADLE_BIN:-gradle}"
+SDK_VERSION="${HANDS_ANDROID_SDK_TEST_VERSION:-0.12.4}"
+
+command -v "${GRADLE_BIN}" >/dev/null 2>&1 || {
+  echo "error: ${GRADLE_BIN} is required" >&2
+  exit 1
+}
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+symbols_archive="${ROOT_DIR}/clients/android/build/outputs/native-symbols/hands-android-sdk-${SDK_VERSION}-native-symbols.zip"
+source_commit="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+
+if "${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" validatePublicationVersion \
+  --no-daemon --console=plain >"${work_dir}/missing-version.log" 2>&1; then
+  echo "publication version gate accepted a missing VERSION_NAME" >&2
+  exit 1
+fi
+grep -Fq "Refusing Maven publication without -PVERSION_NAME" \
+  "${work_dir}/missing-version.log"
+
+"${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" publishToMavenLocal \
+  --dry-run --no-daemon --console=plain -PVERSION_NAME="${SDK_VERSION}" \
+  >"${work_dir}/local.log"
+"${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" publish \
+  --dry-run --no-daemon --console=plain -PVERSION_NAME="${SDK_VERSION}" \
+  >"${work_dir}/remote.log"
+
+for task in \
+  validatePublicationVersion \
+  testAndroidElfVerifier \
+  verifyReleaseAarElfAlignment \
+  verifyReleaseNativeSymbolsElfAlignment \
+  verifyReleaseElfAlignment; do
+  grep -Fq ":${task} SKIPPED" "${work_dir}/local.log" || {
+    echo "local Maven publication bypasses ${task}" >&2
+    exit 1
+  }
+  grep -Fq ":${task} SKIPPED" "${work_dir}/remote.log" || {
+    echo "remote Maven publication bypasses ${task}" >&2
+    exit 1
+  }
+done
+
+grep -Fq ":publishReleasePublicationToMavenLocal SKIPPED" \
+  "${work_dir}/local.log"
+grep -Fq ":publishReleasePublicationToGitHubPackagesRepository SKIPPED" \
+  "${work_dir}/remote.log"
+
+"${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" packageReleaseNativeSymbols \
+  --no-daemon --console=plain -PVERSION_NAME="${SDK_VERSION}" \
+  >"${work_dir}/package-first.log"
+cp "${symbols_archive}" "${work_dir}/symbols-first.zip"
+"${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" packageReleaseNativeSymbols \
+  --no-daemon --console=plain -PVERSION_NAME="${SDK_VERSION}" \
+  >"${work_dir}/package-second.log"
+cmp "${work_dir}/symbols-first.zip" "${symbols_archive}"
+
+python3 - "${symbols_archive}" "${SDK_VERSION}" "${source_commit}" <<'PY'
+import json
+import sys
+import zipfile
+
+archive_path, expected_version, expected_commit = sys.argv[1:]
+with zipfile.ZipFile(archive_path) as archive:
+    manifest = json.loads(archive.read("manifest.json"))
+if manifest.get("sdk_version") != expected_version:
+    raise SystemExit("native-symbols manifest version does not match VERSION_NAME")
+if manifest.get("source", {}).get("commit") != expected_commit:
+    raise SystemExit("native-symbols manifest source does not match HEAD")
+PY
+
+echo "Android SDK publication gate contract: PASS"

--- a/scripts/test_android_publication_gate.sh
+++ b/scripts/test_android_publication_gate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PYTHONDONTWRITEBYTECODE=1
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GRADLE_BIN="${GRADLE_BIN:-gradle}"
@@ -14,6 +15,28 @@ work_dir="$(mktemp -d)"
 trap 'rm -rf "${work_dir}"' EXIT
 symbols_archive="${ROOT_DIR}/clients/android/build/outputs/native-symbols/hands-android-sdk-${SDK_VERSION}-native-symbols.zip"
 source_commit="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+publish_workflow="${ROOT_DIR}/.github/workflows/publish-android-sdk.yml"
+version_expression='${{ github.event.inputs.version }}'
+
+expression_count="$(
+  awk -v needle="${version_expression}" '
+    index($0, needle) { count += 1 }
+    END { print count + 0 }
+  ' "${publish_workflow}"
+)"
+[[ "${expression_count}" == "1" ]] || {
+  echo "workflow dispatch version must have exactly one expression boundary" >&2
+  exit 1
+}
+grep -Eq '^[[:space:]]*INPUT_VERSION:[[:space:]]*\$\{\{ github\.event\.inputs\.version \}\}[[:space:]]*$' \
+  "${publish_workflow}" || {
+  echo "workflow dispatch version must enter the shell through step env" >&2
+  exit 1
+}
+grep -Fq 'VERSION="${INPUT_VERSION}"' "${publish_workflow}" || {
+  echo "version resolver does not read the env-bound workflow input" >&2
+  exit 1
+}
 
 if "${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" validatePublicationVersion \
   --no-daemon --console=plain >"${work_dir}/missing-version.log" 2>&1; then
@@ -59,6 +82,47 @@ cp "${symbols_archive}" "${work_dir}/symbols-first.zip"
   --no-daemon --console=plain -PVERSION_NAME="${SDK_VERSION}" \
   >"${work_dir}/package-second.log"
 cmp "${work_dir}/symbols-first.zip" "${symbols_archive}"
+
+python3 "${ROOT_DIR}/scripts/verify_android_elf_alignment.py" \
+  --archive "${symbols_archive}" >"${work_dir}/symbols-verifier.json"
+
+python3 - "${ROOT_DIR}" "${symbols_archive}" "${work_dir}" <<'PY'
+import sys
+import zipfile
+from pathlib import Path
+
+root, symbols_path, work_dir = map(Path, sys.argv[1:])
+sys.path.insert(0, str(root / "scripts"))
+from verify_android_elf_alignment import verify_archive
+
+library_names = (
+    "arm64-v8a/libhandscrash.so",
+    "x86_64/libhandscrash.so",
+)
+with zipfile.ZipFile(symbols_path) as source:
+    libraries = {name: source.read(name) for name in library_names}
+
+for target_name, truncated_size in (
+    (library_names[0], 1024),
+    (library_names[1], 4096),
+):
+    output = work_dir / f"truncated-{target_name.split('/', 1)[0]}.zip"
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, data in libraries.items():
+            archive.writestr(
+                name,
+                data[:truncated_size] if name == target_name else data,
+            )
+    try:
+        verify_archive(output)
+    except ValueError as error:
+        if "exceeds file bounds" not in str(error):
+            raise SystemExit(
+                f"real {target_name} truncation failed for the wrong reason: {error}"
+            ) from error
+    else:
+        raise SystemExit(f"verifier accepted truncated real ELF: {target_name}")
+PY
 
 python3 - "${symbols_archive}" "${SDK_VERSION}" "${source_commit}" <<'PY'
 import json

--- a/scripts/test_verify_android_elf_alignment.py
+++ b/scripts/test_verify_android_elf_alignment.py
@@ -5,19 +5,28 @@ from __future__ import annotations
 import struct
 import tempfile
 import unittest
+import warnings
 import zipfile
 from pathlib import Path
 
 from verify_android_elf_alignment import verify_archive
 
 
-def elf64(*, alignment: int, congruent: bool = True) -> bytes:
+def elf64(
+    *,
+    alignment: int,
+    machine: int,
+    congruent: bool = True,
+    elf_class: int = 2,
+    congruence_offset: int | None = None,
+) -> bytes:
     data = bytearray(256)
-    data[:6] = b"\x7fELF\x02\x01"
+    data[:6] = b"\x7fELF" + bytes((elf_class, 1))
+    struct.pack_into("<H", data, 18, machine)
     struct.pack_into("<Q", data, 32, 64)
     struct.pack_into("<H", data, 54, 56)
     struct.pack_into("<H", data, 56, 1)
-    offset = 0 if congruent else 4096
+    offset = 0 if congruent else (congruence_offset or 4096)
     struct.pack_into(
         "<IIQQQQQQ",
         data,
@@ -49,12 +58,20 @@ class VerifyAndroidElfAlignmentTest(unittest.TestCase):
             prefix = "" if symbols_layout else "jni/"
             archive.writestr(
                 f"{prefix}arm64-v8a/libhandscrash.so",
-                elf64(alignment=alignment, congruent=congruent),
+                elf64(
+                    alignment=alignment,
+                    machine=183,
+                    congruent=congruent,
+                ),
             )
             if include_x86_64:
                 archive.writestr(
                     f"{prefix}x86_64/libhandscrash.so",
-                    elf64(alignment=alignment, congruent=congruent),
+                    elf64(
+                        alignment=alignment,
+                        machine=62,
+                        congruent=congruent,
+                    ),
                 )
         return archive_path
 
@@ -98,6 +115,91 @@ class VerifyAndroidElfAlignmentTest(unittest.TestCase):
                         include_x86_64=False,
                     )
                 )
+
+    def test_rejects_elfclass32_in_64bit_abi(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=183, elf_class=1),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "must contain ELFCLASS64"):
+                verify_archive(archive_path)
+
+    def test_rejects_wrong_machine_for_abi(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "does not match expected"):
+                verify_archive(archive_path)
+
+    def test_rejects_non_power_of_two_alignment(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "not a power of two"):
+                verify_archive(
+                    self.create_archive(Path(directory), alignment=24 * 1024)
+                )
+
+    def test_checks_congruence_against_segment_alignment(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(
+                        alignment=64 * 1024,
+                        machine=183,
+                        congruent=False,
+                        congruence_offset=16 * 1024,
+                    ),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=64 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "p_align=0x10000"):
+                verify_archive(archive_path)
+
+    def test_rejects_duplicate_archive_member(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = self.create_archive(
+                Path(directory), alignment=16 * 1024
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                with zipfile.ZipFile(archive_path, "a") as archive:
+                    archive.writestr(
+                        "jni/arm64-v8a/libhandscrash.so",
+                        elf64(alignment=16 * 1024, machine=183),
+                    )
+            with self.assertRaisesRegex(ValueError, "duplicate members"):
+                verify_archive(archive_path)
+
+    def test_rejects_duplicate_non_elf_archive_member(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = self.create_archive(
+                Path(directory), alignment=16 * 1024
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                with zipfile.ZipFile(archive_path, "a") as archive:
+                    archive.writestr("AndroidManifest.xml", b"first")
+                    archive.writestr("AndroidManifest.xml", b"second")
+            with self.assertRaisesRegex(ValueError, "AndroidManifest.xml"):
+                verify_archive(archive_path)
 
 
 if __name__ == "__main__":

--- a/scripts/test_verify_android_elf_alignment.py
+++ b/scripts/test_verify_android_elf_alignment.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import struct
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from verify_android_elf_alignment import verify_archive
+
+
+def elf64(*, alignment: int, congruent: bool = True) -> bytes:
+    data = bytearray(256)
+    data[:6] = b"\x7fELF\x02\x01"
+    struct.pack_into("<Q", data, 32, 64)
+    struct.pack_into("<H", data, 54, 56)
+    struct.pack_into("<H", data, 56, 1)
+    offset = 0 if congruent else 4096
+    struct.pack_into(
+        "<IIQQQQQQ",
+        data,
+        64,
+        1,
+        5,
+        offset,
+        0,
+        0,
+        128,
+        128,
+        alignment,
+    )
+    return bytes(data)
+
+
+class VerifyAndroidElfAlignmentTest(unittest.TestCase):
+    def create_archive(
+        self,
+        root: Path,
+        *,
+        alignment: int,
+        congruent: bool = True,
+        include_x86_64: bool = True,
+        symbols_layout: bool = False,
+    ) -> Path:
+        archive_path = root / "sdk.aar"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            prefix = "" if symbols_layout else "jni/"
+            archive.writestr(
+                f"{prefix}arm64-v8a/libhandscrash.so",
+                elf64(alignment=alignment, congruent=congruent),
+            )
+            if include_x86_64:
+                archive.writestr(
+                    f"{prefix}x86_64/libhandscrash.so",
+                    elf64(alignment=alignment, congruent=congruent),
+                )
+        return archive_path
+
+    def test_accepts_16kb_load_segments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = verify_archive(
+                self.create_archive(Path(directory), alignment=16 * 1024)
+            )
+            self.assertEqual(2, len(report["libraries"]))
+
+    def test_rejects_4kb_load_segments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "below 0x4000"):
+                verify_archive(self.create_archive(Path(directory), alignment=4096))
+
+    def test_accepts_native_symbols_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = verify_archive(
+                self.create_archive(
+                    Path(directory), alignment=16 * 1024, symbols_layout=True
+                )
+            )
+            self.assertEqual(2, len(report["libraries"]))
+
+    def test_rejects_noncongruent_load_segments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "not congruent"):
+                verify_archive(
+                    self.create_archive(
+                        Path(directory), alignment=16 * 1024, congruent=False
+                    )
+                )
+
+    def test_requires_both_64bit_abis(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "missing required ABIs: x86_64"):
+                verify_archive(
+                    self.create_archive(
+                        Path(directory),
+                        alignment=16 * 1024,
+                        include_x86_64=False,
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_android_elf_alignment.py
+++ b/scripts/test_verify_android_elf_alignment.py
@@ -19,14 +19,22 @@ def elf64(
     congruent: bool = True,
     elf_class: int = 2,
     congruence_offset: int | None = None,
+    byte_order: int = 1,
+    elf_type: int = 3,
+    file_size: int = 128,
+    memory_size: int = 128,
+    materialize_segment: bool = True,
+    truncate_to: int | None = None,
 ) -> bytes:
-    data = bytearray(256)
-    data[:6] = b"\x7fELF" + bytes((elf_class, 1))
+    offset = 0 if congruent else (congruence_offset or 4096)
+    data_size = max(256, offset + file_size) if materialize_segment else 256
+    data = bytearray(data_size)
+    data[:6] = b"\x7fELF" + bytes((elf_class, byte_order))
+    struct.pack_into("<H", data, 16, elf_type)
     struct.pack_into("<H", data, 18, machine)
     struct.pack_into("<Q", data, 32, 64)
     struct.pack_into("<H", data, 54, 56)
     struct.pack_into("<H", data, 56, 1)
-    offset = 0 if congruent else (congruence_offset or 4096)
     struct.pack_into(
         "<IIQQQQQQ",
         data,
@@ -36,11 +44,12 @@ def elf64(
         offset,
         0,
         0,
-        128,
-        128,
+        file_size,
+        memory_size,
         alignment,
     )
-    return bytes(data)
+    encoded = bytes(data)
+    return encoded if truncate_to is None else encoded[:truncate_to]
 
 
 class VerifyAndroidElfAlignmentTest(unittest.TestCase):
@@ -144,6 +153,125 @@ class VerifyAndroidElfAlignmentTest(unittest.TestCase):
                     elf64(alignment=16 * 1024, machine=62),
                 )
             with self.assertRaisesRegex(ValueError, "does not match expected"):
+                verify_archive(archive_path)
+
+    def test_rejects_big_endian_library(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(
+                        alignment=16 * 1024,
+                        machine=183,
+                        byte_order=2,
+                    ),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "must be little-endian"):
+                verify_archive(archive_path)
+
+    def test_rejects_et_rel_library(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=183, elf_type=1),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "must contain ET_DYN"):
+                verify_archive(archive_path)
+
+    def test_rejects_segment_file_size_above_memory_size(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(
+                        alignment=16 * 1024,
+                        machine=183,
+                        file_size=256,
+                        memory_size=128,
+                    ),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "exceeds memory size"):
+                verify_archive(archive_path)
+
+    def test_rejects_segment_range_past_file_end(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(
+                        alignment=16 * 1024,
+                        machine=183,
+                        file_size=4096,
+                        memory_size=4096,
+                        materialize_segment=False,
+                    ),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "exceeds file bounds"):
+                verify_archive(archive_path)
+
+    def test_rejects_zero_length_segment_offset_past_file_end(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(
+                        alignment=16 * 1024,
+                        machine=183,
+                        congruent=False,
+                        congruence_offset=16 * 1024,
+                        file_size=0,
+                        memory_size=0,
+                        materialize_segment=False,
+                    ),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "exceeds file bounds"):
+                verify_archive(archive_path)
+
+    def test_rejects_truncated_library_with_intact_program_headers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive_path = Path(directory) / "sdk.aar"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "jni/arm64-v8a/libhandscrash.so",
+                    elf64(
+                        alignment=16 * 1024,
+                        machine=183,
+                        file_size=8192,
+                        memory_size=8192,
+                        truncate_to=1024,
+                    ),
+                )
+                archive.writestr(
+                    "jni/x86_64/libhandscrash.so",
+                    elf64(alignment=16 * 1024, machine=62),
+                )
+            with self.assertRaisesRegex(ValueError, "exceeds file bounds"):
                 verify_archive(archive_path)
 
     def test_rejects_non_power_of_two_alignment(self) -> None:

--- a/scripts/verify_android_elf_alignment.py
+++ b/scripts/verify_android_elf_alignment.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 
 PT_LOAD = 1
+ET_DYN = 3
 MIN_PAGE_ALIGNMENT = 16 * 1024
 REQUIRED_ABIS = ("arm64-v8a", "x86_64")
 EXPECTED_MACHINES = {
@@ -26,6 +27,8 @@ EXPECTED_MACHINES = {
 class LoadSegment:
     offset: int
     virtual_address: int
+    file_size: int
+    memory_size: int
     alignment: int
 
 
@@ -37,12 +40,17 @@ def load_segments(
 
     elf_class = data[4]
     byte_order = data[5]
-    endian = "<" if byte_order == 1 else ">" if byte_order == 2 else None
-    if endian is None:
-        raise ValueError(f"unsupported ELF byte order: {byte_order}")
+    if byte_order != 1:
+        raise ValueError(
+            f"64-bit Android ELF must be little-endian, got byte order {byte_order}"
+        )
+    endian = "<"
 
     if elf_class != 2:
         raise ValueError(f"64-bit ABI entry must contain ELFCLASS64, got class {elf_class}")
+    elf_type = struct.unpack_from(f"{endian}H", data, 16)[0]
+    if elf_type != ET_DYN:
+        raise ValueError(f"shared library must contain ET_DYN, got ELF type {elf_type}")
     machine = struct.unpack_from(f"{endian}H", data, 18)[0]
     if expected_machine is not None and machine != expected_machine:
         raise ValueError(
@@ -69,8 +77,17 @@ def load_segments(
         fields = struct.unpack_from(segment_format, data, start)
         if fields[0] != PT_LOAD:
             continue
-        offset, virtual_address, alignment = fields[2], fields[3], fields[7]
-        segments.append(LoadSegment(offset, virtual_address, alignment))
+        offset, virtual_address = fields[2], fields[3]
+        file_size, memory_size, alignment = fields[5], fields[6], fields[7]
+        segments.append(
+            LoadSegment(
+                offset=offset,
+                virtual_address=virtual_address,
+                file_size=file_size,
+                memory_size=memory_size,
+                alignment=alignment,
+            )
+        )
 
     if not segments:
         raise ValueError("ELF file contains no PT_LOAD segments")
@@ -105,11 +122,25 @@ def verify_archive(archive_path: Path) -> dict[str, object]:
             if abi is None:
                 raise ValueError(f"internal ABI resolution failure: {entry.filename}")
             seen_abis.add(abi)
+            elf_data = archive.read(entry)
             segments = load_segments(
-                archive.read(entry),
+                elf_data,
                 expected_machine=EXPECTED_MACHINES[abi],
             )
             for segment in segments:
+                if segment.file_size > segment.memory_size:
+                    raise ValueError(
+                        f"{entry.filename} PT_LOAD file size {segment.file_size} "
+                        f"exceeds memory size {segment.memory_size}"
+                    )
+                if segment.offset > len(elf_data) or (
+                    segment.offset + segment.file_size > len(elf_data)
+                ):
+                    raise ValueError(
+                        f"{entry.filename} PT_LOAD file range "
+                        f"[{segment.offset}, {segment.offset + segment.file_size}) "
+                        f"exceeds file bounds {len(elf_data)}"
+                    )
                 if segment.alignment == 0 or (
                     segment.alignment & (segment.alignment - 1)
                 ) != 0:

--- a/scripts/verify_android_elf_alignment.py
+++ b/scripts/verify_android_elf_alignment.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Verify 64-bit Android native libraries are safe for 16 KB page devices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PT_LOAD = 1
+MIN_PAGE_ALIGNMENT = 16 * 1024
+REQUIRED_ABIS = ("arm64-v8a", "x86_64")
+
+
+@dataclass(frozen=True)
+class LoadSegment:
+    offset: int
+    virtual_address: int
+    alignment: int
+
+
+def load_segments(data: bytes) -> list[LoadSegment]:
+    if len(data) < 64 or data[:4] != b"\x7fELF":
+        raise ValueError("not an ELF file")
+
+    elf_class = data[4]
+    byte_order = data[5]
+    endian = "<" if byte_order == 1 else ">" if byte_order == 2 else None
+    if endian is None:
+        raise ValueError(f"unsupported ELF byte order: {byte_order}")
+
+    if elf_class == 1:
+        phoff_offset, phoff_format = 28, "I"
+        phentsize_offset, phnum_offset = 42, 44
+        program_header_size = 32
+        segment_format = f"{endian}IIIIIIII"
+    elif elf_class == 2:
+        phoff_offset, phoff_format = 32, "Q"
+        phentsize_offset, phnum_offset = 54, 56
+        program_header_size = 56
+        segment_format = f"{endian}IIQQQQQQ"
+    else:
+        raise ValueError(f"unsupported ELF class: {elf_class}")
+
+    phoff = struct.unpack_from(f"{endian}{phoff_format}", data, phoff_offset)[0]
+    phentsize = struct.unpack_from(f"{endian}H", data, phentsize_offset)[0]
+    phnum = struct.unpack_from(f"{endian}H", data, phnum_offset)[0]
+    if phentsize < program_header_size:
+        raise ValueError(f"invalid ELF program-header size: {phentsize}")
+
+    segments: list[LoadSegment] = []
+    for index in range(phnum):
+        start = phoff + index * phentsize
+        end = start + program_header_size
+        if end > len(data):
+            raise ValueError("ELF program headers exceed file bounds")
+        fields = struct.unpack_from(segment_format, data, start)
+        if fields[0] != PT_LOAD:
+            continue
+        if elf_class == 1:
+            offset, virtual_address, alignment = fields[1], fields[2], fields[7]
+        else:
+            offset, virtual_address, alignment = fields[2], fields[3], fields[7]
+        segments.append(LoadSegment(offset, virtual_address, alignment))
+
+    if not segments:
+        raise ValueError("ELF file contains no PT_LOAD segments")
+    return segments
+
+
+def verify_archive(archive_path: Path) -> dict[str, object]:
+    results: dict[str, object] = {}
+    seen_abis: set[str] = set()
+    with zipfile.ZipFile(archive_path) as archive:
+        entries = sorted(
+            (entry for entry in archive.infolist() if archive_abi(entry.filename)),
+            key=lambda entry: entry.filename,
+        )
+        if not entries:
+            raise ValueError("archive contains no required 64-bit Android libraries")
+
+        for entry in entries:
+            abi = archive_abi(entry.filename)
+            if abi is None:
+                raise ValueError(f"internal ABI resolution failure: {entry.filename}")
+            seen_abis.add(abi)
+            segments = load_segments(archive.read(entry))
+            for segment in segments:
+                if segment.alignment < MIN_PAGE_ALIGNMENT:
+                    raise ValueError(
+                        f"{entry.filename} PT_LOAD alignment "
+                        f"0x{segment.alignment:x} is below 0x{MIN_PAGE_ALIGNMENT:x}"
+                    )
+                if (
+                    segment.offset % MIN_PAGE_ALIGNMENT
+                    != segment.virtual_address % MIN_PAGE_ALIGNMENT
+                ):
+                    raise ValueError(
+                        f"{entry.filename} PT_LOAD offset/vaddr are not congruent "
+                        "for 16 KB pages"
+                    )
+            results[entry.filename] = {
+                "load_segments": len(segments),
+                "min_alignment": min(segment.alignment for segment in segments),
+            }
+
+    missing_abis = sorted(set(REQUIRED_ABIS) - seen_abis)
+    if missing_abis:
+        raise ValueError(f"archive is missing required ABIs: {', '.join(missing_abis)}")
+    return {
+        "archive": str(archive_path),
+        "minimum_page_alignment": MIN_PAGE_ALIGNMENT,
+        "libraries": results,
+    }
+
+
+def archive_abi(filename: str) -> str | None:
+    parts = filename.split("/")
+    if (
+        len(parts) == 3
+        and parts[0] in {"jni", "lib"}
+        and parts[1] in REQUIRED_ABIS
+        and parts[2].endswith(".so")
+    ):
+        return parts[1]
+    if len(parts) == 2 and parts[0] in REQUIRED_ABIS and parts[1].endswith(".so"):
+        return parts[0]
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        report = verify_archive(args.archive)
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(f"Android 16 KB ELF verification failed: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_android_elf_alignment.py
+++ b/scripts/verify_android_elf_alignment.py
@@ -8,6 +8,7 @@ import json
 import struct
 import sys
 import zipfile
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -15,6 +16,10 @@ from pathlib import Path
 PT_LOAD = 1
 MIN_PAGE_ALIGNMENT = 16 * 1024
 REQUIRED_ABIS = ("arm64-v8a", "x86_64")
+EXPECTED_MACHINES = {
+    "arm64-v8a": 183,  # EM_AARCH64
+    "x86_64": 62,  # EM_X86_64
+}
 
 
 @dataclass(frozen=True)
@@ -24,7 +29,9 @@ class LoadSegment:
     alignment: int
 
 
-def load_segments(data: bytes) -> list[LoadSegment]:
+def load_segments(
+    data: bytes, *, expected_machine: int | None = None
+) -> list[LoadSegment]:
     if len(data) < 64 or data[:4] != b"\x7fELF":
         raise ValueError("not an ELF file")
 
@@ -34,18 +41,18 @@ def load_segments(data: bytes) -> list[LoadSegment]:
     if endian is None:
         raise ValueError(f"unsupported ELF byte order: {byte_order}")
 
-    if elf_class == 1:
-        phoff_offset, phoff_format = 28, "I"
-        phentsize_offset, phnum_offset = 42, 44
-        program_header_size = 32
-        segment_format = f"{endian}IIIIIIII"
-    elif elf_class == 2:
-        phoff_offset, phoff_format = 32, "Q"
-        phentsize_offset, phnum_offset = 54, 56
-        program_header_size = 56
-        segment_format = f"{endian}IIQQQQQQ"
-    else:
-        raise ValueError(f"unsupported ELF class: {elf_class}")
+    if elf_class != 2:
+        raise ValueError(f"64-bit ABI entry must contain ELFCLASS64, got class {elf_class}")
+    machine = struct.unpack_from(f"{endian}H", data, 18)[0]
+    if expected_machine is not None and machine != expected_machine:
+        raise ValueError(
+            f"ELF machine {machine} does not match expected machine {expected_machine}"
+        )
+
+    phoff_offset, phoff_format = 32, "Q"
+    phentsize_offset, phnum_offset = 54, 56
+    program_header_size = 56
+    segment_format = f"{endian}IIQQQQQQ"
 
     phoff = struct.unpack_from(f"{endian}{phoff_format}", data, phoff_offset)[0]
     phentsize = struct.unpack_from(f"{endian}H", data, phentsize_offset)[0]
@@ -62,10 +69,7 @@ def load_segments(data: bytes) -> list[LoadSegment]:
         fields = struct.unpack_from(segment_format, data, start)
         if fields[0] != PT_LOAD:
             continue
-        if elf_class == 1:
-            offset, virtual_address, alignment = fields[1], fields[2], fields[7]
-        else:
-            offset, virtual_address, alignment = fields[2], fields[3], fields[7]
+        offset, virtual_address, alignment = fields[2], fields[3], fields[7]
         segments.append(LoadSegment(offset, virtual_address, alignment))
 
     if not segments:
@@ -77,6 +81,18 @@ def verify_archive(archive_path: Path) -> dict[str, object]:
     results: dict[str, object] = {}
     seen_abis: set[str] = set()
     with zipfile.ZipFile(archive_path) as archive:
+        duplicate_names = sorted(
+            name
+            for name, count in Counter(
+                entry.filename for entry in archive.infolist()
+            ).items()
+            if count > 1
+        )
+        if duplicate_names:
+            raise ValueError(
+                f"archive contains duplicate members: {', '.join(duplicate_names)}"
+            )
+
         entries = sorted(
             (entry for entry in archive.infolist() if archive_abi(entry.filename)),
             key=lambda entry: entry.filename,
@@ -89,20 +105,30 @@ def verify_archive(archive_path: Path) -> dict[str, object]:
             if abi is None:
                 raise ValueError(f"internal ABI resolution failure: {entry.filename}")
             seen_abis.add(abi)
-            segments = load_segments(archive.read(entry))
+            segments = load_segments(
+                archive.read(entry),
+                expected_machine=EXPECTED_MACHINES[abi],
+            )
             for segment in segments:
+                if segment.alignment == 0 or (
+                    segment.alignment & (segment.alignment - 1)
+                ) != 0:
+                    raise ValueError(
+                        f"{entry.filename} PT_LOAD alignment "
+                        f"0x{segment.alignment:x} is not a power of two"
+                    )
                 if segment.alignment < MIN_PAGE_ALIGNMENT:
                     raise ValueError(
                         f"{entry.filename} PT_LOAD alignment "
                         f"0x{segment.alignment:x} is below 0x{MIN_PAGE_ALIGNMENT:x}"
                     )
                 if (
-                    segment.offset % MIN_PAGE_ALIGNMENT
-                    != segment.virtual_address % MIN_PAGE_ALIGNMENT
+                    segment.offset % segment.alignment
+                    != segment.virtual_address % segment.alignment
                 ):
                     raise ValueError(
                         f"{entry.filename} PT_LOAD offset/vaddr are not congruent "
-                        "for 16 KB pages"
+                        f"for p_align=0x{segment.alignment:x}"
                     )
             results[entry.filename] = {
                 "load_segments": len(segments),


### PR DESCRIPTION
## Summary

- link `libhandscrash.so` with a 16 KiB maximum ELF page size on the existing NDK r26 toolchain
- verify every 64-bit AAR/native-symbol ELF is little-endian ELFCLASS64 `ET_DYN`, matches its ABI machine, and has power-of-two `p_align >= 0x4000` with offset/vaddr congruent modulo the actual `p_align`
- reject malformed `PT_LOAD` file/memory sizes and file ranges, truncated real ELFs, duplicate ZIP members, and missing required 64-bit ABIs
- make one Gradle gate cover AAR, native-symbols, verifier tests, JitPack, Maven local, and GitHub Packages publication
- bind the workflow-dispatch version through step `env` before shell parsing, then derive Maven coordinates, native-symbol metadata, and the public compile-time runtime SDK constant from the same explicit `VERSION_NAME`
- keep release-symbol packaging exact-source, release-variant-only, and byte-deterministic across workflow evidence and Maven publication
- bump the Android SDK release line and documentation default to `0.12.4`

## Why

Android 1.8.0 admission on an API 37 / 16 KiB page-size device found that `libhandscrash.so` was the sole real ELF failure: its `PT_LOAD` segments used `p_align=0x1000`. The other libraries named by the compatibility dialog independently verify at `0x4000`, so this PR fixes the actual producer instead of upgrading unrelated dependencies.

The first reviewed exact `9eba2331...` and second exact `65314ef7...` remain historical only. Third successor `9647220380d53fb8cb8eb735ede34b0730433d34` closes both zero-inheritance review rounds: publication bypass/version drift, malformed class/machine/alignment/archive acceptance, workflow input injection, compile-time constant compatibility, and loadable-ELF bounds.

## Verification

- Gradle 8.10.2, JDK 17, NDK `26.3.11579264`
- `testReleaseUnitTest`: 49/49 PASS; compile-time annotation consumer proves `HandsFeedback.SDK_VERSION` remains a JVM `ConstantValue`; QNC2 native record test PASS
- ELF verifier: 17/17 PASS, including ELFCLASS32, wrong machine, big-endian, `ET_REL`, non-power-of-two alignment, 64 KiB congruence, `filesz > memsz`, zero-length offset/range beyond EOF, truncation, and duplicate-member negatives
- publication contract mutates the real release arm64 ELF to 1,024 bytes and x86_64 ELF to 4,096 bytes; both must fail on file bounds
- release AAR + native-symbols central gate PASS; both required 64-bit ABIs have three `PT_LOAD` segments at `0x4000`
- `assembleDebugAndroidTest` PASS
- local, remote, and JitPack publication graphs all include version + ELF gates; workflow static gate permits the dispatch expression only at `INPUT_VERSION` step env
- actual isolated `publishToMavenLocal` PASS; missing-version real publication fails before Maven output (0 files)
- repeated symbol packaging is byte-identical and manifest source equals exact HEAD `9647220...`
- isolated publication receipts: POM `fe32146498c2f02aff962818932f9c0363c27df6803192fd6e92122702eba1db`; AAR `7efafc1bbb86c645bcd3d1c7734913200da9d139243993d6887b0660a1ad3078`; symbols `5112b03f01b86d7bc5633e78fa9ca8a474ff86a2c0c45d29c26b6c09ae22464b`
- published AAR/classifier are byte-equal to gated outputs; frozen Android 1.8.0 APK correctly FAILS on old `libhandscrash.so p_align=0x1000`

## Release contract

Publication remains fail-closed: do not merge, tag `android-sdk-v0.12.4`, or publish until this third successor receives zero-inheritance exact review and its new Hosted checks are terminal green. After an explicitly authorized release, independently read back the canonical POM/AAR/native-symbol classifier hashes, Build IDs, `.debug_info`, and 16 KiB alignment before Mobile consumes the SDK.

Raft: task #158 / Hands review task #211
