### PR TITLE
perf: enable Smart Placement for Hands Worker

### DIFF
--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -46,6 +46,7 @@ test("production config keeps reporter sessions disabled by default", () => {
   try {
     assert.equal(fixture.result.status, 0, fixture.result.stderr);
     const config = JSON.parse(readFileSync(fixture.output, "utf8"));
+    assert.deepEqual(config.placement, { mode: "smart" });
     assert.equal(config.vars.FEEDBACK_REPORTER_SESSION_ENABLED, "false");
     assert.equal("FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION" in config.vars, false);
   } finally {

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -6,6 +6,7 @@
   "compatibility_flags": ["nodejs_compat"],
   "observability": { "enabled": true },
   "upload_source_maps": true,
+  "placement": { "mode": "smart" },
   // Keep Cloudflare version preview URLs disabled so uploaded versions never
   // get a publicly browsable workers.dev URL.
   "preview_urls": false,


### PR DESCRIPTION
## Problem

The Hands Worker performs several D1-backed stages per feedback request. Cloudflare Workers run near the caller by default, which can add repeated cross-region latency when the database is elsewhere.

## Changes

- enable Cloudflare Smart Placement for the Hands business Worker
- assert the rendered production configuration retains `placement.mode = smart`
- leave the legacy proxy Worker and reporter-session enablement unchanged

## Testing

- `production_config.test.ts`: 3/3
- Worker tests: 271/271
- Worker TypeScript build
- mutation check: removing the placement setting fails the production-config assertion
- `git diff --check`
