### PR TITLE
Fix feedback commit readback after D1 batch

### DIFF
--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -478,7 +478,8 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
           AND active_ri.app_id = r.app_id AND active_ri.archived_at IS NULL
          WHERE r.app_id = ?2 AND r.reporter_integration_id = ?20
            AND r.reporter_id = ?19
-       )`,
+       )
+       RETURNING id`,
     ).bind(
       ticketId,
       app.id,
@@ -604,7 +605,8 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
   );
   try {
     const results = await c.env.DB.batch(statements);
-    if ((results[0]?.meta.changes ?? 0) !== 1) {
+    const committedTicket = results[0]?.results[0] as { id?: unknown } | undefined;
+    if (committedTicket?.id !== ticketId) {
       await cleanupInlineUploads();
       return c.json({ error: "route_required" }, 409);
     }

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -9492,6 +9492,34 @@ describe("quiver public API v2 — scope resolution", () => {
       "SELECT COUNT(*) AS count FROM feedback_submission_events WHERE app_id = 'app-scope' AND reporter_id = ?1",
     ).bind("g".repeat(64)).first() as any).count).toBe(0);
 
+    // Production D1 has returned a zero `meta.changes` for a successful
+    // INSERT ... SELECT batch. Commit authority comes from the exact row
+    // returned by the ticket insert, never from advisory batch metadata.
+    const dbBeforeCommitMetadata = env.DB as unknown as D1Database;
+    const batchBeforeCommitMetadata = dbBeforeCommitMetadata.batch.bind(dbBeforeCommitMetadata);
+    env.DB = {
+      ...dbBeforeCommitMetadata,
+      async batch(statements: D1PreparedStatement[]) {
+        const results = await batchBeforeCommitMetadata(statements);
+        return results.map((result, index) => index === 0
+          ? { ...result, meta: { ...result.meta, changes: 0 } }
+          : result);
+      },
+    } as unknown as typeof env.DB;
+    const committedWithZeroMetadata = await submit("h".repeat(64));
+    expect(committedWithZeroMetadata.status).toBe(201);
+    const committedWithZeroMetadataBody = await responseJson<any>(committedWithZeroMetadata);
+    env.DB = dbBeforeCommitMetadata as unknown as typeof env.DB;
+    expect(await env.DB.prepare(
+      `SELECT 1 AS ok FROM feedback_tickets
+       WHERE id = ?1 AND app_id = 'app-scope'
+         AND reporter_integration_id = 'integration-proxy' AND reporter_id = ?2`,
+    ).bind(committedWithZeroMetadataBody.id, "h".repeat(64)).first()).toMatchObject({ ok: 1 });
+    expect(await env.DB.prepare(
+      `SELECT 1 AS ok FROM feedback_submission_events
+       WHERE ticket_id = ?1 AND route_outcome = 'route_bound'`,
+    ).bind(committedWithZeroMetadataBody.id).first()).toMatchObject({ ok: 1 });
+
     for (let index = 0; index < 100; index += 1) {
       const response = await submit(reporterA);
       expect(response.status).toBe(201);


### PR DESCRIPTION
## Summary

- return the inserted feedback ticket id from the existing route-gated `INSERT ... SELECT`
- treat that exact returned id as commit authority instead of advisory D1 batch `meta.changes`
- retain both reporter-route checks and the atomic event/delivery batch
- add a regression case where D1 commits the ticket and routed event while reporting zero changes metadata

## Validation

- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-worker test` (28 files, 319 tests)
- reverse RED: restoring the `meta.changes` fence makes the production-shaped regression return 409 instead of 201
- `pnpm --filter @botiverse/hands-worker lint` remains blocked by the repository's existing ESLint 9 configuration gap (`eslint.config.*` is absent)

## Security

No permission or route requirement is relaxed. A missing or concurrently removed route still yields no returned ticket row and remains fail-closed with 409; successful responses now require the exact newly generated ticket id from the gated insert.
