### PR TITLE
Bind activated release versions to their binary after cancellation

### DIFF
--- a/migrations/sql/0057_activated_version_reuse_guard.sql
+++ b/migrations/sql/0057_activated_version_reuse_guard.sql
@@ -1,0 +1,26 @@
+-- Once a release has been activated (shipped to clients), its version
+-- coordinate is permanently bound to that build's binary. Migration 0056
+-- released every cancelled coordinate for reuse; that silently allowed two
+-- different binaries to ship under one version coordinate, which breaks the
+-- version_code leg of the binary/build/symbols identity binding (crash
+-- symbolication selects symbol assets by version_code; Android retrace has no
+-- build-id check and would produce silently wrong stacks).
+--
+-- New rule, both directions:
+--   * never-activated cancelled coordinates remain reusable (0056 intent:
+--     a wrong upload that never shipped can be corrected under the same
+--     version);
+--   * a cancelled release with activated_at set blocks any OTHER build from
+--     taking the coordinate — on insert and on un-cancel of a different
+--     release — while re-releasing the SAME build (identical binary) stays
+--     allowed.
+--
+-- Cloudflare's remote D1 migration parser requires trigger bodies on one
+-- physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact.
+
+DROP TRIGGER IF EXISTS trg_releases_version_once_insert;
+DROP TRIGGER IF EXISTS trg_releases_version_once_reactivate;
+
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_insert BEFORE INSERT ON releases WHEN EXISTS (SELECT 1 FROM builds incoming JOIN releases existing ON existing.app_id = NEW.app_id AND existing.channel_id = NEW.channel_id AND existing.product_type = NEW.product_type AND existing.release_type = NEW.release_type JOIN builds existing_build ON existing_build.id = existing.build_id WHERE incoming.id = NEW.build_id AND incoming.app_id = NEW.app_id AND existing_build.version_code = incoming.version_code AND (existing.status <> 'cancelled' OR (existing.activated_at IS NOT NULL AND existing.build_id <> NEW.build_id))) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
+
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_reactivate BEFORE UPDATE OF status ON releases WHEN OLD.status = 'cancelled' AND NEW.status <> 'cancelled' AND EXISTS (SELECT 1 FROM builds target_build JOIN releases existing ON existing.app_id = OLD.app_id AND existing.channel_id = OLD.channel_id AND existing.product_type = OLD.product_type AND existing.release_type = OLD.release_type AND existing.id <> OLD.id JOIN builds existing_build ON existing_build.id = existing.build_id WHERE target_build.id = OLD.build_id AND existing_build.version_code = target_build.version_code AND (existing.status <> 'cancelled' OR (existing.activated_at IS NOT NULL AND existing.build_id <> OLD.build_id))) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;

--- a/migrations/sql/0057_activated_version_reuse_guard.sql
+++ b/migrations/sql/0057_activated_version_reuse_guard.sql
@@ -10,10 +10,14 @@
 --   * never-activated cancelled coordinates remain reusable (0056 intent:
 --     a wrong upload that never shipped can be corrected under the same
 --     version);
---   * a cancelled release with activated_at set blocks any OTHER build from
---     taking the coordinate — on insert and on un-cancel of a different
---     release — while re-releasing the SAME build (identical binary) stays
---     allowed.
+--   * a cancelled release with activated_at set blocks EVERY new release at
+--     that coordinate — on insert and on un-cancel of another release. No
+--     same-build exemption: "same build row" does not currently guarantee
+--     "same bytes" (build assets are mutable after activation), so an
+--     exemption keyed on build_id would be bypassable by swapping the build's
+--     installable asset. Restoring the original shipped release is still
+--     possible by un-cancelling that release itself (rollback), which the
+--     reactivate trigger permits via its existing self-exclusion.
 --
 -- Cloudflare's remote D1 migration parser requires trigger bodies on one
 -- physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact.
