### PR TITLE
fix(ohos-sdk): preserve pending native crash reports

### DIFF
--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "SDK version to publish. Must match clients/ohos/hands/oh-package.json5."
         required: true
-        default: "0.2.1"
+        default: "0.3.3"
       dry_run:
         description: "Build and prepublish only; skip ohpm publish."
         required: true
@@ -82,6 +82,14 @@ jobs:
           command -v hvigorw
           ohpm --version
           hvigorw --version
+
+      - name: Test crash storage contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          pnpm install --filter @botiverse/hands-ohos-contract-tests... --frozen-lockfile
+          pnpm --filter @botiverse/hands-ohos-contract-tests test
 
       - name: Build HAR
         working-directory: clients/ohos

--- a/clients/ohos/README.md
+++ b/clients/ohos/README.md
@@ -29,10 +29,12 @@ Hands.install({
   appSlug: 'my-app',
   channel: 'main',          // Hands release-channel routing field
   clientKey: 'qk_…',
-});
+}, this.context);
 ```
 
-Call it as early as possible (UIAbility `onCreate`).
+Call it as early as possible (UIAbility `onCreate`). Passing the context
+enables ArkTS/native crash capture, device analytics, and next-launch pending
+crash upload.
 
 ## Feedback
 
@@ -43,7 +45,7 @@ const ticketId = await HandsFeedbackClient.submit(
   context,                    // common.UIAbilityContext
   'Feed does not refresh',    // message
   'bug',                      // 'feedback' | 'bug' | 'crash'
-  [logFilePath],              // up to 3 files, 10 MB each
+  [logFilePath],              // up to 9 files; 50 MB OHOS cap
   [],                         // extras: Array<{ key, value }>
 );
 ```
@@ -52,6 +54,13 @@ Device metadata (version, model, OS, ABI, locale, per-install device id) is
 attached automatically.
 
 ## Crash reporting (store-then-send)
+
+`Hands.install(config, context)` automatically registers the ArkTS error
+observer and the system `APP_CRASH` / `APP_FREEZE` watcher. Native faults are
+retained by HarmonyOS and converted into pending crash pairs on the next
+launch; Hands deletes each pair only after its ticket is created.
+
+The lower-level uploader remains available for app-owned crash sources:
 
 At crash time (e.g. an `errorManager` observer), write the crash log and its
 signature sidecar — no network in the dying process:

--- a/clients/ohos/hands/README.md
+++ b/clients/ohos/hands/README.md
@@ -6,7 +6,8 @@ Hands feedback + crash reporting SDK for HarmonyOS (ArkTS).
   device metadata. Large attachments (up to the configured cap) upload directly
   to storage via presigned URLs; smaller ones go inline.
 - **Crash reporting** — store-then-send crash capture, uploaded as crash tickets
