### PR TITLE
Route step outputs through the environment in publish workflows

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -53,7 +53,9 @@ jobs:
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build SDK and run central publication gate
-        run: gradle -p clients/android testReleaseUnitTest verifyReleaseElfAlignment -PVERSION_NAME=${{ steps.version.outputs.value }}
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        run: gradle -p clients/android testReleaseUnitTest verifyReleaseElfAlignment "-PVERSION_NAME=$RESOLVED_VERSION"
 
       - name: Verify local and remote publication task graphs
         env:
@@ -70,4 +72,5 @@ jobs:
       - name: Publish SDK to GitHub Packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gradle -p clients/android publish -PVERSION_NAME=${{ steps.version.outputs.value }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        run: gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -92,18 +92,22 @@ jobs:
 
       - name: Publish dry run
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
-        run: npm publish "${{ steps.pack.outputs.path }}" --access public --dry-run
+        run: npm publish "$PACKAGE_PATH" --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_PATH: ${{ steps.pack.outputs.path }}
 
       - name: Publish to npm
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
-        run: npm publish "${{ steps.pack.outputs.path }}" --access public
+        run: npm publish "$PACKAGE_PATH" --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_PATH: ${{ steps.pack.outputs.path }}
 
       - name: Summary
         shell: bash
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### CLI publish"
@@ -111,6 +115,6 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands-cli\` |"
-            echo "| Version | \`${{ steps.version.outputs.value }}\` |"
+            echo "| Version | \`${RESOLVED_VERSION}\` |"
             echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-electron-sdk.yml
+++ b/.github/workflows/publish-electron-sdk.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Summary
         shell: bash
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### Electron SDK publish"
@@ -93,6 +95,6 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands-electron\` |"
-            echo "| Version | \`${{ steps.version.outputs.value }}\` |"
+            echo "| Version | \`${RESOLVED_VERSION}\` |"
             echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Summary
         shell: bash
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### Hands Node SDK publish"
@@ -97,6 +99,6 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands-node\` |"
-            echo "| Version | \`${{ steps.version.outputs.value }}\` |"
+            echo "| Version | \`${RESOLVED_VERSION}\` |"
             echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -101,6 +101,7 @@ jobs:
         shell: bash
         env:
           REQUESTED_VERSION: ${{ inputs.version }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           packaged_manifest="$RUNNER_TEMP/hands-oh-package.json5"
@@ -113,8 +114,8 @@ jobs:
             "${GITHUB_REF_TYPE}" \
             "${GITHUB_REF_NAME}" \
             "${REQUESTED_VERSION:-}")"
-          if [[ "$packaged_version" != "${{ steps.version.outputs.value }}" ]]; then
-            echo "Packed HAR version $packaged_version differs from resolved version ${{ steps.version.outputs.value }}." >&2
+          if [[ "$packaged_version" != "${RESOLVED_VERSION}" ]]; then
+            echo "Packed HAR version $packaged_version differs from resolved version ${RESOLVED_VERSION}." >&2
             exit 1
           fi
 
@@ -197,6 +198,8 @@ jobs:
       - name: Summary
         if: always()
         shell: bash
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### OHOS SDK"
@@ -204,6 +207,6 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands\` |"
-            echo "| Version | \`${{ steps.version.outputs.value }}\` |"
+            echo "| Version | \`${RESOLVED_VERSION}\` |"
             echo "| Dry run | \`${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

#393 closed the `workflow_dispatch` input, but @Sentinel identified a second feed into the same sink: step outputs interpolated with `${{ }}` inside `run:`.

```yaml
echo "| Version | \`${{ steps.version.outputs.value }}\` |"
```

`${{ }}` is substituted as script text before bash parses the line, so a value containing `$(...)` executes inside the double quotes. These values derive from repository content — `package.json` for the npm packages, the packed tarball path for the CLI — and `workflow_dispatch` runs the workflow *and* the repository content of the selected ref, which any write-access collaborator can push. The version equality check does not help: both sides come from the same `package.json`.

## The original scan was itself incomplete

#393 claimed 12 expansions reached a shell, all constrained. That count came from a scanner that **only matched block scalars (`run: |`) and skipped single-line `run:`**. Corrected, the real number was **16**, and the four it had never inspected included:

- `publish-cli.yml:95,101` — ``npm publish "${{ steps.pack.outputs.path }}"``, where the path comes from a `find -name 'botiverse-hands-cli-*.tgz' -print -quit` glob, so a committed file whose name contains `$(...)` is selected and executed
- `publish-android-sdk.yml:56,73` — both `gradle -PVERSION_NAME=` calls, in a workflow previously considered fixed

Two separate lessons, recorded because they generalise: an exhaustive search proves *coverage*, not *classification* — #393 also misjudged 6 found sites as safe because they were "repo-controlled", which is not a boundary when dispatch selects the ref. And a search is only as exhaustive as the pattern it uses.

## Changes

All 10 shell-reaching, non-type-constrained expansions now pass through `env:`, matching the shape already used for `REQUESTED_VERSION`:

| File | Sites |
| --- | --- |
| `publish-cli.yml` | 2 × `PACKAGE_PATH`, 1 × `RESOLVED_VERSION` |
| `publish-node.yml` | 1 × `RESOLVED_VERSION` |
| `publish-electron-sdk.yml` | 1 × `RESOLVED_VERSION` |
| `publish-ohos-sdk.yml` | 3 × `RESOLVED_VERSION` (validate step + summary) |
| `publish-android-sdk.yml` | 2 × `RESOLVED_VERSION` |

The android gradle arguments are also now quoted; they were bare before. The version there is semver-validated, so this changes no behaviour — it is defence in depth, not a fix.

No publish semantics change: same resolution order, same equality checks, same outputs and summaries.

## Verification

Rescan after the change reports **6** expansions reaching a shell, all Actions-typed and not free text:

- `inputs.dry_run` × 4 — `type: boolean`
- `inputs.containers_rollout` × 2 — `type: choice`, options `none|immediate`

All 8 workflow files parse, with job and step counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)