@@ -21,6 +25,6 @@
 DROP TRIGGER IF EXISTS trg_releases_version_once_insert;
 DROP TRIGGER IF EXISTS trg_releases_version_once_reactivate;
 
-CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_insert BEFORE INSERT ON releases WHEN EXISTS (SELECT 1 FROM builds incoming JOIN releases existing ON existing.app_id = NEW.app_id AND existing.channel_id = NEW.channel_id AND existing.product_type = NEW.product_type AND existing.release_type = NEW.release_type JOIN builds existing_build ON existing_build.id = existing.build_id WHERE incoming.id = NEW.build_id AND incoming.app_id = NEW.app_id AND existing_build.version_code = incoming.version_code AND (existing.status <> 'cancelled' OR (existing.activated_at IS NOT NULL AND existing.build_id <> NEW.build_id))) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_insert BEFORE INSERT ON releases WHEN EXISTS (SELECT 1 FROM builds incoming JOIN releases existing ON existing.app_id = NEW.app_id AND existing.channel_id = NEW.channel_id AND existing.product_type = NEW.product_type AND existing.release_type = NEW.release_type JOIN builds existing_build ON existing_build.id = existing.build_id WHERE incoming.id = NEW.build_id AND incoming.app_id = NEW.app_id AND existing_build.version_code = incoming.version_code AND (existing.status <> 'cancelled' OR existing.activated_at IS NOT NULL)) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
 
-CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_reactivate BEFORE UPDATE OF status ON releases WHEN OLD.status = 'cancelled' AND NEW.status <> 'cancelled' AND EXISTS (SELECT 1 FROM builds target_build JOIN releases existing ON existing.app_id = OLD.app_id AND existing.channel_id = OLD.channel_id AND existing.product_type = OLD.product_type AND existing.release_type = OLD.release_type AND existing.id <> OLD.id JOIN builds existing_build ON existing_build.id = existing.build_id WHERE target_build.id = OLD.build_id AND existing_build.version_code = target_build.version_code AND (existing.status <> 'cancelled' OR (existing.activated_at IS NOT NULL AND existing.build_id <> OLD.build_id))) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;
+CREATE TRIGGER IF NOT EXISTS trg_releases_version_once_reactivate BEFORE UPDATE OF status ON releases WHEN OLD.status = 'cancelled' AND NEW.status <> 'cancelled' AND EXISTS (SELECT 1 FROM builds target_build JOIN releases existing ON existing.app_id = OLD.app_id AND existing.channel_id = OLD.channel_id AND existing.product_type = OLD.product_type AND existing.release_type = OLD.release_type AND existing.id <> OLD.id JOIN builds existing_build ON existing_build.id = existing.build_id WHERE target_build.id = OLD.build_id AND existing_build.version_code = target_build.version_code AND (existing.status <> 'cancelled' OR existing.activated_at IS NOT NULL)) BEGIN SELECT RAISE(ABORT, 'release version already exists'); END;

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1093,7 +1093,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "cancel-release",
-        description: "Disable one draft or active release without deleting its build, assets, or audit history. If the release never activated, the cancelled row stops reserving its version so a corrected build may use that coordinate. If the release ever activated (reached clients), its version stays bound to that binary and is enforced: corrected client bits require a higher version code; only the identical build may re-release under the same version. Requires app publisher.",
+        description: "Disable one draft or active release without deleting its build, assets, or audit history. If the release never activated, the cancelled row stops reserving its version so a corrected build may use that coordinate. If the release ever activated (reached clients), its version coordinate stays permanently reserved and this is enforced: corrected client bits require a higher version code. Restoring the original shipped release is done by un-cancelling it (rollback), not by publishing a new release at that version. Requires app publisher.",
         endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1093,7 +1093,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
       },
       {
         name: "cancel-release",
-        description: "Disable one draft or active release without deleting its build, assets, or audit history. The cancelled row stops reserving its version so a corrected build may use that coordinate; if the release reached clients, corrected client bits still require a higher version code. Requires app publisher.",
+        description: "Disable one draft or active release without deleting its build, assets, or audit history. If the release never activated, the cancelled row stops reserving its version so a corrected build may use that coordinate. If the release ever activated (reached clients), its version stays bound to that binary and is enforced: corrected client bits require a higher version code; only the identical build may re-release under the same version. Requires app publisher.",
         endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}" },
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "App UUID." },

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -449,7 +449,7 @@ async function findReleaseForVersionIdentity(
      JOIN builds b ON b.id = r.build_id
      WHERE r.app_id = ?1 AND r.channel_id = ?2 AND r.product_type = ?3
        AND r.release_type = ?4 AND b.version_code = ?5
-       AND r.status <> 'cancelled'
+       AND (r.status <> 'cancelled' OR r.activated_at IS NOT NULL)
      ORDER BY CASE r.status
        WHEN 'active' THEN 0 WHEN 'draft' THEN 1 WHEN 'superseded' THEN 2 ELSE 3
      END, r.created_at ASC, r.id ASC
@@ -504,7 +504,13 @@ export async function createRelease(
     releaseType,
     build.version_code,
   );
-  if (existingVersion) throw new ReleaseVersionAlreadyExistsError(existingVersion);
+  // A cancelled release that never activated does not appear in the lookup
+  // (coordinate is free). A cancelled release that DID activate keeps the
+  // coordinate bound to its binary: only the identical build may re-release.
+  if (
+    existingVersion
+    && !(existingVersion.status === "cancelled" && existingVersion.build_id === input.build_id)
+  ) throw new ReleaseVersionAlreadyExistsError(existingVersion);
   const now = Date.now();
   const changelog = inputChangelog(input);
 

--- a/worker/src/routes/releases.ts
+++ b/worker/src/routes/releases.ts
@@ -505,12 +505,11 @@ export async function createRelease(
     build.version_code,
   );
   // A cancelled release that never activated does not appear in the lookup
-  // (coordinate is free). A cancelled release that DID activate keeps the
-  // coordinate bound to its binary: only the identical build may re-release.
-  if (
-    existingVersion
-    && !(existingVersion.status === "cancelled" && existingVersion.build_id === input.build_id)
-  ) throw new ReleaseVersionAlreadyExistsError(existingVersion);
+  // (coordinate is free). A cancelled release that DID activate keeps its
+  // coordinate permanently: restoring it means un-cancelling that release,
+  // not creating a new one. There is no same-build exemption — a build row's
+  // assets are mutable, so "same build" would not guarantee "same bytes".
+  if (existingVersion) throw new ReleaseVersionAlreadyExistsError(existingVersion);
   const now = Date.now();
   const changelog = inputChangelog(input);
 

--- a/worker/test/release_version_reuse_migration.test.ts
+++ b/worker/test/release_version_reuse_migration.test.ts
@@ -199,11 +199,11 @@ describe("cancelled release version reuse migration", () => {
       "release-corrected", "build-corrected", "draft", null,
     )).toThrow("release version already exists");
 
-    // The identical shipped binary may re-release under the same coordinate.
+    // Even the same build row may NOT create a new release at the coordinate:
+    // build assets are mutable, so "same build" does not guarantee "same bytes".
     expect(() => insertRelease.run(
       "release-reissue", "build-shipped", "draft", null,
-    )).not.toThrow();
-    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-reissue'").run();
+    )).toThrow("release version already exists");
 
     // Reactivating a different pre-ship cancelled draft (other binary) is also
     // blocked — un-cancel is the second door into the shipped coordinate.
@@ -211,7 +211,8 @@ describe("cancelled release version reuse migration", () => {
       "UPDATE releases SET status = 'draft' WHERE id = 'release-early-draft'",
     ).run()).toThrow("release version already exists");
 
