### PR TITLE
fix(ohos-sdk): validate publish author metadata

### DIFF
--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -54,23 +54,19 @@ jobs:
             echo "$required_path" >> "$GITHUB_PATH"
           done
 
-      - name: Resolve version
+      - name: Resolve and validate release metadata
         id: version
         shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          package_version="$(node -e "const fs=require('fs'); const text=fs.readFileSync('clients/ohos/hands/oh-package.json5','utf8'); const m=text.match(/\"version\"\\s*:\\s*\"([^\"]+)\"/); if (!m) process.exit(1); process.stdout.write(m[1]);")"
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            requested="${GITHUB_REF_NAME#ohos-sdk-v}"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            requested="${{ inputs.version }}"
-          else
-            requested="${package_version}"
-          fi
-          if [[ "${requested}" != "${package_version}" ]]; then
-            echo "Requested version ${requested} does not match clients/ohos/hands/oh-package.json5 ${package_version}" >&2
-            exit 1
-          fi
+          package_version="$(node clients/ohos/scripts/release-metadata.mjs \
+            clients/ohos/hands/oh-package.json5 \
+            "${GITHUB_EVENT_NAME}" \
+            "${GITHUB_REF_TYPE}" \
+            "${GITHUB_REF_NAME}" \
+            "${REQUESTED_VERSION:-}")"
           echo "value=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: Print tool versions
@@ -100,6 +96,27 @@ jobs:
           hvigorw --sync --analyze=normal --parallel
           hvigorw clean --analyze=normal
           hvigorw --mode module -p module=hands@default assembleHar --analyze=normal --parallel
+
+      - name: Validate packaged release metadata
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          packaged_manifest="$RUNNER_TEMP/hands-oh-package.json5"
+          tar -xOzf \
+            clients/ohos/hands/build/default/outputs/default/hands.har \
+            package/oh-package.json5 > "$packaged_manifest"
+          packaged_version="$(node clients/ohos/scripts/release-metadata.mjs \
+            "$packaged_manifest" \
+            "${GITHUB_EVENT_NAME}" \
+            "${GITHUB_REF_TYPE}" \
+            "${GITHUB_REF_NAME}" \
+            "${REQUESTED_VERSION:-}")"
+          if [[ "$packaged_version" != "${{ steps.version.outputs.value }}" ]]; then
+            echo "Packed HAR version $packaged_version differs from resolved version ${{ steps.version.outputs.value }}." >&2
+            exit 1
+          fi
 
       - name: Prepublish check
         working-directory: clients/ohos

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -3,7 +3,7 @@
   "version": "0.3.3",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
-  "author": "Oranix",
+  "author": "jiacheng <jiacheng@botiverse.dev>",
   "license": "MIT",
   "homepage": "https://github.com/botiverse/hands",
   "repository": "https://github.com/botiverse/hands",

--- a/clients/ohos/oh-package.json5
+++ b/clients/ohos/oh-package.json5
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Workspace for the @botiverse/hands HarmonyOS SDK (HAR).",
   "main": "",
-  "author": "Oranix",
+  "author": "jiacheng <jiacheng@botiverse.dev>",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {}

