### PR TITLE
Add feedback material delta feed

### DIFF
--- a/docs/feedback-material-delta-contract.md
+++ b/docs/feedback-material-delta-contract.md
@@ -136,8 +136,7 @@ Assign a strictly larger per-app sequence for:
 - an assignee change where the stored value really changes;
 - a reporter comment;
 - an external staff comment;
-- an internal staff comment;
-- a system comment.
+- an internal staff comment.
 
 The schema, rather than only the new Worker, must classify these writes. This
 keeps the migration-before-code window and a Worker-only rollback correct:
@@ -145,14 +144,22 @@ keeps the migration-before-code window and a Worker-only rollback correct:
 - `AFTER INSERT` on `feedback_tickets` allocates once for ticket creation;
 - `AFTER UPDATE OF status, assignee` allocates once only when either stored
   value changes; changing both in the existing single CAS is one mutation;
-- `AFTER INSERT` on `feedback_comments` allocates once for every comment,
-  including `internal = 1` and every author type.
+- `AFTER INSERT` on `feedback_comments` allocates once for every comment from
+  the two current production writers: reporter and staff, with staff covered
+  separately for `internal = 0` and `internal = 1`.
 
 The comment trigger is intentionally independent of migration 0059's reporter
 trigger. One inserted visible comment advances both domains for their different
 audiences; neither high-water is copied from, compared with, or derived from the
 other. An internal comment advances material delta and leaves
 `reporter_sequence` NULL.
+
+The schema already permits and read paths understand `author_type = 'system'`,
+but the current production source has no system-comment writer. Version 1 does
+not invent one. The generic comment trigger may remain author-agnostic, but a
+direct SQL fixture is not evidence of a production system path. The first
+future change that introduces a system-comment writer must also add its real
+entry-point material RED in the same change.
 
 Internal comments count because they often represent real handling progress
 that a patrol must observe. Their content and even the frequency of their
@@ -172,10 +179,21 @@ therefore produce zero material delta. A conflicting replay, failed attachment
 batch, or any transaction that rolls back after allocation must leave both the
 ticket sequence and allocator high-water unchanged.
 
-If a future feature adds ticket hard deletion, this snapshot-only contract must
-first gain an explicit tombstone carrier. A deleted row cannot be represented
-by the current ticket-column design, so hard deletion must not be silently
-classified as supported material delta.
+### Deletion boundary
+
+The snapshot carrier has no tombstone, so a hard-deleted ticket would be a
+permanent omission. Version 1 therefore installs a ticket-delete guard:
+
+- direct `DELETE feedback_tickets` is rejected while the parent app exists;
+- deleting a reporter integration while its app exists cannot cascade-delete
+  tickets;
+- the existing full app purge remains supported and must cascade the app's
+  tickets, integrations, and allocator state successfully.
+
+This is a deliberate behavior change at the database boundary, not a claim
+that “no HTTP route currently deletes tickets” is sufficient protection. Any
+future per-ticket deletion requires a tombstone carrier and a new contract
+version before the guard can be relaxed.
 
 ## Read contract
 
@@ -296,7 +314,8 @@ app's material volume, exact consumer checkpoints, and completeness of the
 agent's delta feed. The primary threats are reporter-surface leakage, cross-app
 cursor replay, cursor confusion with reporter pagination, attacker-supplied or
 unsafe sequence values, importing another numbering domain during migration,
-and a missing production write-path hook that silently omits a material change.
+an unguarded hard delete with no tombstone, and a missing production write-path
+hook that silently omits a material change.
 
 The system fails closed on invalid cursors and allocator invariant violations.
 It does not reset an invalid cursor to zero, return a partial cross-app result,
@@ -322,8 +341,8 @@ The migration must:
 3. create one allocator row per app with tickets and set `high_water` to the
    exact maximum assigned ticket value;
 4. install the exact unique `(app_id, material_sequence)` query index;
-5. install lazy-state, `old + 1`, managed-ticket, creation, real
-   status/assignee, and all-comment triggers only after backfill is complete;
+5. install lazy-state, `old + 1`, managed-ticket, ticket-delete, creation, real
+   status/assignee, and comment triggers only after backfill is complete;
 6. leave status, assignee, comments, reporter sequences, reporter events,
    reporter cursors, receipts, and audit rows unchanged;
 7. remain compatible with the previous Worker revision throughout the normal
@@ -376,10 +395,13 @@ separate relative SQLite opcode evidence from production cost claims.
 2. Migration backfill derives dense per-app values only from tickets ordered by
    `(created_at,id)`. Injecting `reporter_sequence`, comment `rowid`,
    `updated_at`, or a foreign high-water into the seed makes a RED fail.
-3. Ticket creation and every listed comment class each commit exactly one new
-   sequence to the affected ticket. A visible comment may advance both the
-   material and reporter domains, but neither value is copied or derived from
-   the other; an internal comment advances material only.
+3. Both current ticket-creation entry points—ordinary public-v2 feedback and
+   Electron minidump—each allocate exactly once. Reporter comment and the real
+   staff route with `internal=false` and `internal=true` each allocate exactly
+   once. A visible comment may advance both material and reporter domains, but
+   neither value is copied or derived from the other; an internal comment
+   advances material only. A future system-comment writer must add its own
+   entry-point RED before shipping.
 4. A batch changing both status and assignee is one material mutation and
    assigns one new sequence, matching the existing single CAS/audit operation.
 5. Exact status/assignee replay, idempotent reporter-comment replay, lost CAS,
@@ -418,16 +440,23 @@ separate relative SQLite opcode evidence from production cost claims.
     reporter event, reporter sequence, reporter cursor, or reporter read state.
     Old-writer/new-schema, new-writer/new-schema, and Worker-rollback/new-schema
     traffic all preserve material semantics.
-15. App deletion cascades tickets and allocator state without a durability
-    trigger blocking purge. Individual ticket hard deletion remains unsupported
-    until a tombstone carrier is designed and tested.
-16. Backup/restore validation rejects missing state for a non-empty app, NULL,
-    unsafe, regressed, cross-app, duplicate, ticket-ahead-of-high-water, and
-    high-water-ahead-of-maximum state.
+15. The ticket-delete guard rejects direct ticket deletion and an integration
+    deletion that would cascade tickets while the parent app exists. The real
+    app-purge entry point still cascades tickets, integrations, and allocator
+    state; removing the guard makes both negative REDs fail.
+16. Backup/restore validation rejects the locally provable corruptions: missing
+    state for a non-empty app, NULL/non-positive/unsafe/duplicate sequence,
+    ticket-ahead-of-high-water, and `MAX(ticket sequence) != high_water`.
+    Runtime guards separately reject app-id reassignment and ticket sequence
+    regression. Detecting a complete but older self-consistent backup or an
+    externally rewritten provenance requires lineage/generation metadata and is
+    not claimed by this carrier.
 17. Removing any material trigger from a real production write entry point
     makes an entry-point test fail. Service-helper-only green tests do not count
-    as proof that ticket creation, admin CAS, reporter comments, staff comments,
-    and system comments are wired.
+    as proof. The required entry points are ordinary public-v2 ticket creation,
+    Electron minidump creation, admin status/assignee CAS, reporter comment, and
+    the staff comment route exercised separately for external and internal
+    comments.
 
 ## Explicitly deferred
 
@@ -440,6 +469,9 @@ separate relative SQLite opcode evidence from production cost claims.
 - field-level delta history;
 - an append-only triage event ledger;
 - Notion migration or backfill;
+- a production system-comment writer;
+- backup generation/provenance able to detect a complete but older
+  self-consistent restore;
 - any further opacity/signing redesign of the existing reporter comment cursor.
 
 Migration 0059 already changed future reporter numbering to ticket-local,

--- a/docs/feedback-material-delta-contract.md
+++ b/docs/feedback-material-delta-contract.md
@@ -4,7 +4,14 @@ Status: proposed contract for independent review. This document does not
 authorize or include a migration, API implementation, merge, backfill, or
 deployment.
 
-Source baseline: `493a3384011b5894275da3387b86f8c89c409ead`.
+Source baseline: `9c52baadf9458b6d48e22eb545a46ca758120923`.
+
+The current reporter pagination domain is the post-migration-0059 schema:
+`reporter_sequence` is ticket-local, assigned only to `internal = 0` comments,
+and protected by the partial unique index
+`(ticket_id, reporter_sequence) WHERE internal = 0`. This contract treats that
+domain as an immutable external compatibility boundary. Material delta uses a
+separate allocator, column, decoder, and cursor discriminator.
 
 ## Decision in plain language
 
@@ -14,14 +21,16 @@ cannot answer it. Symbolication and other internal processing produce false
 changes, while two real changes to the same ticket in the same millisecond can
 collapse behind the same timestamp cursor.
 
-Give every app its own monotonically increasing material-change counter. Store
-the latest assigned number on each ticket. Creating a ticket, really changing
-its status or assignee, or adding any comment assigns that ticket the app's next
-number. Symbolication, reads, downloads, views, and exact no-op replays do not.
+Give every app its own monotonically increasing internal material-change
+counter. Store the latest assigned number on each ticket. Creating a ticket,
+really changing its status or assignee, or adding any comment assigns that
+ticket the app's next number. Symbolication, reads, downloads, views, and exact
+no-op replays do not.
 
 The patrol keeps its own last cursor and asks for current ticket snapshots with
-a larger number. This is intentionally an internal agent surface. Reporter
-surfaces never expose the number, its gaps, or derived activity counts.
+a larger number. This is an authenticated admin/agent surface, not a reporter
+integration surface. Reporter surfaces never expose the number, its gaps, or
+derived activity counts.
 
 ## Existing objects remain authoritative
 
@@ -47,8 +56,9 @@ Add an internal high-water state keyed by `app_id`:
 
 ```sql
 feedback_material_sequence_state (
-  app_id TEXT PRIMARY KEY,
-  high_water INTEGER NOT NULL CHECK (high_water >= 0)
+  app_id TEXT PRIMARY KEY REFERENCES apps(id) ON DELETE CASCADE,
+  high_water INTEGER NOT NULL
+    CHECK (high_water BETWEEN 0 AND 9007199254740991)
 )
 ```
 
@@ -61,14 +71,24 @@ material mutation advances `high_water` by exactly one and assigns that value
 to the affected ticket in the same atomic database unit. Failed or rolled-back
 mutations expose neither a changed ticket nor a new committed cursor. SQLite/D1
 already serializes writes; this contract does not claim a separate concurrency
-benefit from the state row.
+benefit from the state row. Allocation fails closed at JavaScript's maximum
+safe integer rather than emitting a cursor that cannot be decoded exactly.
 
-The implementation may adapt the managed high-water trigger shape from
-migration 0054, but it must not reuse
-`feedback_comment_sequence_state`. That state owns reporter comment pagination,
-while the new state includes internal material activity. Combining the two
-audiences would violate the isolation contract through cursor gaps even if no
-new DTO field were added.
+The allocator is lazy for an app with no tickets: create state at zero, then
+advance to one in the same transaction that creates its first ticket. Database
+guards must reject a state update other than `old + 1`, a non-zero lazy-state
+insert, and deletion while the parent app still exists. App deletion must still
+cascade through both tickets and allocator state; a durability guard must not
+turn normal app purge into an undeletable row.
+
+The implementation may adapt the managed high-water shape from migration 0054,
+but it must not reuse the retired global comment state or derive from any
+`reporter_sequence`. Migration 0059 deliberately left some historical internal
+comments carrying values from the old global reporter-numbering domain. Using
+their `MAX`, `rowid`, or any other foreign-domain value to seed material delta
+would import cross-tenant gaps into the new allocator. Backfill values are
+generated solely from the set of tickets within each app, using the deterministic
+ordering defined below.
 
 ### Ticket carrier
 
@@ -83,6 +103,22 @@ ON feedback_tickets(app_id, material_sequence);
 The `app_id` prefix is mandatory because the query scope is one app. A
 sequence-only index may say `SEARCH` in a plan while still walking other apps'
 rows and filtering them afterward.
+
+The migration backfills every existing ticket before installing runtime
+guards. Afterward:
+
+- application request bodies never accept `material_sequence`;
+- new-ticket, material status/assignee, and comment triggers are the only
+  ordinary writers;
+- a ticket sequence update must be strictly greater than its previous value and
+  equal the allocator's current high-water for the same app;
+- `app_id` cannot change as a side effect of sequence allocation;
+- every committed ticket has a positive, non-null sequence.
+
+These guards do not claim to defend against a database administrator who
+deliberately reproduces the allocator protocol. They prevent route drift,
+accidental direct writes, regression, cross-app assignment, and a ticket value
+that runs ahead of or behind its allocator.
 
 The ticket column is preferred over an append-only change table. A comment
 already updates the ticket row's `updated_at`, so assigning the new sequence in
@@ -103,6 +139,21 @@ Assign a strictly larger per-app sequence for:
 - an internal staff comment;
 - a system comment.
 
+The schema, rather than only the new Worker, must classify these writes. This
+keeps the migration-before-code window and a Worker-only rollback correct:
+
+- `AFTER INSERT` on `feedback_tickets` allocates once for ticket creation;
+- `AFTER UPDATE OF status, assignee` allocates once only when either stored
+  value changes; changing both in the existing single CAS is one mutation;
+- `AFTER INSERT` on `feedback_comments` allocates once for every comment,
+  including `internal = 1` and every author type.
+
+The comment trigger is intentionally independent of migration 0059's reporter
+trigger. One inserted visible comment advances both domains for their different
+audiences; neither high-water is copied from, compared with, or derived from the
+other. An internal comment advances material delta and leaves
+`reporter_sequence` NULL.
+
 Internal comments count because they often represent real handling progress
 that a patrol must observe. Their content and even the frequency of their
 existence remain private under the isolation rules below.
@@ -116,6 +167,11 @@ Do not assign a new sequence for:
 - views, counters, or other internal processing;
 - a mutation that fails or loses its existing CAS.
 
+Idempotent reporter-comment replay does not insert a second comment and must
+therefore produce zero material delta. A conflicting replay, failed attachment
+batch, or any transaction that rolls back after allocation must leave both the
+ticket sequence and allocator high-water unchanged.
+
 If a future feature adds ticket hard deletion, this snapshot-only contract must
 first gain an explicit tombstone carrier. A deleted row cannot be represented
 by the current ticket-column design, so hard deletion must not be silently
@@ -123,28 +179,69 @@ classified as supported material delta.
 
 ## Read contract
 
-The internal agent query has this logical shape:
+Add this route before the existing `feedback/:ticketId` route so the literal is
+not interpreted as a ticket id:
+
+```text
+GET /api/apps/:appId/feedback/material-delta?cursor=<opaque>&limit=<1..200>
+```
+
+It uses the existing admin router and `requireAppRole("viewer")`. Reporter
+integration tokens with `feedback:read` are a different principal and must not
+reach it. Version 1 has no status, owner, kind, SLA, or updated-time filters;
+adding a filter later requires a new query-shape/cursor version or an explicit
+binding in the authenticated cursor.
+
+The database query has this logical shape and fetches `limit + 1` rows:
 
 ```sql
-SELECT <existing internal ticket snapshot fields>, material_sequence
+SELECT <existing admin ticket-list snapshot fields>, material_sequence
 FROM feedback_tickets
 WHERE app_id = ? AND material_sequence > ?
 ORDER BY material_sequence ASC
 LIMIT ?;
 ```
 
-The API is authenticated as an internal admin/agent capability and returns:
+The response is:
+
+```json
+{
+  "tickets": [],
+  "next_cursor": "...",
+  "has_more": false
+}
+```
+
+`tickets` reuses the existing authenticated admin list snapshot and does not
+expose `material_sequence` as a standalone field. The handler uses it only to
+order the page and create `next_cursor`. `has_more` comes from the extra row;
+that row is not returned or acknowledged. An empty page preserves the input
+checkpoint rather than advancing to the allocator's current high-water.
+
+The only accepted cursor payload is exactly
+`["material-v1", app_id, material_sequence]`, encoded behind the existing
+cursor helper. The app id must equal the path parameter and the sequence must be
+a JavaScript-safe, non-negative integer. A cursor for another app, an unsafe
+integer, a malformed/extra-field payload, a reporter `sequence-v1`, a reserved
+reporter `sequence-v2`, or a legacy `(created_at,id)` cursor returns
+`400 invalid cursor`; none is silently reinterpreted or reset to zero.
+“Opaque” is an API abstraction, not a claim of encryption: authorization and
+non-exposure to reporter surfaces are the security boundary.
+
+The API returns:
 
 - current ticket snapshots only;
 - ascending material order;
-- an opaque, versioned next cursor bound to the app and query shape;
+- a versioned next cursor bound to the app and query shape;
 - no consumer-specific server-side checkpoint.
 
-The cursor represents the greatest sequence returned by that page. A ticket can
-appear again after it changes again while a consumer is paging; consumers must
-upsert snapshots by ticket id. Duplication is permitted, omission is not. A
-consumer advances its durable checkpoint only after it has successfully
-processed the whole response it intends to acknowledge.
+The cursor represents the greatest sequence actually returned by that page. A
+ticket can appear again after it changes again while a consumer is paging;
+consumers must upsert snapshots by ticket id. Duplication is permitted,
+omission is not. A consumer advances its durable checkpoint only after it has
+successfully processed the whole page, and continues while `has_more` is true.
+Continuous writes may extend pagination; no endpoint can promise termination
+while the app remains perpetually busy.
 
 The first version does not return a field-level `last_delta`. Consumers already
 hold an older snapshot and can diff it locally. Persisting consumer progress or
