### PR TITLE
Use segmented control for Feedback status

### DIFF
--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -15,6 +15,9 @@ import {
   EmptyState,
   EmptyStateTitle,
   Input,
+  SegmentedControl,
+  SegmentedControlItem,
+  SegmentedControlLabel,
   Skeleton,
 } from "raft-ui";
 import type { FeedbackMessageKey, FeedbackMessageValues } from "./locale.js";
@@ -285,24 +288,22 @@ export function FeedbackInbox({
         </div>
         <Button onClick={onNewFeedback}>{message("newFeedback")}</Button>
       </header>
-      <div
+      <SegmentedControl<"all" | "open" | "resolved">
         className="hands-feedback-filter"
-        role="group"
-        aria-label={message("statusFilter")}
+        ariaLabel={message("statusFilter")}
+        value={filter}
+        onValueChange={setFilter}
       >
         {(["all", "open", "resolved"] as const).map((value) => (
-          <Button
-            key={value}
-            variant={filter === value ? "primary" : "outline"}
-            aria-pressed={filter === value}
-            onClick={() => setFilter(value)}
-          >
-            {value === "all"
-              ? message("all")
-              : message(value === "open" ? "active" : "statusResolved")}
-          </Button>
+          <SegmentedControlItem key={value} value={value}>
+            <SegmentedControlLabel>
+              {value === "all"
+                ? message("all")
+                : message(value === "open" ? "active" : "statusResolved")}
+            </SegmentedControlLabel>
+          </SegmentedControlItem>
         ))}
-      </div>
+      </SegmentedControl>
       <div
         className="hands-feedback-middle hands-feedback-list-scroll"
         data-feedback-list-scroll

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { useState } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FeedbackWorkspace } from "./components.js";
 import { FeedbackProvider } from "./provider.js";
 import { FeedbackTransportError } from "./types.js";
@@ -17,6 +17,13 @@ import type {
   FeedbackTicketPage,
   HandsFeedbackTransport,
 } from "./types.js";
+
+beforeAll(() => {
+  Object.defineProperty(window, "PointerEvent", {
+    configurable: true,
+    value: MouseEvent,
+  });
+});
 
 afterEach(cleanup);
 
@@ -91,7 +98,9 @@ describe("FeedbackWorkspace browser behavior", () => {
     );
     expect(await screen.findByText(ticket.message)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Create report" })).toBeTruthy();
-    expect(screen.getByRole("group", { name: "Ticket state" })).toBeTruthy();
+    expect(
+      screen.getByRole("radiogroup", { name: "Ticket state" }),
+    ).toBeTruthy();
     expect(screen.getByLabelText("2 new items")).toBeTruthy();
     expect(screen.getByText("DATE:en:2", { exact: false })).toBeTruthy();
     fireEvent.click(screen.getByText(ticket.message));
@@ -209,12 +218,35 @@ describe("FeedbackWorkspace browser behavior", () => {
     );
 
     await screen.findByText("Ticket open");
-    expect(screen.getByRole("button", { name: "Active" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Active" })).toBeTruthy();
     expect(
       Array.from(
         container.querySelectorAll<HTMLElement>("[data-feedback-status]"),
       ).map((badge) => badge.dataset.feedbackStatus),
     ).toEqual(["open", "in_progress", "resolved", "closed"]);
+  });
+
+  it("uses the shared segmented control with radio and keyboard semantics", async () => {
+    render(
+      <FeedbackProvider transport={transport()}>
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    await screen.findByText(ticket.message);
+    const group = screen.getByRole("radiogroup", { name: "Status filter" });
+    const all = screen.getByRole("radio", { name: "All" });
+    const active = screen.getByRole("radio", { name: "Active" });
+    expect(group.getAttribute("data-slot")).toBe("segmented-control");
+    expect(all.getAttribute("data-slot")).toBe("segmented-control-item");
+    expect(all.getAttribute("aria-checked")).toBe("true");
+
+    all.focus();
+    fireEvent.keyDown(all, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(active.getAttribute("aria-checked")).toBe("true");
+      expect(document.activeElement).toBe(active);
+    });
   });
 
   it("does not re-notify when list and detail return the same authoritative total", async () => {
@@ -246,7 +278,7 @@ describe("FeedbackWorkspace browser behavior", () => {
     const row = await screen.findByRole("button", {
       name: /A reporter-visible ticket/,
     });
-    fireEvent.click(screen.getByRole("button", { name: "Active" }));
+    fireEvent.click(screen.getByRole("radio", { name: "Active" }));
     const listScroll = document.querySelector<HTMLElement>(
       "[data-feedback-list-scroll]",
     )!;
@@ -258,8 +290,8 @@ describe("FeedbackWorkspace browser behavior", () => {
     expect(listScroll.scrollTop).toBe(91);
     expect(
       screen
-        .getByRole("button", { name: "Active" })
-        .getAttribute("aria-pressed"),
+        .getByRole("radio", { name: "Active" })
+        .getAttribute("aria-checked"),
     ).toBe("true");
     expect(row.getAttribute("data-unread")).toBeNull();
   });

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -91,7 +91,6 @@
   align-content: start;
   padding: 2px;
 }
-.hands-feedback-filter,
 .hands-feedback-kind {
   display: flex;
   flex: none;


### PR DESCRIPTION
## Problem

The reporter Feedback inbox rendered its `All` / `Active` / `Resolved` status filter as three independent buttons. That duplicated selection styling and keyboard semantics already provided by the shared `raft-ui` segmented control.

## Changes

- Replace the hand-rolled status buttons with `SegmentedControl`, `SegmentedControlItem`, and `SegmentedControlLabel`.
- Preserve the existing filter values, localized labels, filtered ticket behavior, and Back-navigation state.
- Remove the obsolete filter layout rule so the shared component owns spacing and visual state.
- Update DOM assertions from pressed buttons to the segmented control's `radiogroup` / `radio` contract.
- Add a regression test for the shared component slots, checked state, and ArrowRight keyboard selection.

## Follow-up

The consuming Raft Web app can update its source pin after this change lands. No npm publication or production deployment is included here.

## Testing

- `pnpm --filter @botiverse/hands-feedback-react test` (33/33)
- `pnpm --filter @botiverse/hands-feedback-react build`
- `git diff --check`
