### PR TITLE
Index the feedback comment subquery predicates

### DIFF
--- a/migrations/sql/0058_feedback_comment_lookup_indexes.sql
+++ b/migrations/sql/0058_feedback_comment_lookup_indexes.sql
@@ -1,0 +1,26 @@
+-- The reporter ticket list runs three correlated subqueries per returned
+-- ticket -- comment count, latest comment time, and unread count -- plus the
+-- detail view's unread count. All of them filter feedback_comments by
+-- `internal`, and the unread paths additionally by `author_type` and
+-- `reporter_sequence`, but the only existing index is
+-- idx_feedback_comments_ticket(ticket_id, created_at, id). EXPLAIN QUERY PLAN
+-- confirms each subquery narrowed to `ticket_id=?` and then scanned every
+-- comment on that ticket to apply the remaining filters, so a 20-ticket page
+-- scanned the full comment set of 20 tickets three times over.
+--
+-- D1 bills and times queries by rows read, so these two covering indexes
+-- target that metric directly: after adding them, EXPLAIN reports
+-- COVERING INDEX for all three comment subqueries.
+--
+--   * ..._unread covers the unread predicate (internal + author_type +
+--     reporter_sequence) used by both the list and detail paths;
+--   * ..._internal_created covers the count and MAX(created_at) subqueries.
+--
+-- Both are read-side only; feedback_comments is append-mostly, so the write
+-- overhead is two index inserts per comment.
+
+CREATE INDEX IF NOT EXISTS idx_feedback_comments_unread
+  ON feedback_comments(ticket_id, internal, author_type, reporter_sequence);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_comments_internal_created
+  ON feedback_comments(ticket_id, internal, created_at);

--- a/migrations/sql/0058_feedback_comment_lookup_indexes.sql
+++ b/migrations/sql/0058_feedback_comment_lookup_indexes.sql
@@ -16,8 +16,20 @@
 --     reporter_sequence) used by both the list and detail paths;
 --   * ..._internal_created covers the count and MAX(created_at) subqueries.
 --
--- Both are read-side only; feedback_comments is append-mostly, so the write
--- overhead is two index inserts per comment.
+-- Write cost, measured rather than assumed: inserting one comment is not a
+-- single row write. Migration 0054's feedback_comments_reporter_sequence_insert
+-- is an AFTER INSERT trigger that UPDATEs reporter_sequence on the row just
+-- inserted, and reporter_sequence is a column of ..._unread. So per comment the
+-- two indexes here add 3 index inserts and 1 index delete: both indexes take an
+-- entry on the INSERT (..._unread with reporter_sequence still NULL), then the
+-- trigger's UPDATE deletes and re-inserts the ..._unread entry under its final
+-- sequence. ..._internal_created holds no updated column and is untouched by
+-- that UPDATE. Verified by opcode delta on EXPLAIN of the insert against the
+-- full migration set: IdxInsert 8 -> 11, IdxDelete 1 -> 2.
+--
+-- That cost is accepted: feedback_comments is append-mostly and a comment
+-- insert is a single user action, whereas the read path pays per ticket on
+-- every page of every list request.
 
 CREATE INDEX IF NOT EXISTS idx_feedback_comments_unread
   ON feedback_comments(ticket_id, internal, author_type, reporter_sequence);

