### PR TITLE
chore(worker): wire reporter-session deploy config

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -40,6 +40,8 @@ jobs:
       HANDS_RAFT_ORIGIN: ${{ vars.HANDS_RAFT_ORIGIN }}
       HANDS_RAFT_API_ORIGIN: ${{ vars.HANDS_RAFT_API_ORIGIN }}
       HANDS_RAFT_CLIENT_ID: ${{ vars.HANDS_RAFT_CLIENT_ID }}
+      HANDS_FEEDBACK_REPORTER_SESSION_ENABLED: ${{ vars.HANDS_FEEDBACK_REPORTER_SESSION_ENABLED }}
+      HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION: ${{ vars.HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION }}
     steps:
       - uses: actions/checkout@v6
 
@@ -54,6 +56,23 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Validate reporter-session rollout inputs
+        env:
+          FEEDBACK_REPORTER_SESSION_KEYS: ${{ secrets.HANDS_FEEDBACK_REPORTER_SESSION_KEYS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${HANDS_FEEDBACK_REPORTER_SESSION_ENABLED:-false}" == "true" ]]; then
+            if [[ -z "${HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION:-}" ]]; then
+              echo "Missing repository variable HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION." >&2
+              exit 1
+            fi
+            if [[ -z "${FEEDBACK_REPORTER_SESSION_KEYS:-}" ]]; then
+              echo "Missing GitHub secret HANDS_FEEDBACK_REPORTER_SESSION_KEYS." >&2
+              exit 1
+            fi
+          fi
 
       - name: Render production Wrangler config
         working-directory: worker
@@ -133,6 +152,7 @@ jobs:
           ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
           AGC_CRED_ENC_KEY: ${{ secrets.HANDS_AGC_CRED_ENC_KEY }}
           FEEDBACK_AUDIT_HMAC_KEY: ${{ secrets.HANDS_FEEDBACK_AUDIT_HMAC_KEY }}
+          FEEDBACK_REPORTER_SESSION_KEYS: ${{ secrets.HANDS_FEEDBACK_REPORTER_SESSION_KEYS }}
           R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
           # Optional: R2 S3-API credentials enable direct-to-R2 presigned downloads
           # (bandwidth bypasses the Worker). When unset, downloads fall back to the
@@ -172,6 +192,12 @@ jobs:
           printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${AGC_CRED_ENC_KEY}" | pnpm exec wrangler secret put AGC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${FEEDBACK_AUDIT_HMAC_KEY}" | pnpm exec wrangler secret put FEEDBACK_AUDIT_HMAC_KEY --config "${config}"
+          # Provision the keyring while the feature remains disabled, then flip
+          # the repository flag in a separate deploy. This avoids an enabled
+          # Worker version ever depending on a keyring that has not been bound.
+          if [[ -n "${FEEDBACK_REPORTER_SESSION_KEYS:-}" ]]; then
+            printf '%s' "${FEEDBACK_REPORTER_SESSION_KEYS}" | pnpm exec wrangler secret put FEEDBACK_REPORTER_SESSION_KEYS --config "${config}"
+          fi
           printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
           # Optional R2 S3-API credentials (only put when configured).
           if [[ -n "${R2_S3_ACCESS_KEY_ID:-}" ]]; then

--- a/worker/scripts/render-production-config.mjs
+++ b/worker/scripts/render-production-config.mjs
@@ -43,6 +43,23 @@ function uuid(name) {
   return value;
 }
 
+function booleanString(name, fallback) {
+  const value = process.env[name]?.trim() || fallback;
+  if (value !== "true" && value !== "false") {
+    throw new Error(`${name} must be exactly true or false`);
+  }
+  return value;
+}
+
+function optionalKeyVersion(name) {
+  const value = process.env[name]?.trim();
+  if (!value) return null;
+  if (!/^[A-Za-z0-9._-]{1,64}$/.test(value)) {
+    throw new Error(`${name} must be a valid key version`);
+  }
+  return value;
+}
+
 const errors = [];
 const config = parse(readFileSync(sourcePath, "utf8"), errors, {
   allowTrailingComma: true,
@@ -55,6 +72,15 @@ if (errors.length > 0 || !config || typeof config !== "object") {
 
 const businessDomain = domain("HANDS_BUSINESS_DOMAIN");
 const dashboardDomain = domain("HANDS_DASHBOARD_DOMAIN");
+const reporterSessionEnabled = booleanString("HANDS_FEEDBACK_REPORTER_SESSION_ENABLED", "false");
+const reporterSessionActiveKeyVersion = optionalKeyVersion(
+  "HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION",
+);
+if (reporterSessionEnabled === "true" && !reporterSessionActiveKeyVersion) {
+  throw new Error(
+    "HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION is required when reporter sessions are enabled",
+  );
+}
 const d1 = config.d1_databases?.find((binding) => binding.binding === "DB");
 const r2 = config.r2_buckets?.find((binding) => binding.binding === "APK_BUCKET");
 if (!d1 || !r2) throw new Error("Hands DB or APK_BUCKET binding is missing from the base config");
@@ -81,7 +107,13 @@ config.vars = {
   RAFT_API_ORIGIN: required("HANDS_RAFT_API_ORIGIN"),
   RAFT_CLIENT_ID: required("HANDS_RAFT_CLIENT_ID"),
   R2_BUCKET_NAME: r2.bucket_name,
+  FEEDBACK_REPORTER_SESSION_ENABLED: reporterSessionEnabled,
 };
+if (reporterSessionActiveKeyVersion) {
+  config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION = reporterSessionActiveKeyVersion;
+} else {
+  delete config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION;
+}
 
 mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });

--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "vitest";
+
+const workerDir = resolve(import.meta.dirname, "..");
+const repositoryDir = resolve(workerDir, "..");
+const renderScript = resolve(workerDir, "scripts/render-production-config.mjs");
+
+const BASE_ENV = {
+  HANDS_WORKER_NAME: "hands-test",
+  HANDS_D1_DATABASE_NAME: "hands-test-db",
+  HANDS_D1_DATABASE_ID: "11111111-1111-4111-8111-111111111111",
+  HANDS_R2_BUCKET_NAME: "hands-test-artifacts",
+  HANDS_BUSINESS_DOMAIN: "hands.build",
+  HANDS_DASHBOARD_DOMAIN: "app.hands.build",
+  HANDS_CORS_ALLOWED_ORIGINS: "https://hands.build",
+  HANDS_RAFT_ORIGIN: "https://app.raft.build",
+  HANDS_RAFT_API_ORIGIN: "https://api.raft.build",
+  HANDS_RAFT_CLIENT_ID: "hands-test-client",
+};
+
+function render(extraEnv: Record<string, string> = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "hands-production-config-"));
+  const output = join(directory, "wrangler.json");
+  const result = spawnSync(process.execPath, [renderScript, "--output", output], {
+    cwd: workerDir,
+    encoding: "utf8",
+    env: { ...process.env, ...BASE_ENV, ...extraEnv },
+  });
+  return {
+    result,
+    output,
+    cleanup: () => rmSync(directory, { recursive: true, force: true }),
+  };
+}
+
+test("production config keeps reporter sessions disabled by default", () => {
+  const fixture = render();
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    const config = JSON.parse(readFileSync(fixture.output, "utf8"));
+    assert.equal(config.vars.FEEDBACK_REPORTER_SESSION_ENABLED, "false");
+    assert.equal("FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION" in config.vars, false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("production config requires a closed key version before enabling reporter sessions", () => {
+  const invalidFlag = render({ HANDS_FEEDBACK_REPORTER_SESSION_ENABLED: "TRUE" });
+  try {
+    assert.notEqual(invalidFlag.result.status, 0);
+    assert.match(invalidFlag.result.stderr, /must be exactly true or false/);
+  } finally {
+    invalidFlag.cleanup();
+  }
+
+  const missing = render({ HANDS_FEEDBACK_REPORTER_SESSION_ENABLED: "true" });
+  try {
+    assert.notEqual(missing.result.status, 0);
+    assert.match(missing.result.stderr, /ACTIVE_KEY_VERSION is required/);
+  } finally {
+    missing.cleanup();
+  }
+
+  const enabled = render({
+    HANDS_FEEDBACK_REPORTER_SESSION_ENABLED: "true",
+    HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION: "staging-v1",
+  });
+  try {
+    assert.equal(enabled.result.status, 0, enabled.result.stderr);
+    const config = JSON.parse(readFileSync(enabled.output, "utf8"));
+    assert.equal(config.vars.FEEDBACK_REPORTER_SESSION_ENABLED, "true");
+    assert.equal(config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION, "staging-v1");
+  } finally {
+    enabled.cleanup();
+  }
+});
+
+test("deploy workflow binds the keyring only through the secret store", () => {
+  const workflow = readFileSync(resolve(repositoryDir, ".github/workflows/deploy-hands-server.yml"), "utf8");
+  assert.match(
+    workflow,
+    /FEEDBACK_REPORTER_SESSION_KEYS: \$\{\{ secrets\.HANDS_FEEDBACK_REPORTER_SESSION_KEYS \}\}/,
+  );
+  assert.match(
+    workflow,
+    /wrangler secret put FEEDBACK_REPORTER_SESSION_KEYS --config/,
+  );
+  assert.doesNotMatch(workflow, /FEEDBACK_REPORTER_SESSION_KEYS: \$\{\{ vars\./);
+  assert.match(
+    workflow,
+    /HANDS_FEEDBACK_REPORTER_SESSION_ENABLED: \$\{\{ vars\.HANDS_FEEDBACK_REPORTER_SESSION_ENABLED \}\}/,
+  );
+  const validationIndex = workflow.indexOf("- name: Validate reporter-session rollout inputs");
+  const deployIndex = workflow.indexOf("- name: Deploy Hands Worker and admin assets");
+  assert.ok(validationIndex >= 0 && deployIndex > validationIndex, "enabled inputs fail before Worker deploy");
+});


### PR DESCRIPTION
## Summary

- render the short-lived reporter-session enable flag and active key version into the production Worker config, defaulting the feature to disabled
- bind the reporter-session keyring only through a GitHub secret and Cloudflare Worker secret, never through checked-in config or repository variables
- fail before Worker deployment when an enabled rollout lacks either its active key version or keyring input
- support a two-deploy rollout: provision the keyring while disabled, then enable the flag in a later deploy so an enabled version never depends on an unbound keyring

## Scope boundary

This PR adds deployment plumbing only. It does not set repository variables or secrets, enable the feature, mint credentials, change session verification, or deploy anything. Existing production behavior remains disabled by default.

## Required-Test Admission

- **Protected invariant:** session keys remain secret-store-only; an enabled rollout requires both closed active-key metadata and the secret keyring before the deploy step.
- **Terminal oracle:** the renderer is executed as a child process against the checked-in production base config, and the resulting Wrangler JSON is inspected for disabled-default and enabled exact values. The workflow source tooth binds the keyring to `secrets.*`, rejects `vars.*`, proves the secret-put carrier exists, and proves validation precedes Worker deployment.
- **Mutation RED:** changing the rollout preflight keyring binding from `secrets.HANDS_FEEDBACK_REPORTER_SESSION_KEYS` to `vars.HANDS_FEEDBACK_REPORTER_SESSION_KEYS` made the focused suite fail 1/3 at the secret-store invariant. Restoring the secret binding returned 3/3 GREEN. K=1, S=0.
- **Isolation/cost:** local temp files only; no network, Cloudflare, GitHub, credential, or deployment mutation. Focused suite completes in under one second.

## Validation

- Worker tests: 271/271
- Worker TypeScript build: pass (after the same rendered-config `wrangler types` step used by deployment)
- focused production-config contract: 3/3
- `git diff --check`: pass

Exact source: `93bbbbc72f7f8b19fcb2dc5d4211c123c1a77855`
Parent: `6bc3fee74a9b1d71f8134fba0865a5bd688fa2d1`
Tree: `2488e793ad75875dd65121127e45a6757b1a4e2f`
DCO: `Volta <volta@mail.build>`

## i18n exemption

No user-visible copy changes. New strings are deployment variable names and operator diagnostics.
