### PR TITLE
[codex] enable bounded production traces

### DIFF
--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -54,6 +54,11 @@ test("production config keeps reporter sessions disabled by default", () => {
         app_id: BASE_ENV.HANDS_FLAGSHIP_APP_ID,
       },
     ]);
+    assert.deepEqual(config.observability.traces, {
+      enabled: true,
+      head_sampling_rate: 0.05,
+      persist: true,
+    });
     assert.equal(config.vars.FEEDBACK_REPORTER_SESSION_ENABLED, "false");
     assert.equal("FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION" in config.vars, false);
   } finally {

--- a/worker/wrangler.hands.jsonc
+++ b/worker/wrangler.hands.jsonc
@@ -4,7 +4,16 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-10-08",
   "compatibility_flags": ["nodejs_compat"],
-  "observability": { "enabled": true },
+  "observability": {
+    "enabled": true,
+    "traces": {
+      "enabled": true,
+      // Keep production trace volume bounded while retaining enough samples
+      // to diagnose intermittent Feedback authorization and D1 latency.
+      "head_sampling_rate": 0.05,
+      "persist": true
+    }
+  },
   "upload_source_maps": true,
   "placement": { "mode": "smart" },
   // Keep Cloudflare version preview URLs disabled so uploaded versions never


### PR DESCRIPTION
## What changed

- enable native Workers Traces for the production Hands Worker
- persist traces in Cloudflare Workers Observability with 5% head sampling
- assert the rendered production config preserves the bounded trace policy

## Why

Feedback list requests have shown intermittent authorization and D1 latency that cannot be decomposed from aggregate request timing alone. Automatic Worker and D1 spans provide that decomposition without adding custom payload attributes.

## Privacy and cost boundary

- no external trace destination
- automatic request/response body content is not captured; body sizes are captured
- full URL metadata and D1 query text are captured, so traces remain sensitive account telemetry
- Feedback credentials and reporter identity remain in headers not included in the automatic attribute list; D1 values use bound parameters
- 5% head sampling bounds span volume and observability-event cost

## Validation

- `pnpm --filter @botiverse/hands-worker test -- production_config.test.ts`
- `pnpm -w build`
- `pnpm -w test`
- `pnpm exec wrangler deploy --dry-run --config wrangler.hands.generated.jsonc`
- `pnpm -w lint` cannot start because the repository has no ESLint 9 `eslint.config.*`; this is an existing tooling baseline issue, not a source lint finding

## Deployment

Do not deploy this PR alone. Per owner direction, combine it with the Flagship binding PR in one controlled production deploy and bind the runtime receipt to the final merged source SHA and Cloudflare Worker version.
