### PR TITLE
test: isolate reporter session deploy checks

### DIFF
--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -25,10 +25,14 @@ const BASE_ENV = {
 function render(extraEnv: Record<string, string> = {}) {
   const directory = mkdtempSync(join(tmpdir(), "hands-production-config-"));
   const output = join(directory, "wrangler.json");
+  const inheritedEnv = { ...process.env };
+  for (const key of Object.keys(inheritedEnv)) {
+    if (key.startsWith("HANDS_FEEDBACK_REPORTER_SESSION_")) delete inheritedEnv[key];
+  }
   const result = spawnSync(process.execPath, [renderScript, "--output", output], {
     cwd: workerDir,
     encoding: "utf8",
-    env: { ...process.env, ...BASE_ENV, ...extraEnv },
+    env: { ...inheritedEnv, ...BASE_ENV, ...extraEnv },
   });
   return {
     result,

--- a/worker/test/reporter_sessions.test.ts
+++ b/worker/test/reporter_sessions.test.ts
@@ -170,7 +170,11 @@ describe("reporter sessions", () => {
       scopes: ["feedback:read"],
       nowSeconds: 1_000,
     });
-    const tampered = `${minted!.token.slice(0, -1)}${minted!.token.endsWith("A") ? "B" : "A"}`;
+    const parts = minted!.token.slice("hrps_v1_".length).split(".");
+    expect(parts).toHaveLength(3);
+    const [header, payload, signature] = parts as [string, string, string];
+    const tamperedSignature = `${signature.startsWith("A") ? "B" : "A"}${signature.slice(1)}`;
+    const tampered = `hrps_v1_${header}.${payload}.${tamperedSignature}`;
     await expect(verifyReporterSession(env(), tampered, 1_010)).resolves.toEqual({
       ok: false,
       reason: "invalid",


### PR DESCRIPTION
## Problem

The production deploy job now supplies reporter-session repository variables to its test process. Two production-config fixtures unintentionally inherit those ambient values, so their default and missing-version scenarios no longer test isolated inputs.

The signed-session tamper test changes the final base64url character. For a 32-byte signature, some final-character changes affect only unused padding bits and decode to the original valid signature, making the assertion flaky.

## Changes

- remove the two reporter-session variables from inherited fixture environment before applying each test's explicit inputs
- tamper the first signature character, whose bits are fully significant, instead of the final character

## Testing

- focused tests under the production repository variables: 8 passed
- Worker tests under the production repository variables: 271 passed
- Worker typecheck
- `git diff --check`
- failure evidence: the prior deploy run deterministically failed both ambient-variable fixtures and hit the base64url alias case
