### PR TITLE
Allow cancelled release versions to be reused safely

### DIFF
--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -751,7 +751,7 @@ function ReleaseRow({
         body={
           r.status === "draft"
             ? "The draft will be disabled. Its build, assets, and audit history stay available, while this version becomes available for a corrected upload. No live release is affected."
-            : "This release will stop being served by update checks. Its build, assets, and audit history stay available, while this version becomes available for a corrected upload."
+            : "This release will stop being served by update checks. Its build, assets, and audit history stay available. Although the version becomes available for historical correction, devices that already received this release will not update to different bits with the same version code; publish any client update with a higher version code."
         }
         confirmLabel={r.status === "draft" ? "Delete draft" : "Cancel release"}
         confirmKind="danger"

--- a/admin/src/pages/Releases.tsx
+++ b/admin/src/pages/Releases.tsx
@@ -750,8 +750,8 @@ function ReleaseRow({
         objectHint={r.id.slice(0, 8)}
         body={
           r.status === "draft"
-            ? "The draft will be marked cancelled. The build metadata and any uploaded assets stay available in storage; no live release is affected."
-            : "This release will stop being served by update checks. The build metadata and uploaded assets stay available in storage."
+            ? "The draft will be disabled. Its build, assets, and audit history stay available, while this version becomes available for a corrected upload. No live release is affected."
+            : "This release will stop being served by update checks. Its build, assets, and audit history stay available, while this version becomes available for a corrected upload."
         }
         confirmLabel={r.status === "draft" ? "Delete draft" : "Cancel release"}
         confirmKind="danger"

--- a/docs/public/admin-user-guide.md
+++ b/docs/public/admin-user-guide.md
@@ -38,11 +38,13 @@ The standard flow follows the draft-first policy: CI creates a **draft** release
 
 For Android, Hands selects updates by `version_code`. A device receives an update only when the published release has a higher `version_code` than the client reports.
 
-Hands keeps one release lifecycle per app, channel, product type, release type,
-and version code. Cancelling preserves the row and audit history and does not
-free the version for another release. **Restore as active** reactivates a
-superseded or cancelled row with the same release ID; active and draft rows do
-not expose that action.
+A draft, active, or superseded release reserves its app, channel, product type,
+release type, and version-code coordinate. Cancelling disables that lifecycle
+and releases the coordinate for a corrected upload while preserving the old
+release ID, build, assets, and audit history. An old cancelled release can be
+restored only until a replacement owns the version; after that, operate on the
+replacement release instead. For Android builds that were already distributed,
+use a higher version code so installed clients can receive the correction.
 
 ### Staged rollouts
 

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -161,11 +161,17 @@ the target while other identified clients remain percentage-gated. Raise
 `PATCH /api/apps/:id/releases/:releaseId` as confidence grows. Release rows
 expose `offered_count` / `current_count` so you can watch real coverage.
 
-Each app/channel/product/release-type/version code has one durable release
-lifecycle. A duplicate create, including after cancellation, returns
-`RELEASE_VERSION_ALREADY_EXISTS`; continue with the returned release or use a
-higher version code. Restoring a superseded or cancelled version reactivates
-that same release ID instead of creating a new row.
+Each non-cancelled app/channel/product/release-type/version coordinate has one
+release owner. A duplicate create returns `RELEASE_VERSION_ALREADY_EXISTS`
+with that release/build/status. Cancelling disables the old lifecycle and
+releases the coordinate for a corrected upload without deleting its build,
+assets, or audit history. Restore reactivates the same release ID only if no
+replacement owns the version. The publish CLI checks this before creating a
+build so a known conflict cannot leave uploaded orphan assets. If another
+publisher wins the coordinate after that preflight, the CLI marks its new build
+`failed`, records the conflicting release in provenance, and reports the new
+build ID for audit or manual inspection. For an Android version that reached
+devices, use a higher version code so clients can update.
 
 For a fuller per-version view, call
 `GET /api/apps/:id/analytics/versions?window_days=30` with Agent Login or a

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -13,7 +13,7 @@ npm install -g @botiverse/hands-cli
 Or run it without a permanent install:
 
 ```bash
-npm exec --package @botiverse/hands-cli@0.5.13 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.14 -- hands --help
 ```
 
 In CI, pin a version so release scripts stay reproducible.
@@ -476,10 +476,16 @@ itself resets the scope to full only. `--rollout-percent` accepts integers from
 update form `--device-group <id>` still replaces the scope with one exact
 group-only rollout and cannot be combined with the full-rollout options.
 
-There is one release lifecycle per app/channel/product/release-type/version
-code. Cancelling does not free a version for a second release. Restoring a
-superseded or cancelled release reactivates its original ID; it does not create
-a replacement row for the same version.
+There is one non-cancelled release owner per
+app/channel/product/release-type/version code. The publish commands preflight
+that coordinate before creating a build or uploading assets. Cancelling
+disables the old release and frees the version for a corrected upload while
+preserving its build, assets, and audit history. Restore reactivates an old
+release only while no replacement owns the version. A rare conflict that wins
+after CLI preflight marks the new build `failed`, writes the conflict identity
+to provenance, and includes the build ID in the terminal error. For Android
+releases that already reached devices, publish the correction with a higher
+version code so clients can update.
 
 ## Share Links
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -83,15 +83,17 @@ and force-update writes. A stale revision returns
 `409 RELEASE_REVISION_CONFLICT` without changing the release, its scopes,
 fallback releases, or audit log.
 
-The admin release API permits only one lifecycle for each
+The admin release API permits only one **non-cancelled** lifecycle for each
 app/channel/product/release-type/version code. Duplicate creation returns
-`409 RELEASE_VERSION_ALREADY_EXISTS` with the existing release/build/status
-coordinates, including after cancellation. The rollback endpoint restores a
-superseded or cancelled release in place. A cancelled row whose
-`activated_at` is null was never published, so it returns to `draft` and must
-pass normal publish readiness, exact-scope, external-target, and revision
-gates. Only a previously active row returns to `active` with a new activation
-time.
+`409 RELEASE_VERSION_ALREADY_EXISTS` with the current release/build/status
+coordinates. Cancelling disables that lifecycle and releases the version for a
+corrected build while retaining the old release, build, assets, and audit
+history. The rollback endpoint restores a cancelled row only if no replacement
+owns its coordinate; otherwise it returns the same structured 409. A cancelled
+row whose `activated_at` is null was never published, so an eligible restore
+returns it to `draft` and must pass normal publish readiness, exact-scope,
+external-target, and revision gates. Only a previously active row returns to
+`active` with a new activation time.
 
 ### Update Available
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -93,7 +93,9 @@ owns its coordinate; otherwise it returns the same structured 409. A cancelled
 row whose `activated_at` is null was never published, so an eligible restore
 returns it to `draft` and must pass normal publish readiness, exact-scope,
 external-target, and revision gates. Only a previously active row returns to
-`active` with a new activation time.
+`active` with a new activation time. Reusing a coordinate does not make clients
+that already received that version install different bits; publish client
+corrections with a higher version code.
 
 ### Update Available
 

--- a/docs/publish-architecture.md
+++ b/docs/publish-architecture.md
@@ -368,7 +368,7 @@ ToDesktop runs builds on actual Win/Mac/Linux VMs, captures screenshots + auto-u
    - Build status is 'succeeded' ✓
    - Version is higher/lower than previous release ✓
    - Signing credentials valid ✓
-   - No release lifecycle with the same version_code in this lane ✓
+   - No non-cancelled release lifecycle with the same version_code in this lane ✓
 
 3. Admin picks release scope:
    - [Full release] — all users on this (channel, product_type, release_type)
@@ -384,7 +384,8 @@ ToDesktop runs builds on actual Win/Mac/Linux VMs, captures screenshots + auto-u
 6. Server:
    a. Insert the one releases row (status='draft'); return
       `409 RELEASE_VERSION_ALREADY_EXISTS` with the existing coordinates if
-      the lane/version lifecycle already exists, including if it is cancelled
+      a non-cancelled lane/version lifecycle already exists. A cancelled row
+      remains addressable history but no longer reserves that coordinate
    b. Insert release_scopes row(s)
    c. Publish only after the fresh `expected_revision` and exact
       `expected_scopes` set match atomically; set status=`active`, increment
@@ -406,6 +407,11 @@ the server clears the supersession link and refreshes `activated_at`. Neither
 path inserts a second release for the version. Every path requires the fresh
 revision. A full-coverage active restore supersedes the current active release;
 a partial active restore preserves or reactivates its fallback.
+
+Cancelling a release that already reached clients does not let those clients
+update to different bits with the same version code. Use version reuse to
+correct never-published history; ship any client correction with a higher
+version code.
 
 ## 5. Public client API
 
@@ -845,7 +851,7 @@ After push, build sits in `succeeded` state in the Builds tab. User then opens i
 ✓ Build status: succeeded
 ✓ Version is higher than previous release (1.2.3 = 42)
 ✓ Code signing credentials valid for: darwin-arm64, darwin-x64, linux-x64, win32-x64, win32-arm64
-✓ No existing release lifecycle with same version_code
+✓ No non-cancelled release lifecycle with same version_code
 
 Release scope:
 ( ) Full release           — all users on this (channel, product_type, release_type)

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -184,11 +184,16 @@ hands releases publish raft-android <releaseId>
 hands releases share raft-android <releaseId> --password <pw>
 ```
 
-Hands keeps exactly one release lifecycle for each
-app/channel/product/release-type/version-code identity. Draft, active,
-superseded, and cancelled are states of that same release ID. A cancelled
-version remains reserved; publish corrected bytes under a higher version code
-instead of creating a second release for the old version.
+Hands keeps exactly one non-cancelled owner for each
+app/channel/product/release-type/version-code identity. Cancelling disables a
+lifecycle and frees that coordinate for a corrected upload while retaining the
+old release ID, build, assets, and audit history. The publish CLI checks the
+coordinate before build creation and asset upload. If a concurrent publisher
+wins after that check, the CLI terminalizes its new build as failed, records
+the conflict in provenance, and prints the build ID instead of leaving an
+unidentified orphan. Reusing a version is suited to replacing a never-published
+draft; if an Android build reached devices, publish corrected bytes under a
+higher version code so clients can update.
 
 For a staged full rollout with mandatory acceptance devices, configure both
 behaviors on the same draft:
@@ -214,10 +219,11 @@ release. Raising the rollout to 100% supersedes that fallback. `--full` without
 `--always-include-group` resets the scope to only `full:all`. The legacy
 `--device-group <id>` update remains an exact group-only rollout.
 
-Restoring always reuses the same release ID and never clones the build into a
-second lifecycle. A cancelled release with `activated_at = null` was never
-published: Admin shows **Restore draft**, and rollback returns it to `draft` so
-normal publish gates still apply. A superseded release or a cancelled release
-with a prior activation uses **Restore as active** and records a fresh
-activation time. Send the revision from fresh release detail; stale restore
+Restoring always reuses the same release ID and never clones the build. A
+cancelled release with `activated_at = null` was never published: Admin shows
+**Restore draft**, and rollback returns it to `draft` so normal publish gates
+still apply. A superseded release or a cancelled release with a prior
+activation uses **Restore as active** and records a fresh activation time.
+Restore fails with `RELEASE_VERSION_ALREADY_EXISTS` after a replacement owns
+that coordinate. Send the revision from fresh release detail; stale restore
 requests return `409 RELEASE_REVISION_CONFLICT` with zero side effects.

--- a/migrations/sql/0056_cancelled_release_version_reuse.sql
+++ b/migrations/sql/0056_cancelled_release_version_reuse.sql
@@ -1,0 +1,17 @@
+-- Cancelling a release disables that lifecycle and releases its version
+-- identity for a corrected upload. The cancelled release, build, assets, and
+-- audit history remain immutable and addressable; only non-cancelled rows
+-- reserve an app/channel/product/release-type/version coordinate.
+--
+-- Replacing the insert trigger is required because migration 0053 deliberately
+-- reserved cancelled versions. The reactivation trigger closes the inverse
+-- race: an old cancelled lifecycle cannot be restored while a replacement owns
+-- the same version coordinate.
+
+DROP TRIGGER IF EXISTS trg_releases_version_once_insert;
+
+-- Cloudflare's remote D1 migration parser requires trigger bodies on one
+-- physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact.
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_insert BEFORE INSERT ON releases WHEN EXISTS (SELECT 1 FROM builds incoming JOIN releases existing ON existing.app_id = NEW.app_id AND existing.channel_id = NEW.channel_id AND existing.product_type = NEW.product_type AND existing.release_type = NEW.release_type JOIN builds existing_build ON existing_build.id = existing.build_id WHERE incoming.id = NEW.build_id AND incoming.app_id = NEW.app_id AND existing_build.version_code = incoming.version_code AND existing.status <> 'cancelled') BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_reactivate BEFORE UPDATE OF status ON releases WHEN OLD.status = 'cancelled' AND NEW.status <> 'cancelled' AND EXISTS (SELECT 1 FROM builds target_build JOIN releases existing ON existing.app_id = OLD.app_id AND existing.channel_id = OLD.channel_id AND existing.product_type = OLD.product_type AND existing.release_type = OLD.release_type AND existing.id <> OLD.id JOIN builds existing_build ON existing_build.id = existing.build_id WHERE target_build.id = OLD.build_id AND existing_build.version_code = target_build.version_code AND existing.status <> 'cancelled') BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.13 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.14 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -675,9 +675,20 @@ describe("Android delta patch metadata", () => {
         versionCode: 1080000,
       };
       await expect(assertReleaseVersionAvailable(args)).rejects.toThrow(
-        "cancel that release before uploading this version again",
+        "cancel that never-published draft before uploading this version again",
       );
       expect(requests[0]).toContain("version_code=1080000");
+
+      for (const publishedStatus of ["active", "superseded"]) {
+        releases = [{ ...releases[0]!, status: publishedStatus }];
+        const error = await assertReleaseVersionAvailable(args).catch((caught) => caught);
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain("choose a higher version code");
+        expect((error as Error).message).toContain(
+          "cannot make installed clients update to different bits with the same version code",
+        );
+        expect((error as Error).message).not.toContain("cancel that release");
+      }
 
       releases = [{ ...releases[0]!, status: "cancelled" }];
       await expect(assertReleaseVersionAvailable(args)).resolves.toBeUndefined();
@@ -900,6 +911,208 @@ describe("Android delta patch metadata", () => {
         "must be a complete gzip-compressed official PatchGen output",
       );
       expect(requests).toEqual([]);
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("publish lane release-version admission", () => {
+  it("preflights and terminalizes a trigger race for every mobile and desktop lane", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hands-publish-admission-"));
+    const files = {
+      apk: join(dir, "app.apk"),
+      ipa: join(dir, "app.ipa"),
+      app: join(dir, "app.app"),
+      hap: join(dir, "app.hap"),
+      tauri: join(dir, "App.AppImage"),
+      signature: join(dir, "App.AppImage.sig"),
+      electron: join(dir, "App-Setup.exe"),
+    };
+    for (const file of Object.values(files)) writeFileSync(file, `bytes:${file}`);
+
+    const lanes = [
+      {
+        name: "android",
+        productType: "android-apk",
+        argv: ["builds", "publish-android", "mobile", "--apk", files.apk,
+          "--version-name", "1.8.0", "--version-code", "1080000", "--draft"],
+      },
+      {
+        name: "ios",
+        productType: "ios-ipa",
+        argv: ["builds", "publish-ios", "mobile", "--ipa", files.ipa,
+          "--version-name", "1.8.0", "--version-code", "1080000", "--draft"],
+      },
+      {
+        name: "ohos",
+        productType: "ohos-app",
+        argv: ["builds", "publish-ohos", "mobile", "--app", files.app, "--hap", files.hap,
+          "--version-name", "1.8.0", "--version-code", "1080000", "--draft"],
+      },
+      {
+        name: "tauri",
+        productType: "tauri-updater",
+        argv: ["builds", "publish-tauri", "mobile", "--bundle", files.tauri,
+          "--signature", files.signature, "--target", "linux-x86_64",
+          "--version-name", "1.8.0", "--version-code", "1080000"],
+      },
+      {
+        name: "electron",
+        productType: "electron-installer",
+        argv: ["builds", "publish-electron", "mobile", "--installer", files.electron,
+          "--version-name", "1.8.0", "--version-code", "1080000", "--draft"],
+      },
+    ] as const;
+
+    const requests: Array<{
+      method: string;
+      url: string;
+      body?: Record<string, any>;
+    }> = [];
+    let mode: "occupied" | "race" = "occupied";
+    let buildCounter = 0;
+    let uploadCounter = 0;
+    const server = createServer(async (req, res) => {
+      let body: Record<string, any> | undefined;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } else {
+        for await (const _chunk of req) {
+          // Drain multipart uploads before responding.
+        }
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.method === "GET" && req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "mobile" }] }));
+      }
+      if (req.method === "GET" && req.url === "/api/apps/app-1/channels") {
+        return res.end(JSON.stringify({
+          channels: [{ id: "channel-1", slug: "main", name: "Main" }],
+        }));
+      }
+      if (req.method === "GET" && req.url?.startsWith("/api/apps/app-1/releases?")) {
+        return res.end(JSON.stringify({
+          releases: mode === "occupied" ? [{
+            id: "release-published",
+            build_id: "build-published",
+            status: "active",
+            version_name: "1.8.0",
+            version_code: 1080000,
+          }] : [],
+        }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/builds") {
+        buildCounter += 1;
+        return res.end(JSON.stringify({ id: `build-race-${buildCounter}` }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/upload") {
+        uploadCounter += 1;
+        return res.end(JSON.stringify({
+          file_hash: String(uploadCounter).padStart(64, "0"),
+          r2_key: `apps/app-1/upload-${uploadCounter}`,
+          size_bytes: 10 + uploadCounter,
+          original_filename: `upload-${uploadCounter}`,
+        }));
+      }
+      if (req.method === "POST" && req.url?.endsWith("/assets")) {
+        return res.end(JSON.stringify({ id: `asset-${uploadCounter}` }));
+      }
+      if (req.method === "POST" && req.url === "/api/apps/app-1/releases") {
+        res.statusCode = 409;
+        return res.end(JSON.stringify({
+          error: "release version already exists",
+          code: "RELEASE_VERSION_ALREADY_EXISTS",
+          release_id: "release-winner",
+          build_id: "build-winner",
+          release_status: "draft",
+          version_name: "1.8.0",
+          version_code: 1080000,
+        }));
+      }
+      if (req.method === "PATCH" && req.url?.startsWith("/api/apps/app-1/builds/build-race-")) {
+        return res.end(JSON.stringify({ ok: true }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    const run = async (argv: readonly string[]) => {
+      const { registerBuildCommands } = await import("../src/commands/builds.js");
+      const program = new Command().version("0.5.14").option("--json", "JSON output", false);
+      registerBuildCommands(program);
+      await program.parseAsync(["node", "hands", ...argv]);
+    };
+
+    try {
+      for (const lane of lanes) {
+        mode = "occupied";
+        requests.length = 0;
+        await expect(run(lane.argv)).rejects.toThrow("choose a higher version code");
+        const occupiedPreflight = requests.find((request) =>
+          request.method === "GET" && request.url.startsWith("/api/apps/app-1/releases?"));
+        expect(occupiedPreflight, lane.name).toBeDefined();
+        const query = new URL(occupiedPreflight!.url, "https://hands.test").searchParams;
+        expect(query.get("channel"), lane.name).toBe("channel-1");
+        expect(query.get("product_type"), lane.name).toBe(lane.productType);
+        expect(query.get("release_type"), lane.name).toBe("stable");
+        expect(query.get("version_code"), lane.name).toBe("1080000");
+        expect(requests.some((request) =>
+          request.method === "POST" && request.url === "/api/apps/app-1/builds"), lane.name,
+        ).toBe(false);
+
+        mode = "race";
+        requests.length = 0;
+        await expect(run(lane.argv)).rejects.toThrow(
+          /new build build-race-\d+ was terminalized as failed/,
+        );
+        const sequence = requests.map((request) => `${request.method} ${request.url}`);
+        const preflightIndex = sequence.findIndex((entry) =>
+          entry.startsWith("GET /api/apps/app-1/releases?"));
+        const buildIndex = sequence.indexOf("POST /api/apps/app-1/builds");
+        const releaseIndex = sequence.indexOf("POST /api/apps/app-1/releases");
+        const terminalIndex = sequence.findIndex((entry) =>
+          entry.startsWith("PATCH /api/apps/app-1/builds/build-race-"));
+        expect(preflightIndex, lane.name).toBeGreaterThanOrEqual(0);
+        expect(buildIndex, lane.name).toBeGreaterThan(preflightIndex);
+        expect(releaseIndex, lane.name).toBeGreaterThan(buildIndex);
+        expect(terminalIndex, lane.name).toBeGreaterThan(releaseIndex);
+        expect(requests[buildIndex]?.body, lane.name).toMatchObject({
+          channel_id: "channel-1",
+          product_type: lane.productType,
+          release_type: "stable",
+          version_name: "1.8.0",
+          version_code: 1080000,
+        });
+        expect(requests[terminalIndex]?.body, lane.name).toMatchObject({
+          status: "failed",
+          provenance_json: {
+            hands_cli_terminal: {
+              state: "failed",
+              reason: "release_version_conflict",
+              conflicting_release_id: "release-winner",
+              conflicting_build_id: "build-winner",
+              version_code: 1080000,
+            },
+          },
+        });
+      }
     } finally {
       if (originalApi === undefined) delete process.env.HANDS_API;
       else process.env.HANDS_API = originalApi;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -638,6 +638,147 @@ describe("Android delta patch metadata", () => {
     }
   });
 
+  it("blocks occupied versions before build creation and ignores cancelled history", async () => {
+    let releases = [{
+      id: "release-old",
+      build_id: "build-old",
+      status: "draft",
+      version_name: "1.8.0",
+      version_code: 1080000,
+    }];
+    const requests: string[] = [];
+    const server = createServer((req, res) => {
+      requests.push(req.url ?? "");
+      res.setHeader("content-type", "application/json");
+      if (req.url?.startsWith("/api/apps/app-1/releases?")) {
+        return res.end(JSON.stringify({ releases }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { assertReleaseVersionAvailable } = await import("../src/commands/builds.js");
+      const args = {
+        appId: "app-1",
+        channelId: "channel-main",
+        productType: "android-apk",
+        releaseType: "stable",
+        versionName: "1.8.0",
+        versionCode: 1080000,
+      };
+      await expect(assertReleaseVersionAvailable(args)).rejects.toThrow(
+        "cancel that release before uploading this version again",
+      );
+      expect(requests[0]).toContain("version_code=1080000");
+
+      releases = [{ ...releases[0]!, status: "cancelled" }];
+      await expect(assertReleaseVersionAvailable(args)).resolves.toBeUndefined();
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("terminalizes a build when the release version is lost to a concurrent publisher", async () => {
+    const requests: Array<{ method: string; url: string; body: Record<string, any> }> = [];
+    let terminalWriteFails = false;
+    const server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      const text = Buffer.concat(chunks).toString("utf8");
+      const body = text ? JSON.parse(text) as Record<string, any> : {};
+      requests.push({ method: req.method ?? "", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.method === "POST" && req.url === "/api/apps/app-1/releases") {
+        res.statusCode = 409;
+        return res.end(JSON.stringify({
+          error: "release version already exists",
+          code: "RELEASE_VERSION_ALREADY_EXISTS",
+          release_id: "release-winner",
+          build_id: "build-winner",
+          release_status: "draft",
+          version_name: "1.8.0",
+          version_code: 1080000,
+        }));
+      }
+      if (req.method === "PATCH" && req.url?.startsWith("/api/apps/app-1/builds/")) {
+        if (terminalWriteFails) {
+          res.statusCode = 500;
+          return res.end(JSON.stringify({ error: "terminal write unavailable" }));
+        }
+        return res.end(JSON.stringify({ ok: true }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+
+    try {
+      const { createReleaseOrTerminalizeVersionConflict } = await import(
+        "../src/commands/builds.js"
+      );
+      await expect(createReleaseOrTerminalizeVersionConflict({
+        appId: "app-1",
+        buildId: "build-race",
+        releaseBody: { build_id: "build-race", status: "draft" },
+        provenance: { source_commit: "abc123" },
+      })).rejects.toThrow(
+        "new build build-race was terminalized as failed",
+      );
+      expect(requests.map(({ method, url }) => `${method} ${url}`)).toEqual([
+        "POST /api/apps/app-1/releases",
+        "PATCH /api/apps/app-1/builds/build-race",
+      ]);
+      expect(requests[1]?.body).toMatchObject({
+        status: "failed",
+        provenance_json: {
+          source_commit: "abc123",
+          hands_cli_terminal: {
+            state: "failed",
+            reason: "release_version_conflict",
+            conflicting_release_id: "release-winner",
+            conflicting_build_id: "build-winner",
+            version_code: 1080000,
+          },
+        },
+      });
+
+      requests.length = 0;
+      terminalWriteFails = true;
+      await expect(createReleaseOrTerminalizeVersionConflict({
+        appId: "app-1",
+        buildId: "build-needs-inspection",
+        releaseBody: { build_id: "build-needs-inspection", status: "draft" },
+        provenance: {},
+      })).rejects.toThrow(
+        "release version conflict left build build-needs-inspection requiring manual inspection",
+      );
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("preflights before HTTP and sends the exact gzip asset metadata", async () => {
     const dir = mkdtempSync(join(tmpdir(), "hands-android-publish-"));
     const apk = join(dir, "app.apk");
@@ -671,6 +812,9 @@ describe("Android delta patch metadata", () => {
       if (req.method === "GET" && req.url === "/api/apps/app-1/channels") {
         return res.end(JSON.stringify({ channels: [{ id: "channel-1", slug: "main", name: "Main" }] }));
       }
+      if (req.method === "GET" && req.url?.startsWith("/api/apps/app-1/releases?")) {
+        return res.end(JSON.stringify({ releases: [] }));
+      }
       if (req.method === "POST" && req.url === "/api/apps/app-1/builds") {
         return res.end(JSON.stringify({ id: "build-1" }));
       }
@@ -703,7 +847,7 @@ describe("Android delta patch metadata", () => {
 
     const runPublish = async (patchPath: string) => {
       const { registerBuildCommands } = await import("../src/commands/builds.js");
-      const program = new Command().version("0.5.13").option("--json", "JSON output", false);
+      const program = new Command().version("0.5.14").option("--json", "JSON output", false);
       registerBuildCommands(program);
       await program.parseAsync([
         "node", "hands", "builds", "publish-android", "android-app",
@@ -717,6 +861,14 @@ describe("Android delta patch metadata", () => {
 
     try {
       await runPublish(validPatch);
+      const releasePreflightIndex = requests.findIndex(
+        (request) => request.method === "GET" && request.url.startsWith("/api/apps/app-1/releases?"),
+      );
+      const buildCreateIndex = requests.findIndex(
+        (request) => request.method === "POST" && request.url === "/api/apps/app-1/builds",
+      );
+      expect(releasePreflightIndex).toBeGreaterThanOrEqual(0);
+      expect(buildCreateIndex).toBeGreaterThan(releasePreflightIndex);
       const deltaAsset = requests.find(
         (request) =>
           request.method === "POST" &&
@@ -797,6 +949,7 @@ describe("Tauri build helpers", () => {
       res.setHeader("content-type", "application/json");
       if (req.url === "/api/apps") return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "desktop" }] }));
       if (req.url === "/api/apps/app-1/channels") return res.end(JSON.stringify({ channels: [{ id: "channel-1", slug: "main", name: "Main" }] }));
+      if (req.url?.startsWith("/api/apps/app-1/releases?")) return res.end(JSON.stringify({ releases: [] }));
       if (req.url === "/api/apps/app-1/builds") return res.end(JSON.stringify({ id: "build-1" }));
       if (req.url === "/api/apps/app-1/upload") return res.end(JSON.stringify({
         file_hash: "hash-1", r2_key: "apps/app-1/App.AppImage", size_bytes: 12, original_filename: "App.AppImage",
@@ -817,7 +970,7 @@ describe("Tauri build helpers", () => {
 
     try {
       const { registerBuildCommands } = await import("../src/commands/builds.js");
-      const program = new Command().version("0.5.9").option("--json", "JSON output", false);
+      const program = new Command().version("0.5.14").option("--json", "JSON output", false);
       registerBuildCommands(program);
       await program.parseAsync([
         "node", "hands", "builds", "publish-tauri", "desktop",

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -200,11 +200,44 @@ export async function assertReleaseVersionAvailable(args: {
       release.status !== "cancelled",
   );
   if (!conflict) return;
+  const recovery = conflict.status === "draft"
+    ? "cancel that never-published draft before uploading this version again, or choose a higher version code"
+    : "choose a higher version code; cancelling a published or superseded release cannot make installed clients update to different bits with the same version code";
   throw new Error(
     `release version ${args.versionName} (${args.versionCode}) is already owned by ` +
       `${conflict.status} release ${conflict.id} (build ${conflict.build_id}); ` +
-      "cancel that release before uploading this version again, or choose a higher version code",
+      recovery,
   );
+}
+
+export async function createAdmittedPublishBuild(args: {
+  appId: string;
+  channelId: string;
+  productType: string;
+  releaseType: string;
+  versionName: string;
+  versionCode: number;
+  buildBody: Record<string, unknown>;
+}): Promise<{ id: string }> {
+  await assertReleaseVersionAvailable({
+    appId: args.appId,
+    channelId: args.channelId,
+    productType: args.productType,
+    releaseType: args.releaseType,
+    versionName: args.versionName,
+    versionCode: args.versionCode,
+  });
+  return apiRequest<{ id: string }>(`/api/apps/${args.appId}/builds`, {
+    method: "POST",
+    body: {
+      ...args.buildBody,
+      channel_id: args.channelId,
+      product_type: args.productType,
+      release_type: args.releaseType,
+      version_name: args.versionName,
+      version_code: args.versionCode,
+    },
+  });
 }
 
 function releaseVersionConflict(error: unknown): ReleaseVersionConflictBody | null {
@@ -807,18 +840,14 @@ export function registerBuildCommands(program: Command): void {
         };
         const appId = await resolveAppId(appIdOrSlug);
         const channelId = await resolveChannelId(appId, opts.channel);
-        await assertReleaseVersionAvailable({
+        const build = await createAdmittedPublishBuild({
           appId,
           channelId,
           productType: opts.productType,
           releaseType: opts.releaseType,
           versionName: opts.versionName,
           versionCode,
-        });
-
-        const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
-          method: "POST",
-          body: {
+          buildBody: {
             channel_id: channelId,
             product_type: opts.productType,
             release_type: opts.releaseType,
@@ -1061,18 +1090,14 @@ export function registerBuildCommands(program: Command): void {
           ci_run_id: opts.ciRunId ?? null,
           ci_url: opts.ciUrl ?? null,
         };
-        await assertReleaseVersionAvailable({
+        const build = await createAdmittedPublishBuild({
           appId,
           channelId,
           productType: opts.productType,
           releaseType: opts.releaseType,
           versionName: opts.versionName,
           versionCode,
-        });
-
-        const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
-          method: "POST",
-          body: {
+          buildBody: {
             channel_id: channelId,
             product_type: opts.productType,
             release_type: opts.releaseType,
@@ -1511,18 +1536,14 @@ export function registerBuildCommands(program: Command): void {
           ci_run_id: opts.ciRunId ?? null,
           ci_url: opts.ciUrl ?? null,
         };
-        await assertReleaseVersionAvailable({
+        const build = await createAdmittedPublishBuild({
           appId,
           channelId,
           productType: opts.productType,
           releaseType: opts.releaseType,
           versionName: opts.versionName,
           versionCode,
-        });
-
-        const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
-          method: "POST",
-          body: {
+          buildBody: {
             channel_id: channelId,
             product_type: opts.productType,
             release_type: opts.releaseType,
@@ -1670,17 +1691,14 @@ export function registerBuildCommands(program: Command): void {
         ? parseNonNegativeInteger(opts.versionCode, "--version-code")
         : versionCodeFromVersion(opts.versionName);
       const changelog = parseChangelogOptions(opts);
-      await assertReleaseVersionAvailable({
+      const build = await createAdmittedPublishBuild({
         appId,
         channelId,
         productType: "tauri-updater",
         releaseType: opts.releaseType,
         versionName: opts.versionName,
         versionCode,
-      });
-      const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
-        method: "POST",
-        body: {
+        buildBody: {
           channel_id: channelId, product_type: "tauri-updater", release_type: opts.releaseType,
           version_name: opts.versionName, version_code: versionCode, changelog,
           source: "cli", status: "succeeded",
@@ -1825,18 +1843,14 @@ export function registerBuildCommands(program: Command): void {
             arch,
           },
         };
-        await assertReleaseVersionAvailable({
+        const build = await createAdmittedPublishBuild({
           appId,
           channelId,
           productType: opts.productType,
           releaseType: opts.releaseType,
           versionName: opts.versionName,
           versionCode,
-        });
-
-        const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
-          method: "POST",
-          body: {
+          buildBody: {
             channel_id: channelId,
             product_type: opts.productType,
             release_type: opts.releaseType,

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -15,7 +15,7 @@ import { Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 import { createGunzip } from "node:zlib";
-import { apiRequest, apiUploadFile } from "../lib/api.js";
+import { apiRequest, apiUploadFile, QuiverApiError } from "../lib/api.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -45,6 +45,23 @@ interface ChannelRow {
   id: string;
   slug: string;
   name: string;
+}
+
+interface ReleaseVersionRow {
+  id: string;
+  build_id: string;
+  status: string;
+  version_name: string;
+  version_code: number;
+}
+
+interface ReleaseVersionConflictBody {
+  code: "RELEASE_VERSION_ALREADY_EXISTS";
+  release_id?: string;
+  build_id?: string;
+  release_status?: string;
+  version_name?: string;
+  version_code?: number;
 }
 
 interface TestflightGroup {
@@ -156,6 +173,109 @@ async function preflightAndroidDeltaPatches(
     await assertGzipAndroidDeltaPatch(patch.patchPath);
   }
   return parsed;
+}
+
+export async function assertReleaseVersionAvailable(args: {
+  appId: string;
+  channelId: string;
+  productType: string;
+  releaseType: string;
+  versionName: string;
+  versionCode: number;
+}): Promise<void> {
+  const { releases } = await apiRequest<{ releases: ReleaseVersionRow[] }>(
+    `/api/apps/${args.appId}/releases`,
+    {
+      query: {
+        channel: args.channelId,
+        product_type: args.productType,
+        release_type: args.releaseType,
+        version_code: args.versionCode,
+      },
+    },
+  );
+  const conflict = releases.find(
+    (release) =>
+      release.version_code === args.versionCode &&
+      release.status !== "cancelled",
+  );
+  if (!conflict) return;
+  throw new Error(
+    `release version ${args.versionName} (${args.versionCode}) is already owned by ` +
+      `${conflict.status} release ${conflict.id} (build ${conflict.build_id}); ` +
+      "cancel that release before uploading this version again, or choose a higher version code",
+  );
+}
+
+function releaseVersionConflict(error: unknown): ReleaseVersionConflictBody | null {
+  if (!(error instanceof QuiverApiError) || error.status !== 409) return null;
+  if (!error.body || typeof error.body !== "object" || Array.isArray(error.body)) return null;
+  const body = error.body as Partial<ReleaseVersionConflictBody>;
+  return body.code === "RELEASE_VERSION_ALREADY_EXISTS"
+    ? body as ReleaseVersionConflictBody
+    : null;
+}
+
+export async function createReleaseOrTerminalizeVersionConflict(args: {
+  appId: string;
+  buildId: string;
+  releaseBody: Record<string, unknown>;
+  provenance: Record<string, unknown>;
+}): Promise<{ id: string }> {
+  try {
+    return await apiRequest<{ id: string }>(`/api/apps/${args.appId}/releases`, {
+      method: "POST",
+      body: args.releaseBody,
+    });
+  } catch (error) {
+    const conflict = releaseVersionConflict(error);
+    if (!conflict) {
+      throw new Error(
+        `release creation did not complete for build ${args.buildId}; inspect that build before retrying: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+
+    const terminal = {
+      state: "failed",
+      reason: "release_version_conflict",
+      at: new Date().toISOString(),
+      conflicting_release_id: conflict.release_id ?? null,
+      conflicting_build_id: conflict.build_id ?? null,
+      conflicting_release_status: conflict.release_status ?? null,
+      version_name: conflict.version_name ?? null,
+      version_code: conflict.version_code ?? null,
+    };
+    try {
+      await apiRequest(`/api/apps/${args.appId}/builds/${args.buildId}`, {
+        method: "PATCH",
+        body: {
+          status: "failed",
+          provenance_json: {
+            ...args.provenance,
+            hands_cli_terminal: terminal,
+          },
+        },
+      });
+    } catch (terminalError) {
+      throw new Error(
+        `release version conflict left build ${args.buildId} requiring manual inspection; ` +
+          `automatic failed-terminal write did not complete: ${
+            terminalError instanceof Error ? terminalError.message : String(terminalError)
+          }`,
+        { cause: error },
+      );
+    }
+
+    throw new Error(
+      `release version conflict; new build ${args.buildId} was terminalized as failed and remains ` +
+        `auditable (existing release ${conflict.release_id ?? "unknown"}, ` +
+        `build ${conflict.build_id ?? "unknown"}, status ${conflict.release_status ?? "unknown"})`,
+      { cause: error },
+    );
+  }
 }
 
 export function shouldOutputJson(program: Command, localJson?: boolean): boolean {
@@ -687,6 +807,14 @@ export function registerBuildCommands(program: Command): void {
         };
         const appId = await resolveAppId(appIdOrSlug);
         const channelId = await resolveChannelId(appId, opts.channel);
+        await assertReleaseVersionAvailable({
+          appId,
+          channelId,
+          productType: opts.productType,
+          releaseType: opts.releaseType,
+          versionName: opts.versionName,
+          versionCode,
+        });
 
         const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
           method: "POST",
@@ -793,9 +921,11 @@ export function registerBuildCommands(program: Command): void {
           );
         }
 
-        const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
-          method: "POST",
-          body: {
+        const release = await createReleaseOrTerminalizeVersionConflict({
+          appId,
+          buildId: build.id,
+          provenance,
+          releaseBody: {
             build_id: build.id,
             channel_id: channelId,
             product_type: opts.productType,
@@ -931,6 +1061,14 @@ export function registerBuildCommands(program: Command): void {
           ci_run_id: opts.ciRunId ?? null,
           ci_url: opts.ciUrl ?? null,
         };
+        await assertReleaseVersionAvailable({
+          appId,
+          channelId,
+          productType: opts.productType,
+          releaseType: opts.releaseType,
+          versionName: opts.versionName,
+          versionCode,
+        });
 
         const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
           method: "POST",
@@ -986,9 +1124,11 @@ export function registerBuildCommands(program: Command): void {
           );
         }
 
-        const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
-          method: "POST",
-          body: {
+        const release = await createReleaseOrTerminalizeVersionConflict({
+          appId,
+          buildId: build.id,
+          provenance,
+          releaseBody: {
             build_id: build.id,
             channel_id: channelId,
             product_type: opts.productType,
@@ -1371,6 +1511,14 @@ export function registerBuildCommands(program: Command): void {
           ci_run_id: opts.ciRunId ?? null,
           ci_url: opts.ciUrl ?? null,
         };
+        await assertReleaseVersionAvailable({
+          appId,
+          channelId,
+          productType: opts.productType,
+          releaseType: opts.releaseType,
+          versionName: opts.versionName,
+          versionCode,
+        });
 
         const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
           method: "POST",
@@ -1449,9 +1597,11 @@ export function registerBuildCommands(program: Command): void {
           );
         }
 
-        const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
-          method: "POST",
-          body: {
+        const release = await createReleaseOrTerminalizeVersionConflict({
+          appId,
+          buildId: build.id,
+          provenance,
+          releaseBody: {
             build_id: build.id,
             channel_id: channelId,
             product_type: opts.productType,
@@ -1520,6 +1670,14 @@ export function registerBuildCommands(program: Command): void {
         ? parseNonNegativeInteger(opts.versionCode, "--version-code")
         : versionCodeFromVersion(opts.versionName);
       const changelog = parseChangelogOptions(opts);
+      await assertReleaseVersionAvailable({
+        appId,
+        channelId,
+        productType: "tauri-updater",
+        releaseType: opts.releaseType,
+        versionName: opts.versionName,
+        versionCode,
+      });
       const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
         method: "POST",
         body: {
@@ -1545,9 +1703,11 @@ export function registerBuildCommands(program: Command): void {
           metadata_json: { filename: basename(bundle), tauri_target: opts.target[index] },
         }));
       }
-      const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
-        method: "POST",
-        body: {
+      const release = await createReleaseOrTerminalizeVersionConflict({
+        appId,
+        buildId: build.id,
+        provenance: {},
+        releaseBody: {
           build_id: build.id, channel_id: channelId, product_type: "tauri-updater",
           release_type: opts.releaseType, status: opts.publish ? "active" : "draft",
           changelog, scopes: [{ scope_type: "full", scope_value: "all" }],
@@ -1665,6 +1825,14 @@ export function registerBuildCommands(program: Command): void {
             arch,
           },
         };
+        await assertReleaseVersionAvailable({
+          appId,
+          channelId,
+          productType: opts.productType,
+          releaseType: opts.releaseType,
+          versionName: opts.versionName,
+          versionCode,
+        });
 
         const build = await apiRequest<{ id: string }>(`/api/apps/${appId}/builds`, {
           method: "POST",
@@ -1735,9 +1903,11 @@ export function registerBuildCommands(program: Command): void {
           );
         }
 
-        const release = await apiRequest<{ id: string }>(`/api/apps/${appId}/releases`, {
-          method: "POST",
-          body: {
+        const release = await createReleaseOrTerminalizeVersionConflict({
+          appId,
+          buildId: build.id,
+          provenance,
+          releaseBody: {
             build_id: build.id,
             channel_id: channelId,
             product_type: opts.productType,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.13")
+  .version("0.5.14")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",

--- a/worker/src/openapi/releases.ts
+++ b/worker/src/openapi/releases.ts
@@ -223,9 +223,12 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
     request: {
       params: AppIdParam,
       query: z.object({
+        channel: z.string().optional(),
         channel_id: z.string().optional(),
         product_type: z.string().optional(),
+        release_type: z.string().optional(),
         status: z.string().optional(),
+        version_code: z.coerce.number().int().nonnegative().optional(),
       }),
     },
     responses: {
@@ -238,7 +241,7 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
     method: "post",
     path: "/api/apps/{appId}/releases",
     tags: ["Releases"],
-    summary: "Create the single release lifecycle for a build version",
+    summary: "Create a release lifecycle for an unoccupied or cancelled build version",
     security: auth,
     request: {
       params: AppIdParam,
@@ -248,7 +251,7 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
       201: success("Created release.", GenericObject),
       400: error("Invalid release payload."),
       403: error("Current principal cannot create releases."),
-      409: error("A release already exists for this app/channel/product/release-type/version."),
+      409: error("A non-cancelled release already exists for this app/channel/product/release-type/version."),
     },
   });
 

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1027,10 +1027,15 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "list-releases",
-        description: "List an app's releases (id, status, channel, version, rollout). Requires app viewer.",
+        description: "List an app's releases (id, status, channel, version, rollout), optionally filtered to an exact release lane/version preflight. Requires app viewer.",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/releases" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          status: { type: "string", in: "query", required: false, description: "Optional release status filter." },
+          channel: { type: "string", in: "query", required: false, description: "Optional channel UUID or slug." },
+          product_type: { type: "string", in: "query", required: false, description: "Optional product-type filter." },
+          release_type: { type: "string", in: "query", required: false, description: "Optional release-type filter." },
+          version_code: { type: "number", in: "query", required: false, description: "Optional exact non-negative version-code filter." },
         },
       },
       {
@@ -1045,7 +1050,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       {
         name: "create-release",
         description:
-          "Create the one DRAFT release lifecycle for a build version. A second release in the same app/channel/product/release-type/version lane fails with RELEASE_VERSION_ALREADY_EXISTS and returns the existing release id. Requires app publisher.",
+          "Create a DRAFT release lifecycle for a build version. A non-cancelled release in the same app/channel/product/release-type/version lane fails with RELEASE_VERSION_ALREADY_EXISTS; cancelling disables the old lifecycle and releases that version for a corrected upload while preserving its audit history. Requires app publisher.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/draft" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
@@ -1088,7 +1093,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "cancel-release",
-        description: "Cancel one draft or active release without deleting its build, assets, or audit history. Requires app publisher.",
+        description: "Disable one draft or active release without deleting its build, assets, or audit history. The cancelled row stops reserving its version so a corrected build may use that coordinate. Requires app publisher.",
         endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },
@@ -1098,7 +1103,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "restore-release",
-        description: "Restore the same release row. A never-published cancelled draft returns to draft and must pass normal publish gates; a previously active release returns to active. Requires app publisher.",
+        description: "Restore the same release row only while no replacement owns its version. A never-published cancelled draft returns to draft and must pass normal publish gates; a previously active release returns to active. Requires app publisher.",
         endpoint: { method: "POST", path: "/api/apps/{app_id}/releases/{release_id}/rollback" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1093,7 +1093,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "cancel-release",
-        description: "Disable one draft or active release without deleting its build, assets, or audit history. The cancelled row stops reserving its version so a corrected build may use that coordinate. Requires app publisher.",
+        description: "Disable one draft or active release without deleting its build, assets, or audit history. The cancelled row stops reserving its version so a corrected build may use that coordinate; if the release reached clients, corrected client bits still require a higher version code. Requires app publisher.",
         endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -442,6 +442,7 @@ async function findReleaseForVersionIdentity(
      JOIN builds b ON b.id = r.build_id
      WHERE r.app_id = ?1 AND r.channel_id = ?2 AND r.product_type = ?3
        AND r.release_type = ?4 AND b.version_code = ?5
+       AND r.status <> 'cancelled'
      ORDER BY CASE r.status
        WHEN 'active' THEN 0 WHEN 'draft' THEN 1 WHEN 'superseded' THEN 2 ELSE 3
      END, r.created_at ASC, r.id ASC
@@ -783,9 +784,10 @@ export async function handleListReleases(c: Context<{ Bindings: Env }>) {
   const conditions = ["r.app_id = ?1"];
   const binds: (string | number)[] = [appId];
   const status = c.req.query("status");
-  const channel = c.req.query("channel");
+  const channel = c.req.query("channel") ?? c.req.query("channel_id");
   const productType = c.req.query("product_type");
   const releaseType = c.req.query("release_type");
+  const versionCodeRaw = c.req.query("version_code");
 
   if (status) {
     conditions.push(`r.status = ?${binds.length + 1}`);
@@ -802,6 +804,14 @@ export async function handleListReleases(c: Context<{ Bindings: Env }>) {
   if (releaseType) {
     conditions.push(`r.release_type = ?${binds.length + 1}`);
     binds.push(releaseType);
+  }
+  if (versionCodeRaw !== undefined) {
+    const versionCode = Number(versionCodeRaw);
+    if (!Number.isSafeInteger(versionCode) || versionCode < 0) {
+      return c.json({ error: "version_code must be a non-negative integer" }, 400);
+    }
+    conditions.push(`b.version_code = ?${binds.length + 1}`);
+    binds.push(versionCode);
   }
 
   const { results } = await c.env.DB.prepare(
@@ -1797,6 +1807,25 @@ export async function handleRollbackRelease(c: AdminContext) {
     return c.json({ error: "release is already active" }, 409);
   }
 
+  const existingBuild = await getBuildForApp(c.env.DB, appId, existing.build_id);
+  if (!existingBuild) {
+    return c.json({ error: "release build not found" }, 409);
+  }
+  const currentVersionOwner = await findReleaseForVersionIdentity(
+    c.env.DB,
+    appId,
+    existing.channel_id,
+    existing.product_type,
+    existing.release_type,
+    existingBuild.version_code,
+  );
+  if (currentVersionOwner && currentVersionOwner.id !== existing.id) {
+    return releaseVersionConflictResponse(
+      c,
+      new ReleaseVersionAlreadyExistsError(currentVersionOwner),
+    );
+  }
+
   const existingScopes = await releaseScopesForMutation(c.env.DB, releaseId);
   const requestedBuildId = body.build_id ?? c.req.query("build_id");
   if (requestedBuildId && requestedBuildId !== existing.build_id) {
@@ -1945,6 +1974,22 @@ export async function handleRollbackRelease(c: AdminContext) {
   } catch (e) {
     if (e instanceof ReleaseRevisionConflictError) {
       return releaseRevisionConflictResponse(c, e.expectedRevision, e.currentRevision);
+    }
+    if (e instanceof Error && e.message.includes("release version already exists")) {
+      const conflict = await findReleaseForVersionIdentity(
+        c.env.DB,
+        appId,
+        existing.channel_id,
+        existing.product_type,
+        existing.release_type,
+        existingBuild.version_code,
+      );
+      if (conflict && conflict.id !== existing.id) {
+        return releaseVersionConflictResponse(
+          c,
+          new ReleaseVersionAlreadyExistsError(conflict),
+        );
+      }
     }
     return c.json({ error: (e as Error).message }, 400);
   }

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -26,9 +26,16 @@ type ReleaseVersionIdentity = {
 export class ReleaseVersionAlreadyExistsError extends Error {
   readonly code = "RELEASE_VERSION_ALREADY_EXISTS";
 
-  constructor(readonly existing: ReleaseVersionIdentity) {
+  constructor(
+    readonly existing: ReleaseVersionIdentity | null,
+    readonly attempted?: { version_name: string; version_code: number },
+  ) {
+    const versionName = existing?.version_name ?? attempted?.version_name ?? "unknown";
+    const versionCode = existing?.version_code ?? attempted?.version_code ?? "unknown";
     super(
-      `release version ${existing.version_name} (${existing.version_code}) already exists as ${existing.id}`,
+      existing
+        ? `release version ${versionName} (${versionCode}) already exists as ${existing.id}`
+        : `release version ${versionName} (${versionCode}) was claimed by another publisher`,
     );
     this.name = "ReleaseVersionAlreadyExistsError";
   }
@@ -454,11 +461,11 @@ function releaseVersionConflictResponse(c: AdminContext, error: ReleaseVersionAl
   return c.json({
     error: error.message,
     code: error.code,
-    release_id: error.existing.id,
-    build_id: error.existing.build_id,
-    release_status: error.existing.status,
-    version_name: error.existing.version_name,
-    version_code: error.existing.version_code,
+    release_id: error.existing?.id,
+    build_id: error.existing?.build_id,
+    release_status: error.existing?.status,
+    version_name: error.existing?.version_name ?? error.attempted?.version_name,
+    version_code: error.existing?.version_code ?? error.attempted?.version_code,
   }, 409);
 }
 
@@ -578,7 +585,10 @@ export async function createRelease(
         releaseType,
         build.version_code,
       );
-      if (conflict) throw new ReleaseVersionAlreadyExistsError(conflict);
+      throw new ReleaseVersionAlreadyExistsError(conflict, {
+        version_name: build.version_name,
+        version_code: build.version_code,
+      });
     }
     throw error;
   }
@@ -1984,12 +1994,16 @@ export async function handleRollbackRelease(c: AdminContext) {
         existing.release_type,
         existingBuild.version_code,
       );
-      if (conflict && conflict.id !== existing.id) {
-        return releaseVersionConflictResponse(
-          c,
-          new ReleaseVersionAlreadyExistsError(conflict),
-        );
-      }
+      return releaseVersionConflictResponse(
+        c,
+        new ReleaseVersionAlreadyExistsError(
+          conflict?.id !== existing.id ? conflict : null,
+          {
+            version_name: existingBuild.version_name,
+            version_code: existingBuild.version_code,
+          },
+        ),
+      );
     }
     return c.json({ error: (e as Error).message }, 400);
   }

--- a/worker/test/release_version_reuse_migration.test.ts
+++ b/worker/test/release_version_reuse_migration.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const identityMigrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0053_release_identity_and_activation.sql", import.meta.url),
+);
+const reuseMigrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0056_cancelled_release_version_reuse.sql", import.meta.url),
+);
+
+describe("cancelled release version reuse migration", () => {
+  it("keeps every remote-D1 trigger body on one physical line", () => {
+    const triggerLines = readFileSync(reuseMigrationPath, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("CREATE TRIGGER"));
+
+    expect(triggerLines).toHaveLength(2);
+    for (const line of triggerLines) {
+      expect(line).toContain(" BEGIN ");
+      expect(line).toMatch(/ END;$/);
+      expect(line.match(/\bEND;/g)).toHaveLength(1);
+    }
+  });
+
+  it("releases only cancelled identities and prevents conflicting reactivation", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE builds (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        channel_id TEXT,
+        product_type TEXT NOT NULL,
+        release_type TEXT NOT NULL,
+        version_name TEXT NOT NULL,
+        version_code INTEGER NOT NULL
+      );
+      CREATE TABLE releases (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        build_id TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        product_type TEXT NOT NULL,
+        release_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE release_scopes (
+        id TEXT PRIMARY KEY,
+        release_id TEXT NOT NULL,
+        scope_type TEXT NOT NULL,
+        scope_value TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name, version_code)
+      VALUES
+        ('build-old', 'app-a', 'main', 'android-apk', 'stable', '1.8.0', 1080000),
+        ('build-new', 'app-a', 'main', 'android-apk', 'stable', '1.8.0', 1080000),
+        ('build-third', 'app-a', 'main', 'android-apk', 'stable', '1.8.0', 1080000),
+        ('build-other', 'app-a', 'beta', 'android-apk', 'stable', '1.8.0', 1080000);
+
+      INSERT INTO releases
+        (id, app_id, build_id, channel_id, product_type, release_type, status, created_at, updated_at)
+      VALUES
+        ('release-old', 'app-a', 'build-old', 'main', 'android-apk', 'stable', 'draft', 1, 1);
+    `);
+
+    db.exec(readFileSync(identityMigrationPath, "utf8"));
+    db.exec(readFileSync(reuseMigrationPath, "utf8"));
+
+    const insertRelease = db.prepare(`
+      INSERT INTO releases
+        (id, app_id, build_id, channel_id, product_type, release_type, status,
+         created_at, updated_at, activated_at)
+      VALUES (?, 'app-a', ?, ?, 'android-apk', 'stable', 'draft', 2, 2, NULL)
+    `);
+
+    expect(() => insertRelease.run(
+      "release-new",
+      "build-new",
+      "main",
+    )).toThrow("release version already exists");
+
+    for (const reservedStatus of ["active", "superseded"]) {
+      db.prepare("UPDATE releases SET status = ? WHERE id = 'release-old'")
+        .run(reservedStatus);
+      expect(() => insertRelease.run(
+        `release-new-${reservedStatus}`,
+        "build-new",
+        "main",
+      )).toThrow("release version already exists");
+    }
+
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-old'").run();
+    expect(() => insertRelease.run(
+      "release-new",
+      "build-new",
+      "main",
+    )).not.toThrow();
+    expect(() => insertRelease.run(
+      "release-third",
+      "build-third",
+      "main",
+    )).toThrow("release version already exists");
+    expect(() => insertRelease.run(
+      "release-other",
+      "build-other",
+      "beta",
+    )).not.toThrow();
+
+    expect(() => db.prepare(
+      "UPDATE releases SET status = 'draft' WHERE id = 'release-old'",
+    ).run()).toThrow("release version already exists");
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-new'").run();
+    expect(() => db.prepare(
+      "UPDATE releases SET status = 'draft' WHERE id = 'release-old'",
+    ).run()).not.toThrow();
+
+    expect(db.prepare(
+      `SELECT id, status FROM releases
+       WHERE channel_id = 'main' ORDER BY id`,
+    ).all()).toEqual([
+      { id: "release-new", status: "cancelled" },
+      { id: "release-old", status: "draft" },
+    ]);
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
 import {
@@ -49,6 +50,11 @@ import {
   handleGetIosSimulatorArtifact,
   handleListIosSimulatorArtifacts,
 } from "../src/routes/qa_artifacts";
+
+const releaseVersionReuseTriggerStatements = readFileSync(
+  new URL("../../migrations/sql/0056_cancelled_release_version_reuse.sql", import.meta.url),
+  "utf8",
+).split("\n").filter((line) => line.startsWith("CREATE TRIGGER"));
 
 // ---------- Test harness ----------
 
@@ -3461,6 +3467,13 @@ describe("quiver releases — draft lifecycle", () => {
       .run();
   }
 
+  async function installReleaseVersionReuseTriggers() {
+    expect(releaseVersionReuseTriggerStatements).toHaveLength(2);
+    for (const statement of releaseVersionReuseTriggerStatements) {
+      await env.DB.prepare(statement).run();
+    }
+  }
+
   beforeEach(async () => {
     env = makeMockEnv();
     const now = Date.now();
@@ -3605,6 +3618,211 @@ describe("quiver releases — draft lifecycle", () => {
     await expect(env.DB.prepare(
       "SELECT status FROM releases WHERE id = 'rel-version-reserved'",
     ).first()).resolves.toEqual({ status: "cancelled" });
+  });
+
+  it("returns a structured conflict when create loses a trigger race to restore", async () => {
+    const {
+      createRelease,
+      handleCreateReleaseDraft,
+      handleRollbackRelease,
+    } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-create-loser", 34);
+    await seedReleaseBuild("build-restore-winner", 34);
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-restore-winner",
+      status: "draft",
+    }, "tester", "rel-restore-winner");
+    await env.DB.prepare(
+      "UPDATE releases SET status = 'cancelled', revision = 1 WHERE id = 'rel-restore-winner'",
+    ).run();
+    await installReleaseVersionReuseTriggers();
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    let winnerStatus: number | null = null;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        const winner = await handleRollbackRelease(makeReleaseContext(
+          "rel-restore-winner",
+          { expected_revision: 1 },
+        ));
+        winnerStatus = winner.status;
+      }
+      return originalBatch(statements);
+    };
+
+    let response: Response;
+    try {
+      response = await handleCreateReleaseDraft(makeReleaseContext("", {
+        build_id: "build-create-loser",
+      }));
+    } finally {
+      db.batch = originalBatch;
+    }
+
+    expect(winnerStatus).toBe(200);
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "RELEASE_VERSION_ALREADY_EXISTS",
+      release_id: "rel-restore-winner",
+      build_id: "build-restore-winner",
+      release_status: "draft",
+      version_code: 34,
+    });
+    await expect(env.DB.prepare(
+      "SELECT id, status, revision FROM releases ORDER BY id",
+    ).all()).resolves.toEqual({
+      results: [{ id: "rel-restore-winner", status: "draft", revision: 2 }],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT release_id, scope_type, scope_value FROM release_scopes ORDER BY release_id",
+    ).all()).resolves.toEqual({
+      results: [{
+        release_id: "rel-restore-winner",
+        scope_type: "full",
+        scope_value: "all",
+      }],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT action, COUNT(*) AS count FROM audit_logs GROUP BY action ORDER BY action",
+    ).all()).resolves.toEqual({
+      results: [
+        { action: "release.create", count: 1 },
+        { action: "release.rollback", count: 1 },
+      ],
+      success: true,
+    });
+  });
+
+  it("keeps restore side-effect free when create wins the trigger race", async () => {
+    const {
+      createRelease,
+      handleCreateReleaseDraft,
+      handleRollbackRelease,
+    } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-restore-loser", 35);
+    await seedReleaseBuild("build-create-winner", 35);
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-restore-loser",
+      status: "draft",
+    }, "tester", "rel-restore-loser");
+    await env.DB.prepare(
+      "UPDATE releases SET status = 'cancelled', revision = 1 WHERE id = 'rel-restore-loser'",
+    ).run();
+    await installReleaseVersionReuseTriggers();
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    let winnerId: string | undefined;
+    db.batch = async (statements: any[]) => {
+      if (!injected) {
+        injected = true;
+        const created = await handleCreateReleaseDraft(makeReleaseContext("", {
+          build_id: "build-create-winner",
+        }));
+        expect(created.status).toBe(201);
+        winnerId = (await responseJson<any>(created)).id;
+      }
+      return originalBatch(statements);
+    };
+
+    let response: Response;
+    try {
+      response = await handleRollbackRelease(makeReleaseContext(
+        "rel-restore-loser",
+        { expected_revision: 1 },
+      ));
+    } finally {
+      db.batch = originalBatch;
+    }
+
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "RELEASE_VERSION_ALREADY_EXISTS",
+      release_id: winnerId,
+      build_id: "build-create-winner",
+      release_status: "draft",
+      version_code: 35,
+    });
+    await expect(env.DB.prepare(
+      "SELECT status, revision FROM releases WHERE id = 'rel-restore-loser'",
+    ).first()).resolves.toEqual({ status: "cancelled", revision: 1 });
+    await expect(env.DB.prepare(
+      `SELECT release_id, scope_type, scope_value FROM release_scopes
+       WHERE release_id = 'rel-restore-loser'`,
+    ).all()).resolves.toEqual({
+      results: [{
+        release_id: "rel-restore-loser",
+        scope_type: "full",
+        scope_value: "all",
+      }],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.rollback'",
+    ).first()).resolves.toEqual({ count: 0 });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.create'",
+    ).first()).resolves.toEqual({ count: 2 });
+  });
+
+  it("keeps the trigger conflict structured if the winning owner cancels before requery", async () => {
+    const { createRelease, handleCreateReleaseDraft } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-transient-loser", 36);
+    await seedReleaseBuild("build-transient-winner", 36);
+    await installReleaseVersionReuseTriggers();
+
+    const db = env.DB as any;
+    const originalBatch = db.batch.bind(db);
+    let injected = false;
+    db.batch = async (statements: any[]) => {
+      if (injected) return originalBatch(statements);
+      injected = true;
+      await createRelease(env.DB as any, "app-release", {
+        build_id: "build-transient-winner",
+        status: "draft",
+      }, "winner", "rel-transient-winner");
+      try {
+        return await originalBatch(statements);
+      } catch (error) {
+        await env.DB.prepare(
+          "UPDATE releases SET status = 'cancelled' WHERE id = 'rel-transient-winner'",
+        ).run();
+        throw error;
+      }
+    };
+
+    let response: Response;
+    try {
+      response = await handleCreateReleaseDraft(makeReleaseContext("", {
+        build_id: "build-transient-loser",
+      }));
+    } finally {
+      db.batch = originalBatch;
+    }
+
+    expect(response.status).toBe(409);
+    const body = await responseJson<any>(response);
+    expect(body).toMatchObject({
+      code: "RELEASE_VERSION_ALREADY_EXISTS",
+      version_name: "1.0.36",
+      version_code: 36,
+    });
+    expect(body).not.toHaveProperty("release_id");
+    await expect(env.DB.prepare(
+      "SELECT id, status FROM releases ORDER BY id",
+    ).all()).resolves.toEqual({
+      results: [{ id: "rel-transient-winner", status: "cancelled" }],
+      success: true,
+    });
+    await expect(env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release.create'",
+    ).first()).resolves.toEqual({ count: 1 });
   });
 
   it("blocks restoring a cancelled lifecycle after a replacement owns its version", async () => {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3578,7 +3578,7 @@ describe("quiver releases — draft lifecycle", () => {
     ]);
   });
 
-  it("returns the existing lifecycle in a structured 409 even when it is cancelled", async () => {
+  it("allows a new lifecycle after the prior version is cancelled", async () => {
     const { createRelease, handleCreateReleaseDraft } = await import("../src/routes/releases");
     await seedReleaseBuild("build-version-original", 30);
     await seedReleaseBuild("build-version-race", 30);
@@ -3594,18 +3594,88 @@ describe("quiver releases — draft lifecycle", () => {
       build_id: "build-version-race",
     }));
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(201);
     await expect(responseJson<any>(response)).resolves.toMatchObject({
-      code: "RELEASE_VERSION_ALREADY_EXISTS",
-      release_id: "rel-version-reserved",
-      build_id: "build-version-original",
-      release_status: "cancelled",
-      version_name: "1.0.30",
-      version_code: 30,
+      build_id: "build-version-race",
+      status: "draft",
     });
     await expect(env.DB.prepare(
       "SELECT COUNT(*) AS count FROM releases WHERE build_id = 'build-version-race'",
-    ).first()).resolves.toEqual({ count: 0 });
+    ).first()).resolves.toEqual({ count: 1 });
+    await expect(env.DB.prepare(
+      "SELECT status FROM releases WHERE id = 'rel-version-reserved'",
+    ).first()).resolves.toEqual({ status: "cancelled" });
+  });
+
+  it("blocks restoring a cancelled lifecycle after a replacement owns its version", async () => {
+    const { createRelease, handleRollbackRelease } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-version-old", 31);
+    await seedReleaseBuild("build-version-replacement", 31);
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-version-old",
+      status: "draft",
+    }, "tester", "rel-version-old");
+    await env.DB.prepare(
+      "UPDATE releases SET status = 'cancelled', revision = 1 WHERE id = 'rel-version-old'",
+    ).run();
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-version-replacement",
+      status: "draft",
+    }, "tester", "rel-version-replacement");
+
+    const response = await handleRollbackRelease(makeReleaseContext(
+      "rel-version-old",
+      { expected_revision: 1 },
+    ));
+
+    expect(response.status).toBe(409);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      code: "RELEASE_VERSION_ALREADY_EXISTS",
+      release_id: "rel-version-replacement",
+      build_id: "build-version-replacement",
+      release_status: "draft",
+      version_code: 31,
+    });
+    await expect(env.DB.prepare(
+      "SELECT status, revision FROM releases WHERE id = 'rel-version-old'",
+    ).first()).resolves.toEqual({ status: "cancelled", revision: 1 });
+  });
+
+  it("filters release preflights by exact lane and version code", async () => {
+    const { createRelease, handleListReleases } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-version-filter", 32);
+    await seedReleaseBuild("build-version-other", 33);
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-version-filter",
+      status: "draft",
+    }, "tester", "rel-version-filter");
+    await createRelease(env.DB as any, "app-release", {
+      build_id: "build-version-other",
+      status: "draft",
+    }, "tester", "rel-version-other");
+
+    const response = await handleListReleases(makeReleaseContext("", {}, {
+      channel: "main",
+      product_type: "android-apk",
+      release_type: "stable",
+      version_code: "32",
+    }));
+    expect(response.status).toBe(200);
+    await expect(responseJson<any>(response)).resolves.toMatchObject({
+      releases: [{
+        id: "rel-version-filter",
+        build_id: "build-version-filter",
+        version_code: 32,
+      }],
+    });
+
+    const invalid = await handleListReleases(makeReleaseContext("", {}, {
+      version_code: "-1",
+    }));
+    expect(invalid.status).toBe(400);
+    await expect(responseJson<any>(invalid)).resolves.toEqual({
+      error: "version_code must be a non-negative integer",
+    });
   });
 
   it("publishes a draft and supersedes the previous active release", async () => {


### PR DESCRIPTION
## Problem

A cancelled Hands release still reserved its app/channel/product/release-type/version coordinate. Correcting a never-published draft with the same version therefore failed after the CLI had already created a new build and uploaded assets, leaving an unidentified build without a release.

## Changes

- release only `draft`, `active`, and `superseded` rows reserve a version; `cancelled` rows retain their build/assets/audit history but release the coordinate
- add D1 insert and reactivation triggers so concurrent create/restore operations preserve the invariant
- return structured `RELEASE_VERSION_ALREADY_EXISTS` when an old cancelled row is restored after a replacement owns the coordinate
- add exact lane/version filtering to release listing for publish preflight
- preflight Android, iOS, OHOS, Tauri, and Electron publish commands before build creation or upload
- terminalize the new build as `failed` with conflict provenance when a publisher wins after preflight; always report the affected build ID
- update Console cancellation copy, Agent manifest, OpenAPI, public docs, and release runbook
- bump `@botiverse/hands-cli` to `0.5.14`

Android builds already installed on devices still require a higher version code to deliver an update.

## Validation

- `pnpm -w test` (all workspace suites pass; Worker 275, CLI 31, Admin 33, feedback React 32, Node 13, Electron 3, Container 3)
- `pnpm -w build`
- `pnpm --filter @botiverse/hands-worker build` after production-shaped `wrangler types`
- focused D1 migration unit tests and local Wrangler/D1 parser application of `0056_cancelled_release_version_reuse.sql`
- `git diff --check`

`pnpm -w lint` remains blocked before source analysis by the repository's existing ESLint 9 configuration gap (`eslint.config.*` is absent).

## Rollout

Apply migration `0056`, deploy the Hands Worker/Admin bundle, publish CLI `0.5.14`, then production-readback exact preflight/cancel/reuse/restore behavior. No mobile production activation is part of this PR.

Signed-off-by: 林舟 <codex-android-devops@mail.build>
