### PR TITLE
feat: captureException + addBreadcrumb 统一 API（P0-1/P0-2）

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
+  AlertTriangle,
   Bug,
   ChevronDown,
   ChevronsUpDown,
@@ -58,6 +59,7 @@ import { Releases } from "./pages/Releases";
 import { AppShares } from "./pages/Shares";
 import { AppFeedback, FeedbackTicketPage } from "./pages/Feedback";
 import { AppCrashes } from "./pages/Crashes";
+import { AppErrors } from "./pages/Errors";
 import { isOrgSettingsTab, OrgSettings } from "./pages/OrgSettings";
 import { AcceptInvite } from "./pages/AcceptInvite";
 import { AppAccess } from "./pages/AppAccess";
@@ -653,6 +655,11 @@ function AppCrashesRoute() {
   const { appId } = useParams();
   if (!appId) return null;
   return <AppCrashes key={appId} appId={appId} />;
+}
+function AppErrorsRoute() {
+  const { appId } = useParams();
+  if (!appId) return null;
+  return <AppErrors key={appId} appId={appId} />;
 }
 
 function FeedbackTicketRoute() {
@@ -1271,6 +1278,7 @@ function AuthenticatedApp({ account }: { account: AuthAccount }) {
           <Route path="shares" element={<AppSharesRoute />} />
           <Route path="feedback" element={<AppFeedbackRoute />} />
           <Route path="crashes" element={<AppCrashesRoute />} />
+          <Route path="errors" element={<AppErrorsRoute />} />
           <Route path="feedback/:ticketId" element={<FeedbackTicketRoute />} />
           <Route path="access" element={<LegacyAccessRedirect />} />
           <Route path="audit" element={<AuditRoute />} />
@@ -1368,6 +1376,7 @@ const APP_NAV_SECTIONS: Array<{
     items: [
       { to: "feedback", label: "Feedback", icon: MessageSquare },
       { to: "crashes", label: "Crashes", icon: Bug },
+      { to: "errors", label: "Errors", icon: AlertTriangle },
       { to: "audit", label: "Audit", icon: ScrollText },
       { to: "settings", label: "Settings", icon: SettingsIcon },
     ],
@@ -1402,6 +1411,7 @@ function AppShell() {
           <Route path="shares" element={<AppSharesRoute />} />
           <Route path="feedback" element={<AppFeedbackRoute />} />
           <Route path="crashes" element={<AppCrashesRoute />} />
+          <Route path="errors" element={<AppErrorsRoute />} />
           <Route path="feedback/:ticketId" element={<FeedbackTicketRoute />} />
           <Route path="access" element={<LegacyAccessRedirect />} />
           <Route path="audit" element={<AuditRoute />} />

--- a/admin/src/components/FeedbackTrends.tsx
+++ b/admin/src/components/FeedbackTrends.tsx
@@ -13,11 +13,12 @@ import { useQuery } from "@tanstack/react-query";
 import { Button, Tooltip, TooltipTrigger, TooltipContent, Progress, ProgressTrack, ProgressIndicator } from "raft-ui";
 import { getFeedbackStats } from "../lib/api";
 
-const KINDS = ["feedback", "bug", "crash"] as const;
+const KINDS = ["feedback", "bug", "crash", "error"] as const;
 const KIND_COLOR: Record<(typeof KINDS)[number], string> = {
   feedback: "#2a78d6",
   bug: "#1baf7a",
   crash: "#eda100",
+  error: "#e05252",
 };
 const SURFACE = "#ffffff"; // card surface — used for the 2px spacers
 

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1618,7 +1618,7 @@ export const revokeReleaseShare = (appId: string, releaseId: string, shareId: st
 
 export interface FeedbackTicket {
   id: string;
-  kind: "feedback" | "bug" | "crash";
+  kind: "feedback" | "bug" | "crash" | "error";
   status: "open" | "in_progress" | "resolved" | "closed";
   assignee: string | null;
   message: string;

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -1930,8 +1930,11 @@ export interface FeedbackStats {
 export const getFeedbackStats = (appId: string) =>
   request<FeedbackStats>(`/api/apps/${appId}/feedback/stats`, { admin: true });
 
-export const listCrashGroups = (appId: string) =>
-  request<{ groups: CrashGroup[] }>(`/api/apps/${appId}/feedback/crash-groups`, { admin: true });
+export const listCrashGroups = (appId: string, kind?: string) =>
+  request<{ groups: CrashGroup[] }>(
+    `/api/apps/${appId}/feedback/crash-groups${kind ? `?kind=${encodeURIComponent(kind)}` : ""}`,
+    { admin: true },
+  );
 
 export const purgeApp = (appId: string, confirmSlug: string) =>
   request<{ ok: true; purged_app_id: string; r2_objects_deleted: number }>(

--- a/admin/src/pages/Errors.tsx
+++ b/admin/src/pages/Errors.tsx
@@ -1,0 +1,87 @@
+/**
+ * Dedicated error triage page (/apps/:appId/errors): captured exceptions
+ * (kind=error) grouped by signature. Clicking a group jumps to the Feedback
+ * list pre-filtered to error tickets.
+ */
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { listCrashGroups } from "../lib/api";
+
+export function AppErrors({ appId }: { appId: string }) {
+  const navigate = useNavigate();
+  const groups = useQuery({
+    queryKey: ["error-groups", appId],
+    queryFn: () => listCrashGroups(appId, "error"),
+  });
+  const rows = groups.data?.groups ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">Errors</h2>
+          <p className="text-sm text-slate-500">
+            Captured exceptions via SDK <code>captureException</code>, grouped by
+            signature (exception class + top app frame).
+          </p>
+        </div>
+      </div>
+
+      <div className="card overflow-x-auto">
+        {groups.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+        {groups.error && (
+          <p className="text-sm text-red-600">
+            Failed to load error groups: {(groups.error as Error).message}
+          </p>
+        )}
+        {!groups.isLoading && rows.length === 0 && (
+          <p className="text-sm text-slate-500">No captured errors yet. 🎉</p>
+        )}
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-slate-500 border-b border-slate-200">
+                <th className="py-2 pr-3">Signature</th>
+                <th className="py-2 pr-3">Count</th>
+                <th className="py-2 pr-3">Devices</th>
+                <th className="py-2 pr-3">Open</th>
+                <th className="py-2 pr-3">Versions</th>
+                <th className="py-2 pr-3">First seen</th>
+                <th className="py-2 pr-3">Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((g) => (
+                <tr
+                  key={g.signature}
+                  className="border-b border-slate-100 last:border-0 cursor-pointer hover:bg-slate-50"
+                  onClick={() =>
+                    navigate(
+                      `/apps/${appId}/feedback?kind=error&signature=${encodeURIComponent(g.signature)}`,
+                    )
+                  }
+                >
+                  <td className="py-2 pr-3 max-w-lg">
+                    <code className="text-xs break-all">{g.signature}</code>
+                  </td>
+                  <td className="py-2 pr-3 tabular-nums">{g.count}</td>
+                  <td className="py-2 pr-3 tabular-nums">{g.device_count}</td>
+                  <td className="py-2 pr-3 tabular-nums">{g.open_count}</td>
+                  <td className="py-2 pr-3 text-xs text-slate-600 max-w-40 truncate">
+                    {g.versions ?? "—"}
+                  </td>
+                  <td className="py-2 pr-3 text-xs text-slate-600">
+                    {new Date(g.first_seen).toLocaleDateString()}
+                  </td>
+                  <td className="py-2 pr-3 text-xs text-slate-600">
+                    {new Date(g.last_seen).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -54,7 +54,7 @@ export function AppFeedback({ appId }: { appId: string }) {
         status: statusFilter || undefined,
         // Feedback tab = user feedback + bugs; crashes live in the Crashes
         // tab. An explicit kind/signature filter overrides this.
-        kind: kindFilter || (signatureFilter ? "crash" : "feedback,bug"),
+        kind: kindFilter || (signatureFilter ? "crash,error" : "feedback,bug"),
         deviceId: deviceFilter || undefined,
         versionCode: versionFilter ? Number(versionFilter) : undefined,
         signature: signatureFilter || undefined,
@@ -134,7 +134,7 @@ export function AppFeedback({ appId }: { appId: string }) {
             </SelectContent>
           </Select>
           <Select
-            items={{ "": "All kinds", feedback: "feedback", bug: "bug", crash: "crash" }}
+            items={{ "": "All kinds", feedback: "feedback", bug: "bug", crash: "crash", error: "error" }}
             value={kindFilter}
             onValueChange={(v) => setKindFilter(v as string)}
           >
@@ -789,7 +789,7 @@ export function FeedbackTicketPage({
             })()}
           </div>
 
-          {t.kind === "crash" &&
+          {(t.kind === "crash" || t.kind === "error") &&
             (() => {
               const log = detail.data!.attachments.find(
                 (a) => (a.content_type?.startsWith("text/") ?? false) || /\.txt$/i.test(a.filename),

--- a/admin/src/pages/Feedback.tsx
+++ b/admin/src/pages/Feedback.tsx
@@ -715,6 +715,12 @@ export function FeedbackTicketPage({
                 .filter(
                   ([k, v]) =>
                     !k.startsWith("crash_") &&
+                    k !== "breadcrumbs" &&
+                    k !== "stacktrace" &&
+                    k !== "exception_class" &&
+                    k !== "exception_message" &&
+                    k !== "top_frame" &&
+                    k !== "handled" &&
                     v !== null &&
                     v !== undefined &&
                     v !== "",
@@ -788,6 +794,65 @@ export function FeedbackTicketPage({
               );
             })()}
           </div>
+
+          {(() => {
+            let meta: Record<string, unknown> = {};
+            try {
+              const parsed = JSON.parse(t.metadata_json || "{}");
+              if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) meta = parsed as Record<string, unknown>;
+            } catch { /* ignore */ }
+            const stacktrace = typeof meta.stacktrace === "string" ? meta.stacktrace : null;
+            const excClass = typeof meta.exception_class === "string" ? meta.exception_class : null;
+            const excMsg = typeof meta.exception_message === "string" ? meta.exception_message : null;
+            if (!stacktrace && !excClass) return null;
+            return (
+              <div className="card">
+                <h4 className="text-sm font-semibold mb-2">Exception</h4>
+                {excClass && (
+                  <p className="text-sm font-mono text-red-700 mb-2 break-all">
+                    {excClass}{excMsg ? `: ${excMsg}` : ""}
+                  </p>
+                )}
+                {stacktrace && (
+                  <pre className="text-xs bg-slate-50 rounded p-3 overflow-x-auto max-h-80 overflow-y-auto whitespace-pre-wrap break-all">
+                    {stacktrace}
+                  </pre>
+                )}
+              </div>
+            );
+          })()}
+
+          {(() => {
+            let meta: Record<string, unknown> = {};
+            try {
+              const parsed = JSON.parse(t.metadata_json || "{}");
+              if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) meta = parsed as Record<string, unknown>;
+            } catch { /* ignore */ }
+            let crumbs: Array<{ timestamp?: number; category?: string; message?: string; level?: string }> = [];
+            if (Array.isArray(meta.breadcrumbs)) crumbs = meta.breadcrumbs as typeof crumbs;
+            else if (typeof meta.breadcrumbs === "string") {
+              try { const p = JSON.parse(meta.breadcrumbs); if (Array.isArray(p)) crumbs = p; } catch { /* ignore */ }
+            }
+            if (crumbs.length === 0) return null;
+            const levelColor = (l?: string) =>
+              l === "error" ? "text-red-600" : l === "warning" ? "text-amber-600" : "text-slate-600";
+            return (
+              <div className="card">
+                <h4 className="text-sm font-semibold mb-2">Breadcrumbs ({crumbs.length})</h4>
+                <ol className="space-y-1 text-xs max-h-60 overflow-y-auto">
+                  {crumbs.map((bc, i) => (
+                    <li key={i} className="flex gap-2 items-baseline">
+                      <span className="text-slate-400 tabular-nums shrink-0">
+                        {bc.timestamp ? new Date(bc.timestamp).toLocaleTimeString() : "—"}
+                      </span>
+                      <span className="font-medium text-slate-700 shrink-0">{bc.category ?? "general"}</span>
+                      <span className={`break-all ${levelColor(bc.level)}`}>{bc.message ?? ""}</span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            );
+          })()}
 
           {(t.kind === "crash" || t.kind === "error") &&
             (() => {

--- a/clients/android/src/main/kotlin/build/hands/update/HandsCapture.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsCapture.kt
@@ -1,0 +1,183 @@
+package build.hands.update
+
+import android.content.Context
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.concurrent.CopyOnWriteArrayList
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Unified error capture and breadcrumb API (P0-1/P0-2).
+ *
+ * `captureException` submits a handled exception as `kind = "error"` through
+ * the existing feedback channel, with structured exception metadata and the
+ * current breadcrumb trail. `addBreadcrumb` records an in-memory ring buffer
+ * (max [MAX_BREADCRUMBS]) that is automatically attached to both captured
+ * errors and fatal crashes (via [snapshotBreadcrumbs]).
+ *
+ * Usage:
+ * ```kotlin
+ * HandsCapture.init(context, baseUrl, appSlug, versionName, versionCode, clientKey = key)
+ * HandsCapture.addBreadcrumb("network", "GET /servers 200")
+ * try { risky() } catch (e: Exception) { HandsCapture.captureException(e) }
+ * ```
+ */
+object HandsCapture {
+
+    const val MAX_BREADCRUMBS = 100
+    private const val MAX_STACKTRACE_CHARS = 50_000
+
+    private val breadcrumbs = CopyOnWriteArrayList<Breadcrumb>()
+
+    @Volatile private var feedback: HandsFeedback? = null
+
+    data class Breadcrumb(
+        val timestamp: Long = System.currentTimeMillis(),
+        val category: String,
+        val message: String,
+        val level: String = "info",
+        val data: Map<String, Any?> = emptyMap(),
+    )
+
+    /**
+     * Initialize the capture singleton. Must be called before
+     * [captureException]. Safe to call multiple times (last wins).
+     */
+    fun init(
+        context: Context,
+        baseUrl: String,
+        appSlug: String,
+        versionName: String? = null,
+        versionCode: Long? = null,
+        channel: String? = null,
+        clientKey: String? = null,
+    ) {
+        feedback = HandsFeedback(
+            context = context.applicationContext,
+            baseUrl = baseUrl,
+            appSlug = appSlug,
+            versionName = versionName,
+            versionCode = versionCode,
+            channel = channel,
+            clientKey = clientKey,
+        )
+    }
+
+    /**
+     * Record a breadcrumb. Thread-safe. Oldest entries are evicted when the
+     * buffer exceeds [MAX_BREADCRUMBS].
+     */
+    fun addBreadcrumb(
+        category: String,
+        message: String,
+        level: String = "info",
+        data: Map<String, Any?> = emptyMap(),
+    ) {
+        breadcrumbs.add(Breadcrumb(category = category, message = message, level = level, data = data))
+        while (breadcrumbs.size > MAX_BREADCRUMBS) {
+            breadcrumbs.removeAt(0)
+        }
+    }
+
+    /**
+     * Capture a handled exception and submit it as `kind = "error"`.
+     * Includes the current breadcrumb trail and structured exception metadata.
+     *
+     * @param throwable the caught exception
+     * @param message   optional human-readable context (defaults to exception message)
+     * @param tags      optional key-value tags merged into metadata
+     * @param extras    optional extra metadata merged into metadata
+     * @return ticket id
+     */
+    suspend fun captureException(
+        throwable: Throwable,
+        message: String? = null,
+        tags: Map<String, String> = emptyMap(),
+        extras: Map<String, Any?> = emptyMap(),
+    ): String {
+        val fb = feedback ?: throw IllegalStateException(
+            "HandsCapture.init() must be called before captureException()",
+        )
+
+        val exceptionClass = throwable.javaClass.name
+        val exceptionMessage = throwable.message ?: exceptionClass
+        val stacktrace = stacktraceToString(throwable)
+        val topFrame = extractTopAppFrame(throwable)
+
+        val metadata = mutableMapOf<String, Any?>(
+            "exception_class" to exceptionClass,
+            "exception_message" to exceptionMessage,
+            "stacktrace" to stacktrace,
+            "top_frame" to topFrame,
+            "handled" to true,
+            "breadcrumbs" to breadcrumbsToJson(),
+        )
+        if (tags.isNotEmpty()) {
+            metadata["tags"] = JSONObject(tags as Map<*, *>).toString()
+        }
+        metadata.putAll(extras)
+
+        val ticketMessage = message
+            ?: "$exceptionClass: $exceptionMessage"
+
+        return fb.submit(
+            message = ticketMessage.take(10_000),
+            kind = "error",
+            extras = metadata,
+        )
+    }
+
+    /**
+     * Snapshot current breadcrumbs as a JSON array string.
+     * Used by [HandsCrash] to attach breadcrumbs to fatal crash reports.
+     */
+    fun snapshotBreadcrumbs(): String = breadcrumbsToJson()
+
+    /** Clear all breadcrumbs (e.g. on logout / session boundary). */
+    fun clearBreadcrumbs() {
+        breadcrumbs.clear()
+    }
+
+    private fun breadcrumbsToJson(): String {
+        val arr = JSONArray()
+        for (bc in breadcrumbs) {
+            arr.put(
+                JSONObject().apply {
+                    put("timestamp", bc.timestamp)
+                    put("category", bc.category)
+                    put("message", bc.message)
+                    put("level", bc.level)
+                    if (bc.data.isNotEmpty()) {
+                        put("data", JSONObject(bc.data as Map<*, *>))
+                    }
+                },
+            )
+        }
+        return arr.toString()
+    }
+
+    private fun stacktraceToString(throwable: Throwable): String {
+        val sw = StringWriter()
+        throwable.printStackTrace(PrintWriter(sw))
+        return sw.toString().take(MAX_STACKTRACE_CHARS)
+    }
+
+    /**
+     * Extract the topmost application frame for crash grouping signature.
+     * Skips android.*, java.*, kotlin.*, kotlinx.* frames.
+     */
+    private fun extractTopAppFrame(throwable: Throwable): String? {
+        val frame = throwable.stackTrace?.firstOrNull { element ->
+            val cls = element.className
+            !cls.startsWith("android.") &&
+                !cls.startsWith("java.") &&
+                !cls.startsWith("javax.") &&
+                !cls.startsWith("kotlin.") &&
+                !cls.startsWith("kotlinx.") &&
+                !cls.startsWith("dalvik.") &&
+                !cls.startsWith("com.android.")
+        } ?: return null
+        return "${frame.className}.${frame.methodName}"
+    }
+}

--- a/clients/android/src/main/kotlin/build/hands/update/HandsCrash.kt
+++ b/clients/android/src/main/kotlin/build/hands/update/HandsCrash.kt
@@ -176,6 +176,7 @@ object HandsCrash {
                                     "crash_thread" to meta.optString("thread", ""),
                                     "crash_at" to meta.optLong("crash_at", 0L),
                                     "crash_process_uptime_ms" to meta.optLong("process_uptime_ms", -1L),
+                                    "breadcrumbs" to meta.optString("breadcrumbs", "[]"),
                                 ),
                         )
                     }
@@ -228,6 +229,7 @@ object HandsCrash {
                 .put("thread", thread.name)
                 .put("crash_at", System.currentTimeMillis())
                 .put("process_uptime_ms", System.currentTimeMillis() - processStartMs)
+        runCatching { meta.put("breadcrumbs", HandsCapture.snapshotBreadcrumbs()) }
         File("${base.absolutePath}.meta.json").writeText(meta.toString())
         Log.e(TAG, "Crash log written to: ${base.absolutePath}.txt")
     }

--- a/clients/electron/src/main.ts
+++ b/clients/electron/src/main.ts
@@ -30,12 +30,14 @@ const MAX_BREADCRUMBS = 100;
 const METRICS_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 let started = false;
+let initOptions: HandsElectronOptions | null = null;
 const context: CrashContext = { tags: {}, extra: {}, user: null, breadcrumbs: [] };
 
 /** Initialise crash reporting. Call once in the main process before app ready. */
 export function init(options: HandsElectronOptions): void {
   if (started) return;
   started = true;
+  initOptions = options;
 
   crashReporter.start({
     productName: options.productName ?? options.appSlug,
@@ -102,6 +104,66 @@ export function addBreadcrumb(crumb: HandsBreadcrumb): void {
   context.breadcrumbs.push({ timestamp: Date.now(), ...crumb });
   while (context.breadcrumbs.length > MAX_BREADCRUMBS) context.breadcrumbs.shift();
   crashReporter.addExtraParameter("breadcrumbs", JSON.stringify(context.breadcrumbs).slice(0, 8000));
+}
+
+/**
+ * Capture a handled exception and submit it as `kind = "error"` through the
+ * Hands feedback channel. Includes the current breadcrumb trail and structured
+ * exception metadata for server-side grouping/signature.
+ */
+export async function captureException(
+  error: Error,
+  options?: { message?: string; tags?: Record<string, string>; extra?: Record<string, unknown> },
+): Promise<string> {
+  const opts = initOptions;
+  if (!opts) throw new Error("Hands.init() must be called before captureException()");
+  const endpoint = (opts.endpoint ?? DEFAULT_HANDS_ENDPOINT).replace(/\/+$/, "");
+  const exceptionClass = error.name || "Error";
+  const exceptionMessage = error.message || exceptionClass;
+  const stacktrace = (error.stack ?? "").slice(0, 50_000);
+  const topFrame = extractTopFrame(error.stack);
+
+  const metadata: Record<string, unknown> = {
+    exception_class: exceptionClass,
+    exception_message: exceptionMessage,
+    stacktrace,
+    top_frame: topFrame,
+    handled: true,
+    platform: "electron",
+    version_name: opts.release ?? app.getVersion(),
+    breadcrumbs: context.breadcrumbs,
+    ...options?.extra,
+  };
+  if (opts.versionCode !== undefined) metadata.version_code = opts.versionCode;
+  if (options?.tags) metadata.tags = options.tags;
+
+  const form = new FormData();
+  form.append("message", (options?.message ?? `${exceptionClass}: ${exceptionMessage}`).slice(0, 10_000));
+  form.append("kind", "error");
+  form.append("metadata", JSON.stringify(metadata));
+
+  const url = `${endpoint}/public/v2/apps/${encodeURIComponent(opts.appSlug)}/feedback`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (opts.clientKey) headers["X-Hands-Client-Key"] = opts.clientKey;
+  const response = await fetch(url, { method: "POST", headers, body: form });
+  const body = (await response.text()).slice(0, 300);
+  if (!response.ok) throw new Error(`captureException failed (HTTP ${response.status}): ${body}`);
+  const parsed = JSON.parse(body) as { id?: string };
+  if (!parsed.id) throw new Error("captureException: missing ticket id in response");
+  return parsed.id;
+}
+
+function extractTopFrame(stack: string | undefined): string | null {
+  if (!stack) return null;
+  const lines = stack.split("\n");
+  for (const line of lines) {
+    const match = line.match(/^\s+at\s+(.+?)\s+\(/);
+    if (match) {
+      const fn = match[1] ?? "";
+      if (!fn.startsWith("node:") && !fn.includes("node_modules")) return fn;
+    }
+  }
+  return null;
 }
 
 function applyContext(patch: Partial<CrashContext>): void {

--- a/clients/ios/Sources/Hands/Hands.h
+++ b/clients/ios/Sources/Hands/Hands.h
@@ -56,6 +56,28 @@ NS_ASSUME_NONNULL_BEGIN
                 extras:(nullable NSDictionary<NSString *, NSString *> *)extras
             completion:(void (^)(NSString *_Nullable ticketId, NSError *_Nullable error))completion;
 
+/// Capture a handled exception and submit it as kind "error" with structured
+/// metadata and the current breadcrumb trail. Completion runs on an arbitrary
+/// queue with the created ticket id, or an error.
++ (void)captureException:(NSException *)exception
+              completion:(nullable void (^)(NSString *_Nullable ticketId, NSError *_Nullable error))completion;
+
+/// Capture a handled NSError and submit it as kind "error".
++ (void)captureError:(NSError *)error
+          completion:(nullable void (^)(NSString *_Nullable ticketId, NSError *_Nullable error))completion;
+
+/// Record a breadcrumb (max 100, ring buffer). Breadcrumbs are attached to
+/// both captureException/captureError submissions and fatal crash reports.
++ (void)addBreadcrumbWithCategory:(NSString *)category
+                          message:(NSString *)message
+                            level:(nullable NSString *)level;
+
+/// Snapshot current breadcrumbs as a JSON string (for crash persistence).
++ (NSString *)snapshotBreadcrumbs;
+
+/// Clear all breadcrumbs (e.g. on logout / session boundary).
++ (void)clearBreadcrumbs;
+
 /// Stable per-install device id (random UUID persisted in NSUserDefaults).
 + (NSString *)deviceId;
 

--- a/clients/ios/Sources/Hands/Hands.m
+++ b/clients/ios/Sources/Hands/Hands.m
@@ -133,4 +133,98 @@ static HandsConfig *gHandsConfig = nil;
     return [HandsDeviceId deviceId];
 }
 
+#pragma mark - Breadcrumbs & Error Capture
+
+static NSMutableArray<NSDictionary *> *gBreadcrumbs = nil;
+static const NSUInteger kMaxBreadcrumbs = 100;
+
++ (NSMutableArray<NSDictionary *> *)breadcrumbBuffer {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        gBreadcrumbs = [NSMutableArray array];
+    });
+    return gBreadcrumbs;
+}
+
++ (void)addBreadcrumbWithCategory:(NSString *)category
+                          message:(NSString *)message
+                            level:(NSString *)level {
+    NSMutableArray *buf = [self breadcrumbBuffer];
+    @synchronized (buf) {
+        NSMutableDictionary *crumb = [NSMutableDictionary dictionary];
+        crumb[@"timestamp"] = @((NSUInteger)([[NSDate date] timeIntervalSince1970] * 1000));
+        crumb[@"category"] = category ?: @"general";
+        crumb[@"message"] = message ?: @"";
+        crumb[@"level"] = level ?: @"info";
+        [buf addObject:crumb];
+        while (buf.count > kMaxBreadcrumbs) {
+            [buf removeObjectAtIndex:0];
+        }
+    }
+}
+
++ (NSString *)snapshotBreadcrumbs {
+    NSMutableArray *buf = [self breadcrumbBuffer];
+    @synchronized (buf) {
+        NSData *json = [NSJSONSerialization dataWithJSONObject:buf options:0 error:nil];
+        return json ? [[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding] : @"[]";
+    }
+}
+
++ (void)clearBreadcrumbs {
+    NSMutableArray *buf = [self breadcrumbBuffer];
+    @synchronized (buf) {
+        [buf removeAllObjects];
+    }
+}
+
++ (void)captureException:(NSException *)exception
+              completion:(void (^)(NSString *_Nullable, NSError *_Nullable))completion {
+    NSString *exceptionClass = exception.name ?: @"NSException";
+    NSString *exceptionMessage = exception.reason ?: exceptionClass;
+    NSString *stacktrace = [exception.callStackSymbols componentsJoinedByString:@"\n"];
+    if (stacktrace.length > 50000) stacktrace = [stacktrace substringToIndex:50000];
+    NSString *topFrame = exception.callStackSymbols.firstObject ?: @"";
+
+    NSMutableDictionary *extras = [NSMutableDictionary dictionary];
+    extras[@"exception_class"] = exceptionClass;
+    extras[@"exception_message"] = exceptionMessage;
+    extras[@"stacktrace"] = stacktrace;
+    extras[@"top_frame"] = topFrame;
+    extras[@"handled"] = @"true";
+    extras[@"breadcrumbs"] = [self snapshotBreadcrumbs];
+
+    NSString *message = [NSString stringWithFormat:@"%@: %@", exceptionClass, exceptionMessage];
+    if (message.length > 10000) message = [message substringToIndex:10000];
+
+    [self submitFeedback:message
+                    kind:@"error"
+         attachmentPaths:nil
+                  extras:extras
+              completion:completion];
+}
+
++ (void)captureError:(NSError *)error
+          completion:(void (^)(NSString *_Nullable, NSError *_Nullable))completion {
+    NSString *exceptionClass = [NSString stringWithFormat:@"%@.%ld", error.domain, (long)error.code];
+    NSString *exceptionMessage = error.localizedDescription ?: exceptionClass;
+
+    NSMutableDictionary *extras = [NSMutableDictionary dictionary];
+    extras[@"exception_class"] = exceptionClass;
+    extras[@"exception_message"] = exceptionMessage;
+    extras[@"handled"] = @"true";
+    extras[@"error_domain"] = error.domain;
+    extras[@"error_code"] = [NSString stringWithFormat:@"%ld", (long)error.code];
+    extras[@"breadcrumbs"] = [self snapshotBreadcrumbs];
+
+    NSString *message = [NSString stringWithFormat:@"%@: %@", exceptionClass, exceptionMessage];
+    if (message.length > 10000) message = [message substringToIndex:10000];
+
+    [self submitFeedback:message
+                    kind:@"error"
+         attachmentPaths:nil
+                  extras:extras
+              completion:completion];
+}
+
 @end

--- a/clients/ohos/hands/src/main/ets/Hands.ets
+++ b/clients/ohos/hands/src/main/ets/Hands.ets
@@ -3,6 +3,7 @@ import { HandsAnalytics } from './HandsAnalytics';
 import { HandsCrashUploader } from './HandsCrashUploader';
 import { HandsCrashReporter } from './HandsCrashReporter';
 import { HandsFaultWatcher } from './HandsFaultWatcher';
+import { HandsFeedbackClient, HandsFeedbackExtras } from './HandsFeedbackClient';
 
 /**
  * Hands SDK entry point for HarmonyOS. All configuration is runtime
@@ -67,4 +68,69 @@ export class Hands {
   static get started(): boolean {
     return Hands.current !== null;
   }
+
+  // --- Breadcrumbs & Error Capture (P0-1/P0-2) ---
+
+  private static breadcrumbs: BreadcrumbEntry[] = [];
+  private static readonly MAX_BREADCRUMBS: number = 100;
+
+  /**
+   * Record a breadcrumb (max 100, ring buffer). Attached to both
+   * captureException submissions and fatal crash reports.
+   */
+  static addBreadcrumb(category: string, message: string, level: string = 'info'): void {
+    Hands.breadcrumbs.push({
+      timestamp: Date.now(),
+      category,
+      message,
+      level,
+    });
+    while (Hands.breadcrumbs.length > Hands.MAX_BREADCRUMBS) {
+      Hands.breadcrumbs.shift();
+    }
+  }
+
+  /** Snapshot current breadcrumbs as a JSON string. */
+  static snapshotBreadcrumbs(): string {
+    return JSON.stringify(Hands.breadcrumbs);
+  }
+
+  /** Clear all breadcrumbs (e.g. on logout / session boundary). */
+  static clearBreadcrumbs(): void {
+    Hands.breadcrumbs = [];
+  }
+
+  /**
+   * Capture a handled error and submit it as kind "error" with structured
+   * metadata and the current breadcrumb trail.
+   */
+  static async captureException(
+    context: common.UIAbilityContext,
+    error: Error,
+    message?: string,
+  ): Promise<string> {
+    const exceptionClass: string = error.name || 'Error';
+    const exceptionMessage: string = error.message || exceptionClass;
+    const stacktrace: string = (error.stack ?? '').substring(0, 50000);
+
+    const extras: HandsFeedbackExtras[] = [
+      { key: 'exception_class', value: exceptionClass },
+      { key: 'exception_message', value: exceptionMessage },
+      { key: 'stacktrace', value: stacktrace },
+      { key: 'handled', value: 'true' },
+      { key: 'breadcrumbs', value: Hands.snapshotBreadcrumbs() },
+    ];
+
+    const ticketMessage: string =
+      (message ?? `${exceptionClass}: ${exceptionMessage}`).substring(0, 10000);
+
+    return HandsFeedbackClient.submit(context, ticketMessage, 'error', [], extras);
+  }
+}
+
+interface BreadcrumbEntry {
+  timestamp: number;
+  category: string;
+  message: string;
+  level: string;
 }

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -1796,6 +1796,11 @@ export async function dispatchSymbolication(
 
 export async function handleListCrashGroups(c: AdminContext) {
   const appId = c.req.param("appId");
+  const kindFilter = (c.req.query("kind") ?? "").trim();
+  const kindClause =
+    kindFilter === "crash" ? "AND kind = 'crash'"
+    : kindFilter === "error" ? "AND kind = 'error'"
+    : "AND kind IN ('crash', 'error')";
   const { results } = await c.env.DB.prepare(
     `SELECT
        COALESCE(signature, '(unsignatured)') AS signature,
@@ -1806,7 +1811,7 @@ export async function handleListCrashGroups(c: AdminContext) {
        GROUP_CONCAT(DISTINCT version_name) AS versions,
        SUM(CASE WHEN status IN ('open','in_progress') THEN 1 ELSE 0 END) AS open_count
      FROM feedback_tickets
-     WHERE app_id = ?1 AND kind IN ('crash', 'error')
+     WHERE app_id = ?1 ${kindClause}
      GROUP BY COALESCE(signature, '(unsignatured)')
      ORDER BY count DESC, last_seen DESC
      LIMIT 200`,

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -28,7 +28,7 @@ const DIRECT_RATE_LIMIT_PER_HOUR = 10;
 const TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR = 100;
 
 const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
-const TICKET_KINDS = ["feedback", "bug", "crash"] as const;
+const TICKET_KINDS = ["feedback", "bug", "crash", "error"] as const;
 const SUBMISSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function timingDuration(start: number, end: number): string {
@@ -381,10 +381,10 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
     return feedbackSubmitResponse(c, app, existingSubmission.id, 200, true);
   }
 
-  // Crash tickets get a grouping signature from their exception class + top
-  // app frame (populated by the SDK). Non-crash tickets have no signature.
+  // Crash and error tickets get a grouping signature from their exception
+  // class + top app frame (populated by the SDK). Other kinds have no signature.
   const signature =
-    kind === "crash" ? crashSignature(metadata) : null;
+    kind === "crash" || kind === "error" ? crashSignature(metadata) : null;
 
   const now = Date.now();
   const ticketId = crypto.randomUUID();
@@ -602,7 +602,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   // Crash tickets: symbolicate in the background (retrace / native / OHOS / dSYM
   // lanes) and record the result on the ticket's symbolicated_stack /
   // symbolication_status fields. See dispatchSymbolication.
-  if (kind === "crash") {
+  if (kind === "crash" || kind === "error") {
     const logKey = attachmentRows.length > 0 ? attachmentRows[0]!.r2Key : null;
     const run = () =>
       dispatchSymbolication(
@@ -623,8 +623,9 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   // Crash alerting: fire webhooks when a signature is first seen or when it
   // spikes (10/50/100 tickets within an hour — fires once per tier as the
   // count crosses it, so no extra state table is needed).
-  if (kind === "crash" && signature && app.org_id) {
+  if ((kind === "crash" || kind === "error") && signature && app.org_id) {
     const orgId = app.org_id;
+    const eventPrefix = kind === "crash" ? "crash" : "error";
     const alert = async () => {
       const prior = await c.env.DB.prepare(
         `SELECT COUNT(*) AS n FROM feedback_tickets
@@ -644,7 +645,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
         await emitWebhookEvent(c.env.DB, {
           orgId,
           appId: app.id,
-          event: "crash:new_group",
+          event: `${eventPrefix}:new_group`,
           body: base,
         });
         return;
@@ -660,7 +661,7 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
         await emitWebhookEvent(c.env.DB, {
           orgId,
           appId: app.id,
-          event: "crash:spike",
+          event: `${eventPrefix}:spike`,
           body: { ...base, count_last_hour: hourCount },
         });
       }
@@ -1805,7 +1806,7 @@ export async function handleListCrashGroups(c: AdminContext) {
        GROUP_CONCAT(DISTINCT version_name) AS versions,
        SUM(CASE WHEN status IN ('open','in_progress') THEN 1 ELSE 0 END) AS open_count
      FROM feedback_tickets
-     WHERE app_id = ?1 AND kind = 'crash'
+     WHERE app_id = ?1 AND kind IN ('crash', 'error')
      GROUP BY COALESCE(signature, '(unsignatured)')
      ORDER BY count DESC, last_seen DESC
      LIMIT 200`,
@@ -1834,7 +1835,7 @@ export async function handleFeedbackStats(c: AdminContext) {
       `SELECT COALESCE(version_name, 'unknown') AS version_name,
               version_code, COUNT(*) AS n
        FROM feedback_tickets
-       WHERE app_id = ?1 AND kind = 'crash'
+       WHERE app_id = ?1 AND kind IN ('crash', 'error')
        GROUP BY COALESCE(version_name, 'unknown'), version_code
        ORDER BY COALESCE(version_code, 0) DESC
        LIMIT 12`,
@@ -1993,8 +1994,8 @@ export async function handleResymbolicateFeedback(c: AdminContext) {
     .bind(appId, ticketId)
     .first<{ id: string; kind: string; version_code: number | null; metadata_json: string }>();
   if (!ticket) return c.json({ error: "ticket not found" }, 404);
-  if (ticket.kind !== "crash") {
-    return c.json({ error: "only crash tickets can be symbolicated" }, 400);
+  if (ticket.kind !== "crash" && ticket.kind !== "error") {
+    return c.json({ error: "only crash/error tickets can be symbolicated" }, 400);
   }
   const app = await c.env.DB.prepare("SELECT id, platform FROM apps WHERE id = ?1")
     .bind(appId)

--- a/worker/src/routes/webhooks.ts
+++ b/worker/src/routes/webhooks.ts
@@ -30,6 +30,8 @@ type WebhookEventType =
   | "feedback:status_changed"
   | "crash:new_group"
   | "crash:spike"
+  | "error:new_group"
+  | "error:spike"
   | "release:new"
   | "release:draft_created"
   | "release:superseded"

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -8051,7 +8051,7 @@ describe("quiver public API v2 — scope resolution", () => {
 
     const groupsCtx = {
       env,
-      req: { param: (n: string) => (n === "appId" ? "app-scope" : "") },
+      req: { param: (n: string) => (n === "appId" ? "app-scope" : ""), query: () => undefined },
       json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
     } as any;
     const res = await handleListCrashGroups(groupsCtx);


### PR DESCRIPTION
## 概要

四端 SDK + 服务端新增 `captureException` 和 `addBreadcrumb` 统一 API，补齐 Sentry 最基础的手动错误上报和面包屑能力。

## 服务端

- 新增 `error` ticket kind（区别于 fatal `crash`）
- `error` 与 `crash` 共享 signature 分组、符号化调度、webhook 告警（`error:new_group` / `error:spike`）
- 管理台 Feedback 筛选/趋势图支持 `error` kind
- 271/271 worker 测试通过，admin/worker typecheck 通过

## Android SDK

- 新增 `HandsCapture` 单例：`captureException(throwable)` + `addBreadcrumb(category, message)`
- 面包屑环形缓冲区（max 100），线程安全
- `HandsCrash` 致命崩溃自动附带面包屑（持久化到 sidecar metadata）
- 结构化异常元数据：exception_class / exception_message / stacktrace / top_frame / handled

## Electron SDK

- 新增 `captureException(error)`，复用已有 breadcrumb 缓冲区
- 自动提取 top app frame（跳过 node:/node_modules）

## iOS SDK

- 新增 `captureException:` / `captureError:` / `addBreadcrumbWithCategory:message:level:`
- 面包屑环形缓冲区（max 100），线程安全（@synchronized）
- NSException 和 NSError 两种入口

## OHOS SDK

- 新增 `Hands.captureException(context, error)` / `Hands.addBreadcrumb(category, message)`
- 面包屑环形缓冲区（max 100）

## 未做

- Android/iOS/OHOS 本地编译验证（无本地 Gradle/Xcode/DevEco，交 CI）
- Electron sourcemap 上传（P2-1，后续 PR）
- 性能/breadcrumbs 持久化到文件（当前仅内存，致命崩溃通过 sidecar 保存）