--- a/clients/ohos/scripts/release-metadata.mjs
+++ b/clients/ohos/scripts/release-metadata.mjs
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const EXPECTED_OHPM_AUTHOR = Object.freeze({
+  name: 'jiacheng',
+  email: 'jiacheng@botiverse.dev',
+});
+
+const EMAIL_PATTERN = /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$/i;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export function validateOhpmAuthor(author) {
+  if (typeof author !== 'string') {
+    throw new Error('OHPM author must be a string in "name <email>" form.');
+  }
+
+  const match = author.match(/^\s*([^<>]+?)\s*<\s*([^<>\s]+)\s*>\s*$/);
+  if (!match) {
+    throw new Error('OHPM author must include both name and email in "name <email>" form.');
+  }
+
+  const name = match[1].trim();
+  const email = match[2].trim();
+  if (!EMAIL_PATTERN.test(email)) {
+    throw new Error(`OHPM author email is invalid: ${email}`);
+  }
+  if (name !== EXPECTED_OHPM_AUTHOR.name || email !== EXPECTED_OHPM_AUTHOR.email) {
+    throw new Error(
+      `OHPM author must be ${EXPECTED_OHPM_AUTHOR.name} <${EXPECTED_OHPM_AUTHOR.email}>.`,
+    );
+  }
+
+  return { name, email };
+}
+
+export function validatePackageManifest(manifest) {
+  if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error('OHPM package manifest must be an object.');
+  }
+
+  const version = manifest.version;
+  if (typeof version !== 'string' || !VERSION_PATTERN.test(version)) {
+    throw new Error(`OHPM package version is missing or invalid: ${String(version)}`);
+  }
+
+  const author = validateOhpmAuthor(manifest.author);
+  return { version, author };
+}
+
+export function resolveReleaseVersion({
+  packageVersion,
+  eventName,
+  refType,
+  refName,
+  inputVersion = '',
+}) {
+  let requestedVersion = packageVersion;
+  if (refType === 'tag') {
+    const canonicalTag = `ohos-sdk-v${packageVersion}`;
+    const escapedCanonicalTag = canonicalTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const retryTag = new RegExp(`^${escapedCanonicalTag}-retry\\.[1-9]\\d*$`);
+    if (refName !== canonicalTag && !retryTag.test(refName)) {
+      throw new Error(
+        `Tag ${refName} does not identify OHPM package version ${packageVersion}.`,
+      );
+    }
+  } else if (eventName === 'workflow_dispatch') {
+    requestedVersion = inputVersion;
+  }
+
+  if (requestedVersion !== packageVersion) {
+    throw new Error(
+      `Requested version ${requestedVersion} does not match OHPM package version ${packageVersion}.`,
+    );
+  }
+  return packageVersion;
+}
+
+export function resolveReleaseMetadata({ manifestPath, ...releaseContext }) {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const { version, author } = validatePackageManifest(manifest);
+  return {
+    version: resolveReleaseVersion({ packageVersion: version, ...releaseContext }),
+    author,
+  };
+}
+
+function main(argv) {
+  const [manifestPath, eventName, refType, refName, inputVersion = ''] = argv;
+  if (!manifestPath || !eventName || !refType || !refName) {
+    throw new Error(
+      'Usage: release-metadata.mjs <manifest> <event> <ref-type> <ref-name> [input-version]',
+    );
+  }
+  const metadata = resolveReleaseMetadata({
+    manifestPath,
+    eventName,
+    refType,
+    refName,
+    inputVersion,
+  });
+  process.stdout.write(metadata.version);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/clients/ohos/scripts/release-metadata.test.mjs
+++ b/clients/ohos/scripts/release-metadata.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import {
+  EXPECTED_OHPM_AUTHOR,
+  resolveReleaseMetadata,
+  resolveReleaseVersion,
+  validatePackageManifest,
+} from './release-metadata.mjs';
+
+const packageManifestPath = fileURLToPath(
+  new URL('../hands/oh-package.json5', import.meta.url),
+);
+
+test('published HAR manifest carries the authorized OHPM author identity', () => {
+  const metadata = resolveReleaseMetadata({
+    manifestPath: packageManifestPath,
+    eventName: 'pull_request',
+    refType: 'branch',
+    refName: 'codex/task215-ohpm-author-retry',
+  });
+  assert.equal(metadata.version, '0.3.3');
+  assert.deepEqual(metadata.author, EXPECTED_OHPM_AUTHOR);
+});
+
+test('missing and malformed author fixtures fail before HAR publication', () => {
+  const invalidAuthors = [
+    undefined,
+    '',
+    'jiacheng',
+    'jiacheng <not-an-email>',
+    'other <jiacheng@botiverse.dev>',
+    'jiacheng <other@botiverse.dev>',
+  ];
+
+  for (const author of invalidAuthors) {
+    assert.throws(
+      () => validatePackageManifest({ version: '0.3.3', author }),
+      /OHPM author/,
+      `fixture should be rejected: ${String(author)}`,
+    );
+  }
+});
+
+test('canonical and numbered recovery tags resolve to the same package version', () => {
+  const context = {
+    packageVersion: '0.3.3',
+    eventName: 'push',
+    refType: 'tag',
+  };
+  assert.equal(
+    resolveReleaseVersion({ ...context, refName: 'ohos-sdk-v0.3.3' }),
+    '0.3.3',
+  );
+  assert.equal(
+    resolveReleaseVersion({ ...context, refName: 'ohos-sdk-v0.3.3-retry.1' }),
+    '0.3.3',
+  );
+});
+
+test('stale or malformed recovery tags fail closed', () => {
+  const context = {
+    packageVersion: '0.3.3',
+    eventName: 'push',
+    refType: 'tag',
+  };
+  for (const refName of [
+    'ohos-sdk-v0.3.2',
+    'ohos-sdk-v0.3.3-retry.0',
+    'ohos-sdk-v0.3.3-retry.latest',
+  ]) {
+    assert.throws(
+      () => resolveReleaseVersion({ ...context, refName }),
+      /does not identify OHPM package version/,
+    );
+  }
+});
+
+test('manual release input must still match the package version', () => {
+  assert.throws(
+    () => resolveReleaseVersion({
+      packageVersion: '0.3.3',
+      eventName: 'workflow_dispatch',
+      refType: 'branch',
+      refName: 'main',
+      inputVersion: '0.3.2',
+    }),
+    /does not match OHPM package version/,
+  );
+});

--- a/clients/ohos/tests/package.json
+++ b/clients/ohos/tests/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "tsx --test src/*.test.ts",
+    "test": "tsx --test src/*.test.ts && node --test ../scripts/*.test.mjs",
     "lint": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The protected `ohos-sdk-v0.3.3` release run built and prepublished the HAR, but the OHPM registry rejected the final write because the packaged manifest only declared `author: Oranix` and provided neither an author email nor URL.

## Change

- encode the authorized identity `jiacheng <jiacheng@botiverse.dev>` in the actual HAR manifest and OHOS workspace metadata;
- validate the packaged manifest's exact author name/email and version before build/publish;
- add missing, malformed, and drifted author negative fixtures;
- allow immutable numbered recovery tags such as `ohos-sdk-v0.3.3-retry.1` to publish the unchanged package version after a failed registry attempt, while rejecting stale/malformed tags.

No package has been published by this PR.

## Testing

- `pnpm --filter @botiverse/hands-ohos-contract-tests test` (13/13)
- `pnpm --filter @botiverse/hands-ohos-contract-tests build`
- release metadata CLI readback for `ohos-sdk-v0.3.3-retry.1`
- workflow YAML parse and `git diff --check`

Signed-off-by: Codex-Kuikly-KMP <raft-mobile-codex-kuikly-kmp@mail.build>
