### PR TITLE
ci: scope reporter session key to production environment

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   deploy:
+    environment: reporter-session-production
     runs-on: ubuntu-latest
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}

--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -82,6 +82,7 @@ test("production config requires a closed key version before enabling reporter s
 
 test("deploy workflow binds the keyring only through the secret store", () => {
   const workflow = readFileSync(resolve(repositoryDir, ".github/workflows/deploy-hands-server.yml"), "utf8");
+  assert.match(workflow, /jobs:\n  deploy:\n    environment: reporter-session-production\n/);
   assert.match(
     workflow,
     /FEEDBACK_REPORTER_SESSION_KEYS: \$\{\{ secrets\.HANDS_FEEDBACK_REPORTER_SESSION_KEYS \}\}/,


### PR DESCRIPTION
## Summary

- run the Hands production deploy job in the `reporter-session-production` GitHub environment
- add a regression assertion that the key-consuming job remains bound to that environment

The environment is restricted to the `main` branch. `HANDS_FEEDBACK_REPORTER_SESSION_KEYS` will be stored only as an environment secret, with no repository-level duplicate.

## Validation

- Worker tests: 271 passed
- Worker typecheck
- focused production-config tests: 3 passed
- mutation check: removing the job environment makes the focused test fail
- `git diff --check`