-  on the next launch.
+  on the next launch. Existing crash directories and individual malformed
+  system fault events do not block the rest of the pending batch.
 - **Device id** — a stable per-install id for rollout/analytics correlation.
 
 Configured at runtime (base URL, app slug, channel, client key are init

--- a/clients/ohos/hands/changelog.md
+++ b/clients/ohos/hands/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.3
+
+- Add unified `addBreadcrumb` and handled-error `captureException` APIs.
+- Make crash-directory creation idempotent on HarmonyOS, where recursive
+  `mkdirSync` still throws when the leaf directory already exists.
+- Isolate system fault events so one malformed or unwritable event cannot drop
+  the rest of the `APP_CRASH` / `APP_FREEZE` batch.
+- Use collision-resistant crash filenames, keep the full five-file retention
+  window, and delete a pending crash pair only after ticket creation succeeds.
+- Align the `hands_sdk` ticket metadata with the published package version.
+
 ## 0.3.2
 
 - Native crashes now ship the full backtrace, not just a top-frame summary.

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "Oranix",

--- a/clients/ohos/hands/src/main/ets/Hands.ets
+++ b/clients/ohos/hands/src/main/ets/Hands.ets
@@ -51,7 +51,12 @@ export class Hands {
       // Device ping + pending-crash upload off the launch critical path.
       setTimeout(() => {
         HandsAnalytics.reportDevice(context).catch((): void => {});
-        HandsCrashUploader.enforceRetention(context);
+        try {
+          HandsCrashUploader.enforceRetention(context);
+        } catch (_error) {
+          // Retention is best-effort; it must never suppress upload of an
+          // already-complete pending crash pair.
+        }
         HandsCrashUploader.uploadPending(context).catch((): void => {});
       }, 3000);
     }

--- a/clients/ohos/hands/src/main/ets/HandsCrashReporter.ets
+++ b/clients/ohos/hands/src/main/ets/HandsCrashReporter.ets
@@ -1,7 +1,7 @@
 import { bundleManager, common, errorManager } from '@kit.AbilityKit';
 import deviceInfo from '@ohos.deviceInfo';
-import fs from '@ohos.file.fs';
 import hilog from '@ohos.hilog';
+import { HandsCrashStorage } from './HandsCrashStorage';
 import { HandsCrashUploader } from './HandsCrashUploader';
 
 const TAG: string = 'HandsCrashReporter';
@@ -35,8 +35,7 @@ export class HandsCrashReporter {
   private static capture(context: common.UIAbilityContext, reason: string, errorText: string): void {
     try {
       const crashLog = HandsCrashReporter.buildCrashLog(context, reason, errorText).slice(0, CRASH_LOG_MAX_CHARS);
-      const crashPath = HandsCrashReporter.writeCrashLog(context, crashLog);
-      HandsCrashUploader.enforceRetention(context);
+      const crashPath = HandsCrashStorage.writeLog(context, crashLog);
       const firstLine = errorText.split('\n')[0] ?? '';
       const exceptionClass = firstLine.split(':')[0]?.trim() ?? 'OhosCrash';
       const exceptionMessage = firstLine.slice(exceptionClass.length + 1).trim();
@@ -50,6 +49,12 @@ export class HandsCrashReporter {
       });
     } catch (error) {
       hilog.error(0x0000, TAG, 'failed to write crash: %{public}s', String(error));
+      return;
+    }
+    try {
+      HandsCrashUploader.enforceRetention(context);
+    } catch (error) {
+      hilog.warn(0x0000, TAG, 'failed enforcing crash retention: %{public}s', String(error));
     }
   }
 
@@ -69,20 +74,6 @@ export class HandsCrashReporter {
       errorText,
     ];
     return lines.join('\n');
-  }
-
-  private static writeCrashLog(context: common.UIAbilityContext, crashLog: string): string {
-    const crashDir = `${context.filesDir}/crashes`;
-    fs.mkdirSync(crashDir, true);
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crashPath = `${crashDir}/crash-${timestamp}.txt`;
-    const file = fs.openSync(crashPath, fs.OpenMode.CREATE | fs.OpenMode.TRUNC | fs.OpenMode.WRITE_ONLY);
-    try {
-      fs.writeSync(file.fd, crashLog);
-    } finally {
-      fs.closeSync(file);
-    }
-    return crashPath;
   }
 
   private static errorToText(error: Error): string {

--- a/clients/ohos/hands/src/main/ets/HandsCrashStorage.ets
+++ b/clients/ohos/hands/src/main/ets/HandsCrashStorage.ets
@@ -1,0 +1,59 @@
+import { common } from '@kit.AbilityKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import fs from '@ohos.file.fs';
+import util from '@ohos.util';
+import {
+  crashLogFileName,
+  ensureCrashDirectory,
+} from './HandsCrashStoragePolicy';
+
+const FILE_EXISTS_ERROR_CODE: number = 13900015;
+
+/** Shared, fail-closed storage boundary for ArkTS and system fault captures. */
+export class HandsCrashStorage {
+  static crashDir(context: common.UIAbilityContext): string {
+    return `${context.filesDir}/crashes`;
+  }
+
+  static writeLog(
+    context: common.UIAbilityContext,
+    crashLog: string,
+    label: string = '',
+    timestampMillis: number = Date.now(),
+  ): string {
+    const crashDir = HandsCrashStorage.crashDir(context);
+    HandsCrashStorage.ensureDirectory(crashDir);
+    const crashPath = `${crashDir}/${crashLogFileName(
+      timestampMillis,
+      util.generateRandomUUID(true),
+      label,
+    )}`;
+    const file = fs.openSync(
+      crashPath,
+      fs.OpenMode.CREATE | fs.OpenMode.TRUNC | fs.OpenMode.WRITE_ONLY,
+    );
+    try {
+      fs.writeSync(file.fd, crashLog);
+    } finally {
+      fs.closeSync(file);
+    }
+    return crashPath;
+  }
+
+  private static ensureDirectory(path: string): void {
+    ensureCrashDirectory(
+      (): boolean => HandsCrashStorage.pathIsDirectory(path),
+      (): void => fs.mkdirSync(path, true),
+      (error: Object): boolean => (error as BusinessError).code === FILE_EXISTS_ERROR_CODE,
+    );
+  }
+
+  private static pathIsDirectory(path: string): boolean {
+    try {
+      const stat = fs.lstatSync(path);
+      return !stat.isSymbolicLink() && stat.isDirectory();
+    } catch (_error) {
+      return false;
+    }
+  }
+}

--- a/clients/ohos/hands/src/main/ets/HandsCrashStoragePolicy.ts
+++ b/clients/ohos/hands/src/main/ets/HandsCrashStoragePolicy.ts
@@ -1,0 +1,71 @@
+/** Runtime/package version reported with OHOS feedback and crash tickets. */
+export const HANDS_OHOS_SDK_VERSION: string = '0.3.3';
+
+/**
+ * Creates a directory exactly once without treating an already-created
+ * directory as a failure. The caller supplies the platform file operations so
+ * this policy stays executable in host-side contract tests.
+ */
+export function ensureCrashDirectory(
+  isDirectory: () => boolean,
+  createDirectory: () => void,
+  isFileExistsError: (error: Object) => boolean,
+): void {
+  if (isDirectory()) {
+    return;
+  }
+  try {
+    createDirectory();
+  } catch (error) {
+    if (isFileExistsError(error as Object) && isDirectory()) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/** Build a collision-resistant crash filename from a fixed timestamp and id. */
+export function crashLogFileName(
+  timestampMillis: number,
+  uniqueId: string,
+  label: string = '',
+): string {
+  if (uniqueId.length === 0) {
+    throw new Error('Crash log unique id must not be empty');
+  }
+  const timestamp = new Date(timestampMillis).toISOString().replace(/[:.]/g, '-');
+  const labelSuffix = label.length > 0 ? `-${label}` : '';
+  return `crash-${timestamp}-${uniqueId}${labelSuffix}.txt`;
+}
+
+/** Return only the oldest crash logs that exceed the bounded retention cap. */
+export function crashLogsBeyondRetention(logNames: string[], maxStoredCrashes: number): string[] {
+  if (maxStoredCrashes < 0) {
+    throw new Error('Crash retention cap must not be negative');
+  }
+  return logNames.slice().sort().reverse().slice(maxStoredCrashes);
+}
+
+/** Run one capture without letting its failure abort later events in a batch. */
+export function runIsolatedCrashCapture(
+  capture: () => void,
+  onFailure: (error: Object) => void,
+): boolean {
+  try {
+    capture();
+    return true;
+  } catch (error) {
+    onFailure(error as Object);
+    return false;
+  }
+}
+
+/** Delete a pending crash pair only after the ticket upload has succeeded. */
+export async function uploadCrashThenDelete(
+  upload: () => Promise<string>,
+  deletePending: () => void,
+): Promise<string> {
+  const ticketId = await upload();
+  deletePending();
+  return ticketId;
+}

--- a/clients/ohos/hands/src/main/ets/HandsCrashUploader.ets
+++ b/clients/ohos/hands/src/main/ets/HandsCrashUploader.ets
@@ -1,6 +1,11 @@
 import { common } from '@kit.AbilityKit';
 import fs from '@ohos.file.fs';
 import hilog from '@ohos.hilog';
+import { HandsCrashStorage } from './HandsCrashStorage';
+import {
+  crashLogsBeyondRetention,
+  uploadCrashThenDelete,
+} from './HandsCrashStoragePolicy';
 import { HandsFeedbackClient, HandsFeedbackExtras } from './HandsFeedbackClient';
 
 const TAG: string = 'HandsCrashUploader';
@@ -24,7 +29,7 @@ export interface CrashMeta {
  */
 export class HandsCrashUploader {
   static crashDir(context: common.UIAbilityContext): string {
-    return `${context.filesDir}/crashes`;
+    return HandsCrashStorage.crashDir(context);
   }
 
   /** Write the signature sidecar next to a crash log. */
@@ -46,10 +51,8 @@ export class HandsCrashUploader {
     }
     const logs = fs
       .listFileSync(dir)
-      .filter((name: string): boolean => name.startsWith('crash-') && name.endsWith('.txt'))
-      .sort()
-      .reverse();
-    for (const name of logs.slice(MAX_STORED_CRASHES - 1)) {
+      .filter((name: string): boolean => name.startsWith('crash-') && name.endsWith('.txt'));
+    for (const name of crashLogsBeyondRetention(logs, MAX_STORED_CRASHES)) {
       HandsCrashUploader.deletePair(`${dir}/${name}`);
     }
   }
@@ -94,8 +97,10 @@ export class HandsCrashUploader {
         { key: 'crash_at', value: String(meta.crash_at ?? 0) },
       ];
       try {
-        const ticketId = await HandsFeedbackClient.submit(context, message, 'crash', [logPath], extras);
-        HandsCrashUploader.deletePair(logPath);
+        const ticketId = await uploadCrashThenDelete(
+          (): Promise<string> => HandsFeedbackClient.submit(context, message, 'crash', [logPath], extras),
+          (): void => HandsCrashUploader.deletePair(logPath),
+        );
         hilog.info(0x0000, TAG, 'uploaded crash %{public}s as %{public}s', sidecarName, ticketId.slice(0, 8));
       } catch (error) {
         hilog.warn(0x0000, TAG, 'crash upload failed for %{public}s: %{public}s', sidecarName, String(error));

--- a/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFaultWatcher.ets
@@ -2,6 +2,8 @@ import { common } from '@kit.AbilityKit';
 import { hiAppEvent } from '@kit.PerformanceAnalysisKit';
 import fs from '@ohos.file.fs';
 import hilog from '@ohos.hilog';
+import { HandsCrashStorage } from './HandsCrashStorage';
+import { runIsolatedCrashCapture } from './HandsCrashStoragePolicy';
 import { HandsCrashUploader } from './HandsCrashUploader';
 
 const TAG: string = 'HandsFaultWatcher';
@@ -57,19 +59,36 @@ export class HandsFaultWatcher {
     domain: string,
     appEventGroups: Array<hiAppEvent.AppEventGroup>,
   ): void {
-    try {
-      for (const group of appEventGroups) {
-        for (const eventInfo of group.appEventInfos) {
-          HandsFaultWatcher.captureFault(context, group.name, eventInfo);
-        }
+    for (const group of appEventGroups) {
+      for (const eventInfo of group.appEventInfos) {
+        runIsolatedCrashCapture(
+          (): void => {
+            HandsFaultWatcher.captureFault(context, group.name, eventInfo);
+          },
+          (error: Object): void => {
+            hilog.error(
+              0x0000,
+              TAG,
+              'failed capturing %{public}s fault event: %{public}s',
+              group.name,
+              String(error),
+            );
+          },
+        );
       }
-      // Fault events arrive while the app is alive (freeze) or on the launch
-      // after a crash — either way an immediate upload attempt is safe.
-      HandsCrashUploader.enforceRetention(context);
-      HandsCrashUploader.uploadPending(context).catch((): void => {});
-    } catch (error) {
-      hilog.error(0x0000, TAG, 'failed handling fault events: %{public}s', String(error));
     }
+    // Fault events arrive while the app is alive (freeze) or on the launch
+    // after a crash — either way an immediate upload attempt is safe. Keep
+    // retention and upload independent so one maintenance failure does not
+    // suppress the other.
+    try {
+      HandsCrashUploader.enforceRetention(context);
+    } catch (error) {
+      hilog.error(0x0000, TAG, 'failed enforcing crash retention: %{public}s', String(error));
+    }
+    HandsCrashUploader.uploadPending(context).catch((error: Object): void => {
+      hilog.warn(0x0000, TAG, 'failed scheduling pending crash upload: %{public}s', String(error));
+    });
   }
 
   private static captureFault(
@@ -100,11 +119,13 @@ export class HandsFaultWatcher {
     // Read those file contents so the crash ticket actually ships the stack.
     const externalFileContents = HandsFaultWatcher.readFaultFiles(params['external_log']);
 
+    const rawFaultTime = Number(params['time'] ?? Date.now());
+    const faultTime = Number.isFinite(rawFaultTime) ? rawFaultTime : Date.now();
     const lines: string[] = [
       'Hands OHOS fault log (hiAppEvent)',
       `Event: ${eventName}`,
       `Fault kind: ${kind}`,
-      `Fault time: ${new Date(Number(params['time'] ?? Date.now())).toString()}`,
+      `Fault time: ${new Date(faultTime).toString()}`,
       `Foreground: ${String(params['foreground'] ?? 'unknown')}`,
       `Bundle version: ${String(params['bundle_version'] ?? '')}`,
       `Pid/Uid: ${String(params['pid'] ?? '')}/${String(params['uid'] ?? '')}`,
@@ -126,14 +147,14 @@ export class HandsFaultWatcher {
     }
     const crashLog = lines.join('\n').slice(0, FAULT_LOG_MAX_CHARS);
 
-    const crashPath = HandsFaultWatcher.writeFaultLog(context, crashLog);
+    const crashPath = HandsCrashStorage.writeLog(context, crashLog, 'fault', faultTime);
     const summary = HandsFaultWatcher.exceptionSummary(exception, kind);
     HandsCrashUploader.writeMeta(crashPath, {
       exception_class: summary.cls,
       exception_message: summary.message,
       top_frame: summary.topFrame,
       reason: eventName === hiAppEvent.event.APP_FREEZE ? 'appFreeze' : 'nativeCrash',
-      crash_at: Number(params['time'] ?? Date.now()),
+      crash_at: faultTime,
     });
     hilog.info(0x0000, TAG, 'captured %{public}s fault', kind);
   }
@@ -240,20 +261,6 @@ export class HandsFaultWatcher {
       }
     }
     return blocks.join('\n\n');
-  }
-
-  private static writeFaultLog(context: common.UIAbilityContext, crashLog: string): string {
-    const crashDir = `${context.filesDir}/crashes`;
-    fs.mkdirSync(crashDir, true);
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const crashPath = `${crashDir}/crash-${timestamp}-fault.txt`;
-    const file = fs.openSync(crashPath, fs.OpenMode.CREATE | fs.OpenMode.TRUNC | fs.OpenMode.WRITE_ONLY);
-    try {
-      fs.writeSync(file.fd, crashLog);
-    } finally {
-      fs.closeSync(file);
-    }
-    return crashPath;
   }
 }
 

--- a/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
@@ -8,13 +8,10 @@ import display from '@ohos.display';
 import statvfs from '@ohos.file.statvfs';
 import batteryInfo from '@ohos.batteryInfo';
 import { Hands } from './Hands';
+import { HANDS_OHOS_SDK_VERSION } from './HandsCrashStoragePolicy';
 import { HandsDeviceId } from './HandsDeviceId';
 
 const TAG: string = 'HandsFeedbackClient';
-
-// Hands OHOS SDK version — reported in feedback/crash environment metadata.
-// Keep in sync with oh-package.json5 on release.
-const HANDS_SDK_VERSION: string = '0.3.1';
 
 // @ohos.batteryInfo BatteryChargeState: NONE=0, ENABLE=1, DISABLE=2, FULL=3.
 function ohBatteryStateName(status: number): string {
@@ -132,7 +129,7 @@ export class HandsFeedbackClient {
       'version_code': bundleInfo.versionCode,
       'bundle_id': bundleInfo.name,
       'platform': 'ohos',
-      'hands_sdk': HANDS_SDK_VERSION,
+      'hands_sdk': HANDS_OHOS_SDK_VERSION,
       'channel': Hands.config.channel,
       // Device
       'device_id': HandsDeviceId.get(context),

--- a/clients/ohos/tests/package.json
+++ b/clients/ohos/tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@botiverse/hands-ohos-contract-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/clients/ohos/tests/src/HandsCrashStoragePolicy.test.ts
+++ b/clients/ohos/tests/src/HandsCrashStoragePolicy.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import {
+  crashLogFileName,
+  crashLogsBeyondRetention,
+  ensureCrashDirectory,
+  HANDS_OHOS_SDK_VERSION,
+  runIsolatedCrashCapture,
+  uploadCrashThenDelete,
+} from '../../hands/src/main/ets/HandsCrashStoragePolicy.ts';
+
+test('pre-existing crash directory is accepted without another mkdir', () => {
+  let createCalls = 0;
+  ensureCrashDirectory(
+    () => true,
+    () => {
+      createCalls += 1;
+    },
+    () => false,
+  );
+  assert.equal(createCalls, 0);
+});
+
+test('EEXIST race is accepted only when the resulting path is a directory', () => {
+  const existsError = { code: 13900015 };
+  let directoryChecks = 0;
+  ensureCrashDirectory(
+    () => {
+      directoryChecks += 1;
+      return directoryChecks > 1;
+    },
+    () => {
+      throw existsError;
+    },
+    (error) => (error as { code?: number }).code === 13900015,
+  );
+  assert.equal(directoryChecks, 2);
+
+  assert.throws(
+    () => ensureCrashDirectory(
+      () => false,
+      () => {
+        throw existsError;
+      },
+      (error) => (error as { code?: number }).code === 13900015,
+    ),
+    (error) => error === existsError,
+  );
+});
+
+test('non-EEXIST directory failures remain fail-closed', () => {
+  const permissionError = { code: 13900012 };
+  assert.throws(
+    () => ensureCrashDirectory(
+      () => false,
+      () => {
+        throw permissionError;
+      },
+      (error) => (error as { code?: number }).code === 13900015,
+    ),
+    (error) => error === permissionError,
+  );
+});
+
+test('same-millisecond crashes receive different stable filenames', () => {
+  const at = Date.parse('2026-07-30T00:19:23.123Z');
+  const first = crashLogFileName(at, 'id-one', 'fault');
+  const second = crashLogFileName(at, 'id-two', 'fault');
+  assert.notEqual(first, second);
+  assert.match(first, /^crash-2026-07-30T00-19-23-123Z-id-one-fault\.txt$/);
+  assert.match(second, /^crash-2026-07-30T00-19-23-123Z-id-two-fault\.txt$/);
+});
+
+test('one failed fault event does not abort later events in the batch', () => {
+  const attempted: number[] = [];
+  const failures: number[] = [];
+  const results = [1, 2, 3].map((value) => runIsolatedCrashCapture(
+    () => {
+      attempted.push(value);
+      if (value === 2) {
+        throw new Error('bad fault event');
+      }
+    },
+    () => failures.push(value),
+  ));
+
+  assert.deepEqual(attempted, [1, 2, 3]);
+  assert.deepEqual(failures, [2]);
+  assert.deepEqual(results, [true, false, true]);
+});
+
+test('retention keeps the newest five logs instead of only four', () => {
+  const logs = [
+    'crash-2026-07-30T00-00-00-000Z-a.txt',
+    'crash-2026-07-30T00-00-01-000Z-b.txt',
+    'crash-2026-07-30T00-00-02-000Z-c.txt',
+    'crash-2026-07-30T00-00-03-000Z-d.txt',
+    'crash-2026-07-30T00-00-04-000Z-e.txt',
+    'crash-2026-07-30T00-00-05-000Z-f.txt',
+  ];
+  assert.deepEqual(crashLogsBeyondRetention(logs, 5), [logs[0]]);
+  assert.deepEqual(crashLogsBeyondRetention(logs.slice(1), 5), []);
+});
+
+test('pending crash is deleted only after ticket creation succeeds', async () => {
+  const successOrder: string[] = [];
+  const ticketId = await uploadCrashThenDelete(
+    async () => {
+      successOrder.push('upload');
+      return 'ticket-123';
+    },
+    () => successOrder.push('delete'),
+  );
+  assert.equal(ticketId, 'ticket-123');
+  assert.deepEqual(successOrder, ['upload', 'delete']);
+
+  let deletedAfterFailure = false;
+  await assert.rejects(
+    uploadCrashThenDelete(
+      async () => {
+        throw new Error('offline');
+      },
+      () => {
+        deletedAfterFailure = true;
+      },
+    ),
+    /offline/,
+  );
+  assert.equal(deletedAfterFailure, false);
+});
+
+test('runtime Hands metadata version matches the OHPM package version', async () => {
+  const packageText = await readFile(new URL('../../hands/oh-package.json5', import.meta.url), 'utf8');
+  const packageJson = JSON.parse(packageText) as { version: string };
+  assert.equal(HANDS_OHOS_SDK_VERSION, packageJson.version);
+});

--- a/clients/ohos/tests/tsconfig.json
+++ b/clients/ohos/tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "../hands/src/main/ets/HandsCrashStoragePolicy.ts"
+  ]
+}

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -4,9 +4,8 @@
 tickets** and **crash reporting** against a Hands server's
 public feedback endpoint. Mirrors the Android and iOS SDKs.
 
-> **Status:** the package is being published to ohpm. Until it's live,
-> consume the `@botiverse/hands@0.3.0` HAR from a local build of `clients/ohos`
-> in the [Hands repo](https://github.com/botiverse/hands).
+If the registry version lags the source release, build the exact HAR from
+`clients/ohos` in the [Hands repo](https://github.com/botiverse/hands).
 
 ## Install
 
@@ -48,19 +47,33 @@ const ticketId = await HandsFeedbackClient.submit(
   context,                    // common.UIAbilityContext
   'Feed does not refresh',    // message
   'bug',                      // 'feedback' | 'bug' | 'crash'
-  [logFilePath],              // up to 3 files, 10 MB each
+  [logFilePath],              // up to 9 files
   [],                         // extras: Array<{ key, value }>
 );
 ```
 
 Device metadata (version, model, OS, ABI, locale, per-install device id) is
-attached automatically.
+attached automatically. Files up to 10 MB use the multipart request; larger
+files use a presigned upload, with a 50 MB OHOS cap.
 
 ## Crash reporting
 
-`Hands.install(config, context)` captures uncaught ArkTS errors and uploads
-them as `kind=crash` tickets, grouped by signature in the console. Nothing
-else to wire.
+`Hands.install(config, context)` captures uncaught ArkTS errors plus system
+`APP_CRASH` / `APP_FREEZE` events, including native C/C++ faults that cannot
+reach the in-process ArkTS observer. Nothing else is required.
+
+Native faults are store-then-send: HarmonyOS retains the fault record after
+the process dies, and Hands consumes it on the next launch. Pending crash
+files are kept until ticket creation succeeds (subject to the bounded
+five-crash retention cap). One malformed system event does not block later
+events in the same batch.
+
+For handled errors and diagnostic context:
+
+```ts
+Hands.addBreadcrumb('member-detail', 'opened from thread');
+await Hands.captureException(context, error, 'Could not open member detail');
+```
 
 ## Device analytics
 

--- a/docs/sdk-parity/ohos.md
+++ b/docs/sdk-parity/ohos.md
@@ -1,10 +1,9 @@
 # OHOS SDK inventory (`@botiverse/hands`)
 
-Source: `clients/ohos/hands` (all ArkTS read 2026-07-09).
+Source: `clients/ohos/hands` (ArkTS and release contract read 2026-07-30).
 
-**Version drift (P1.6):** `oh-package.json5` `0.2.0` vs reported
-`QUIVER_SDK_VERSION = 0.1.0` — tickets claim 0.1.0 regardless of package
-bump.
+The package and runtime `hands_sdk` metadata share one `0.3.3` release
+constant, covered by a host-side parity test.
 
 Positioning note: this SDK is a feedback + crash-ticket client mirroring the
 Android classes; crashes are delivered as feedback tickets (`kind=crash`).
@@ -14,6 +13,12 @@ Android classes; crashes are delivered as feedback tickets (`kind=crash`).
 - **ArkTS/JS crashes** — `errorManager.on('error')` uncaught-error capture;
   store-then-send (`filesDir/crashes`, retention 5, upload next launch,
   deferred 3 s).
+- **Native crash / freeze capture** — system `hiAppEvent` `APP_CRASH` and
+  `APP_FREEZE` watcher, including bounded reads of the full FaultLogger file
+  for server symbolication. Existing crash directories are accepted, events
+  are isolated per item, and filenames are collision-resistant.
+- **Handled errors + breadcrumbs** — `Hands.captureException` and a bounded
+  `Hands.addBreadcrumb` ring.
 - **Crash/feedback context** — device (manufacturer/model/brand/marketName/
   deviceType), OS/API, bundle version, arch, locale, timezone, screen, disk,
   battery, per-install device id.
@@ -24,9 +29,7 @@ Android classes; crashes are delivered as feedback tickets (`kind=crash`).
 
 ## Absent (→ roadmap)
 
-- **Native crash capture — none** (no `faultLogger`/`hiAppEvent`) (P1.3)
-- Symbolication entirely — raw ArkTS stack text only, no sourcemaps
-- Breadcrumbs (P0.3); `captureException` (P0.2); sessions (P0.1)
+- ArkTS sourcemap symbolication and full session tracking
 - Performance monitoring (P2.2)
 - **Update checking — none** (prefs store is even named `quiver_update`,
   but no check API exists)
@@ -36,4 +39,5 @@ Android classes; crashes are delivered as feedback tickets (`kind=crash`).
 ## Config surface
 
 `Hands.install(config, context?)` — `HandsConfig = { baseUrl, appSlug,
-channel, clientKey }`. Everything else hardcoded (no hooks, no toggles).
+channel, clientKey }`. Pass the `UIAbilityContext` to enable device analytics,
+crash observers, system-fault intake, and pending-crash upload.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,18 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
 
+  clients/ohos/tests:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.0
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   container:
     dependencies:
       '@hono/node-server':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - "migrations"
   - "packages/*"
   - "clients/electron"
+  - "clients/ohos/tests"


### PR DESCRIPTION
## Problem

HarmonyOS `mkdirSync(path, true)` still throws when the leaf crash directory already exists. The native fault watcher treated that `EEXIST` as a batch-level failure, so a restart could consume neither the current `APP_CRASH` event nor later events, leaving no pending file to upload. Millisecond-only filenames could also overwrite sibling events, retention kept four files instead of five, and runtime `hands_sdk` metadata lagged the packaged version.

## Changes

- add a shared, idempotent crash-storage boundary for ArkTS and system faults
- use timestamp plus UUID filenames and reject non-directory collisions
- isolate each `APP_CRASH` / `APP_FREEZE` capture and keep retention/upload failures independent
- delete a pending crash pair only after ticket creation succeeds, while retaining the newest five pairs
- align package and runtime metadata at OHOS SDK `0.3.3`
- add executable host contract tests and run them in the OHOS publish workflow
- update OHOS SDK docs for native store-then-send behavior and handled-error APIs

## Follow-up

Publishing `0.3.3`, updating consuming vendored HARs, and the physical fault-to-ticket smoke remain separate approval-gated steps after source review.

## Testing

- `pnpm -w build`
- `pnpm -w test`
- `pnpm --filter @botiverse/hands-ohos-contract-tests lint`
- clean `hvigorw --mode module -p module=hands@default assembleHar --analyze=normal --parallel`
- `ohpm prepublish hands/build/default/outputs/default/hands.har --log_level info`
- `git diff --check`

The repository-wide `pnpm -w lint` remains blocked by the pre-existing Worker ESLint 9 configuration gap (`eslint.config.*` is absent); the new OHOS contract-test package typecheck/lint passes.