@@ -155,8 +252,9 @@ backfilled tickets for that app in sequence order.
 
 ## Isolation contract
 
-`material_sequence`, the internal cursor, cursor gaps, and all values derived
-from them are internal-only metadata.
+`material_sequence`, the admin/agent cursor, cursor gaps, and all values derived
+from them are app-internal metadata. They may be documented in the authenticated
+admin/agent action surface, but not in the separate reporter API contract.
 
 They must not appear in:
 
@@ -165,7 +263,7 @@ They must not appear in:
 - reporter-visible events;
 - signed reporter webhooks;
 - attachment responses;
-- public OpenAPI schemas or public action manifests;
+- reporter OpenAPI schemas or reporter action manifests;
 - error messages, response headers, analytics identifiers, or logs returned to
   a reporter.
 
@@ -175,38 +273,82 @@ frequency of staff-only activity. Per-app allocation limits the blast radius
 if this boundary ever regresses, but it does not make such disclosure allowed.
 
 The new allocator must not advance, renumber, or otherwise influence the
-existing `reporter_sequence` domain.
+existing `reporter_sequence` domain. Its decoder accepts only `material-v1`;
+the reporter decoder accepts neither `material-v1` nor any value produced by
+the material endpoint.
+
+Cross-app cursor replay fails before the query. Even a viewer who is authorized
+for two apps cannot use one app's cursor as a numeric oracle for the other.
+Per-app allocation limits the impact of accidental disclosure, but does not
+make disclosure to a reporter acceptable.
+
+## Threat model and failure posture
+
+Relevant actors are: an unauthenticated caller; a reporter integration token;
+an app viewer with legitimate admin read access; a viewer of two different
+apps; and an ordinary Worker route accidentally writing or serializing the new
+field. Database administrators are trusted to mutate storage but their actions
+remain subject to operational audit; the schema cannot protect against an
+administrator intentionally emulating the allocator protocol.
+
+The protected assets are staff-only activity existence/frequency, another
+app's material volume, exact consumer checkpoints, and completeness of the
+agent's delta feed. The primary threats are reporter-surface leakage, cross-app
+cursor replay, cursor confusion with reporter pagination, attacker-supplied or
+unsafe sequence values, importing another numbering domain during migration,
+and a missing production write-path hook that silently omits a material change.
+
+The system fails closed on invalid cursors and allocator invariant violations.
+It does not reset an invalid cursor to zero, return a partial cross-app result,
+or acknowledge a sequence it did not return. A query/read failure leaves the
+consumer checkpoint unchanged. A write failure rolls back state and ticket
+together. Per-app allocation is defense in depth for accidental leakage; it is
+not authorization to disclose the value.
+
+Availability is bounded with an indexed app-scoped query and a hard page limit.
+The endpoint does not offer arbitrary filters or unbounded history expansion.
+Allocator exhaustion at the maximum safe integer is a terminal operator error
+and aborts the material mutation rather than silently losing numeric precision.
 
 ## Migration and rollout contract
 
 The migration must:
 
-1. create one allocator state per app that has feedback tickets;
-2. deterministically assign every existing ticket a non-null per-app sequence,
-   ordered by `(created_at, id)`;
-3. set each app's `high_water` to the maximum assigned value;
-4. install database ownership/monotonicity guards and the exact
-   `(app_id, material_sequence)` index;
-5. leave status, assignee, comments, reporter events, reporter cursors, and
-   audit rows byte-for-byte or value-for-value unchanged as appropriate;
-6. remain compatible with the previous Worker revision throughout the normal
-   migration-before-code rollout window.
+1. add the nullable carrier column, then deterministically assign every existing
+   ticket a positive per-app sequence ordered by `(created_at, id)`;
+2. generate those values solely from `feedback_tickets` membership/order —
+   never from `reporter_sequence`, comment ids, comment `rowid`, `updated_at`,
+   or another allocator domain;
+3. create one allocator row per app with tickets and set `high_water` to the
+   exact maximum assigned ticket value;
+4. install the exact unique `(app_id, material_sequence)` query index;
+5. install lazy-state, `old + 1`, managed-ticket, creation, real
+   status/assignee, and all-comment triggers only after backfill is complete;
+6. leave status, assignee, comments, reporter sequences, reporter events,
+   reporter cursors, receipts, and audit rows unchanged;
+7. remain compatible with the previous Worker revision throughout the normal
+   migration-before-code rollout window and a Worker-only rollback.
 
 Apps without tickets may create allocator state lazily on their first ticket.
 Backup and restore must preserve ticket sequences and allocator rows together;
 restoring either side alone is invalid. A validation query must prove for every
-app that ticket sequences are unique, positive, and no greater than that app's
-high-water.
+non-empty app that ticket sequences are non-null, unique, positive, safe
+integers, and that `MAX(ticket.material_sequence) = state.high_water`. An app
+with no tickets has either no state row or a zero state row; runtime allocation
+must normalize it before assigning one.
 
 No production backfill is authorized by this document. The implementation PR
-must state the exact compatibility strategy for nullable/default state during
-the rollout window and prove it with old-writer/new-schema tests.
+must state the exact compatibility strategy for the temporarily nullable ALTER
+state inside the migration and prove old-writer/new-schema, new-writer/new-
+schema, and Worker-rollback/new-schema behavior. No committed post-migration
+ticket may remain NULL.
 
 ## Carrier evidence and required pre-implementation recheck
 
-A local SQLite 3.45 source-shaped fixture measured the existing comment insert
-plus ticket `updated_at` update as the baseline. These are relative opcode
-shapes, not production latency or cost claims:
+A pre-implementation local SQLite 3.45 source-shaped fixture measured the
+comment insert plus ticket `updated_at` update as its then-current baseline.
+These historical numbers explain the carrier choice; they are relative opcode
+shapes, not current production latency or cost claims:
 
 | carrier | Insert | Delete | IdxInsert | IdxDelete | delta from baseline |
 | --- | ---: | ---: | ---: | ---: | --- |
@@ -219,38 +361,73 @@ With 100,000 fixture rows, the ticket carrier used one indexed search on
 plus a ticket primary-key search per result.
 
 Before implementation, executable RED tests must repeat the opcode and query-
-plan comparison against the exact then-current full schema. The test must prove
-that the plan constrains both `app_id = ?` and `material_sequence > ?`; merely
-containing the word `SEARCH` is insufficient. Removing or misordering the index
-must make the plan test fail.
+plan comparison against the exact current full schema, including migrations
+0058 and 0059. The test must prove that the plan constrains both `app_id = ?`
+and `material_sequence > ?`; merely containing the word `SEARCH` is
+insufficient. Removing the index, reversing its columns, or querying without
+the app predicate must make the plan tooth fail. The implementation report must
+separate relative SQLite opcode evidence from production cost claims.
 
 ## Acceptance matrix
 
-1. Two apps start independent sequences; mutations in one never change the
-   other's high-water or create gaps in its observed sequence.
-2. Ticket creation and every listed comment class each assign exactly one new
-   sequence to the affected ticket.
-3. A batch changing both status and assignee is one material mutation and
+1. Two apps start independent sequences. Mutations in one never change the
+   other's high-water or create a cross-app gap; replaying its cursor against
+   the other app returns `400` before querying.
+2. Migration backfill derives dense per-app values only from tickets ordered by
+   `(created_at,id)`. Injecting `reporter_sequence`, comment `rowid`,
+   `updated_at`, or a foreign high-water into the seed makes a RED fail.
+3. Ticket creation and every listed comment class each commit exactly one new
+   sequence to the affected ticket. A visible comment may advance both the
+   material and reporter domains, but neither value is copied or derived from
+   the other; an internal comment advances material only.
+4. A batch changing both status and assignee is one material mutation and
    assigns one new sequence, matching the existing single CAS/audit operation.
-4. Exact status/assignee replay, lost CAS, symbolication-only update, read
-   receipt, attachment read/download, and failed transaction leave both ticket
-   sequence and app high-water unchanged.
-5. Equal-millisecond and concurrent material changes are not omitted across
-   cursor pages. Repeated snapshots of a ticket remain safe to upsert.
-6. Cursor zero returns every migrated ticket once in deterministic bootstrap
-   order; a second query from the returned cursor is empty when nothing changed.
-7. The 100k-ticket query uses the exact per-app index without a full table scan;
-   the RED mutation for a missing or wrong-order index fails.
-8. Reporter list, detail, comments, events, webhooks, attachments, schemas,
-   headers, and errors contain no material sequence, cursor, gap, or derived
-   count. Injection into any one of them makes its isolation test fail.
-9. Material mutations do not change existing reporter cursor bytes or the
-   `feedback_comment_sequence_state` high-water.
-10. Migration backfill changes no ticket business field, comment, audit row,
-    reporter event, or reporter read state, and old-writer/new-schema traffic
-    remains valid.
-11. Backup/restore validation rejects missing, regressed, cross-app, duplicate,
-    or ticket-ahead-of-high-water state.
+5. Exact status/assignee replay, idempotent reporter-comment replay, lost CAS,
+   symbolication-only update, read receipt, attachment read/download, and a
+   failed or rolled-back transaction leave both ticket sequence and app
+   high-water unchanged.
+6. Two material writes in one D1 batch and competing writes to one app receive
+   distinct consecutive committed numbers. A duplicate, regression, skipped
+   high-water update, unsafe-integer advance, or ticket-ahead-of-state attempt
+   aborts rather than becoming queryable.
+7. Equal-millisecond and concurrent material changes are not omitted across
+   cursor pages. A ticket that changes again may reappear and remains safe to
+   upsert; a limit-plus-one row is never accidentally acknowledged.
+8. Cursor zero returns every migrated ticket once in deterministic bootstrap
+   order. A second query from the returned cursor is empty when nothing changed;
+   an empty page does not jump to an unseen allocator high-water.
+9. Only exact `material-v1` with the current app and a safe integer is accepted.
+   Reporter `sequence-v1`, reserved `sequence-v2`, legacy timestamp cursors,
+   cross-app values, malformed payloads, and negative/unsafe integers are all
+   `400` with no reset-to-zero fallback.
+10. The literal `/feedback/material-delta` route resolves before
+    `/feedback/:ticketId`, requires the existing app-viewer admin principal,
+    and rejects reporter integration credentials even when they possess
+    reporter `feedback:read`.
+11. The 100k-ticket query uses the exact `(app_id,material_sequence)` index and
+    constrains both predicates without a full scan. Missing, reversed, or
+    sequence-only indexes each make the plan tooth fail.
+12. Reporter list, detail, comments, pagination, events, webhooks, attachments,
+    reporter schemas/manifests, headers, errors, and reporter-visible logs
+    contain no material sequence, material cursor, gap, or derived count.
+    Injection into any one makes its isolation test fail.
+13. The material decoder rejects reporter cursors and the reporter decoder
+    rejects `material-v1`; changes in either domain do not alter the other's
+    cursor bytes, stored values, ordering, receipts, or high-water behavior.
+14. Migration backfill changes no ticket business field, comment, audit row,
+    reporter event, reporter sequence, reporter cursor, or reporter read state.
+    Old-writer/new-schema, new-writer/new-schema, and Worker-rollback/new-schema
+    traffic all preserve material semantics.
+15. App deletion cascades tickets and allocator state without a durability
+    trigger blocking purge. Individual ticket hard deletion remains unsupported
+    until a tombstone carrier is designed and tested.
+16. Backup/restore validation rejects missing state for a non-empty app, NULL,
+    unsafe, regressed, cross-app, duplicate, ticket-ahead-of-high-water, and
+    high-water-ahead-of-maximum state.
+17. Removing any material trigger from a real production write entry point
+    makes an entry-point test fail. Service-helper-only green tests do not count
+    as proof that ticket creation, admin CAS, reporter comments, staff comments,
+    and system comments are wired.
 
 ## Explicitly deferred
 
@@ -263,8 +440,10 @@ must make the plan test fail.
 - field-level delta history;
 - an append-only triage event ledger;
 - Notion migration or backfill;
-- any redesign of the existing reporter comment cursor.
+- any further opacity/signing redesign of the existing reporter comment cursor.
 
-The last item is a separate compatibility and security domain. It must be
-designed under its own task; this contract does not silently change reporter
-pagination behavior.
+Migration 0059 already changed future reporter numbering to ticket-local,
+visible-only allocation while preserving historical cursor values. This
+contract neither reopens that design nor claims historical reporter gaps were
+erased. Any later cursor opacity/signing work is a separate compatibility and
+security domain.

