### PR TITLE
Pass the dispatch version input through the environment

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -47,13 +47,15 @@ jobs:
       - name: Resolve version
         id: version
         shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           package_version="$(node -p "require('./packages/cli/package.json').version")"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             requested="${GITHUB_REF_NAME#cli-v}"
-          elif [[ -n "${{ inputs.version }}" ]]; then
-            requested="${{ inputs.version }}"
+          elif [[ -n "${REQUESTED_VERSION:-}" ]]; then
+            requested="${REQUESTED_VERSION}"
           else
             requested="${package_version}"
           fi

--- a/.github/workflows/publish-electron-sdk.yml
+++ b/.github/workflows/publish-electron-sdk.yml
@@ -46,13 +46,15 @@ jobs:
       - name: Resolve version
         id: version
         shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           package_version="$(node -p "require('./clients/electron/package.json').version")"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             requested="${GITHUB_REF_NAME#electron-sdk-v}"
-          elif [[ -n "${{ inputs.version }}" ]]; then
-            requested="${{ inputs.version }}"
+          elif [[ -n "${REQUESTED_VERSION:-}" ]]; then
+            requested="${REQUESTED_VERSION}"
           else
             requested="${package_version}"
           fi

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -47,13 +47,15 @@ jobs:
       - name: Resolve version
         id: version
         shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           package_version="$(node -p "require('./packages/node/package.json').version")"
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             requested="${GITHUB_REF_NAME#node-v}"
-          elif [[ -n "${{ inputs.version }}" ]]; then
-            requested="${{ inputs.version }}"
+          elif [[ -n "${REQUESTED_VERSION:-}" ]]; then
+            requested="${REQUESTED_VERSION}"
           else
             requested="${package_version}"
           fi


### PR DESCRIPTION
## Problem

`publish-cli.yml`, `publish-node.yml` and `publish-electron-sdk.yml` interpolated the `workflow_dispatch` input directly into the *Resolve version* shell script:

```yaml
elif [[ -n "${{ inputs.version }}" ]]; then
  requested="${{ inputs.version }}"
```

`${{ }}` is substituted as text before bash parses the line, so the input is not data — it is script. These jobs publish to npm and have `NPM_TOKEN` in scope.

**The existing equality check does not mitigate it.** A payload of `1.2.3$(<command>)` keeps the script syntactically valid, executes the command, and the substitution is then replaced by the command's output — so `requested` still compares equal to `packages/*/package.json` and the job continues. Reproduced locally:

```
BEFORE  generated line:  requested="1.2.3$(touch /tmp/PWNED)"
        resolved: 1.2.3            <-- equality check passes
        RESULT: INJECTION EXECUTED

AFTER   generated line:  requested="${REQUESTED_VERSION}"
        resolved: 1.2.3$(touch /tmp/PWNED)
        RESULT: inert — carried as data
```

(A quote-breaking payload like `"; cmd; #` corrupts the `[[ -n "..." ]]` guard and dies on a parse error, which reads as a false negative. Command substitution is the shape that works.)

## Changes

The same env-indirection already shipped in `publish-ohos-sdk.yml` and `publish-android-sdk.yml`:

```yaml
env:
  REQUESTED_VERSION: ${{ inputs.version }}
run: |
  elif [[ -n "${REQUESTED_VERSION:-}" ]]; then
    requested="${REQUESTED_VERSION}"
```

The value reaches bash through the environment and is never parsed as shell syntax. No publish semantics change: same resolution order (tag → dispatch input → package.json), same equality check, same outputs.

## Scope

Three files, 12 insertions, 6 deletions. No other job, step or workflow touched.

After this change, no free-text `workflow_dispatch` input reaches a `run:` block anywhere in `.github/workflows/`. Verified by scanning every `${{ }}` expansion inside a `run:` block — 12 remain, all constrained:

- `inputs.containers_rollout` ×2 — `type: choice`, options `none|immediate`
- `inputs.dry_run` ×4 — `type: boolean`
- `steps.version.outputs.value` ×6 — derived from `package.json` after the equality check, repo-controlled

## Testing

- The before/after reproduction above
- No workflow run is triggered by this PR; the publish workflows fire on tag or dispatch only

🤖 Generated with [Claude Code](https://claude.com/claude-code)