-    // Restoring the shipped release itself (same binary) stays allowed.
+    // Restoring the shipped release itself (rollback) stays allowed — that is
+    // the supported way to bring a cancelled shipped version back.
     expect(() => db.prepare(
       "UPDATE releases SET status = 'draft' WHERE id = 'release-shipped'",
     ).run()).not.toThrow();

--- a/worker/test/release_version_reuse_migration.test.ts
+++ b/worker/test/release_version_reuse_migration.test.ts
@@ -9,18 +9,23 @@ const identityMigrationPath = fileURLToPath(
 const reuseMigrationPath = fileURLToPath(
   new URL("../../migrations/sql/0056_cancelled_release_version_reuse.sql", import.meta.url),
 );
+const activatedGuardMigrationPath = fileURLToPath(
+  new URL("../../migrations/sql/0057_activated_version_reuse_guard.sql", import.meta.url),
+);
 
 describe("cancelled release version reuse migration", () => {
   it("keeps every remote-D1 trigger body on one physical line", () => {
-    const triggerLines = readFileSync(reuseMigrationPath, "utf8")
-      .split("\n")
-      .filter((line) => line.startsWith("CREATE TRIGGER"));
+    for (const path of [reuseMigrationPath, activatedGuardMigrationPath]) {
+      const triggerLines = readFileSync(path, "utf8")
+        .split("\n")
+        .filter((line) => line.startsWith("CREATE TRIGGER"));
 
-    expect(triggerLines).toHaveLength(2);
-    for (const line of triggerLines) {
-      expect(line).toContain(" BEGIN ");
-      expect(line).toMatch(/ END;$/);
-      expect(line.match(/\bEND;/g)).toHaveLength(1);
+      expect(triggerLines).toHaveLength(2);
+      for (const line of triggerLines) {
+        expect(line).toContain(" BEGIN ");
+        expect(line).toMatch(/ END;$/);
+        expect(line.match(/\bEND;/g)).toHaveLength(1);
+      }
     }
   });
 
@@ -127,5 +132,97 @@ describe("cancelled release version reuse migration", () => {
       { id: "release-new", status: "cancelled" },
       { id: "release-old", status: "draft" },
     ]);
+  });
+
+  it("binds an activated coordinate to its binary even after cancellation", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE builds (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        channel_id TEXT,
+        product_type TEXT NOT NULL,
+        release_type TEXT NOT NULL,
+        version_name TEXT NOT NULL,
+        version_code INTEGER NOT NULL
+      );
+      CREATE TABLE releases (
+        id TEXT PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        build_id TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        product_type TEXT NOT NULL,
+        release_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE release_scopes (
+        id TEXT PRIMARY KEY,
+        release_id TEXT NOT NULL,
+        scope_type TEXT NOT NULL,
+        scope_value TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name, version_code)
+      VALUES
+        ('build-shipped', 'app-a', 'main', 'android-apk', 'stable', '2.0.0', 2000000),
+        ('build-corrected', 'app-a', 'main', 'android-apk', 'stable', '2.0.0', 2000000),
+        ('build-early-draft', 'app-a', 'main', 'android-apk', 'stable', '2.0.0', 2000000),
+        ('build-unshipped', 'app-a', 'main', 'android-apk', 'stable', '2.1.0', 2100000),
+        ('build-unshipped-fix', 'app-a', 'main', 'android-apk', 'stable', '2.1.0', 2100000);
+    `);
+
+    db.exec(readFileSync(identityMigrationPath, "utf8"));
+    db.exec(readFileSync(reuseMigrationPath, "utf8"));
+    db.exec(readFileSync(activatedGuardMigrationPath, "utf8"));
+
+    const insertRelease = db.prepare(`
+      INSERT INTO releases
+        (id, app_id, build_id, channel_id, product_type, release_type, status,
+         created_at, updated_at, activated_at)
+      VALUES (?, 'app-a', ?, 'main', 'android-apk', 'stable', ?, 3, 3, ?)
+    `);
+
+    // A draft that was cancelled before anything shipped at this coordinate.
+    insertRelease.run("release-early-draft", "build-early-draft", "draft", null);
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-early-draft'").run();
+
+    // Ship version 2.0.0 with build-shipped, then cancel it.
+    insertRelease.run("release-shipped", "build-shipped", "active", 100);
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-shipped'").run();
+
+    // Different binary must NOT reuse the shipped coordinate.
+    expect(() => insertRelease.run(
+      "release-corrected", "build-corrected", "draft", null,
+    )).toThrow("release version already exists");
+
+    // The identical shipped binary may re-release under the same coordinate.
+    expect(() => insertRelease.run(
+      "release-reissue", "build-shipped", "draft", null,
+    )).not.toThrow();
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-reissue'").run();
+
+    // Reactivating a different pre-ship cancelled draft (other binary) is also
+    // blocked — un-cancel is the second door into the shipped coordinate.
+    expect(() => db.prepare(
+      "UPDATE releases SET status = 'draft' WHERE id = 'release-early-draft'",
+    ).run()).toThrow("release version already exists");
+
+    // Restoring the shipped release itself (same binary) stays allowed.
+    expect(() => db.prepare(
+      "UPDATE releases SET status = 'draft' WHERE id = 'release-shipped'",
+    ).run()).not.toThrow();
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-shipped'").run();
+
+    // 0056 intent preserved: a never-activated cancelled coordinate stays
+    // fully reusable by a different binary.
+    insertRelease.run("release-unshipped", "build-unshipped", "draft", null);
+    db.prepare("UPDATE releases SET status = 'cancelled' WHERE id = 'release-unshipped'").run();
+    expect(() => insertRelease.run(
+      "release-unshipped-fix", "build-unshipped-fix", "draft", null,
+    )).not.toThrow();
   });
 });

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -3647,11 +3647,12 @@ describe("quiver releases — draft lifecycle", () => {
       version_code: 41,
     });
 
-    // The identical shipped binary may re-release under the same coordinate.
+    // The same build row is rejected too: assets are mutable, so a build id
+    // does not certify identical bytes.
     const reissue = await handleCreateReleaseDraft(makeReleaseContext("", {
       build_id: "build-shipped-41",
     }));
-    expect(reissue.status).toBe(201);
+    expect(reissue.status).toBe(409);
     await env.DB.prepare("DELETE FROM releases").run();
     await env.DB.prepare(
       "DELETE FROM builds WHERE id IN ('build-shipped-41', 'build-corrected-41')",

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -52,7 +52,7 @@ import {
 } from "../src/routes/qa_artifacts";
 
 const releaseVersionReuseTriggerStatements = readFileSync(
-  new URL("../../migrations/sql/0056_cancelled_release_version_reuse.sql", import.meta.url),
+  new URL("../../migrations/sql/0057_activated_version_reuse_guard.sql", import.meta.url),
   "utf8",
 ).split("\n").filter((line) => line.startsWith("CREATE TRIGGER"));
 
@@ -3618,6 +3618,45 @@ describe("quiver releases — draft lifecycle", () => {
     await expect(env.DB.prepare(
       "SELECT status FROM releases WHERE id = 'rel-version-reserved'",
     ).first()).resolves.toEqual({ status: "cancelled" });
+  });
+
+  it("keeps an activated coordinate bound to its binary after cancellation", async () => {
+    const { handleCreateReleaseDraft } = await import("../src/routes/releases");
+    await seedReleaseBuild("build-shipped-41", 41);
+    await seedReleaseBuild("build-corrected-41", 41);
+    const shipped = await handleCreateReleaseDraft(makeReleaseContext("", {
+      build_id: "build-shipped-41",
+    }));
+    expect(shipped.status).toBe(201);
+    const shippedBody = await responseJson<any>(shipped);
+    await env.DB.prepare(
+      "UPDATE releases SET status = 'cancelled', activated_at = ?1, revision = 1 WHERE id = ?2",
+    ).bind(Date.now(), shippedBody.id).run();
+    await installReleaseVersionReuseTriggers();
+
+    // Activated-then-cancelled coordinate: a different binary is rejected by
+    // the application-layer precheck with the real blocking release surfaced.
+    const corrected = await handleCreateReleaseDraft(makeReleaseContext("", {
+      build_id: "build-corrected-41",
+    }));
+    expect(corrected.status).toBe(409);
+    await expect(responseJson<any>(corrected)).resolves.toMatchObject({
+      code: "RELEASE_VERSION_ALREADY_EXISTS",
+      release_id: shippedBody.id,
+      build_id: "build-shipped-41",
+      version_code: 41,
+    });
+
+    // The identical shipped binary may re-release under the same coordinate.
+    const reissue = await handleCreateReleaseDraft(makeReleaseContext("", {
+      build_id: "build-shipped-41",
+    }));
+    expect(reissue.status).toBe(201);
+    await env.DB.prepare("DELETE FROM releases").run();
+    await env.DB.prepare(
+      "DELETE FROM builds WHERE id IN ('build-shipped-41', 'build-corrected-41')",
+    ).run();
+
   });
 
   it("returns a structured conflict when create loses a trigger race to restore", async () => {


### PR DESCRIPTION
## Problem

Migration 0056 released every cancelled version coordinate for reuse. That silently allowed a different binary to ship under a version coordinate that had already reached clients. The version coordinate is the key several downstream systems trust: crash symbolication selects symbol assets by `(app_id, version_code)` newest-first, and the Android retrace lane applies R8 mappings with no build-id check — so crashes from the old binary would produce silently wrong deobfuscated stacks. The agent manifest documented the boundary ("corrected client bits still require a higher version code") but nothing enforced it.

## Changes

- `migrations/sql/0057_activated_version_reuse_guard.sql`: replaces both version-coordinate triggers. Once a release has activated, its coordinate is **permanently reserved** — no new release may take it, on insert or via un-cancelling a different release. Never-activated cancelled coordinates remain fully reusable (0056's corrected-upload intent).
- `worker/src/routes/releases.ts`: the version-identity lookup now also surfaces activated-cancelled blockers, so the 409 carries the real conflicting release instead of a null-conflict "claimed by another publisher" message.
- `worker/src/routes/auth.ts`: agent-manifest description states the enforced rule.
- Tests: migration test covers both doors plus the reverse control (never-activated reuse still permitted); route fixture installs the 0057 triggers (production truth after this migration) with a route-level scenario for the application-layer precheck.

## Behavior change (intentional, not a regression)

Re-publishing a **new release** at an activated-then-cancelled coordinate is no longer possible — **including with the same build row**. There is deliberately no same-build exemption: a build's installable assets are mutable after activation (see follow-up below), so `build_id` equality does not certify identical bytes, and an exemption keyed on it would be bypassable by swapping the build's asset.

Restoring a cancelled shipped release is still supported through **un-cancelling that release itself** (rollback), which the reactivate trigger permits via its self-exclusion. Callers who previously re-created a release at the same coordinate should use rollback instead, or publish under a higher version code.

## Follow-up

- Build-asset byte integrity for activated builds is a separate, broader issue (an active release's offered assets can change with no cancel/re-release at all) and is tracked in its own task; this PR deliberately does **not** depend on byte immutability.
- A read-only production audit should confirm no reuse occurred in the exposure window since #382 deployed (2026-07-28T13:06:07Z); only a seat with production D1 access can run it.
- Migration applies on the next production deploy.

## Testing

- Worker tests: 280/280 (mutation checks: skipping the 0057 migration in the fixture turns the migration case red; reverting the insert guard predicate turns it red)
- Worker TypeScript build (wrangler-generated bindings): pass
- `git diff --check`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)