--- a/docs/feedback-material-delta-contract.md
+++ b/docs/feedback-material-delta-contract.md
@@ -1,0 +1,270 @@
+# Feedback material-delta contract
+
+Status: proposed contract for independent review. This document does not
+authorize or include a migration, API implementation, merge, backfill, or
+deployment.
+
+Source baseline: `493a3384011b5894275da3387b86f8c89c409ead`.
+
+## Decision in plain language
+
+An agent that patrols feedback needs an exact answer to one question: “which
+tickets materially changed since my last successful patrol?” `updated_at`
+cannot answer it. Symbolication and other internal processing produce false
+changes, while two real changes to the same ticket in the same millisecond can
+collapse behind the same timestamp cursor.
+
+Give every app its own monotonically increasing material-change counter. Store
+the latest assigned number on each ticket. Creating a ticket, really changing
+its status or assignee, or adding any comment assigns that ticket the app's next
+number. Symbolication, reads, downloads, views, and exact no-op replays do not.
+
+The patrol keeps its own last cursor and asks for current ticket snapshots with
+a larger number. This is intentionally an internal agent surface. Reporter
+surfaces never expose the number, its gaps, or derived activity counts.
+
+## Existing objects remain authoritative
+
+Hands already has:
+
+- `feedback_tickets.status` for the lifecycle;
+- `feedback_tickets.assignee` for ownership;
+- CAS-protected status/assignee mutation whose SQL requires an `audit_logs`
+  row;
+- audit actions for comments;
+- `feedback_tickets.updated_at` for ordinary presentation ordering.
+
+This change does not add another status, owner, audit log, content fingerprint,
+or “reported” flag. The new sequence is only a lossless ticket-level change
+cursor. `audit_logs` remains the detailed history; `updated_at` remains a
+human-facing timestamp.
+
+## Data contract
+
+### Per-app allocator
+
+Add an internal high-water state keyed by `app_id`:
+
+```sql
+feedback_material_sequence_state (
+  app_id TEXT PRIMARY KEY,
+  high_water INTEGER NOT NULL CHECK (high_water >= 0)
+)
+```
+
+This is deliberately not a global singleton. Each app receives its own dense,
+monotonic sequence. App A's traffic cannot create gaps in App B's sequence, so
+an accidental future disclosure cannot reveal cross-app activity volume.
+
+The database, not request input, owns allocation. For one app, every committed
+material mutation advances `high_water` by exactly one and assigns that value
+to the affected ticket in the same atomic database unit. Failed or rolled-back
+mutations expose neither a changed ticket nor a new committed cursor. SQLite/D1
+already serializes writes; this contract does not claim a separate concurrency
+benefit from the state row.
+
+The implementation may adapt the managed high-water trigger shape from
+migration 0054, but it must not reuse
+`feedback_comment_sequence_state`. That state owns reporter comment pagination,
+while the new state includes internal material activity. Combining the two
+audiences would violate the isolation contract through cursor gaps even if no
+new DTO field were added.
+
+### Ticket carrier
+
+Add an internally managed `feedback_tickets.material_sequence` and a unique
+index whose exact key order is:
+
+```sql
+CREATE UNIQUE INDEX ...
+ON feedback_tickets(app_id, material_sequence);
+```
+
+The `app_id` prefix is mandatory because the query scope is one app. A
+sequence-only index may say `SEARCH` in a plan while still walking other apps'
+rows and filtering them afterward.
+
+The ticket column is preferred over an append-only change table. A comment
+already updates the ticket row's `updated_at`, so assigning the new sequence in
+that same update reuses an existing row write. It also bounds storage, naturally
+coalesces repeated changes into the current snapshot, and avoids a per-result
+join from change row to ticket. It does not preserve intermediate changes;
+`audit_logs` owns that responsibility.
+
+### Material mutations
+
+Assign a strictly larger per-app sequence for:
+
+- creation of a new feedback ticket;
+- a status change where the stored value really changes;
+- an assignee change where the stored value really changes;
+- a reporter comment;
+- an external staff comment;
+- an internal staff comment;
+- a system comment.
+
+Internal comments count because they often represent real handling progress
+that a patrol must observe. Their content and even the frequency of their
+existence remain private under the isolation rules below.
+
+Do not assign a new sequence for:
+
+- symbolication status, stack, or artifact processing;
+- exact status/assignee replay;
+- reporter read receipts;
+- attachment reads or downloads;
+- views, counters, or other internal processing;
+- a mutation that fails or loses its existing CAS.
+
+If a future feature adds ticket hard deletion, this snapshot-only contract must
+first gain an explicit tombstone carrier. A deleted row cannot be represented
+by the current ticket-column design, so hard deletion must not be silently
+classified as supported material delta.
+
+## Read contract
+
+The internal agent query has this logical shape:
+
+```sql
+SELECT <existing internal ticket snapshot fields>, material_sequence
+FROM feedback_tickets
+WHERE app_id = ? AND material_sequence > ?
+ORDER BY material_sequence ASC
+LIMIT ?;
+```
+
+The API is authenticated as an internal admin/agent capability and returns:
+
+- current ticket snapshots only;
+- ascending material order;
+- an opaque, versioned next cursor bound to the app and query shape;
+- no consumer-specific server-side checkpoint.
+
+The cursor represents the greatest sequence returned by that page. A ticket can
+appear again after it changes again while a consumer is paging; consumers must
+upsert snapshots by ticket id. Duplication is permitted, omission is not. A
+consumer advances its durable checkpoint only after it has successfully
+processed the whole response it intends to acknowledge.
+
+The first version does not return a field-level `last_delta`. Consumers already
+hold an older snapshot and can diff it locally. Persisting consumer progress or
+reconstructable field diffs in Hands would create additional truth sources.
+
+An initial query from cursor zero is also the bootstrap path; it must return all
+backfilled tickets for that app in sequence order.
+
+## Isolation contract
+
+`material_sequence`, the internal cursor, cursor gaps, and all values derived
+from them are internal-only metadata.
+
+They must not appear in:
+
+- reporter ticket list or detail DTOs;
+- reporter comment pagination cursors;
+- reporter-visible events;
+- signed reporter webhooks;
+- attachment responses;
+- public OpenAPI schemas or public action manifests;
+- error messages, response headers, analytics identifiers, or logs returned to
+  a reporter.
+
+This is stronger than hiding one column. Because internal comments advance the
+counter, any reversible reporter value derived from it leaks the existence and
+frequency of staff-only activity. Per-app allocation limits the blast radius
+if this boundary ever regresses, but it does not make such disclosure allowed.
+
+The new allocator must not advance, renumber, or otherwise influence the
+existing `reporter_sequence` domain.
+
+## Migration and rollout contract
+
+The migration must:
+
+1. create one allocator state per app that has feedback tickets;
+2. deterministically assign every existing ticket a non-null per-app sequence,
+   ordered by `(created_at, id)`;
+3. set each app's `high_water` to the maximum assigned value;
+4. install database ownership/monotonicity guards and the exact
+   `(app_id, material_sequence)` index;
+5. leave status, assignee, comments, reporter events, reporter cursors, and
+   audit rows byte-for-byte or value-for-value unchanged as appropriate;
+6. remain compatible with the previous Worker revision throughout the normal
+   migration-before-code rollout window.
+
+Apps without tickets may create allocator state lazily on their first ticket.
+Backup and restore must preserve ticket sequences and allocator rows together;
+restoring either side alone is invalid. A validation query must prove for every
+app that ticket sequences are unique, positive, and no greater than that app's
+high-water.
+
+No production backfill is authorized by this document. The implementation PR
+must state the exact compatibility strategy for nullable/default state during
+the rollout window and prove it with old-writer/new-schema tests.
+
+## Carrier evidence and required pre-implementation recheck
+
+A local SQLite 3.45 source-shaped fixture measured the existing comment insert
+plus ticket `updated_at` update as the baseline. These are relative opcode
+shapes, not production latency or cost claims:
+
+| carrier | Insert | Delete | IdxInsert | IdxDelete | delta from baseline |
+| --- | ---: | ---: | ---: | ---: | --- |
+| baseline | 4 | 3 | 4 | 1 | — |
+| ticket column, combined with existing ticket update | 5 | 4 | 5 | 2 | +1 each |
+| append-only change row | 6 | 4 | 5 | 1 | +2 / +1 / +1 / +0 |
+
+With 100,000 fixture rows, the ticket carrier used one indexed search on
+`(app_id, material_sequence)`. The append carrier used one change-index search
+plus a ticket primary-key search per result.
+
+Before implementation, executable RED tests must repeat the opcode and query-
+plan comparison against the exact then-current full schema. The test must prove
+that the plan constrains both `app_id = ?` and `material_sequence > ?`; merely
+containing the word `SEARCH` is insufficient. Removing or misordering the index
+must make the plan test fail.
+
+## Acceptance matrix
+
+1. Two apps start independent sequences; mutations in one never change the
+   other's high-water or create gaps in its observed sequence.
+2. Ticket creation and every listed comment class each assign exactly one new
+   sequence to the affected ticket.
+3. A batch changing both status and assignee is one material mutation and
+   assigns one new sequence, matching the existing single CAS/audit operation.
+4. Exact status/assignee replay, lost CAS, symbolication-only update, read
+   receipt, attachment read/download, and failed transaction leave both ticket
+   sequence and app high-water unchanged.
+5. Equal-millisecond and concurrent material changes are not omitted across
+   cursor pages. Repeated snapshots of a ticket remain safe to upsert.
+6. Cursor zero returns every migrated ticket once in deterministic bootstrap
+   order; a second query from the returned cursor is empty when nothing changed.
+7. The 100k-ticket query uses the exact per-app index without a full table scan;
+   the RED mutation for a missing or wrong-order index fails.
+8. Reporter list, detail, comments, events, webhooks, attachments, schemas,
+   headers, and errors contain no material sequence, cursor, gap, or derived
+   count. Injection into any one of them makes its isolation test fail.
+9. Material mutations do not change existing reporter cursor bytes or the
+   `feedback_comment_sequence_state` high-water.
+10. Migration backfill changes no ticket business field, comment, audit row,
+    reporter event, or reporter read state, and old-writer/new-schema traffic
+    remains valid.
+11. Backup/restore validation rejects missing, regressed, cross-app, duplicate,
+    or ticket-ahead-of-high-water state.
+
+## Explicitly deferred
+
+- new lifecycle states;
+- severity and area taxonomies;
+- SLA or due dates;
+- canonical Raft/GitHub links;
+- close-evidence enforcement;
+- `needs_report` or another consumer checkpoint in Hands;
+- field-level delta history;
+- an append-only triage event ledger;
+- Notion migration or backfill;
+- any redesign of the existing reporter comment cursor.
+
+The last item is a separate compatibility and security domain. It must be
+designed under its own task; this contract does not silently change reporter
+pagination behavior.

--- a/docs/feedback-material-delta-implementation-report.md
+++ b/docs/feedback-material-delta-implementation-report.md
@@ -1,0 +1,74 @@
+# Feedback material-delta implementation evidence
+
+This report records executable local SQLite evidence for migration 0060. It is
+not a production D1 latency or billing claim. The authoritative tests are:
+
+- `worker/test/feedback_material_delta_migration.test.ts`
+- `worker/test/feedback_material_delta_route.test.ts`
+
+## Query plan
+
+The plan fixture applies the complete ordered migration set through 0059,
+inserts 100,000 feedback tickets for one app, applies 0060, and runs the exact
+material-delta query shape. The accepted plan must contain:
+
+```text
+idx_feedback_tickets_app_material_sequence
+(app_id=? AND material_sequence>?)
+```
+
+It must not contain `USE TEMP B-TREE FOR ORDER BY`. The test drops the index,
+recreates it as `(material_sequence, app_id)`, recreates it as
+`(material_sequence)`, and removes the app predicate from the query. Each
+mutation must fail the accepted-plan predicate before the exact
+`(app_id, material_sequence)` index and query are restored.
+
+## Static SQLite write opcode inventory
+
+The opcode fixture uses the complete schema through 0059 as its baseline and
+counts `Insert`, `Delete`, `IdxInsert`, `IdxDelete`, and trigger `Program`
+opcodes from `EXPLAIN`. Counts include conditional trigger programs compiled by
+SQLite; they are a relative static shape, not the number of writes performed by
+every runtime execution.
+
+| write shape | carrier | Insert | Delete | IdxInsert | IdxDelete | Program |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| ticket creation | 0059 baseline | 1 | 0 | 14 | 0 | 1 |
+| ticket creation | 0060 ticket carrier | 4 | 0 | 17 | 1 | 6 |
+| status + assignee | 0059 baseline | 1 | 0 | 5 | 1 | 0 |
+| status + assignee | 0060 ticket carrier | 3 | 0 | 6 | 2 | 3 |
+| comment insert | 0059 baseline | 2 | 0 | 11 | 2 | 4 |
+| comment insert | 0060 ticket carrier | 4 | 0 | 12 | 3 | 7 |
+| comment insert | synthetic append carrier | 5 | 0 | 13 | 2 | 5 |
+
+For the current comment path, the ticket carrier adds two table `Insert`
+opcodes, one `IdxInsert`, and one `IdxDelete` relative to 0059. The synthetic
+append carrier adds three table `Insert` opcodes and two `IdxInsert` opcodes,
+with no additional `IdxDelete`. This comparison is why 0060 keeps the current
+snapshot on the ticket instead of adding a durable change-history row.
+
+## Rollout and restore checks
+
+The full-migration tests prove all of the following:
+
+- a previous Worker insert that omits `material_sequence` commits with a
+  non-null allocated value under the new schema;
+- a Worker-only rollback remains compatible because allocation is enforced by
+  schema triggers rather than new-writer SQL;
+- ticket carrier and allocator writes roll back together on a failed batch;
+- a reusable validation query at
+  `migrations/validation/0060_feedback_material_delta.sql` returns zero rows for
+  valid state and returns a blocking violation for missing allocator state,
+  null, non-positive, non-integer, unsafe, or duplicate ticket sequences,
+  ticket-ahead state, unsafe high-water, and maximum/high-water mismatch;
+- the production app-purge handler still cascades tickets, comments, reporter
+  integrations, and allocator state, while direct ticket or integration
+  deletion is rejected while the parent app exists.
+
+Run the focused evidence with:
+
+```bash
+pnpm --filter @botiverse/hands-worker exec vitest run \
+  test/feedback_material_delta_migration.test.ts \
+  test/feedback_material_delta_route.test.ts
+```