--- a/worker/test/feedback_comment_indexes_migration.test.ts
+++ b/worker/test/feedback_comment_indexes_migration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The reporter list/detail comment subqueries must resolve through covering
+ * indexes instead of scanning every comment on a ticket. D1 bills and times by
+ * rows read, and EXPLAIN QUERY PLAN is the documented way to confirm an index
+ * is actually used, so the assertions are on the plan itself.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+const INDEX_MIGRATION = "0058_feedback_comment_lookup_indexes.sql";
+
+/** Apply the whole ordered migration set so the schema matches production. */
+function applyMigrations(db: Database.Database, includeIndexMigration: boolean) {
+  for (const name of readdirSync(MIGRATION_DIR).sort()) {
+    if (!name.endsWith(".sql")) continue;
+    if (name === INDEX_MIGRATION && !includeIndexMigration) continue;
+    db.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+  }
+}
+
+const UNREAD_SUBQUERY = `(SELECT COUNT(*) FROM feedback_comments u
+  WHERE u.ticket_id = t.id AND u.internal = 0
+    AND u.author_type IN ('staff', 'system')
+    AND (rr.ticket_id IS NULL OR u.reporter_sequence > rr.read_through_sequence))`;
+
+const LIST_QUERY = `SELECT t.id,
+   (SELECT COUNT(*) FROM feedback_comments fc WHERE fc.ticket_id = t.id AND fc.internal = 0) AS comment_count,
+   (SELECT MAX(fc.created_at) FROM feedback_comments fc WHERE fc.ticket_id = t.id AND fc.internal = 0) AS latest_comment_at,
+   ${UNREAD_SUBQUERY} AS unread_count
+ FROM feedback_tickets t
+ LEFT JOIN feedback_reporter_ticket_reads rr
+   ON rr.app_id = t.app_id AND rr.reporter_integration_id = t.reporter_integration_id
+  AND rr.reporter_id = t.reporter_id AND rr.ticket_id = t.id
+ WHERE t.app_id = ? AND t.reporter_integration_id = ? AND t.reporter_id = ?
+ ORDER BY t.created_at DESC, t.id DESC LIMIT 20`;
+
+function schema(withIndexes: boolean) {
+  const db = new Database(":memory:");
+  applyMigrations(db, withIndexes);
+  // Ownership triggers are real: a ticket's integration must belong to its app.
+  db.prepare("INSERT INTO apps (id, slug, name, platform, created_at) VALUES ('app', 'slug', 'name', 'android', 1)").run();
+  db.prepare("INSERT INTO app_reporter_integrations (id, app_id, name, created_at, updated_at) VALUES ('intg', 'app', 'inbox', 1, 1)").run();
+  return db;
+}
+
+function plan(db: Database.Database) {
+  return db
+    .prepare(`EXPLAIN QUERY PLAN ${LIST_QUERY}`)
+    .all("app", "intg", "rep")
+    .map((row) => String((row as { detail: string }).detail));
+}
+
+describe("feedback comment lookup indexes", () => {
+  it("routes every comment subquery through a covering index", () => {
+    const before = plan(schema(false));
+    const after = plan(schema(true));
+
+    // Before: the only usable index is (ticket_id, created_at, id), so the
+    // internal/author_type/reporter_sequence filters are applied by scanning
+    // the ticket's comments.
+    expect(before.some((detail) => detail.includes("idx_feedback_comments_ticket ("))).toBe(true);
+    expect(before.some((detail) => detail.includes("idx_feedback_comments_unread"))).toBe(false);
+    expect(before.some((detail) => detail.includes("idx_feedback_comments_internal_created"))).toBe(false);
+
+    // After: count and MAX(created_at) use the internal+created_at index; the
+    // unread predicate uses the author_type+reporter_sequence index.
+    expect(
+      after.filter((detail) => detail.includes("COVERING INDEX idx_feedback_comments_internal_created")).length,
+    ).toBe(2);
+    expect(after.some((detail) => detail.includes("COVERING INDEX idx_feedback_comments_unread"))).toBe(true);
+    // No comment subquery may fall back to a table scan.
+    expect(after.some((detail) => /SCAN (fc|u)\b/.test(detail))).toBe(false);
+  });
+
+  it("returns the same counts with the indexes in place", () => {
+    const db = schema(true);
+    db.prepare(
+      `INSERT INTO feedback_tickets
+         (id, app_id, kind, status, message, metadata_json, reporter_id,
+          reporter_integration_id, created_at, updated_at)
+       VALUES ('t1', 'app', 'feedback', 'open', 'm', '{}', 'rep', 'intg', 1, 1)`,
+    ).run();
+    const insert = db.prepare(
+      `INSERT INTO feedback_comments
+         (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES (?, 't1', 'staff:test', ?, 'body', ?, ?)`,
+    );
+    for (let i = 0; i < 12; i += 1) {
+      insert.run(`c${i}`, i % 2 === 0 ? "staff" : "system", i % 4 === 0 ? 1 : 0, 2_000 + i);
+    }
+
+    const row = db.prepare(LIST_QUERY).get("app", "intg", "rep") as {
+      comment_count: number;
+      latest_comment_at: number;
+      unread_count: number;
+    };
+    // 12 comments, every 4th internal → 9 reporter-visible; all visible ones are
+    // staff/system and there is no read receipt, so all 9 count as unread.
+    expect(row.comment_count).toBe(9);
+    expect(row.unread_count).toBe(9);
+    expect(row.latest_comment_at).toBe(2_011);
+  });
+});


