### PR TITLE
Add read-only AppGallery listing-review status

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -33,7 +33,7 @@ import {
   handleSetAgcCredentials,
   handleVerifyAgcCredentials,
 } from "./routes/agc_credentials";
-import { handleGetAgcBuildSubmission, handleGetAgcSubmission, handleStartAgcInvitationTest, handleSubmitAgcInvitationTest } from "./routes/agc_testing";
+import { handleAppGalleryReview, handleGetAgcBuildSubmission, handleGetAgcSubmission, handleStartAgcInvitationTest, handleSubmitAgcInvitationTest } from "./routes/agc_testing";
 import {
   handleListApps,
   handleCreateApp,
@@ -942,6 +942,7 @@ admin.post("/api/apps/:appId/builds/:buildId/testflight-expire", requireAppRole(
 admin.post("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("publisher"), handleTestflightPublish);
 admin.get("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("viewer"), handleTestflightPublishStatus);
 admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);
+admin.get("/api/apps/:appId/appgallery-review", requireAppRole("viewer"), handleAppGalleryReview);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);
 // AppGallery Connect Service Account and legacy API client credentials for OHOS publishing.

--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -53,6 +53,56 @@ export async function resolveAgcAppId(auth: AgcAuth, packageName: string, fetchI
   if (!match?.value) throw new AgcApiError(404, `No AGC app found for package ${packageName}`);
   return String(match.value);
 }
+export type AgcReviewStatus = {
+  release_state: number | null;
+  audit_opinion: string | null;
+  copyright_audit_result: string | null;
+  copyright_audit_opinion: string | null;
+  copyright_code_audit_result: string | null;
+  copyright_code_audit_opinion: string | null;
+  record_audit_result: string | null;
+  record_audit_opinion: string | null;
+};
+
+/**
+ * Read-only listing-review status for an AGC app. `releaseType` selects the
+ * lifecycle AGC reports on (1 = the on-sale/listing lane; the invitation-test
+ * lane this file otherwise drives uses 6). Returns the raw provider values
+ * without interpretation: AGC's enums are provider-owned and are surfaced as
+ * received so an unexpected value is visible rather than silently remapped.
+ */
+export async function getAgcReviewStatus(
+  auth: AgcAuth,
+  appId: string,
+  releaseType = 1,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AgcReviewStatus> {
+  const body = await agcJson(
+    auth,
+    `/api/publish/v2/app-info?appId=${encodeURIComponent(appId)}&releaseType=${encodeURIComponent(String(releaseType))}`,
+    {},
+    fetchImpl,
+  );
+  const appInfo = body?.appInfo ?? null;
+  const auditInfo = body?.auditInfo ?? null;
+  const text = (value: unknown): string | null => {
+    if (typeof value === "string") return value.trim() ? value : null;
+    if (typeof value === "number") return String(value);
+    return null;
+  };
+  const releaseState = Number(appInfo?.releaseState);
+  return {
+    release_state: Number.isFinite(releaseState) ? releaseState : null,
+    audit_opinion: text(auditInfo?.auditOpinion),
+    copyright_audit_result: text(auditInfo?.copyRightAuditResult),
+    copyright_audit_opinion: text(auditInfo?.copyRightAuditOpinion),
+    copyright_code_audit_result: text(auditInfo?.copyRightCodeAuditResult),
+    copyright_code_audit_opinion: text(auditInfo?.copyRightCodeAuditOpinion),
+    record_audit_result: text(auditInfo?.recordAuditResult),
+    record_audit_opinion: text(auditInfo?.recordAuditOpinion),
+  };
+}
+
 export async function createAgcInvitationVersion(auth: AgcAuth, appId: string, description: string, selfDetect: boolean, fetchImpl: typeof fetch = fetch) {
   const body = await agcJson(auth, `/api/publish/v2/test/app/version?appId=${encodeURIComponent(appId)}`, { method: "POST", body: JSON.stringify({ releaseType: 6, testType: 3, testDesc: description.slice(0, 50), onshelfSelfDetect: selfDetect ? 1 : 0 }) }, fetchImpl);
   if (!body?.versionId) throw new AgcApiError(502, "AGC did not return a test version id");

--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -90,9 +90,20 @@ export async function getAgcReviewStatus(
     if (typeof value === "number") return String(value);
     return null;
   };
-  const releaseState = Number(appInfo?.releaseState);
+  // Number(null) is 0 and Number("") is 0, so coercing first would report a
+  // missing state as provider enum 0 — inventing a value the provider never
+  // sent. Absent stays absent; the enum itself is passed through unmapped, and
+  // a non-numeric value is reported as absent rather than silently reshaped.
+  const enumValue = (value: unknown): number | null => {
+    if (typeof value === "number") return Number.isFinite(value) ? value : null;
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+  };
   return {
-    release_state: Number.isFinite(releaseState) ? releaseState : null,
+    release_state: enumValue(appInfo?.releaseState),
     audit_opinion: text(auditInfo?.auditOpinion),
     copyright_audit_result: text(auditInfo?.copyRightAuditResult),
     copyright_audit_opinion: text(auditInfo?.copyRightAuditOpinion),

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -40,7 +40,10 @@ export async function handleAppGalleryReview(c: AdminContext) {
     .bind(appId)
     .first<{ platform: string }>();
   if (!app) return c.json({ error: "app not found" }, 404);
-  if (app.platform !== "harmony") return c.json({ platform: app.platform, applicable: false });
+  // AppGallery is the HarmonyOS store. The canonical platform value is "ohos"
+  // (see lib/app_platform.ts); "harmony" is not one of them, so comparing
+  // against it made this route inapplicable for every real app.
+  if (app.platform !== "ohos") return c.json({ platform: app.platform, applicable: false });
 
   let packageName: string | null = null;
   try {
@@ -77,10 +80,15 @@ export async function handleAppGalleryReview(c: AdminContext) {
     // Only AgcApiError carries a message we construct and control (provider
     // text plus HTTP status). Anything else — credential decryption, private
     // key parsing — returns a fixed string so an unbounded internal message
-    // can never reach a viewer; detail stays in the server log.
+    // can never reach a viewer, and only its error class is logged.
     if (!(error instanceof AgcApiError)) {
+      // Only a stable category, never the raw message: these are credential
+      // decryption and private-key parsing failures, whose text can embed the
+      // key material itself. A log sink is persistent storage like any other.
       console.error(
-        `[appgallery-review] app ${appId}: ${error instanceof Error ? error.message : String(error)}`,
+        `[appgallery-review] app ${appId}: unexpected ${
+          error instanceof Error ? error.constructor.name : typeof error
+        }`,
       );
     }
     const message = error instanceof AgcApiError

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { insertAuditLog } from "../lib/permissions";
 import { agcCredentialKind, getAgcCredentials, type AgcApiClientCredential, type AgcServiceAccountCredential } from "../lib/agc_credentials";
-import { addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion, uploadAgcObject } from "../lib/agc_api";
+import { addAgcTestPackage, AgcApiError, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, getAgcReviewStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion, uploadAgcObject } from "../lib/agc_api";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 type Submission = { id: string; app_id: string; build_id: string; state: string; external_app_id: string; external_version_id: string; external_package_id: string; provider_state_json: string; error_message: string | null; created_at: number; updated_at: number };
@@ -27,6 +27,63 @@ async function event(db: D1Database, submissionId: string, state: string, detail
     db.prepare("INSERT INTO market_submission_events (id, submission_id, state, detail_json, created_at) VALUES (?1,?2,?3,?4,?5)").bind(crypto.randomUUID(), submissionId, state, JSON.stringify(detail), now),
   ]);
 }
+/**
+ * Read-only AppGallery listing-review status. Mirrors the App Store review
+ * panel: no submission is performed and nothing is written — the credential is
+ * used strictly to read. Provider enum values are passed through unmapped so an
+ * unrecognised state is visible instead of being silently relabelled.
+ */
+export async function handleAppGalleryReview(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  if (!c.env.AGC_CRED_ENC_KEY) return c.json({ error: "server is missing AGC_CRED_ENC_KEY" }, 500);
+  const app = await c.env.DB.prepare("SELECT platform FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ platform: string }>();
+  if (!app) return c.json({ error: "app not found" }, 404);
+  if (app.platform !== "harmony") return c.json({ platform: app.platform, applicable: false });
+
+  const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, appId);
+  if (!credential) return c.json({ configured: false, applicable: true });
+
+  const packageRow = await c.env.DB.prepare(
+    "SELECT bundle_id FROM channels WHERE app_id = ?1 AND slug = 'main' LIMIT 1",
+  ).bind(appId).first<{ bundle_id: string | null }>();
+  const packageName = (packageRow?.bundle_id ?? "").trim() || null;
+  if (!packageName) {
+    return c.json({
+      configured: true,
+      applicable: true,
+      package_name: null,
+      needs_package_name: true,
+      error: "No AppGallery package name is set on the main channel.",
+    });
+  }
+
+  try {
+    const agcAuth = await auth(c);
+    const externalAppId = await resolveAgcAppId(agcAuth, packageName);
+    const review = await getAgcReviewStatus(agcAuth, externalAppId);
+    return c.json({
+      configured: true,
+      applicable: true,
+      package_name: packageName,
+      agc_app_id: externalAppId,
+      review,
+    });
+  } catch (error) {
+    const message = error instanceof AgcApiError || error instanceof Error
+      ? error.message
+      : "AppGallery review status is unavailable";
+    return c.json({
+      configured: true,
+      applicable: true,
+      package_name: packageName,
+      review: null,
+      review_error: message,
+    });
+  }
+}
+
 export async function handleStartAgcInvitationTest(c: AdminContext) {
   const appId = c.req.param("appId") ?? ""; const buildId = c.req.param("buildId") ?? "";
   const body = await c.req.json().catch(() => ({})) as { package_name?: unknown; test_desc?: unknown; onshelf_self_detect?: unknown };

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -42,24 +42,27 @@ export async function handleAppGalleryReview(c: AdminContext) {
   if (!app) return c.json({ error: "app not found" }, 404);
   if (app.platform !== "harmony") return c.json({ platform: app.platform, applicable: false });
 
-  const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, appId);
-  if (!credential) return c.json({ configured: false, applicable: true });
-
-  const packageRow = await c.env.DB.prepare(
-    "SELECT bundle_id FROM channels WHERE app_id = ?1 AND slug = 'main' LIMIT 1",
-  ).bind(appId).first<{ bundle_id: string | null }>();
-  const packageName = (packageRow?.bundle_id ?? "").trim() || null;
-  if (!packageName) {
-    return c.json({
-      configured: true,
-      applicable: true,
-      package_name: null,
-      needs_package_name: true,
-      error: "No AppGallery package name is set on the main channel.",
-    });
-  }
-
+  let packageName: string | null = null;
   try {
+    // Credential load is inside the guard: decryption and key parsing can
+    // throw, and those messages must never escape to the caller either.
+    const credential = await getAgcCredentials(c.env.DB, c.env.AGC_CRED_ENC_KEY, appId);
+    if (!credential) return c.json({ configured: false, applicable: true });
+
+    const packageRow = await c.env.DB.prepare(
+      "SELECT bundle_id FROM channels WHERE app_id = ?1 AND slug = 'main' LIMIT 1",
+    ).bind(appId).first<{ bundle_id: string | null }>();
+    packageName = (packageRow?.bundle_id ?? "").trim() || null;
+    if (!packageName) {
+      return c.json({
+        configured: true,
+        applicable: true,
+        package_name: null,
+        needs_package_name: true,
+        error: "No AppGallery package name is set on the main channel.",
+      });
+    }
+
     const agcAuth = await auth(c);
     const externalAppId = await resolveAgcAppId(agcAuth, packageName);
     const review = await getAgcReviewStatus(agcAuth, externalAppId);
@@ -71,7 +74,16 @@ export async function handleAppGalleryReview(c: AdminContext) {
       review,
     });
   } catch (error) {
-    const message = error instanceof AgcApiError || error instanceof Error
+    // Only AgcApiError carries a message we construct and control (provider
+    // text plus HTTP status). Anything else — credential decryption, private
+    // key parsing — returns a fixed string so an unbounded internal message
+    // can never reach a viewer; detail stays in the server log.
+    if (!(error instanceof AgcApiError)) {
+      console.error(
+        `[appgallery-review] app ${appId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    const message = error instanceof AgcApiError
       ? error.message
       : "AppGallery review status is unavailable";
     return c.json({

--- a/worker/test/agc_review.test.ts
+++ b/worker/test/agc_review.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the read-only AppGallery listing-review helper. The endpoint
+ * must query the listing lane, surface provider values unmapped, and stay
+ * strictly read-only: no request it issues may be anything but a GET.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { getAgcReviewStatus, AgcApiError } from "../src/lib/agc_api";
+
+const auth = { clientId: "client-1", accessToken: "token-1" };
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+const rejectedBody = {
+  ret: { code: 0, msg: "success" },
+  appInfo: { releaseState: 3, defaultLang: "zh-CN" },
+  auditInfo: {
+    auditOpinion: "应用图标资源需分层，尺寸需满足规范要求",
+    copyRightAuditResult: "1",
+    copyRightAuditOpinion: null,
+    copyRightCodeAuditResult: null,
+    copyRightCodeAuditOpinion: "",
+    recordAuditResult: "0",
+    recordAuditOpinion: "备案通过",
+  },
+  languages: [],
+};
+
+describe("getAgcReviewStatus", () => {
+  it("queries the listing lane and flattens the provider audit fields", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(rejectedBody));
+    const status = await getAgcReviewStatus(auth, "app-42", 1, fetchMock as unknown as typeof fetch);
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(
+      "https://connect-api.cloud.huawei.com/api/publish/v2/app-info?appId=app-42&releaseType=1",
+    );
+    // Read-only: no method override means GET, and no body is ever sent.
+    expect(init.method ?? "GET").toBe("GET");
+    expect(init.body).toBeUndefined();
+
+    expect(status).toEqual({
+      release_state: 3,
+      audit_opinion: "应用图标资源需分层，尺寸需满足规范要求",
+      copyright_audit_result: "1",
+      copyright_audit_opinion: null,
+      copyright_code_audit_result: null,
+      copyright_code_audit_opinion: null,
+      record_audit_result: "0",
+      record_audit_opinion: "备案通过",
+    });
+  });
+
+  it("defaults to the listing lane rather than the invitation-test lane", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(rejectedBody));
+    await getAgcReviewStatus(auth, "app-42", undefined, fetchMock as unknown as typeof fetch);
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toContain("releaseType=1");
+    expect(url).not.toContain("releaseType=6");
+  });
+
+  it("returns nulls instead of guesses when the provider omits audit data", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ ret: { code: 0 }, appInfo: { releaseState: "not-a-number" } }),
+    );
+    const status = await getAgcReviewStatus(auth, "app-42", 1, fetchMock as unknown as typeof fetch);
+    expect(status.release_state).toBeNull();
+    expect(status.audit_opinion).toBeNull();
+    expect(status.record_audit_result).toBeNull();
+  });
+
+  it("surfaces a provider-level error code even on HTTP 200", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ ret: { code: 204144647, msg: "app not exist" } }),
+    );
+    await expect(
+      getAgcReviewStatus(auth, "missing-app", 1, fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(AgcApiError);
+  });
+});

--- a/worker/test/agc_review.test.ts
+++ b/worker/test/agc_review.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { getAgcReviewStatus, AgcApiError } from "../src/lib/agc_api";
+import { handleAppGalleryReview } from "../src/routes/agc_testing";
 
 const auth = { clientId: "client-1", accessToken: "token-1" };
 
@@ -78,5 +79,57 @@ describe("getAgcReviewStatus", () => {
     await expect(
       getAgcReviewStatus(auth, "missing-app", 1, fetchMock as unknown as typeof fetch),
     ).rejects.toBeInstanceOf(AgcApiError);
+  });
+});
+
+describe("handleAppGalleryReview error disclosure", () => {
+  /** Minimal context whose credential read throws the given error. */
+  function contextThrowing(error: unknown) {
+    return {
+      env: {
+        AGC_CRED_ENC_KEY: "test-key",
+        DB: {
+          prepare(sql: string) {
+            return {
+              bind() {
+                return {
+                  async first() {
+                    if (sql.includes("FROM apps")) return { platform: "harmony" };
+                    if (sql.includes("app_agc_credentials")) throw error;
+                    if (sql.includes("FROM channels")) return { bundle_id: "com.example.app" };
+                    return null;
+                  },
+                };
+              },
+            };
+          },
+        },
+      },
+      req: { param: (name: string) => (name === "appId" ? "app-1" : "") },
+      json: (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), { status }),
+    } as never;
+  }
+
+  it("never leaks a non-AgcApiError message to the caller", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = await handleAppGalleryReview(
+      contextThrowing(new Error("BEGIN PRIVATE KEY MIIEvQIBADANBg internal detail")),
+    );
+    const body = await response.json() as { review_error?: string };
+
+    expect(body.review_error).toBe("AppGallery review status is unavailable");
+    expect(JSON.stringify(body)).not.toContain("PRIVATE KEY");
+    // The detail is not lost — it goes to the server log instead.
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+
+  it("still surfaces provider-controlled AgcApiError text", async () => {
+    const response = await handleAppGalleryReview(
+      contextThrowing(new AgcApiError(404, "No AGC app found for package com.example.app")),
+    );
+    const body = await response.json() as { review_error?: string };
+    expect(body.review_error).toBe("No AGC app found for package com.example.app");
   });
 });

--- a/worker/test/agc_review.test.ts
+++ b/worker/test/agc_review.test.ts
@@ -68,8 +68,26 @@ describe("getAgcReviewStatus", () => {
     );
     const status = await getAgcReviewStatus(auth, "app-42", 1, fetchMock as unknown as typeof fetch);
     expect(status.release_state).toBeNull();
+    expect(status.release_state).not.toBe(0);
     expect(status.audit_opinion).toBeNull();
     expect(status.record_audit_result).toBeNull();
+  });
+
+  it("keeps an absent release state absent instead of reporting enum 0", async () => {
+    // Number(null) and Number("") are both 0, so coercing before checking would
+    // report a state the provider never sent — and 0 is a real enum value.
+    for (const releaseState of [null, undefined, ""]) {
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({ ret: { code: 0 }, appInfo: { releaseState } }),
+      );
+      const status = await getAgcReviewStatus(auth, "app-42", 1, fetchMock as unknown as typeof fetch);
+      expect(status.release_state).toBeNull();
+    }
+    // A genuine 0 from the provider is still reported as 0.
+    const zero = vi.fn(async () => jsonResponse({ ret: { code: 0 }, appInfo: { releaseState: 0 } }));
+    expect(
+      (await getAgcReviewStatus(auth, "app-42", 1, zero as unknown as typeof fetch)).release_state,
+    ).toBe(0);
   });
 
   it("surfaces a provider-level error code even on HTTP 200", async () => {
@@ -94,7 +112,7 @@ describe("handleAppGalleryReview error disclosure", () => {
               bind() {
                 return {
                   async first() {
-                    if (sql.includes("FROM apps")) return { platform: "harmony" };
+                    if (sql.includes("FROM apps")) return { platform: "ohos" };
                     if (sql.includes("app_agc_credentials")) throw error;
                     if (sql.includes("FROM channels")) return { bundle_id: "com.example.app" };
                     return null;
@@ -120,9 +138,47 @@ describe("handleAppGalleryReview error disclosure", () => {
 
     expect(body.review_error).toBe("AppGallery review status is unavailable");
     expect(JSON.stringify(body)).not.toContain("PRIVATE KEY");
-    // The detail is not lost — it goes to the server log instead.
+    // The log sink is persistent storage too: it gets the error class, never
+    // the message, because that message can embed the key material itself.
     expect(errorSpy).toHaveBeenCalledOnce();
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).not.toContain("PRIVATE KEY");
+    expect(logged).not.toContain("MIIEvQIBADANBg");
+    expect(logged).toContain("unexpected Error");
     errorSpy.mockRestore();
+  });
+
+  it("applies to a real ohos app rather than a platform value that does not exist", async () => {
+    // "ohos" is the only canonical HarmonyOS value (lib/app_platform.ts). The
+    // previous guard compared against "harmony", so every real app fell through
+    // to applicable:false and the feature could never run in production.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = await handleAppGalleryReview(
+      contextThrowing(new AgcApiError(404, "No AGC app found for package com.example.app")),
+    );
+    const body = await response.json() as { applicable?: boolean; platform?: string };
+
+    expect(body.applicable).toBe(true);
+    expect(body.platform).toBeUndefined();
+    errorSpy.mockRestore();
+  });
+
+  it("reports a non-ohos app as inapplicable", async () => {
+    const context = contextThrowing(new AgcApiError(404, "unused"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx = context as any;
+    const originalPrepare = ctx.env.DB.prepare;
+    ctx.env.DB.prepare = (sql: string) =>
+      sql.includes("FROM apps")
+        ? { bind: () => ({ first: async () => ({ platform: "android" }) }) }
+        : originalPrepare(sql);
+
+    const body = await (await handleAppGalleryReview(context)).json() as {
+      applicable?: boolean;
+      platform?: string;
+    };
+    expect(body.applicable).toBe(false);
+    expect(body.platform).toBe("android");
   });
 
   it("still surfaces provider-controlled AgcApiError text", async () => {


### PR DESCRIPTION
## Problem

Hands surfaces App Store review state (`GET /api/apps/:appId/appstore-review` returns version states and TestFlight beta review states), but has no equivalent for AppGallery. The AGC client's existing functions all serve the invitation-test distribution lane, so a listing-review rejection — for example "应用图标资源需分层" — is invisible in the console and only visible by logging into AGC.

## Changes

- `worker/src/lib/agc_api.ts`: `getAgcReviewStatus()` reads the listing lane's `app-info` and flattens `releaseState` plus the audit verdicts (`auditOpinion`, copyright and record results/opinions). Provider enum values are surfaced unmapped, so an unrecognised state stays visible instead of being silently relabelled.
- `worker/src/routes/agc_testing.ts`: `handleAppGalleryReview()` mirrors the App Store panel's shape — non-HarmonyOS apps return `applicable: false`, a missing credential returns `configured: false`, a missing package name says so explicitly, and a provider failure returns `review_error` alongside the resolved identifiers rather than collapsing the response.
- `worker/src/index.ts`: `GET /api/apps/:appId/appgallery-review`, viewer role, alongside the App Store route.

## Scope boundary

**This lane only reads.** No submission is performed and nothing is written — the credential stays in a strictly-read role for the listing lifecycle. Driving formal submission remains manual and is deliberately out of scope; adding it later would be a separate permission decision, not just more code.

## Follow-up

- Console panel (rendering this next to the App Store review panel) is not included here.
- The AGC listing lane's `releaseType` and audit-field semantics are provider-owned; the first real-account read should confirm the values against a known-rejected app before the panel maps them to product wording.

## Testing

- `worker/test/agc_review.test.ts`: endpoint/lane assertion, read-only assertion (no method override, no body), null-instead-of-guess on missing provider data, and provider-error-on-HTTP-200 propagation
- Worker tests: 282/282 (mutation check: pointing the query at the invitation-test lane turns two cases red)
- Worker TypeScript build (wrangler-generated bindings): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)