--- a/migrations/sql/0060_feedback_material_delta.sql
+++ b/migrations/sql/0060_feedback_material_delta.sql
@@ -1,0 +1,57 @@
+-- Internal agent material-delta cursor for feedback tickets.
+--
+-- This is a separate numbering domain from reporter_sequence. The reporter
+-- domain is ticket-local and visible-comment-only; material delta is app-local
+-- and advances for ticket creation, real status/assignee changes, and every
+-- current production comment insert (reporter or staff, external or internal).
+-- Values are generated only from feedback_tickets and are never seeded from a
+-- comment sequence, rowid, or timestamp.
+
+ALTER TABLE feedback_tickets ADD COLUMN material_sequence INTEGER;
+
+CREATE TABLE feedback_material_sequence_state (
+  app_id TEXT PRIMARY KEY REFERENCES apps(id) ON DELETE CASCADE,
+  high_water INTEGER NOT NULL
+    CHECK (high_water BETWEEN 0 AND 9007199254740991)
+);
+
+-- Deterministic per-app bootstrap. ROW_NUMBER is dense inside each app and
+-- does not import values from any prior numbering domain.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY app_id ORDER BY created_at, id) AS seq
+  FROM feedback_tickets
+)
+UPDATE feedback_tickets
+SET material_sequence = (SELECT seq FROM ranked WHERE ranked.id = feedback_tickets.id);
+
+INSERT INTO feedback_material_sequence_state (app_id, high_water)
+SELECT app_id, MAX(material_sequence)
+FROM feedback_tickets
+GROUP BY app_id;
+
+CREATE UNIQUE INDEX idx_feedback_tickets_app_material_sequence
+  ON feedback_tickets(app_id, material_sequence);
+
+-- Cloudflare's remote D1 migration parser requires trigger bodies on one
+-- physical line (workers-sdk#4998 / CFSQL-1402). Keep these compact.
+
+CREATE TRIGGER feedback_material_state_insert_guard BEFORE INSERT ON feedback_material_sequence_state WHEN NEW.high_water != 0 BEGIN SELECT RAISE(ABORT, 'feedback material state must start at zero'); END;
+
+CREATE TRIGGER feedback_material_state_monotonic BEFORE UPDATE ON feedback_material_sequence_state WHEN NEW.app_id != OLD.app_id OR NEW.high_water != OLD.high_water + 1 BEGIN SELECT RAISE(ABORT, 'feedback material high-water must advance by one'); END;
+
+CREATE TRIGGER feedback_material_state_no_delete BEFORE DELETE ON feedback_material_sequence_state WHEN EXISTS (SELECT 1 FROM apps WHERE id = OLD.app_id) BEGIN SELECT RAISE(ABORT, 'feedback material state is durable while app exists'); END;
+
+CREATE TRIGGER feedback_tickets_material_managed_insert BEFORE INSERT ON feedback_tickets WHEN NEW.material_sequence IS NOT NULL BEGIN SELECT RAISE(ABORT, 'feedback material sequence is managed'); END;
+
+CREATE TRIGGER feedback_tickets_app_immutable BEFORE UPDATE OF app_id ON feedback_tickets WHEN NEW.app_id != OLD.app_id BEGIN SELECT RAISE(ABORT, 'feedback ticket app is immutable'); END;
+
+CREATE TRIGGER feedback_tickets_material_managed_update BEFORE UPDATE OF material_sequence ON feedback_tickets WHEN NEW.material_sequence IS NULL OR NEW.app_id != OLD.app_id OR NEW.material_sequence <= COALESCE(OLD.material_sequence, 0) OR NEW.material_sequence != (SELECT high_water FROM feedback_material_sequence_state WHERE app_id = NEW.app_id) BEGIN SELECT RAISE(ABORT, 'feedback material sequence is managed'); END;
+
+CREATE TRIGGER feedback_tickets_material_no_delete BEFORE DELETE ON feedback_tickets WHEN EXISTS (SELECT 1 FROM apps WHERE id = OLD.app_id) BEGIN SELECT RAISE(ABORT, 'feedback ticket deletion requires app purge or tombstone'); END;
+
+CREATE TRIGGER feedback_tickets_material_insert AFTER INSERT ON feedback_tickets BEGIN INSERT OR IGNORE INTO feedback_material_sequence_state (app_id, high_water) VALUES (NEW.app_id, 0); UPDATE feedback_material_sequence_state SET high_water = high_water + 1 WHERE app_id = NEW.app_id; UPDATE feedback_tickets SET material_sequence = (SELECT high_water FROM feedback_material_sequence_state WHERE app_id = NEW.app_id) WHERE rowid = NEW.rowid; END;
+
+CREATE TRIGGER feedback_tickets_material_status_assignee AFTER UPDATE OF status, assignee ON feedback_tickets WHEN NEW.status IS NOT OLD.status OR NEW.assignee IS NOT OLD.assignee BEGIN UPDATE feedback_material_sequence_state SET high_water = high_water + 1 WHERE app_id = NEW.app_id; UPDATE feedback_tickets SET material_sequence = (SELECT high_water FROM feedback_material_sequence_state WHERE app_id = NEW.app_id) WHERE rowid = NEW.rowid; END;
+
+CREATE TRIGGER feedback_comments_material_insert AFTER INSERT ON feedback_comments BEGIN UPDATE feedback_material_sequence_state SET high_water = high_water + 1 WHERE app_id = (SELECT app_id FROM feedback_tickets WHERE id = NEW.ticket_id); UPDATE feedback_tickets SET material_sequence = (SELECT high_water FROM feedback_material_sequence_state WHERE app_id = feedback_tickets.app_id) WHERE id = NEW.ticket_id; END;

--- a/migrations/validation/0060_feedback_material_delta.sql
+++ b/migrations/validation/0060_feedback_material_delta.sql
@@ -1,0 +1,45 @@
+-- Post-migration / restore validator for feedback material-delta state.
+--
+-- A valid database returns zero rows. Any returned row is a hard rollout or
+-- restore blocker; repair ticket carrier and allocator state together before
+-- allowing material-delta readers or writers to resume.
+WITH app_stats AS (
+  SELECT a.id AS app_id,
+         COUNT(t.id) AS ticket_count,
+         SUM(CASE WHEN t.id IS NOT NULL AND t.material_sequence IS NULL THEN 1 ELSE 0 END) AS null_count,
+         SUM(CASE WHEN t.id IS NOT NULL AND typeof(t.material_sequence) != 'integer' THEN 1 ELSE 0 END) AS noninteger_count,
+         SUM(CASE WHEN t.id IS NOT NULL AND t.material_sequence <= 0 THEN 1 ELSE 0 END) AS nonpositive_count,
+         SUM(CASE WHEN t.id IS NOT NULL AND t.material_sequence > 9007199254740991 THEN 1 ELSE 0 END) AS unsafe_count,
+         COUNT(t.material_sequence) - COUNT(DISTINCT t.material_sequence) AS duplicate_count,
+         MAX(t.material_sequence) AS max_sequence,
+         s.high_water AS high_water,
+         typeof(s.high_water) AS high_water_type
+  FROM apps a
+  LEFT JOIN feedback_tickets t ON t.app_id = a.id
+  LEFT JOIN feedback_material_sequence_state s ON s.app_id = a.id
+  GROUP BY a.id, s.high_water
+), violations AS (
+  SELECT app_id,
+         CASE
+           WHEN ticket_count > 0 AND high_water IS NULL THEN 'missing_state'
+           WHEN null_count > 0 THEN 'null_ticket_sequence'
+           WHEN noninteger_count > 0 THEN 'noninteger_ticket_sequence'
+           WHEN nonpositive_count > 0 THEN 'nonpositive_ticket_sequence'
+           WHEN unsafe_count > 0 THEN 'unsafe_ticket_sequence'
+           WHEN duplicate_count > 0 THEN 'duplicate_ticket_sequence'
+           WHEN high_water IS NOT NULL AND high_water_type != 'integer' THEN 'noninteger_high_water'
+           WHEN high_water IS NOT NULL AND (high_water < 0 OR high_water > 9007199254740991) THEN 'unsafe_high_water'
+           WHEN ticket_count = 0 AND high_water NOT IN (0) THEN 'empty_app_nonzero_state'
+           WHEN ticket_count > 0 AND max_sequence > high_water THEN 'ticket_ahead_of_high_water'
+           WHEN ticket_count > 0 AND max_sequence != high_water THEN 'max_high_water_mismatch'
+           ELSE NULL
+         END AS violation,
+         ticket_count,
+         max_sequence,
+         high_water
+  FROM app_stats
+)
+SELECT app_id, violation, ticket_count, max_sequence, high_water
+FROM violations
+WHERE violation IS NOT NULL
+ORDER BY app_id;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -75,6 +75,7 @@ import {
   handlePublicFeedbackSubmit,
   handlePublicMinidumpSubmit,
   handleListFeedback,
+  handleListFeedbackMaterialDelta,
   handleGetFeedback,
   handleUpdateFeedback,
   handleAddFeedbackComment,
@@ -755,6 +756,11 @@ admin.get("/api/apps/:appId/analytics/versions", requireAppRole("viewer"), handl
 admin.get("/api/apps/:appId/analytics/devices/:deviceId", requireAppRole("viewer"), handleDeviceDetail);
 admin.get("/api/apps/:appId/release-health", requireAppRole("viewer"), handleReleaseHealth);
 admin.get("/api/apps/:appId/feedback", requireAppRole("viewer"), handleListFeedback);
+admin.get(
+  "/api/apps/:appId/feedback/material-delta",
+  requireAppRole("viewer"),
+  handleListFeedbackMaterialDelta,
+);
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);
 admin.patch("/api/apps/:appId/feedback/:ticketId", requireFeedbackTriageRole(), handleUpdateFeedback);
 admin.post("/api/apps/:appId/feedback/:ticketId/comments", requireFeedbackTriageRole(), handleAddFeedbackComment);

--- a/worker/src/openapi/feedback.ts
+++ b/worker/src/openapi/feedback.ts
@@ -253,6 +253,34 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
 
   register(registry, {
     method: "get",
+    path: "/api/apps/{appId}/feedback/material-delta",
+    tags: ["Feedback"],
+    summary: "List materially changed feedback ticket snapshots",
+    description: "Returns current snapshots after an opaque per-app cursor. Process a whole page before persisting next_cursor.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      query: z.object({
+        cursor: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(200).optional(),
+      }),
+    },
+    responses: {
+      200: success(
+        "Materially changed feedback snapshots.",
+        z.object({
+          tickets: z.array(GenericObject),
+          next_cursor: z.string(),
+          has_more: z.boolean(),
+        }),
+      ),
+      400: error("Invalid material cursor or limit."),
+      403: error("Current principal cannot view feedback."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
     path: "/api/apps/{appId}/feedback/stats",
     tags: ["Feedback"],
     summary: "Read feedback ticket statistics",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1439,6 +1439,17 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "list-feedback-material-delta",
+        description:
+          "List current feedback ticket snapshots that materially changed after an opaque per-app cursor. Requires app viewer. Process the whole page before persisting next_cursor.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/feedback/material-delta" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          cursor: { type: "string", in: "query", required: false, description: "Opaque material-v1 cursor from the previous page; omit for bootstrap." },
+          limit: { type: "number", in: "query", required: false, description: "Page size from 1 to 200; defaults to 100." },
+        },
+      },
+      {
         name: "bind-reporter-webhook",
         description:
           "Bind one active app webhook as the exact subscriber for one active reporter integration. Requires app admin and does not create or enable a webhook.",

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -30,6 +30,38 @@ const TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR = 100;
 const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
 const TICKET_KINDS = ["feedback", "bug", "crash", "error"] as const;
 const SUBMISSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MATERIAL_DELTA_DEFAULT_LIMIT = 100;
+const MATERIAL_DELTA_MAX_LIMIT = 200;
+
+function encodeMaterialCursor(appId: string, sequence: number): string {
+  return btoa(JSON.stringify(["material-v1", appId, sequence]))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function decodeMaterialCursor(value: string | undefined, appId: string): number | null {
+  if (value === undefined) return 0;
+  if (!value) return null;
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const decoded = JSON.parse(atob(padded));
+    if (
+      !Array.isArray(decoded)
+      || decoded.length !== 3
+      || decoded[0] !== "material-v1"
+      || decoded[1] !== appId
+      || !Number.isSafeInteger(decoded[2])
+      || decoded[2] < 0
+    ) {
+      return null;
+    }
+    return decoded[2];
+  } catch {
+    return null;
+  }
+}
 
 function timingDuration(start: number, end: number): string {
   return Math.max(0, end - start).toFixed(1);
@@ -1904,6 +1936,44 @@ export async function handleListFeedback(c: AdminContext) {
     .bind(...binds)
     .all();
   return c.json({ tickets: results });
+}
+
+export async function handleListFeedbackMaterialDelta(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const cursor = decodeMaterialCursor(c.req.query("cursor"), appId);
+  if (cursor === null) return c.json({ error: "invalid cursor" }, 400);
+
+  const rawLimit = c.req.query("limit");
+  const limit = rawLimit === undefined ? MATERIAL_DELTA_DEFAULT_LIMIT : Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MATERIAL_DELTA_MAX_LIMIT) {
+    return c.json({ error: `limit must be an integer between 1 and ${MATERIAL_DELTA_MAX_LIMIT}` }, 400);
+  }
+
+  const { results } = await c.env.DB.prepare(
+    `SELECT t.id, t.kind, t.status, t.assignee, t.message, t.contact, t.version_name,
+            t.version_code, t.channel, t.device_id, t.device_model, t.os_version,
+            t.created_at, t.updated_at, t.material_sequence,
+            (SELECT COUNT(*) FROM feedback_attachments fa WHERE fa.ticket_id = t.id) AS attachment_count,
+            (SELECT COUNT(*) FROM feedback_comments fc WHERE fc.ticket_id = t.id) AS comment_count
+     FROM feedback_tickets t
+     WHERE t.app_id = ?1 AND t.material_sequence > ?2
+     ORDER BY t.material_sequence ASC
+     LIMIT ?3`,
+  )
+    .bind(appId, cursor, limit + 1)
+    .all<Record<string, unknown> & { material_sequence: number }>();
+
+  const page = results.slice(0, limit);
+  const lastSequence = page.at(-1)?.material_sequence ?? cursor;
+  if (!Number.isSafeInteger(lastSequence) || lastSequence < 0) {
+    return c.json({ error: "invalid material sequence state" }, 500);
+  }
+  const tickets = page.map(({ material_sequence: _sequence, ...ticket }) => ticket);
+  return c.json({
+    tickets,
+    next_cursor: encodeMaterialCursor(appId, lastSequence),
+    has_more: results.length > limit,
+  });
 }
 
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;

--- a/worker/test/feedback_material_delta_migration.test.ts
+++ b/worker/test/feedback_material_delta_migration.test.ts
@@ -204,6 +204,10 @@ describe("migration 0060 — feedback material delta", () => {
     app(db, "app-a");
     const intg = integration(db, "app-a");
     ticket(db, "ticket", "app-a", 1, intg);
+    staffComment(db, "visible", "ticket", 0);
+    staffComment(db, "internal", "ticket", 1);
+    expect([reporterSequence(db, "visible"), reporterSequence(db, "internal")])
+      .toEqual([1, null]);
 
     expect(() => db.prepare("DELETE FROM feedback_tickets WHERE id='ticket'").run())
       .toThrow(/requires app purge or tombstone/);
@@ -214,6 +218,7 @@ describe("migration 0060 — feedback material delta", () => {
 
     db.prepare("DELETE FROM apps WHERE id='app-a'").run();
     expect(db.prepare("SELECT id FROM feedback_tickets WHERE id='ticket'").get()).toBeUndefined();
+    expect(db.prepare("SELECT id FROM feedback_comments WHERE ticket_id='ticket'").all()).toEqual([]);
     expect(db.prepare("SELECT id FROM app_reporter_integrations WHERE id=?").get(intg)).toBeUndefined();
     expect(db.prepare(
       "SELECT app_id FROM feedback_material_sequence_state WHERE app_id='app-a'",

--- a/worker/test/feedback_material_delta_migration.test.ts
+++ b/worker/test/feedback_material_delta_migration.test.ts
@@ -1,0 +1,236 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+const MIGRATION = "0060_feedback_material_delta.sql";
+
+function applyMigrations(db: Database.Database, includeMaterial = true) {
+  for (const name of readdirSync(MIGRATION_DIR).sort()) {
+    if (!name.endsWith(".sql")) continue;
+    if (name === MIGRATION && !includeMaterial) continue;
+    db.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+  }
+}
+
+const migrate = (db: Database.Database) =>
+  db.exec(readFileSync(`${MIGRATION_DIR}${MIGRATION}`, "utf8"));
+
+function database(includeMaterial = true) {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applyMigrations(db, includeMaterial);
+  return db;
+}
+
+function app(db: Database.Database, id: string) {
+  db.prepare(
+    "INSERT INTO apps (id, slug, name, platform, created_at) VALUES (?,?,?,'android',1)",
+  ).run(id, id, id);
+}
+
+function integration(db: Database.Database, appId: string) {
+  const id = `intg-${appId}`;
+  db.prepare(
+    "INSERT INTO app_reporter_integrations (id, app_id, name, created_at, updated_at) VALUES (?,?,'inbox',1,1)",
+  ).run(id, appId);
+  return id;
+}
+
+function ticket(
+  db: Database.Database,
+  id: string,
+  appId: string,
+  createdAt: number,
+  reporterIntegrationId: string | null = null,
+) {
+  db.prepare(
+    `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+     VALUES (?,?,'feedback','open','message','{}',?,?,?,?)`,
+  ).run(
+    id,
+    appId,
+    reporterIntegrationId ? `reporter-${appId}` : null,
+    reporterIntegrationId,
+    createdAt,
+    createdAt,
+  );
+}
+
+function staffComment(
+  db: Database.Database,
+  id: string,
+  ticketId: string,
+  internal: 0 | 1,
+) {
+  db.prepare(
+    `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+     VALUES (?,?,'staff:test','staff','body',?,1)`,
+  ).run(id, ticketId, internal);
+}
+
+function reporterComment(db: Database.Database, id: string, ticketId: string, integrationId: string) {
+  db.prepare(
+    `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal,
+        reporter_integration_id, reporter_id, submission_id,
+        submission_fingerprint, created_at)
+     VALUES (?,?,'reporter:test','reporter','body',0,?,'reporter-app-a',?,'fingerprint',1)`,
+  ).run(id, ticketId, integrationId, `submission-${id}`);
+}
+
+const material = (db: Database.Database, ticketId: string) =>
+  (db.prepare("SELECT material_sequence AS s FROM feedback_tickets WHERE id = ?")
+    .get(ticketId) as { s: number }).s;
+
+const reporterSequence = (db: Database.Database, commentId: string) =>
+  (db.prepare("SELECT reporter_sequence AS s FROM feedback_comments WHERE id = ?")
+    .get(commentId) as { s: number | null }).s;
+
+const highWater = (db: Database.Database, appId: string) =>
+  (db.prepare("SELECT high_water AS h FROM feedback_material_sequence_state WHERE app_id = ?")
+    .get(appId) as { h: number }).h;
+
+describe("migration 0060 — feedback material delta", () => {
+  it("backfills a deterministic per-app domain without changing reporter state", () => {
+    const db = database(false);
+    app(db, "app-a");
+    app(db, "app-b");
+    const intg = integration(db, "app-a");
+    ticket(db, "a-z", "app-a", 1, intg);
+    ticket(db, "a-a", "app-a", 1, intg);
+    ticket(db, "b-a", "app-b", 1);
+    staffComment(db, "visible", "a-a", 0);
+    staffComment(db, "internal", "a-a", 1);
+    const reporterBefore = [reporterSequence(db, "visible"), reporterSequence(db, "internal")];
+
+    migrate(db);
+
+    expect(material(db, "a-a")).toBe(1);
+    expect(material(db, "a-z")).toBe(2);
+    expect(material(db, "b-a")).toBe(1);
+    expect(highWater(db, "app-a")).toBe(2);
+    expect(highWater(db, "app-b")).toBe(1);
+    expect([reporterSequence(db, "visible"), reporterSequence(db, "internal")])
+      .toEqual(reporterBefore);
+    expect(db.prepare("SELECT COUNT(*) AS n FROM feedback_tickets WHERE material_sequence IS NULL")
+      .get()).toEqual({ n: 0 });
+  });
+
+  it("advances once for each current material writer and not for no-ops or processing", () => {
+    const db = database();
+    app(db, "app-a");
+    const intg = integration(db, "app-a");
+    ticket(db, "ticket", "app-a", 1, intg);
+    expect([material(db, "ticket"), highWater(db, "app-a")]).toEqual([1, 1]);
+
+    db.prepare(
+      "UPDATE feedback_tickets SET status='in_progress', assignee='owner' WHERE id='ticket'",
+    ).run();
+    expect([material(db, "ticket"), highWater(db, "app-a")]).toEqual([2, 2]);
+
+    db.prepare(
+      "UPDATE feedback_tickets SET status='in_progress', assignee='owner' WHERE id='ticket'",
+    ).run();
+    db.prepare(
+      "UPDATE feedback_tickets SET symbolication_status='pending', updated_at=2 WHERE id='ticket'",
+    ).run();
+    expect([material(db, "ticket"), highWater(db, "app-a")]).toEqual([2, 2]);
+
+    staffComment(db, "external", "ticket", 0);
+    expect([material(db, "ticket"), reporterSequence(db, "external")]).toEqual([3, 1]);
+    staffComment(db, "internal", "ticket", 1);
+    expect([material(db, "ticket"), reporterSequence(db, "internal")]).toEqual([4, null]);
+    reporterComment(db, "reporter", "ticket", intg);
+    expect([material(db, "ticket"), reporterSequence(db, "reporter")]).toEqual([5, 2]);
+    expect(highWater(db, "app-a")).toBe(5);
+  });
+
+  it("rolls back allocation with a failed transaction and sequences two writes in one batch", () => {
+    const db = database();
+    app(db, "app-a");
+    ticket(db, "ticket", "app-a", 1);
+    const before = highWater(db, "app-a");
+
+    const fail = db.transaction(() => {
+      staffComment(db, "rolled-back", "ticket", 0);
+      db.prepare("INSERT INTO feedback_comments (id) VALUES ('invalid')").run();
+    });
+    expect(fail).toThrow();
+    expect(highWater(db, "app-a")).toBe(before);
+    expect(db.prepare("SELECT id FROM feedback_comments WHERE id='rolled-back'").get()).toBeUndefined();
+
+    db.transaction(() => {
+      staffComment(db, "one", "ticket", 0);
+      staffComment(db, "two", "ticket", 0);
+    })();
+    expect([material(db, "ticket"), highWater(db, "app-a")]).toEqual([before + 2, before + 2]);
+  });
+
+  it("rejects allocator drift, direct ticket sequence writes, app moves, and exhaustion", () => {
+    const db = database();
+    app(db, "app-a");
+    ticket(db, "one", "app-a", 1);
+    ticket(db, "two", "app-a", 2);
+
+    expect(() => db.prepare(
+      "UPDATE feedback_material_sequence_state SET high_water=high_water+2 WHERE app_id='app-a'",
+    ).run()).toThrow(/must advance by one/);
+    expect(() => db.prepare(
+      "UPDATE feedback_tickets SET material_sequence=1 WHERE id='two'",
+    ).run()).toThrow(/managed/);
+    expect(() => db.prepare(
+      "UPDATE feedback_tickets SET app_id='other' WHERE id='one'",
+    ).run()).toThrow(/app is immutable/);
+
+    const monotonicSql = (db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='trigger' AND name='feedback_material_state_monotonic'",
+    ).get() as { sql: string }).sql;
+    db.exec("DROP TRIGGER feedback_material_state_monotonic");
+    db.prepare(
+      "UPDATE feedback_material_sequence_state SET high_water=9007199254740991 WHERE app_id='app-a'",
+    ).run();
+    db.exec(monotonicSql);
+    expect(() => staffComment(db, "overflow", "one", 0)).toThrow(/CHECK constraint failed/);
+    expect(db.prepare("SELECT id FROM feedback_comments WHERE id='overflow'").get()).toBeUndefined();
+  });
+
+  it("blocks ticket and integration deletion but preserves full app purge", () => {
+    const db = database();
+    app(db, "app-a");
+    const intg = integration(db, "app-a");
+    ticket(db, "ticket", "app-a", 1, intg);
+
+    expect(() => db.prepare("DELETE FROM feedback_tickets WHERE id='ticket'").run())
+      .toThrow(/requires app purge or tombstone/);
+    expect(() => db.prepare("DELETE FROM app_reporter_integrations WHERE id=?").run(intg))
+      .toThrow(/requires app purge or tombstone/);
+    expect(db.prepare("SELECT id FROM app_reporter_integrations WHERE id=?").get(intg)).toBeDefined();
+    expect(db.prepare("SELECT id FROM feedback_tickets WHERE id='ticket'").get()).toBeDefined();
+
+    db.prepare("DELETE FROM apps WHERE id='app-a'").run();
+    expect(db.prepare("SELECT id FROM feedback_tickets WHERE id='ticket'").get()).toBeUndefined();
+    expect(db.prepare("SELECT id FROM app_reporter_integrations WHERE id=?").get(intg)).toBeUndefined();
+    expect(db.prepare(
+      "SELECT app_id FROM feedback_material_sequence_state WHERE app_id='app-a'",
+    ).get()).toBeUndefined();
+  });
+
+  it("uses the exact app-first index for the delta query", () => {
+    const db = database();
+    const plan = db.prepare(
+      `EXPLAIN QUERY PLAN SELECT id, material_sequence
+       FROM feedback_tickets
+       WHERE app_id = ? AND material_sequence > ?
+       ORDER BY material_sequence ASC LIMIT ?`,
+    ).all("app-a", 0, 101).map((row) => String((row as { detail: string }).detail));
+
+    expect(plan.some((detail) => detail.includes("idx_feedback_tickets_app_material_sequence")))
+      .toBe(true);
+    expect(plan.some((detail) => /SCAN feedback_tickets\b/.test(detail))).toBe(false);
+  });
+});

--- a/worker/test/feedback_material_delta_migration.test.ts
+++ b/worker/test/feedback_material_delta_migration.test.ts
@@ -469,6 +469,10 @@ describe("migration 0060 — feedback material delta", () => {
       db.prepare("UPDATE feedback_tickets SET material_sequence=9007199254740992 WHERE id='one'").run();
     })).toContain("unsafe_ticket_sequence");
     expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
+      db.prepare("UPDATE feedback_tickets SET material_sequence=1.5 WHERE id='one'").run();
+    })).toContain("noninteger_ticket_sequence");
+    expect(corrupted((db) => {
       ticket(db, "two", "app-a", 2);
       db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
       db.exec("DROP INDEX idx_feedback_tickets_app_material_sequence");
@@ -489,6 +493,12 @@ describe("migration 0060 — feedback material delta", () => {
         "UPDATE feedback_material_sequence_state SET high_water=9007199254740992 WHERE app_id='app-a'",
       ).run();
     })).toContain("unsafe_high_water");
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_material_state_monotonic");
+      db.prepare(
+        "UPDATE feedback_material_sequence_state SET high_water=1.5 WHERE app_id='app-a'",
+      ).run();
+    })).toContain("noninteger_high_water");
   });
 
   it("reports the exact 0059 full-schema write opcode delta and carrier comparison", () => {

--- a/worker/test/feedback_material_delta_migration.test.ts
+++ b/worker/test/feedback_material_delta_migration.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, it } from "vitest";
 
 const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
 const MIGRATION = "0060_feedback_material_delta.sql";
+const MIGRATION_SQL = readFileSync(`${MIGRATION_DIR}${MIGRATION}`, "utf8");
+const VALIDATION_SQL = readFileSync(
+  new URL("../../migrations/validation/0060_feedback_material_delta.sql", import.meta.url),
+  "utf8",
+);
 
 function applyMigrations(db: Database.Database, includeMaterial = true) {
   for (const name of readdirSync(MIGRATION_DIR).sort()) {
@@ -15,7 +20,7 @@ function applyMigrations(db: Database.Database, includeMaterial = true) {
 }
 
 const migrate = (db: Database.Database) =>
-  db.exec(readFileSync(`${MIGRATION_DIR}${MIGRATION}`, "utf8"));
+  db.exec(MIGRATION_SQL);
 
 function database(includeMaterial = true) {
   const db = new Database(":memory:");
@@ -95,6 +100,19 @@ const highWater = (db: Database.Database, appId: string) =>
   (db.prepare("SELECT high_water AS h FROM feedback_material_sequence_state WHERE app_id = ?")
     .get(appId) as { h: number }).h;
 
+const validationErrors = (db: Database.Database) => db.prepare(VALIDATION_SQL).all() as Array<{
+  app_id: string;
+  violation: string;
+}>;
+
+function writeOpcodeCounts(db: Database.Database, sql: string) {
+  const counts = { Insert: 0, Delete: 0, IdxInsert: 0, IdxDelete: 0, Program: 0 };
+  for (const row of db.prepare(`EXPLAIN ${sql}`).all() as Array<{ opcode: keyof typeof counts }>) {
+    if (row.opcode in counts) counts[row.opcode] += 1;
+  }
+  return counts;
+}
+
 describe("migration 0060 — feedback material delta", () => {
   it("backfills a deterministic per-app domain without changing reporter state", () => {
     const db = database(false);
@@ -104,6 +122,9 @@ describe("migration 0060 — feedback material delta", () => {
     ticket(db, "a-z", "app-a", 1, intg);
     ticket(db, "a-a", "app-a", 1, intg);
     ticket(db, "b-a", "app-b", 1);
+    db.prepare(
+      "UPDATE feedback_tickets SET updated_at = CASE id WHEN 'a-a' THEN 999 ELSE 0 END",
+    ).run();
     staffComment(db, "visible", "a-a", 0);
     staffComment(db, "internal", "a-a", 1);
     const reporterBefore = [reporterSequence(db, "visible"), reporterSequence(db, "internal")];
@@ -119,6 +140,135 @@ describe("migration 0060 — feedback material delta", () => {
       .toEqual(reporterBefore);
     expect(db.prepare("SELECT COUNT(*) AS n FROM feedback_tickets WHERE material_sequence IS NULL")
       .get()).toEqual({ n: 0 });
+  });
+
+  it("kills every forbidden backfill source", () => {
+    const fixture = () => {
+      const db = database(false);
+      app(db, "app-a");
+      const intg = integration(db, "app-a");
+      ticket(db, "a-z", "app-a", 1, intg);
+      ticket(db, "a-a", "app-a", 1, intg);
+      db.prepare(
+        "UPDATE feedback_tickets SET updated_at = CASE id WHEN 'a-a' THEN 999 ELSE 0 END",
+      ).run();
+      staffComment(db, "comment-z", "a-z", 0);
+      for (let index = 0; index < 4; index += 1) {
+        staffComment(db, `padding-${index}`, "a-a", 1);
+      }
+      staffComment(db, "comment-a", "a-a", 0);
+      db.exec("DROP TRIGGER feedback_comments_reporter_sequence_immutable");
+      db.prepare(
+        "UPDATE feedback_comments SET reporter_sequence=900 WHERE id='comment-a'",
+      ).run();
+      db.exec(
+        `CREATE TABLE foreign_material_state (app_id TEXT PRIMARY KEY, high_water INTEGER NOT NULL);
+         INSERT INTO foreign_material_state VALUES ('app-a', 777)`,
+      );
+      return db;
+    };
+    const expected = [
+      { id: "a-a", material_sequence: 1 },
+      { id: "a-z", material_sequence: 2 },
+    ];
+    const killed = (sql: string) => {
+      const db = fixture();
+      try {
+        db.exec(sql);
+        return JSON.stringify(db.prepare(
+          "SELECT id, material_sequence FROM feedback_tickets ORDER BY id",
+        ).all()) !== JSON.stringify(expected);
+      } catch {
+        return true;
+      }
+    };
+
+    expect(killed(MIGRATION_SQL.replace(
+      "PARTITION BY app_id ORDER BY created_at, id",
+      "PARTITION BY app_id ORDER BY updated_at, id",
+    ))).toBe(true);
+    expect(killed(MIGRATION_SQL.replace(
+      "ROW_NUMBER() OVER (PARTITION BY app_id ORDER BY created_at, id) AS seq",
+      `(SELECT COALESCE(MAX(c.reporter_sequence), 0) FROM feedback_comments c
+        WHERE c.ticket_id = feedback_tickets.id) AS seq`,
+    ))).toBe(true);
+    expect(killed(MIGRATION_SQL.replace(
+      "ROW_NUMBER() OVER (PARTITION BY app_id ORDER BY created_at, id) AS seq",
+      `(SELECT COALESCE(MAX(c.rowid), 0) FROM feedback_comments c
+        WHERE c.ticket_id = feedback_tickets.id) AS seq`,
+    ))).toBe(true);
+    expect(killed(MIGRATION_SQL.replace(
+      "ROW_NUMBER() OVER (PARTITION BY app_id ORDER BY created_at, id) AS seq",
+      `(SELECT high_water FROM foreign_material_state f
+        WHERE f.app_id = feedback_tickets.app_id) AS seq`,
+    ))).toBe(true);
+  });
+
+  it("changes no ticket business field or reporter/audit/event/read state during backfill", () => {
+    const db = database(false);
+    app(db, "app-a");
+    const intg = integration(db, "app-a");
+    ticket(db, "ticket", "app-a", 1, intg);
+    db.prepare(
+      `UPDATE feedback_tickets
+       SET kind='bug', status='in_progress', assignee='owner', message='preserve',
+           contact='contact', version_name='1.2.3', version_code=123,
+           channel='main', device_id='device', updated_at=999
+       WHERE id='ticket'`,
+    ).run();
+    staffComment(db, "visible", "ticket", 0);
+    staffComment(db, "internal", "ticket", 1);
+    db.prepare(
+      `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+       VALUES ('audit', 'app-a', 'before', 'staff:test', '{"preserve":true}', 1)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO feedback_events
+       (id, event_type, app_id, ticket_id, reporter_integration_id, reporter_id,
+        payload_json, route_outcome, created_at)
+       VALUES ('event', 'feedback:comment_created', 'app-a', 'ticket', ?,
+               'reporter-app-a', '{"preserve":true}', 'route_unbound', 1)`,
+    ).run(intg);
+    db.prepare(
+      `INSERT INTO feedback_reporter_ticket_reads
+       (app_id, reporter_integration_id, reporter_id, ticket_id,
+        read_through_sequence, read_through_comment_id, updated_at)
+       VALUES ('app-a', ?, 'reporter-app-a', 'ticket', 1, 'visible', 1)`,
+    ).run(intg);
+    const snapshot = {
+      ticket: db.prepare(
+        `SELECT id, app_id, kind, status, assignee, message, contact, version_name,
+                version_code, channel, device_id, created_at, updated_at
+         FROM feedback_tickets WHERE id='ticket'`,
+      ).get(),
+      comments: db.prepare("SELECT * FROM feedback_comments ORDER BY id").all(),
+      audits: db.prepare("SELECT * FROM audit_logs ORDER BY id").all(),
+      events: db.prepare("SELECT * FROM feedback_events ORDER BY id").all(),
+      reads: db.prepare("SELECT * FROM feedback_reporter_ticket_reads ORDER BY ticket_id").all(),
+    };
+
+    migrate(db);
+
+    expect({
+      ticket: db.prepare(
+        `SELECT id, app_id, kind, status, assignee, message, contact, version_name,
+                version_code, channel, device_id, created_at, updated_at
+         FROM feedback_tickets WHERE id='ticket'`,
+      ).get(),
+      comments: db.prepare("SELECT * FROM feedback_comments ORDER BY id").all(),
+      audits: db.prepare("SELECT * FROM audit_logs ORDER BY id").all(),
+      events: db.prepare("SELECT * FROM feedback_events ORDER BY id").all(),
+      reads: db.prepare("SELECT * FROM feedback_reporter_ticket_reads ORDER BY ticket_id").all(),
+    }).toEqual(snapshot);
+    expect(db.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_tickets WHERE material_sequence IS NULL",
+    ).get()).toEqual({ count: 0 });
+
+    // Production old writers do not send material_sequence. The new schema's
+    // AFTER triggers must normalize and allocate before commit.
+    ticket(db, "old-worker-ticket", "app-a", 2, intg);
+    staffComment(db, "old-worker-comment", "old-worker-ticket", 0);
+    expect(material(db, "old-worker-ticket")).toBe(highWater(db, "app-a"));
   });
 
   it("advances once for each current material writer and not for no-ops or processing", () => {
@@ -226,7 +376,18 @@ describe("migration 0060 — feedback material delta", () => {
   });
 
   it("uses the exact app-first index for the delta query", () => {
-    const db = database();
+    const db = database(false);
+    app(db, "app-a");
+    db.exec(
+      `WITH RECURSIVE fixture(n) AS (
+         VALUES(1) UNION ALL SELECT n + 1 FROM fixture WHERE n < 100000
+       )
+       INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       SELECT printf('ticket-%06d', n), 'app-a', 'feedback', 'open', 'message', '{}', n, n
+       FROM fixture`,
+    );
+    migrate(db);
     const plan = (withApp = true) => db.prepare(
       withApp
         ? `EXPLAIN QUERY PLAN SELECT id, material_sequence
@@ -271,5 +432,130 @@ describe("migration 0060 — feedback material delta", () => {
     );
     expect(usesExactAppFirstPlan(plan(false))).toBe(false);
     expect(usesExactAppFirstPlan(plan())).toBe(true);
+  });
+
+  it("ships a reusable validator that rejects every locally provable restore corruption", () => {
+    const valid = database();
+    app(valid, "app-a");
+    app(valid, "empty");
+    ticket(valid, "one", "app-a", 1);
+    valid.prepare(
+      "INSERT INTO feedback_material_sequence_state (app_id, high_water) VALUES ('empty', 0)",
+    ).run();
+    expect(validationErrors(valid)).toEqual([]);
+
+    const corrupted = (mutate: (db: Database.Database) => void) => {
+      const db = database();
+      app(db, "app-a");
+      ticket(db, "one", "app-a", 1);
+      mutate(db);
+      return validationErrors(db).map((row) => row.violation);
+    };
+
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_material_state_no_delete");
+      db.prepare("DELETE FROM feedback_material_sequence_state WHERE app_id='app-a'").run();
+    })).toContain("missing_state");
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
+      db.prepare("UPDATE feedback_tickets SET material_sequence=NULL WHERE id='one'").run();
+    })).toContain("null_ticket_sequence");
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
+      db.prepare("UPDATE feedback_tickets SET material_sequence=0 WHERE id='one'").run();
+    })).toContain("nonpositive_ticket_sequence");
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
+      db.prepare("UPDATE feedback_tickets SET material_sequence=9007199254740992 WHERE id='one'").run();
+    })).toContain("unsafe_ticket_sequence");
+    expect(corrupted((db) => {
+      ticket(db, "two", "app-a", 2);
+      db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
+      db.exec("DROP INDEX idx_feedback_tickets_app_material_sequence");
+      db.prepare("UPDATE feedback_tickets SET material_sequence=1 WHERE id='two'").run();
+    })).toContain("duplicate_ticket_sequence");
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_tickets_material_managed_update");
+      db.prepare("UPDATE feedback_tickets SET material_sequence=2 WHERE id='one'").run();
+    })).toContain("ticket_ahead_of_high_water");
+    expect(corrupted((db) => {
+      db.exec("DROP TRIGGER feedback_material_state_monotonic");
+      db.prepare("UPDATE feedback_material_sequence_state SET high_water=2 WHERE app_id='app-a'").run();
+    })).toContain("max_high_water_mismatch");
+    expect(corrupted((db) => {
+      db.pragma("ignore_check_constraints = ON");
+      db.exec("DROP TRIGGER feedback_material_state_monotonic");
+      db.prepare(
+        "UPDATE feedback_material_sequence_state SET high_water=9007199254740992 WHERE app_id='app-a'",
+      ).run();
+    })).toContain("unsafe_high_water");
+  });
+
+  it("reports the exact 0059 full-schema write opcode delta and carrier comparison", () => {
+    const ticketInsert =
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES ('ticket', 'app-a', 'feedback', 'open', 'message', '{}', 1, 1)`;
+    const ticketUpdate =
+      `UPDATE feedback_tickets
+       SET status='resolved', assignee='owner', updated_at=2 WHERE id='ticket'`;
+    const commentInsert =
+      `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES ('comment', 'ticket', 'staff:test', 'staff', 'message', 0, 2)`;
+    const baseline = database(false);
+    const ticketCarrier = database();
+    const appendCarrier = database(false);
+    appendCarrier.exec(
+      `CREATE TABLE synthetic_material_state (
+         app_id TEXT PRIMARY KEY,
+         high_water INTEGER NOT NULL
+       );
+       CREATE TABLE synthetic_material_changes (
+         app_id TEXT NOT NULL,
+         sequence INTEGER NOT NULL,
+         ticket_id TEXT NOT NULL,
+         PRIMARY KEY (app_id, sequence)
+       );
+       CREATE TRIGGER synthetic_feedback_comment_material_insert
+       AFTER INSERT ON feedback_comments
+       BEGIN
+         INSERT OR IGNORE INTO synthetic_material_state
+         VALUES ((SELECT app_id FROM feedback_tickets WHERE id=NEW.ticket_id), 0);
+         UPDATE synthetic_material_state SET high_water=high_water+1
+         WHERE app_id=(SELECT app_id FROM feedback_tickets WHERE id=NEW.ticket_id);
+         INSERT INTO synthetic_material_changes
+         SELECT t.app_id, s.high_water, t.id
+         FROM feedback_tickets t
+         JOIN synthetic_material_state s ON s.app_id=t.app_id
+         WHERE t.id=NEW.ticket_id;
+       END;`,
+    );
+
+    expect({
+      ticket_insert: writeOpcodeCounts(baseline, ticketInsert),
+      status_assignee: writeOpcodeCounts(baseline, ticketUpdate),
+      comment_insert: writeOpcodeCounts(baseline, commentInsert),
+    }).toEqual({
+      ticket_insert: { Insert: 1, Delete: 0, IdxInsert: 14, IdxDelete: 0, Program: 1 },
+      status_assignee: { Insert: 1, Delete: 0, IdxInsert: 5, IdxDelete: 1, Program: 0 },
+      comment_insert: { Insert: 2, Delete: 0, IdxInsert: 11, IdxDelete: 2, Program: 4 },
+    });
+    expect({
+      ticket_insert: writeOpcodeCounts(ticketCarrier, ticketInsert),
+      status_assignee: writeOpcodeCounts(ticketCarrier, ticketUpdate),
+      comment_insert: writeOpcodeCounts(ticketCarrier, commentInsert),
+    }).toEqual({
+      ticket_insert: { Insert: 4, Delete: 0, IdxInsert: 17, IdxDelete: 1, Program: 6 },
+      status_assignee: { Insert: 3, Delete: 0, IdxInsert: 6, IdxDelete: 2, Program: 3 },
+      comment_insert: { Insert: 4, Delete: 0, IdxInsert: 12, IdxDelete: 3, Program: 7 },
+    });
+    expect(writeOpcodeCounts(appendCarrier, commentInsert)).toEqual({
+      Insert: 5,
+      Delete: 0,
+      IdxInsert: 13,
+      IdxDelete: 2,
+      Program: 5,
+    });
   });
 });

--- a/worker/test/feedback_material_delta_migration.test.ts
+++ b/worker/test/feedback_material_delta_migration.test.ts
@@ -227,15 +227,49 @@ describe("migration 0060 — feedback material delta", () => {
 
   it("uses the exact app-first index for the delta query", () => {
     const db = database();
-    const plan = db.prepare(
-      `EXPLAIN QUERY PLAN SELECT id, material_sequence
-       FROM feedback_tickets
-       WHERE app_id = ? AND material_sequence > ?
-       ORDER BY material_sequence ASC LIMIT ?`,
-    ).all("app-a", 0, 101).map((row) => String((row as { detail: string }).detail));
+    const plan = (withApp = true) => db.prepare(
+      withApp
+        ? `EXPLAIN QUERY PLAN SELECT id, material_sequence
+           FROM feedback_tickets
+           WHERE app_id = ? AND material_sequence > ?
+           ORDER BY material_sequence ASC LIMIT ?`
+        : `EXPLAIN QUERY PLAN SELECT id, material_sequence
+           FROM feedback_tickets
+           WHERE material_sequence > ?
+           ORDER BY material_sequence ASC LIMIT ?`,
+    ).all(...(withApp ? ["app-a", 0, 101] : [0, 101]))
+      .map((row) => String((row as { detail: string }).detail));
+    const usesExactAppFirstPlan = (details: string[]) =>
+      details.some((detail) =>
+        detail.includes("idx_feedback_tickets_app_material_sequence")
+        && /\(app_id=\? AND material_sequence>\?\)/.test(detail)
+      )
+      && details.every((detail) => !/USE TEMP B-TREE FOR ORDER BY/.test(detail));
 
-    expect(plan.some((detail) => detail.includes("idx_feedback_tickets_app_material_sequence")))
-      .toBe(true);
-    expect(plan.some((detail) => /SCAN feedback_tickets\b/.test(detail))).toBe(false);
+    expect(usesExactAppFirstPlan(plan())).toBe(true);
+
+    db.exec("DROP INDEX idx_feedback_tickets_app_material_sequence");
+    expect(usesExactAppFirstPlan(plan())).toBe(false);
+
+    db.exec(
+      `CREATE UNIQUE INDEX idx_feedback_tickets_app_material_sequence
+       ON feedback_tickets(material_sequence, app_id)`,
+    );
+    expect(usesExactAppFirstPlan(plan())).toBe(false);
+
+    db.exec("DROP INDEX idx_feedback_tickets_app_material_sequence");
+    db.exec(
+      `CREATE UNIQUE INDEX idx_feedback_tickets_app_material_sequence
+       ON feedback_tickets(material_sequence)`,
+    );
+    expect(usesExactAppFirstPlan(plan())).toBe(false);
+
+    db.exec("DROP INDEX idx_feedback_tickets_app_material_sequence");
+    db.exec(
+      `CREATE UNIQUE INDEX idx_feedback_tickets_app_material_sequence
+       ON feedback_tickets(app_id, material_sequence)`,
+    );
+    expect(usesExactAppFirstPlan(plan(false))).toBe(false);
+    expect(usesExactAppFirstPlan(plan())).toBe(true);
   });
 });

--- a/worker/test/feedback_material_delta_route.test.ts
+++ b/worker/test/feedback_material_delta_route.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/routes/feedback";
 import {
   handleAddReporterComment,
+  handleGetReporterFeedback,
   handleListReporterFeedback,
 } from "../src/routes/reporter_feedback";
 
@@ -211,18 +212,26 @@ describe("feedback material delta production routes", () => {
     expect(await noop.json()).toMatchObject({ changed: false });
     expect(material(sqlite, ticketId)).toBe(3);
 
+    const concurrent = await Promise.all([
+      handleUpdateFeedback(updateContext({ status: "resolved", assignee: "next-owner" })),
+      handleUpdateFeedback(updateContext({ status: "resolved", assignee: "next-owner" })),
+    ]);
+    const concurrentBodies = await Promise.all(concurrent.map((response) => response.json() as Promise<any>));
+    expect(concurrentBodies.filter((body) => body.changed)).toHaveLength(1);
+    expect(material(sqlite, ticketId)).toBe(4);
+
     expect((await handleAddFeedbackComment(jsonContext(
       env,
       { appId: "app-a", ticketId },
       { body: "external", internal: false },
     ))).status).toBe(201);
-    expect(material(sqlite, ticketId)).toBe(4);
+    expect(material(sqlite, ticketId)).toBe(5);
     expect((await handleAddFeedbackComment(jsonContext(
       env,
       { appId: "app-a", ticketId },
       { body: "internal", internal: true },
     ))).status).toBe(201);
-    expect(material(sqlite, ticketId)).toBe(5);
+    expect(material(sqlite, ticketId)).toBe(6);
 
     const integrationId = "11111111-1111-4111-8111-111111111111";
     const reporterId = "r".repeat(32);
@@ -260,10 +269,28 @@ describe("feedback material delta production routes", () => {
       json: (data: unknown, status = 200) => Response.json(data, { status, headers: reporterHeaders }),
     } as any);
     expect(reporterResponse.status).toBe(201);
-    expect(material(sqlite, ticketId)).toBe(6);
+    expect(material(sqlite, ticketId)).toBe(7);
     expect(sqlite.prepare(
       "SELECT high_water FROM feedback_material_sequence_state WHERE app_id = 'app-a'",
-    ).get()).toEqual({ high_water: 6 });
+    ).get()).toEqual({ high_water: 7 });
+
+    const materialCursorOnReporterRoute = await handleGetReporterFeedback({
+      env,
+      req: {
+        param: (name: string) => name === "appId" ? "app-a" : name === "ticketId" ? ticketId : undefined,
+        header: (name: string) => name.toLowerCase() === "authorization"
+          ? `Bearer ${credential.token}`
+          : name === "X-Hands-Reporter-Id"
+            ? reporterId
+            : undefined,
+        query: (name: string) => name === "comment_cursor"
+          ? cursor(["material-v1", "app-a", 7])
+          : undefined,
+      },
+      header: () => undefined,
+      json: (data: unknown, status = 200) => Response.json(data, { status }),
+    } as any);
+    expect(materialCursorOnReporterRoute.status).toBe(400);
 
     const reporterList = await handleListReporterFeedback({
       env,

--- a/worker/test/feedback_material_delta_route.test.ts
+++ b/worker/test/feedback_material_delta_route.test.ts
@@ -1,0 +1,424 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { openApiDocument } from "../src/openapi";
+import { authMiddleware } from "../src/middleware/auth";
+import { requireAppRole } from "../src/lib/permissions";
+import { generateDeployToken, hashDeployToken } from "../src/lib/deploy_tokens";
+import { handleAgentManifest } from "../src/routes/auth";
+import {
+  handleAddFeedbackComment,
+  handleListFeedbackMaterialDelta,
+  handlePublicFeedbackSubmit,
+  handlePublicMinidumpSubmit,
+  handleUpdateFeedback,
+} from "../src/routes/feedback";
+import {
+  handleAddReporterComment,
+  handleListReporterFeedback,
+} from "../src/routes/reporter_feedback";
+
+vi.mock("@cloudflare/containers", () => ({
+  getRandom: async () => ({
+    fetch: async () => Response.json({ stack_text: "" }),
+  }),
+}));
+
+const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+
+type BoundStatement = {
+  _execute: () => { results: unknown[]; success: true; meta: { changes: number } };
+  run: () => Promise<{ results: unknown[]; success: true; meta: { changes: number } }>;
+  all: () => Promise<{ results: unknown[]; success: true; meta: { changes: number } }>;
+  first: <T>() => Promise<T | null>;
+};
+
+function d1(db: Database.Database) {
+  const prepare = (sql: string) => {
+    const indexes: number[] = [];
+    const normalized = sql.replace(/\?(\d+)/g, (_match, index) => {
+      indexes.push(Number(index));
+      return "?";
+    });
+    const statement = db.prepare(normalized);
+    const bind = (...input: unknown[]): BoundStatement => {
+      const params = (indexes.length > 0 ? indexes.map((index) => input[index - 1]) : input)
+        .map((value) => value === undefined ? null : value);
+      const execute = () => {
+        if (statement.reader) {
+          return { results: statement.all(...params), success: true as const, meta: { changes: 0 } };
+        }
+        const info = statement.run(...params);
+        return { results: [], success: true as const, meta: { changes: info.changes } };
+      };
+      return {
+        _execute: execute,
+        run: async () => execute(),
+        all: async () => execute(),
+        first: async <T>() => (statement.get(...params) as T | undefined) ?? null,
+      };
+    };
+    return {
+      bind,
+      run: () => bind().run(),
+      all: () => bind().all(),
+      first: <T>() => bind().first<T>(),
+    };
+  };
+  return {
+    prepare,
+    batch: async (statements: BoundStatement[]) =>
+      db.transaction(() => statements.map((statement) => statement._execute()))(),
+  };
+}
+
+function environment() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  for (const name of readdirSync(MIGRATION_DIR).sort()) {
+    if (name.endsWith(".sql")) sqlite.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+  }
+  const DB = d1(sqlite);
+  sqlite.prepare(
+    `INSERT INTO organizations
+     (id, slug, name, external_provider, external_id, created_at)
+     VALUES ('org', 'org', 'Org', 'raft', 'server', 1)`,
+  ).run();
+  sqlite.prepare(
+    `INSERT INTO apps (id, org_id, slug, name, platform, client_key, created_at)
+     VALUES ('app-a', 'org', 'app-a', 'App A', 'electron', 'client-key', 1),
+            ('app-b', 'org', 'app-b', 'App B', 'electron', 'client-key-b', 1)`,
+  ).run();
+  const objects = new Map<string, Uint8Array>();
+  const pending: Promise<unknown>[] = [];
+  const env = {
+    DB,
+    APK_BUCKET: {
+      put: async (key: string, value: ArrayBuffer) => objects.set(key, new Uint8Array(value)),
+      delete: async (key: string) => objects.delete(key),
+      head: async (key: string) => objects.has(key) ? { size: objects.get(key)!.byteLength } : null,
+      get: async (key: string) => {
+        const value = objects.get(key);
+        return value ? { arrayBuffer: async () => value.buffer, text: async () => new TextDecoder().decode(value) } : null;
+      },
+    },
+    ENVIRONMENT: "production",
+    DASHBOARD_ORIGIN: "https://dashboard.example",
+    RAFT_CLIENT_ID: "hands-test",
+    FEEDBACK_AUDIT_HMAC_KEY: "material-delta-test-audit-key-with-enough-entropy",
+    FEEDBACK_AUDIT_KEY_VERSION: "test-v1",
+  } as unknown as Env;
+  const executionCtx = {
+    waitUntil: (promise: Promise<unknown>) => {
+      pending.push(promise);
+    },
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  return { sqlite, env, executionCtx, pending };
+}
+
+function jsonContext(
+  env: Env,
+  params: Record<string, string>,
+  body: unknown = {},
+  queries: Record<string, string> = {},
+) {
+  const headers = new Headers();
+  return {
+    env,
+    req: {
+      url: `https://hands.test/api/apps/${params.appId ?? ""}/feedback`,
+      method: "GET",
+      param: (name: string) => params[name],
+      query: (name: string) => queries[name],
+      json: async () => body,
+    },
+    get: (name: string) => name === "admin_actor" ? "staff:test" : undefined,
+    header: (name: string, value: string) => headers.set(name, value),
+    json: (data: unknown, status = 200) => Response.json(data, { status, headers }),
+  } as any;
+}
+
+function material(sqlite: Database.Database, ticketId: string) {
+  return (sqlite.prepare(
+    "SELECT material_sequence AS sequence FROM feedback_tickets WHERE id = ?",
+  ).get(ticketId) as { sequence: number }).sequence;
+}
+
+function cursor(value: unknown) {
+  return btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+describe("feedback material delta production routes", () => {
+  it("advances through every current production writer exactly once", async () => {
+    const { sqlite, env, executionCtx, pending } = environment();
+
+    const feedbackForm = new FormData();
+    feedbackForm.set("message", "ordinary feedback");
+    const feedbackResponse = await handlePublicFeedbackSubmit({
+      env,
+      executionCtx,
+      req: {
+        url: "https://hands.test/public/v2/apps/app-a/feedback",
+        raw: { cf: { clientIp: "192.0.2.1" } },
+        param: (name: string) => name === "slug" ? "app-a" : undefined,
+        header: (name: string) => name === "X-Hands-Client-Key" ? "client-key" : undefined,
+        query: () => undefined,
+        formData: async () => feedbackForm,
+      },
+      header: () => undefined,
+      json: (data: unknown, status = 200) => Response.json(data, { status }),
+    } as any);
+    expect(feedbackResponse.status).toBe(201);
+    const ticketId = String((await feedbackResponse.json() as { id: string }).id);
+    expect(material(sqlite, ticketId)).toBe(1);
+
+    const minidumpForm = new FormData();
+    minidumpForm.set("version", "1.0.0");
+    minidumpForm.append(
+      "upload_file_minidump",
+      new File([new Uint8Array([1, 2, 3])], "minidump.dmp", { type: "application/x-minidump" }),
+    );
+    const minidumpResponse = await handlePublicMinidumpSubmit({
+      env,
+      executionCtx,
+      req: {
+        raw: { cf: { clientIp: "192.0.2.2" } },
+        param: (name: string) => name === "slug" ? "app-a" : undefined,
+        header: (name: string) => name === "X-Hands-Client-Key" ? "client-key" : undefined,
+        query: () => undefined,
+        formData: async () => minidumpForm,
+      },
+      json: (data: unknown, status = 200) => Response.json(data, { status }),
+    } as any);
+    expect(minidumpResponse.status).toBe(201);
+    const minidumpId = String((await minidumpResponse.json() as { id: string }).id);
+    expect(material(sqlite, minidumpId)).toBe(2);
+    await Promise.allSettled(pending);
+    expect(material(sqlite, minidumpId)).toBe(2);
+
+    const updateContext = (body: unknown) => jsonContext(env, { appId: "app-a", ticketId }, body);
+    expect((await handleUpdateFeedback(updateContext({ status: "in_progress", assignee: "owner" }))).status)
+      .toBe(200);
+    expect(material(sqlite, ticketId)).toBe(3);
+    const noop = await handleUpdateFeedback(updateContext({ status: "in_progress", assignee: "owner" }));
+    expect(await noop.json()).toMatchObject({ changed: false });
+    expect(material(sqlite, ticketId)).toBe(3);
+
+    expect((await handleAddFeedbackComment(jsonContext(
+      env,
+      { appId: "app-a", ticketId },
+      { body: "external", internal: false },
+    ))).status).toBe(201);
+    expect(material(sqlite, ticketId)).toBe(4);
+    expect((await handleAddFeedbackComment(jsonContext(
+      env,
+      { appId: "app-a", ticketId },
+      { body: "internal", internal: true },
+    ))).status).toBe(201);
+    expect(material(sqlite, ticketId)).toBe(5);
+
+    const integrationId = "11111111-1111-4111-8111-111111111111";
+    const reporterId = "r".repeat(32);
+    const credential = generateDeployToken();
+    sqlite.prepare(
+      `INSERT INTO app_reporter_integrations (id, app_id, name, created_at, updated_at)
+       VALUES (?, 'app-a', 'inbox', 1, 1)`,
+    ).run(integrationId);
+    sqlite.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+        created_by_actor, created_at, reporter_integration_id)
+       VALUES ('reporter-token', 'app-a', 'reporter', ?, ?, NULL,
+               '["feedback:read","feedback:comment"]', 'test', 1, ?)`,
+    ).run(credential.token_prefix, await hashDeployToken(credential.token), integrationId);
+    sqlite.prepare(
+      "UPDATE feedback_tickets SET reporter_id = ?, reporter_integration_id = ? WHERE id = ?",
+    ).run(reporterId, integrationId, ticketId);
+    const reporterHeaders = new Headers();
+    const reporterResponse = await handleAddReporterComment({
+      env,
+      req: {
+        param: (name: string) => name === "appId" ? "app-a" : name === "ticketId" ? ticketId : undefined,
+        header: (name: string) => name.toLowerCase() === "authorization"
+          ? `Bearer ${credential.token}`
+          : name === "X-Hands-Reporter-Id"
+            ? reporterId
+            : undefined,
+        json: async () => ({
+          body: "reporter follow-up",
+          submission_id: "22222222-2222-4222-8222-222222222222",
+        }),
+      },
+      header: (name: string, value: string) => reporterHeaders.set(name, value),
+      json: (data: unknown, status = 200) => Response.json(data, { status, headers: reporterHeaders }),
+    } as any);
+    expect(reporterResponse.status).toBe(201);
+    expect(material(sqlite, ticketId)).toBe(6);
+    expect(sqlite.prepare(
+      "SELECT high_water FROM feedback_material_sequence_state WHERE app_id = 'app-a'",
+    ).get()).toEqual({ high_water: 6 });
+
+    const reporterList = await handleListReporterFeedback({
+      env,
+      req: {
+        param: (name: string) => name === "appId" ? "app-a" : undefined,
+        header: (name: string) => name.toLowerCase() === "authorization"
+          ? `Bearer ${credential.token}`
+          : name === "X-Hands-Reporter-Id"
+            ? reporterId
+            : undefined,
+        query: () => undefined,
+      },
+      header: () => undefined,
+      json: (data: unknown, status = 200) => Response.json(data, { status }),
+    } as any);
+    expect(reporterList.status).toBe(200);
+    expect(JSON.stringify(await reporterList.json())).not.toMatch(/material_sequence|material-v1/);
+    const eventPayloads = sqlite.prepare(
+      "SELECT payload_json FROM feedback_events WHERE ticket_id = ?",
+    ).all(ticketId);
+    expect(JSON.stringify(eventPayloads)).not.toMatch(/material_sequence|material-v1/);
+  });
+
+  it("pages snapshot deltas without omission and rejects every foreign cursor family", async () => {
+    const { sqlite, env } = environment();
+    const insert = sqlite.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?, 'app-a', 'feedback', 'open', ?, '{}', ?, ?)`,
+    );
+    for (const [index, id] of [
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    ].entries()) insert.run(id, `ticket-${index}`, index + 1, index + 1);
+
+    const firstResponse = await handleListFeedbackMaterialDelta(jsonContext(
+      env,
+      { appId: "app-a" },
+      {},
+      { limit: "2" },
+    ));
+    const first = await firstResponse.json() as any;
+    expect(first.tickets.map((ticket: any) => ticket.id)).toEqual([
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ]);
+    expect(first.has_more).toBe(true);
+    expect(JSON.stringify(first)).not.toContain("material_sequence");
+    expect(JSON.parse(atob(first.next_cursor))).toEqual(["material-v1", "app-a", 2]);
+
+    sqlite.prepare(
+      "UPDATE feedback_tickets SET status = 'resolved' WHERE id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'",
+    ).run();
+    const second = await (await handleListFeedbackMaterialDelta(jsonContext(
+      env,
+      { appId: "app-a" },
+      {},
+      { limit: "2", cursor: first.next_cursor },
+    ))).json() as any;
+    expect(second.tickets.map((ticket: any) => ticket.id)).toEqual([
+      "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    ]);
+    expect(second.has_more).toBe(false);
+
+    const empty = await (await handleListFeedbackMaterialDelta(jsonContext(
+      env,
+      { appId: "app-a" },
+      {},
+      { cursor: second.next_cursor },
+    ))).json() as any;
+    expect(empty).toMatchObject({ tickets: [], next_cursor: second.next_cursor, has_more: false });
+
+    for (const invalid of [
+      cursor(["material-v1", "app-b", 0]),
+      cursor(["sequence-v1", 0, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]),
+      cursor(["sequence-v2", "app-a", 0]),
+      cursor([0, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]),
+      cursor(["material-v1", "app-a", Number.MAX_SAFE_INTEGER + 1]),
+      "",
+      "not-base64",
+    ]) {
+      expect((await handleListFeedbackMaterialDelta(jsonContext(
+        env,
+        { appId: "app-a" },
+        {},
+        { cursor: invalid },
+      ))).status).toBe(400);
+    }
+  });
+
+  it("wires the literal admin route and rejects a feedback:read reporter token", async () => {
+    const { sqlite, env } = environment();
+    const integrationId = "33333333-3333-4333-8333-333333333333";
+    sqlite.prepare(
+      `INSERT INTO app_reporter_integrations (id, app_id, name, created_at, updated_at)
+       VALUES (?, 'app-a', 'inbox', 1, 1)`,
+    ).run(integrationId);
+    const reporter = generateDeployToken();
+    const viewer = generateDeployToken();
+    const insertToken = sqlite.prepare(
+      `INSERT INTO app_deploy_tokens
+       (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
+        created_by_actor, created_at, reporter_integration_id)
+       VALUES (?, 'app-a', ?, ?, ?, ?, ?, 'test', 1, ?)`,
+    );
+    insertToken.run(
+      "reporter", "reporter", reporter.token_prefix, await hashDeployToken(reporter.token),
+      null, '["feedback:read"]', integrationId,
+    );
+    insertToken.run(
+      "viewer", "viewer", viewer.token_prefix, await hashDeployToken(viewer.token),
+      "viewer", null, null,
+    );
+
+    const path = "https://hands.test/api/apps/app-a/feedback/material-delta";
+    const mini = new Hono<any>();
+    mini.use("*", authMiddleware);
+    mini.get(
+      "/api/apps/:appId/feedback/material-delta",
+      requireAppRole("viewer"),
+      handleListFeedbackMaterialDelta,
+    );
+    const reporterResponse = await mini.request(
+      path,
+      { headers: { authorization: `Bearer ${reporter.token}` } },
+      env,
+    );
+    expect(reporterResponse.status).toBe(403);
+    expect(await reporterResponse.json()).toMatchObject({
+      error: "insufficient_app_role",
+      required_role: "viewer",
+      current_role: null,
+    });
+    expect((await mini.request(
+      path,
+      { headers: { authorization: `Bearer ${viewer.token}` } },
+      env,
+    )).status).toBe(200);
+
+    const indexSource = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+    expect(indexSource).toContain(
+      'admin.get(\n  "/api/apps/:appId/feedback/material-delta",\n  requireAppRole("viewer"),\n  handleListFeedbackMaterialDelta,\n);',
+    );
+  });
+
+  it("publishes the admin route in OpenAPI and the agent action manifest", async () => {
+    expect(openApiDocument.paths?.["/api/apps/{appId}/feedback/material-delta"]?.get).toBeDefined();
+    const response = await handleAgentManifest({
+      env: { RAFT_CLIENT_ID: "hands-test" },
+      req: { url: "https://hands.test/.well-known/raft-agent-manifest.json" },
+      header: () => undefined,
+      json: (data: unknown, status = 200) => Response.json(data, { status }),
+    } as any);
+    const manifest = await response.json() as any;
+    expect(manifest.actions.find((action: any) => action.name === "list-feedback-material-delta"))
+      .toMatchObject({
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/feedback/material-delta" },
+      });
+  });
+});

--- a/worker/test/feedback_material_delta_route.test.ts
+++ b/worker/test/feedback_material_delta_route.test.ts
@@ -347,12 +347,30 @@ describe("feedback material delta production routes", () => {
     failedForm.set("submission_id", "23232323-2323-4232-8232-232323232323");
     failedForm.append("attachments", new File(["image"], "failure.png", { type: "image/png" }));
     const originalBatch = (env.DB as any).batch.bind(env.DB);
+    const rollbackCounts = () => sqlite.prepare(
+      `SELECT
+         (SELECT COUNT(*) FROM feedback_comments WHERE ticket_id=@ticket) AS comments,
+         (SELECT COUNT(*) FROM feedback_attachments WHERE ticket_id=@ticket) AS attachments,
+         (SELECT COUNT(*) FROM audit_logs WHERE app_id='app-a') AS audits,
+         (SELECT COUNT(*) FROM feedback_events WHERE ticket_id=@ticket) AS events,
+         (SELECT COUNT(*) FROM webhook_deliveries) AS deliveries`,
+    ).get({ ticket: ticketId });
+    const beforeFailedBatch = rollbackCounts();
     (env.DB as any).batch = async (statements: BoundStatement[]) => {
-      if (statements.length > 4) throw new Error("simulated material comment batch failure");
+      if (statements.length > 4) {
+        // Execute every production statement, including the comment insert and
+        // both 0060 allocator writes, then fail at the tail of the SAME D1
+        // transaction. A non-atomic adapter mutation makes the assertions
+        // below observe the partially committed rows and sequences.
+        return originalBatch([
+          ...statements,
+          env.DB.prepare("INSERT INTO feedback_comments (id) VALUES ('invalid-tail')") as any,
+        ]);
+      }
       return originalBatch(statements);
     };
     await expect(handleAddReporterComment(reporterContext(failedForm)))
-      .rejects.toThrow("simulated material comment batch failure");
+      .rejects.toThrow();
     (env.DB as any).batch = originalBatch;
     expect(material(sqlite, ticketId)).toBe(7);
     expect(sqlite.prepare(
@@ -360,6 +378,10 @@ describe("feedback material delta production routes", () => {
     ).get()).toEqual({ high_water: 7 });
     expect(sqlite.prepare(
       "SELECT COUNT(*) AS count FROM feedback_comments WHERE submission_id='23232323-2323-4232-8232-232323232323'",
+    ).get()).toEqual({ count: 0 });
+    expect(rollbackCounts()).toEqual(beforeFailedBatch);
+    expect(sqlite.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_r2_cleanup",
     ).get()).toEqual({ count: 0 });
 
     const materialCursorOnReporterRoute = await handleGetReporterFeedback(reporterContext(

--- a/worker/test/feedback_material_delta_route.test.ts
+++ b/worker/test/feedback_material_delta_route.test.ts
@@ -8,6 +8,7 @@ import { authMiddleware } from "../src/middleware/auth";
 import { requireAppRole } from "../src/lib/permissions";
 import { generateDeployToken, hashDeployToken } from "../src/lib/deploy_tokens";
 import { handleAgentManifest } from "../src/routes/auth";
+import { handlePurgeApp } from "../src/routes/apps";
 import {
   handleAddFeedbackComment,
   handleListFeedbackMaterialDelta,
@@ -97,7 +98,10 @@ function environment() {
     DB,
     APK_BUCKET: {
       put: async (key: string, value: ArrayBuffer) => objects.set(key, new Uint8Array(value)),
-      delete: async (key: string) => objects.delete(key),
+      delete: async (key: string | string[]) => {
+        for (const item of Array.isArray(key) ? key : [key]) objects.delete(item);
+      },
+      list: async () => ({ objects: [], truncated: false }),
       head: async (key: string) => objects.has(key) ? { size: objects.get(key)!.byteLength } : null,
       get: async (key: string) => {
         const value = objects.get(key);
@@ -402,9 +406,59 @@ describe("feedback material delta production routes", () => {
     )).status).toBe(200);
 
     const indexSource = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
-    expect(indexSource).toContain(
+    const materialRoute = indexSource.indexOf(
       'admin.get(\n  "/api/apps/:appId/feedback/material-delta",\n  requireAppRole("viewer"),\n  handleListFeedbackMaterialDelta,\n);',
     );
+    const ticketRoute = indexSource.indexOf(
+      'admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRole("viewer"), handleGetFeedback);',
+    );
+    expect(materialRoute).toBeGreaterThan(-1);
+    expect(ticketRoute).toBeGreaterThan(materialRoute);
+  });
+
+  it("keeps the production app-purge entrypoint compatible with 0059 comments and 0060 guards", async () => {
+    const { sqlite, env } = environment();
+    const integrationId = "44444444-4444-4444-8444-444444444444";
+    const ticketId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    sqlite.prepare(
+      `INSERT INTO app_reporter_integrations (id, app_id, name, created_at, updated_at)
+       VALUES (?, 'app-a', 'inbox', 1, 1)`,
+    ).run(integrationId);
+    sqlite.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, reporter_id,
+        reporter_integration_id, created_at, updated_at)
+       VALUES (?, 'app-a', 'feedback', 'open', 'ticket', '{}', ?, ?, 1, 1)`,
+    ).run(ticketId, "r".repeat(32), integrationId);
+    sqlite.prepare(
+      `INSERT INTO feedback_comments
+       (id, ticket_id, author_actor, author_type, body, internal, created_at)
+       VALUES ('visible', ?, 'staff:test', 'staff', 'visible', 0, 2),
+              ('internal', ?, 'staff:test', 'staff', 'internal', 1, 3)`,
+    ).run(ticketId, ticketId);
+    expect(sqlite.prepare(
+      "SELECT id, reporter_sequence FROM feedback_comments ORDER BY id DESC",
+    ).all()).toEqual([
+      { id: "visible", reporter_sequence: 1 },
+      { id: "internal", reporter_sequence: null },
+    ]);
+    sqlite.prepare("UPDATE apps SET archived = 1 WHERE id = 'app-a'").run();
+
+    const response = await handlePurgeApp(jsonContext(
+      env,
+      { appId: "app-a" },
+      { confirm_slug: "app-a" },
+    ));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ok: true, purged_app_id: "app-a" });
+    expect(sqlite.prepare(
+      `SELECT
+         (SELECT COUNT(*) FROM apps WHERE id='app-a') AS apps,
+         (SELECT COUNT(*) FROM feedback_tickets WHERE app_id='app-a') AS tickets,
+         (SELECT COUNT(*) FROM feedback_comments WHERE ticket_id=?) AS comments,
+         (SELECT COUNT(*) FROM app_reporter_integrations WHERE app_id='app-a') AS integrations,
+         (SELECT COUNT(*) FROM feedback_material_sequence_state WHERE app_id='app-a') AS state`,
+    ).get(ticketId)).toEqual({ apps: 0, tickets: 0, comments: 0, integrations: 0, state: 0 });
   });
 
   it("publishes the admin route in OpenAPI and the agent action manifest", async () => {

--- a/worker/test/feedback_material_delta_route.test.ts
+++ b/worker/test/feedback_material_delta_route.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/routes/feedback";
 import {
   handleAddReporterComment,
+  handleDownloadReporterAttachment,
   handleGetReporterFeedback,
   handleListReporterFeedback,
 } from "../src/routes/reporter_feedback";
@@ -76,17 +77,25 @@ function d1(db: Database.Database) {
   };
 }
 
-function environment() {
+function environment(includeMaterial = true) {
   const sqlite = new Database(":memory:");
   sqlite.pragma("foreign_keys = ON");
   for (const name of readdirSync(MIGRATION_DIR).sort()) {
-    if (name.endsWith(".sql")) sqlite.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+    if (name.endsWith(".sql") && (includeMaterial || name !== "0060_feedback_material_delta.sql")) {
+      sqlite.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+    }
   }
   const DB = d1(sqlite);
   sqlite.prepare(
     `INSERT INTO organizations
      (id, slug, name, external_provider, external_id, created_at)
      VALUES ('org', 'org', 'Org', 'raft', 'server', 1)`,
+  ).run();
+  sqlite.prepare(
+    `INSERT INTO raft_accounts
+     (id, provider_subject, server_id, principal_type, display_name, raw_profile,
+      created_at, updated_at, last_login_at)
+     VALUES ('account', 'account', 'server', 'agent', 'Account', '{}', 1, 1, 1)`,
   ).run();
   sqlite.prepare(
     `INSERT INTO apps (id, org_id, slug, name, platform, client_key, created_at)
@@ -106,7 +115,13 @@ function environment() {
       head: async (key: string) => objects.has(key) ? { size: objects.get(key)!.byteLength } : null,
       get: async (key: string) => {
         const value = objects.get(key);
-        return value ? { arrayBuffer: async () => value.buffer, text: async () => new TextDecoder().decode(value) } : null;
+        return value
+          ? {
+              body: new Response(value).body,
+              arrayBuffer: async () => value.buffer,
+              text: async () => new TextDecoder().decode(value),
+            }
+          : null;
       },
     },
     ENVIRONMENT: "production",
@@ -203,6 +218,15 @@ describe("feedback material delta production routes", () => {
     expect(material(sqlite, minidumpId)).toBe(2);
     await Promise.allSettled(pending);
     expect(material(sqlite, minidumpId)).toBe(2);
+    const appBTicket = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+    sqlite.prepare(
+      `INSERT INTO feedback_tickets
+       (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
+       VALUES (?, 'app-b', 'feedback', 'open', 'independent', '{}', 1, 1)`,
+    ).run(appBTicket);
+    expect([material(sqlite, appBTicket), sqlite.prepare(
+      "SELECT high_water FROM feedback_material_sequence_state WHERE app_id='app-b'",
+    ).get()]).toEqual([1, { high_water: 1 }]);
 
     const updateContext = (body: unknown) => jsonContext(env, { appId: "app-a", ticketId }, body);
     expect((await handleUpdateFeedback(updateContext({ status: "in_progress", assignee: "owner" }))).status)
@@ -250,72 +274,212 @@ describe("feedback material delta production routes", () => {
     sqlite.prepare(
       "UPDATE feedback_tickets SET reporter_id = ?, reporter_integration_id = ? WHERE id = ?",
     ).run(reporterId, integrationId, ticketId);
-    const reporterHeaders = new Headers();
-    const reporterResponse = await handleAddReporterComment({
-      env,
-      req: {
-        param: (name: string) => name === "appId" ? "app-a" : name === "ticketId" ? ticketId : undefined,
-        header: (name: string) => name.toLowerCase() === "authorization"
-          ? `Bearer ${credential.token}`
-          : name === "X-Hands-Reporter-Id"
-            ? reporterId
-            : undefined,
-        json: async () => ({
-          body: "reporter follow-up",
-          submission_id: "22222222-2222-4222-8222-222222222222",
-        }),
-      },
-      header: (name: string, value: string) => reporterHeaders.set(name, value),
-      json: (data: unknown, status = 200) => Response.json(data, { status, headers: reporterHeaders }),
-    } as any);
+    sqlite.prepare(
+      `INSERT INTO webhooks
+       (id, org_id, app_id, url, secret, events_json, enabled, created_by, created_at, updated_at)
+       VALUES ('reporter-hook', 'org', 'app-a', 'https://example.test/hook', 'secret',
+               '["feedback:comment_created"]', 1, 'account', 1, 1)`,
+    ).run();
+    sqlite.prepare(
+      `INSERT INTO app_reporter_webhook_subscriptions
+       (app_id, reporter_integration_id, webhook_id, created_at)
+       VALUES ('app-a', ?, 'reporter-hook', 1)`,
+    ).run(integrationId);
+    sqlite.prepare(
+      `INSERT INTO app_reporter_routes
+       (app_id, reporter_integration_id, reporter_id, route_subject, subject_version, created_at)
+       VALUES ('app-a', ?, ?, ?, 'v1', 1)`,
+    ).run(integrationId, reporterId, `rfr_v1_${"A".repeat(64)}`);
+
+    const reporterContext = (
+      input: unknown = {},
+      queries: Record<string, string> = {},
+      params: Record<string, string> = {},
+    ) => {
+      const responseHeaders = new Headers();
+      return {
+        env,
+        req: {
+          param: (name: string) => name === "appId"
+            ? "app-a"
+            : name === "ticketId"
+              ? ticketId
+              : params[name],
+          header: (name: string) => name.toLowerCase() === "authorization"
+            ? `Bearer ${credential.token}`
+            : name === "X-Hands-Reporter-Id"
+              ? reporterId
+              : name.toLowerCase() === "content-type" && input instanceof FormData
+                ? "multipart/form-data; boundary=test"
+                : undefined,
+          query: (name: string) => queries[name],
+          json: async () => input instanceof FormData ? {} : input,
+          formData: async () => input instanceof FormData ? input : new FormData(),
+        },
+        header: (name: string, value: string) => responseHeaders.set(name, value),
+        json: (data: unknown, status = 200) => Response.json(data, { status, headers: responseHeaders }),
+      } as any;
+    };
+    const reporterInput = {
+      body: "reporter follow-up",
+      submission_id: "22222222-2222-4222-8222-222222222222",
+    };
+    const reporterResponse = await handleAddReporterComment(reporterContext(reporterInput));
     expect(reporterResponse.status).toBe(201);
     expect(material(sqlite, ticketId)).toBe(7);
     expect(sqlite.prepare(
       "SELECT high_water FROM feedback_material_sequence_state WHERE app_id = 'app-a'",
     ).get()).toEqual({ high_water: 7 });
 
-    const materialCursorOnReporterRoute = await handleGetReporterFeedback({
-      env,
-      req: {
-        param: (name: string) => name === "appId" ? "app-a" : name === "ticketId" ? ticketId : undefined,
-        header: (name: string) => name.toLowerCase() === "authorization"
-          ? `Bearer ${credential.token}`
-          : name === "X-Hands-Reporter-Id"
-            ? reporterId
-            : undefined,
-        query: (name: string) => name === "comment_cursor"
-          ? cursor(["material-v1", "app-a", 7])
-          : undefined,
-      },
-      header: () => undefined,
-      json: (data: unknown, status = 200) => Response.json(data, { status }),
-    } as any);
+    const replay = await handleAddReporterComment(reporterContext(reporterInput));
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({ idempotent_replay: true });
+    expect(material(sqlite, ticketId)).toBe(7);
+    const conflict = await handleAddReporterComment(reporterContext({
+      ...reporterInput,
+      body: "conflicting replay",
+    }));
+    expect(conflict.status).toBe(409);
+    expect(material(sqlite, ticketId)).toBe(7);
+
+    const failedForm = new FormData();
+    failedForm.set("body", "failed attachment batch");
+    failedForm.set("submission_id", "23232323-2323-4232-8232-232323232323");
+    failedForm.append("attachments", new File(["image"], "failure.png", { type: "image/png" }));
+    const originalBatch = (env.DB as any).batch.bind(env.DB);
+    (env.DB as any).batch = async (statements: BoundStatement[]) => {
+      if (statements.length > 4) throw new Error("simulated material comment batch failure");
+      return originalBatch(statements);
+    };
+    await expect(handleAddReporterComment(reporterContext(failedForm)))
+      .rejects.toThrow("simulated material comment batch failure");
+    (env.DB as any).batch = originalBatch;
+    expect(material(sqlite, ticketId)).toBe(7);
+    expect(sqlite.prepare(
+      "SELECT high_water FROM feedback_material_sequence_state WHERE app_id='app-a'",
+    ).get()).toEqual({ high_water: 7 });
+    expect(sqlite.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_comments WHERE submission_id='23232323-2323-4232-8232-232323232323'",
+    ).get()).toEqual({ count: 0 });
+
+    const materialCursorOnReporterRoute = await handleGetReporterFeedback(reporterContext(
+      {},
+      { comment_cursor: cursor(["material-v1", "app-a", 7]) },
+    ));
     expect(materialCursorOnReporterRoute.status).toBe(400);
 
-    const reporterList = await handleListReporterFeedback({
-      env,
-      req: {
-        param: (name: string) => name === "appId" ? "app-a" : undefined,
-        header: (name: string) => name.toLowerCase() === "authorization"
-          ? `Bearer ${credential.token}`
-          : name === "X-Hands-Reporter-Id"
-            ? reporterId
-            : undefined,
-        query: () => undefined,
-      },
-      header: () => undefined,
-      json: (data: unknown, status = 200) => Response.json(data, { status }),
-    } as any);
+    const reporterList = await handleListReporterFeedback(reporterContext());
     expect(reporterList.status).toBe(200);
-    expect(JSON.stringify(await reporterList.json())).not.toMatch(/material_sequence|material-v1/);
+    const listEvidence = JSON.stringify({
+      body: await reporterList.json(),
+      headers: [...reporterList.headers],
+    });
+    expect(listEvidence).not.toMatch(/material_sequence|material-v1/);
+
+    const detailPage1 = await handleGetReporterFeedback(reporterContext({}, { comment_limit: "1" }));
+    expect(detailPage1.status).toBe(200);
+    const detailPage1Body = await detailPage1.json() as any;
+    expect(detailPage1Body.comments).toHaveLength(1);
+    expect(detailPage1Body.next_comment_cursor).toBeTypeOf("string");
+    expect(JSON.stringify({ body: detailPage1Body, headers: [...detailPage1.headers] }))
+      .not.toMatch(/material_sequence|material-v1/);
+    expect(material(sqlite, ticketId)).toBe(7);
+    expect(sqlite.prepare(
+      "SELECT COUNT(*) AS count FROM feedback_reporter_ticket_reads WHERE ticket_id=?",
+    ).get(ticketId)).toEqual({ count: 1 });
+    const detailPage2 = await handleGetReporterFeedback(reporterContext(
+      {},
+      { comment_limit: "1", comment_cursor: detailPage1Body.next_comment_cursor },
+    ));
+    expect(detailPage2.status).toBe(200);
+    expect(JSON.stringify({ body: await detailPage2.json(), headers: [...detailPage2.headers] }))
+      .not.toMatch(/material_sequence|material-v1/);
+    expect(material(sqlite, ticketId)).toBe(7);
+
+    const attachmentId = "24242424-2424-4242-8242-242424242424";
+    const attachmentKey = `feedback/app-a/${ticketId}/evidence.png`;
+    sqlite.prepare(
+      `INSERT INTO feedback_attachments
+       (id, ticket_id, r2_key, filename, content_type, size_bytes, origin, visibility, created_at)
+       VALUES (?, ?, ?, 'evidence.png', 'image/png', 3, 'submission', 'reporter', 4)`,
+    ).run(attachmentId, ticketId, attachmentKey);
+    await env.APK_BUCKET.put(attachmentKey, new Uint8Array([1, 2, 3]).buffer);
+    const download = await handleDownloadReporterAttachment(reporterContext(
+      {},
+      {},
+      { attachmentId },
+    ));
+    expect(download.status).toBe(200);
+    expect(new Uint8Array(await download.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+    expect(JSON.stringify([...download.headers])).not.toMatch(/material_sequence|material-v1/);
+    expect(material(sqlite, ticketId)).toBe(7);
+    expect(sqlite.prepare(
+      `SELECT COUNT(*) AS count FROM feedback_reporter_access_audits
+       WHERE ticket_id=? AND attachment_id=? AND endpoint='attachment'`,
+    ).get(ticketId, attachmentId)).toEqual({ count: 1 });
+
     const eventPayloads = sqlite.prepare(
       "SELECT payload_json FROM feedback_events WHERE ticket_id = ?",
     ).all(ticketId);
     expect(JSON.stringify(eventPayloads)).not.toMatch(/material_sequence|material-v1/);
+    const deliveryPayloads = sqlite.prepare(
+      "SELECT payload_json FROM webhook_deliveries WHERE event_type='feedback:comment_created'",
+    ).all();
+    expect(deliveryPayloads.length).toBeGreaterThan(0);
+    expect(JSON.stringify(deliveryPayloads)).not.toMatch(/material_sequence|material-v1/);
+    const reporterSchema = Object.fromEntries(Object.entries(openApiDocument.paths ?? {})
+      .filter(([path]) => path.includes("reporter-feedback")));
+    expect(JSON.stringify(reporterSchema)).not.toMatch(/material_sequence|material-v1/);
+    for (const source of ["reporter_feedback.ts", "reporter_sessions.ts"]) {
+      expect(readFileSync(new URL(`../src/routes/${source}`, import.meta.url), "utf8"))
+        .not.toMatch(/material_sequence|material-v1/);
+    }
+
+    const beforeBatch = (sqlite.prepare(
+      "SELECT high_water FROM feedback_material_sequence_state WHERE app_id='app-a'",
+    ).get() as { high_water: number }).high_water;
+    await (env.DB as any).batch([
+      env.DB.prepare(
+        `INSERT INTO feedback_comments
+         (id, ticket_id, author_actor, author_type, body, internal, created_at)
+         VALUES ('batch-one', ?1, 'staff:test', 'staff', 'one', 1, 10)`,
+      ).bind(ticketId),
+      env.DB.prepare(
+        `INSERT INTO feedback_comments
+         (id, ticket_id, author_actor, author_type, body, internal, created_at)
+         VALUES ('batch-two', ?1, 'staff:test', 'staff', 'two', 1, 10)`,
+      ).bind(minidumpId),
+    ]);
+    expect([material(sqlite, ticketId), material(sqlite, minidumpId)].sort((a, b) => a - b))
+      .toEqual([beforeBatch + 1, beforeBatch + 2]);
+
+    const beforeCompetingHandlers = beforeBatch + 2;
+    const competingHandlers = await Promise.all([
+      handleAddFeedbackComment(jsonContext(
+        env,
+        { appId: "app-a", ticketId },
+        { body: "competing-one", internal: true },
+      )),
+      handleAddFeedbackComment(jsonContext(
+        env,
+        { appId: "app-a", ticketId: minidumpId },
+        { body: "competing-two", internal: true },
+      )),
+    ]);
+    expect(competingHandlers.map((response) => response.status)).toEqual([201, 201]);
+    expect([material(sqlite, ticketId), material(sqlite, minidumpId)].sort((a, b) => a - b))
+      .toEqual([beforeCompetingHandlers + 1, beforeCompetingHandlers + 2]);
+    expect(sqlite.prepare(
+      "SELECT high_water FROM feedback_material_sequence_state WHERE app_id='app-a'",
+    ).get()).toEqual({ high_water: beforeCompetingHandlers + 2 });
+    expect(sqlite.prepare(
+      "SELECT high_water FROM feedback_material_sequence_state WHERE app_id='app-b'",
+    ).get()).toEqual({ high_water: 1 });
+    expect(material(sqlite, appBTicket)).toBe(1);
   });
 
   it("pages snapshot deltas without omission and rejects every foreign cursor family", async () => {
-    const { sqlite, env } = environment();
+    const { sqlite, env } = environment(false);
     const insert = sqlite.prepare(
       `INSERT INTO feedback_tickets
        (id, app_id, kind, status, message, metadata_json, created_at, updated_at)
@@ -326,6 +490,7 @@ describe("feedback material delta production routes", () => {
       "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
     ].entries()) insert.run(id, `ticket-${index}`, index + 1, index + 1);
+    sqlite.exec(readFileSync(`${MIGRATION_DIR}0060_feedback_material_delta.sql`, "utf8"));
 
     const firstResponse = await handleListFeedbackMaterialDelta(jsonContext(
       env,
@@ -366,21 +531,44 @@ describe("feedback material delta production routes", () => {
     expect(empty).toMatchObject({ tickets: [], next_cursor: second.next_cursor, has_more: false });
 
     for (const invalid of [
-      cursor(["material-v1", "app-b", 0]),
       cursor(["sequence-v1", 0, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]),
       cursor(["sequence-v2", "app-a", 0]),
       cursor([0, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]),
+      cursor(["material-v1", "app-a", -1]),
+      cursor(["material-v1", "app-a", 1.5]),
       cursor(["material-v1", "app-a", Number.MAX_SAFE_INTEGER + 1]),
+      cursor(["material-v1", "app-a", 0, "extra"]),
       "",
       "not-base64",
     ]) {
-      expect((await handleListFeedbackMaterialDelta(jsonContext(
+      const invalidResponse = await handleListFeedbackMaterialDelta(jsonContext(
         env,
         { appId: "app-a" },
         {},
         { cursor: invalid },
-      ))).status).toBe(400);
+      ));
+      expect(invalidResponse.status).toBe(400);
+      expect(JSON.stringify({ body: await invalidResponse.json(), headers: [...invalidResponse.headers] }))
+        .not.toMatch(/material_sequence|material-v1/);
     }
+
+    let crossAppQueries = 0;
+    const failFastEnv = {
+      ...env,
+      DB: {
+        prepare: () => {
+          crossAppQueries += 1;
+          throw new Error("cross-app cursor reached DB");
+        },
+      },
+    } as unknown as Env;
+    expect((await handleListFeedbackMaterialDelta(jsonContext(
+      failFastEnv,
+      { appId: "app-a" },
+      {},
+      { cursor: cursor(["material-v1", "app-b", 0]) },
+    ))).status).toBe(400);
+    expect(crossAppQueries).toBe(0);
   });
 
   it("wires the literal admin route and rejects a feedback:read reporter token", async () => {


### PR DESCRIPTION
## Problem

Feedback consumers need a lossless way to discover tickets whose actionable state changed. `updated_at` is not a suitable cursor: internal processing can advance it without a material change, while timestamp-based pagination can collapse multiple changes in the same millisecond.

## Changes

- add migration 0060 with a per-app material sequence allocator and a managed ticket carrier
- advance the carrier for ticket creation, real status/assignee changes, and reporter, external staff, or internal staff comments
- keep symbolication, reads, downloads, no-op/lost CAS operations, failed transactions, and reporter cursor state outside the material domain
- add an app-viewer-only `GET /api/apps/:appId/feedback/material-delta` snapshot feed with strict app-bound `material-v1` cursors and indexed pagination
- block hard ticket deletion while the parent app exists so a delta consumer cannot silently miss a deletion; full app purge remains supported
- add a reusable migration validation query for carrier/allocator integrity
- document the contract, rollout/restore invariants, query plan, and static SQLite opcode evidence
- add migration, route, authorization, cursor-isolation, reporter-non-exposure, rollback, concurrency, purge, and query-plan regression coverage

## Testing

- `pnpm --filter @botiverse/hands-worker test` — 28 files / 319 tests
- `pnpm --filter @botiverse/hands-worker build`
- focused material migration and route suites — 15 tests
- local Wrangler D1 parse/apply: migration 0060 (15 statements), then validation query (1 statement, 0 violations on valid state)
- `git diff --check`

The opcode inventory is static SQLite evidence only; it is not presented as production D1 latency or billing data.