### PR DESCRIPTION
## Problem

The reporter ticket list runs three correlated subqueries for every returned ticket — comment count, latest comment time, and unread count — and the detail view repeats the unread count. All of them filter `feedback_comments` on `internal`, and the unread paths additionally on `author_type` and `reporter_sequence`. The only index on the table was `idx_feedback_comments_ticket(ticket_id, created_at, id)`.

`EXPLAIN QUERY PLAN` on the list query showed each subquery narrowing to `ticket_id=?` and then scanning every comment on that ticket to apply the remaining filters:

```
CORRELATED SCALAR SUBQUERY 2
  SEARCH fc USING INDEX idx_feedback_comments_ticket (ticket_id=?)
CORRELATED SCALAR SUBQUERY 3
  SEARCH fc USING INDEX idx_feedback_comments_ticket (ticket_id=?)
CORRELATED SCALAR SUBQUERY 4
  SEARCH unread_comment USING INDEX idx_feedback_comments_ticket (ticket_id=?)
```

A 20-ticket page therefore walked those tickets' comment sets three times over. D1 bills and times queries by rows read, so this shows up as both latency and cost.

## Changes

`migrations/sql/0058_feedback_comment_lookup_indexes.sql` adds two covering indexes on `feedback_comments`:

- `(ticket_id, internal, author_type, reporter_sequence)` — the unread predicate, used by both list and detail;
- `(ticket_id, internal, created_at)` — the count and `MAX(created_at)` subqueries.

After the migration, the same plan reports a covering index for all three:

```
SEARCH fc USING COVERING INDEX idx_feedback_comments_internal_created (ticket_id=? AND internal=?)
SEARCH fc USING COVERING INDEX idx_feedback_comments_internal_created (ticket_id=? AND internal=?)
SEARCH u  USING COVERING INDEX idx_feedback_comments_unread (ticket_id=? AND internal=? AND author_type=?)
```

### Write cost

An earlier revision of this PR described the indexes as read-side only, costing two index inserts per comment. Both halves were wrong, corrected in `11891ca` after @Volta's review. Migration 0054's `feedback_comments_reporter_sequence_insert` is an `AFTER INSERT` trigger that `UPDATE`s `reporter_sequence`, and `reporter_sequence` is a column of `..._unread`. So a comment insert is an insert plus an update, and these two indexes add **3 index inserts and 1 index delete** per comment: both take an entry on the `INSERT` (`..._unread` with the sequence still `NULL`), then the trigger's `UPDATE` deletes and re-inserts the `..._unread` entry under its final value. `..._internal_created` holds no updated column and is untouched.

Measured as the opcode delta on `EXPLAIN` of the insert against the full migration set, rather than reasoned about: `IdxInsert` 8 → 11, `IdxDelete` 1 → 2.

The cost is accepted: `feedback_comments` is append-mostly and a comment insert is one user action, whereas the read path pays per ticket on every page of every list request. Index definitions are unchanged from the reviewed revision — the non-comment lines of the migration hash identically at `9dacae8f` and `11891ca` (`fb154e1f0530ac4e…`).

## Follow-up

- The migration applies on the next production deploy; the effect should be confirmed against the D1 console's rows-read figure for these queries, which is the metric that reflects the change.
- Local timings on synthetic data (300 tickets × 20–60 comments) improved 2.0–2.6×, but in-memory SQLite microseconds do not translate to production wall time and are not offered as a projection.

## Testing

- `worker/test/feedback_comment_indexes_migration.test.ts`: asserts the plan before and after the migration (no covering index → covering index for all three subqueries, no table scan on the comment aliases) and that the counts are unchanged with rows present
- Mutation check: removing either index from the migration turns the plan assertion red
- Worker tests: 283/283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
