### PR TITLE
Derive the crash product at ingest, drop it from the symbolication lane

### DIFF
--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -871,16 +871,39 @@ function stableJson(value: unknown): string {
 const MINIDUMP_MAX_BYTES = 64 * 1024 * 1024; // Crashpad dumps are usually < a few MB
 
 /**
- * Electron/Crashpad crash ingest. Electron's built-in crashReporter POSTs a
+ * Crashpad minidump crash ingest. Electron's built-in crashReporter POSTs a
  * multipart/form-data with the minidump under `upload_file_minidump` plus a
  * flat set of annotation fields (productName, version, and any `extra`/
  * `globalExtra` the SDK set). We store the dump as a crash-ticket attachment,
- * fold every annotation into metadata (product_type=electron), and fire the
+ * fold every annotation into metadata (product_type from the annotation, see
+ * crashProductKind), and fire the
  * minidump symbolication lane against the version's breakpad-symbols asset.
  *
  * Client-key gate: the SDK puts it in the submitURL query (`?client_key=`),
  * which Crashpad preserves, or an X-Quiver-Client-Key header.
  */
+/**
+ * Which product produced a Crashpad minidump. Closed set: anything absent or
+ * unrecognised is Electron, so clients that predate this annotation keep the
+ * exact output they had before — the only producer of a non-Electron value is a
+ * client that deliberately sends one.
+ */
+const CRASH_PRODUCT_KINDS = ["electron", "tauri"] as const;
+type CrashProductKind = (typeof CRASH_PRODUCT_KINDS)[number];
+
+function crashProductKind(annotated: string | null): CrashProductKind {
+  const value = (annotated ?? "").trim().toLowerCase();
+  return (CRASH_PRODUCT_KINDS as readonly string[]).includes(value)
+    ? (value as CrashProductKind)
+    : "electron";
+}
+
+/** Human-facing product name for a ticket title. */
+const CRASH_PRODUCT_LABEL: Record<CrashProductKind, string> = {
+  electron: "Electron",
+  tauri: "Tauri",
+};
+
 export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) {
   const slug = c.req.param("slug");
   if (!slug) return c.json({ error: "slug required" }, 400);
@@ -938,11 +961,12 @@ export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) 
   const versionCode =
     versionCodeRaw && /^\d+$/.test(versionCodeRaw) ? Math.trunc(Number(versionCodeRaw)) : null;
   const processType = pick("process_type", "ptype", "type"); // main / renderer / gpu / utility
+  const productKind = crashProductKind(pick("product_type", "product"));
   const metadata: Record<string, unknown> = {
     ...annotations,
-    product_type: "electron",
+    product_type: productKind,
     process_type: processType,
-    crash_platform: pick("platform", "os") ?? "electron",
+    crash_platform: pick("platform", "os") ?? productKind,
   };
 
   const clientIp =
@@ -968,7 +992,8 @@ export async function handlePublicMinidumpSubmit(c: Context<{ Bindings: Env }>) 
   });
 
   const reasonBits = [processType, versionName].filter(Boolean).join(" · ");
-  const message = `Electron crash${reasonBits ? ` (${reasonBits})` : ""}`;
+  const message =
+    `${CRASH_PRODUCT_LABEL[productKind]} crash${reasonBits ? ` (${reasonBits})` : ""}`;
 
   await c.env.DB.batch([
     c.env.DB.prepare(
@@ -1660,7 +1685,40 @@ export async function symbolicateDsymCrashTicket(
 }
 
 /**
- * Resolve an Electron/Crashpad minidump against the version's breakpad-symbols
+ * The Breakpad lane symbolicates any Crashpad minidump, so its output names no
+ * product. It previously said "Electron" and pointed at `publish-electron`,
+ * which told operators of every other product the wrong thing — including the
+ * wrong command to run. The product is already on the ticket as `product_type`.
+ *
+ * Extracted from the symbolicate path so the wording is assertable without a
+ * container binding: the rule "this text mentions no product" needs something
+ * that can fail.
+ */
+export const MINIDUMP_SYMBOLICATION_LABEL = "minidump";
+
+export function minidumpSymbolicationText(input: {
+  hasSymbols: boolean;
+  crashReason: string | null;
+  crashAddress: string | null;
+  versionCode: number | null;
+  stack: string;
+}): string {
+  const header =
+    `Symbolicated minidump crash (minidump-stackwalk` +
+    `${input.hasSymbols ? "" : ", no breakpad-symbols asset — module+offset only"}):` +
+    `${input.crashReason ? `\nReason: ${input.crashReason}${input.crashAddress ? ` @ ${input.crashAddress}` : ""}` : ""}`;
+  const tip =
+    !input.hasSymbols && input.versionCode !== null
+      ? `\n\nTip: upload the version's Breakpad symbols (run dump_syms, then ` +
+        `this product's "hands builds" publish command with --symbols) ` +
+        `for version_code ${input.versionCode} to get function/file:line ` +
+        `resolution instead of raw module+offset.`
+      : "";
+  return `${header}\n\n${input.stack}${tip}`.slice(0, 20_000);
+}
+
+/**
+ * Resolve a Crashpad minidump against the version's breakpad-symbols
  * asset via the container's minidump-stackwalk lane and append the result as an
  * internal comment — mirrors the native/dSYM symbolication flows. Missing
  * symbols leaves an operator-actionable comment.
@@ -1718,22 +1776,18 @@ export async function symbolicateMinidumpCrashTicket(
     const stack = (parsed.stack_text ?? "").trim();
     if (!stack) return;
 
-    const header =
-      `Symbolicated Electron crash (minidump-stackwalk` +
-      `${symBytes ? "" : ", no breakpad-symbols asset — module+offset only"}):` +
-      `${parsed.crash_reason ? `\nReason: ${parsed.crash_reason}${parsed.crash_address ? ` @ ${parsed.crash_address}` : ""}` : ""}`;
-    const tip =
-      !symBytes && versionCode !== null
-        ? `\n\nTip: upload the version's Breakpad symbols (dump_syms → hands builds ` +
-          `publish-electron --symbols) for version_code ${versionCode} to get ` +
-          `function/file:line resolution instead of raw module+offset.`
-        : "";
     await appendSymbolication(
       env,
       ticketId,
-      "electron-minidump",
+      MINIDUMP_SYMBOLICATION_LABEL,
       "symbolicated",
-      `${header}\n\n${stack}${tip}`.slice(0, 20_000),
+      minidumpSymbolicationText({
+        hasSymbols: Boolean(symBytes),
+        crashReason: parsed.crash_reason ?? null,
+        crashAddress: parsed.crash_address ?? null,
+        versionCode,
+        stack,
+      }),
     );
   } catch (err) {
     console.error(

--- a/worker/test/crash_product_kind.test.ts
+++ b/worker/test/crash_product_kind.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Crash ingest derives the product from a closed set instead of hardcoding
+ * Electron, and the Breakpad symbolication lane names no product at all.
+ *
+ * The property that matters for existing clients is the negative one: a client
+ * that sends no product annotation — every Electron client shipped so far —
+ * must get byte-identical output. So each assertion here has an Electron
+ * counterpart, not just a Tauri one.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MINIDUMP_SYMBOLICATION_LABEL,
+  minidumpSymbolicationText,
+} from "../src/routes/feedback";
+
+describe("minidump symbolication output is product-neutral", () => {
+  const text = (over: Partial<Parameters<typeof minidumpSymbolicationText>[0]> = {}) =>
+    minidumpSymbolicationText({
+      hasSymbols: false,
+      crashReason: "EXCEPTION_ACCESS_VIOLATION",
+      crashAddress: "0x0",
+      versionCode: 1020300,
+      stack: "0  app!main + 0x10",
+      ...over,
+    });
+
+  it("names no product anywhere in the block or its label", () => {
+    // The lane handles any Crashpad minidump. Naming one product told operators
+    // of every other product the wrong thing.
+    const produced = `${MINIDUMP_SYMBOLICATION_LABEL}\n${text()}`;
+    for (const product of ["Electron", "electron", "Tauri", "tauri"]) {
+      expect(produced).not.toContain(product);
+    }
+  });
+
+  it("does not tell the operator to run a product-specific command", () => {
+    // The old tip said `publish-electron --symbols`, which is the wrong command
+    // for a Tauri app — worse than saying nothing, because it looks actionable.
+    expect(text()).not.toContain("publish-electron");
+    // Nor a wildcard standing in for one. `hands builds publish-*` is not a
+    // subcommand — the real ones are publish-electron / publish-tauri / etc.
+    // A pseudo-command fails the same test the old text failed: it reads as
+    // copy-pasteable and is not. Naming no command is the point.
+    for (const pseudo of ["publish-*", "publish-<", "publish-{"]) {
+      expect(text()).not.toContain(pseudo);
+    }
+    // Whatever the wording, it must not offer a token that looks runnable.
+    expect(text()).not.toMatch(/`[^`]*publish[^`]*`/);
+    // It still has to be actionable: the symbols hint and the version survive.
+    expect(text()).toContain("Breakpad symbols");
+    expect(text()).toContain("1020300");
+  });
+
+  it("keeps the tip only when symbols are missing and a version is known", () => {
+    expect(text({ hasSymbols: true })).not.toContain("Tip:");
+    expect(text({ versionCode: null })).not.toContain("Tip:");
+    expect(text()).toContain("Tip:");
+  });
+
+  it("carries the stack and the crash reason through unchanged", () => {
+    expect(text()).toContain("0  app!main + 0x10");
+    expect(text()).toContain("EXCEPTION_ACCESS_VIOLATION @ 0x0");
+    expect(text({ crashReason: null })).not.toContain("Reason:");
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -8685,6 +8685,78 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(att.size_bytes).toBe(4);
   });
 
+  it("handlePublicMinidumpSubmit derives the product from a closed set", async () => {
+    const { handlePublicMinidumpSubmit } = await import("../src/routes/feedback");
+
+    const submit = async (product?: string, platform?: string) => {
+      const env = makeEnv();
+      const store = new Map<string, Uint8Array>();
+      env.APK_BUCKET = {
+        put: async (key: string, body: ArrayBuffer) => { store.set(key, new Uint8Array(body)); },
+        get: async () => null,
+        head: async () => null,
+      } as any;
+      const form = new FormData();
+      form.set(
+        "upload_file_minidump",
+        new File([new Uint8Array([77, 68, 77, 80])], "crash.dmp", { type: "application/x-minidump" }),
+      );
+      form.set("version_code", "1020300");
+      if (product !== undefined) form.set("product_type", product);
+      if (platform !== undefined) form.set("platform", platform);
+
+      const waited: Promise<unknown>[] = [];
+      const res = await handlePublicMinidumpSubmit({
+        env,
+        executionCtx: { waitUntil: (pr: Promise<unknown>) => waited.push(pr) },
+        req: {
+          param: (n: string) => (n === "slug" ? "scope-app" : ""),
+          header: (n: string) => (n === "X-Quiver-Client-Key" ? "qk_test" : undefined),
+          query: () => undefined,
+          formData: async () => form,
+          raw: { cf: { clientIp: "203.0.113.7" } },
+        },
+        json: (data: unknown, status = 200) => new Response(JSON.stringify(data), { status }),
+      } as any);
+      await Promise.all(waited).catch(() => {});
+      const body = await responseJson<any>(res);
+      const row = (await env.DB.prepare(
+        "SELECT message, metadata_json FROM feedback_tickets WHERE id = ?1",
+      ).bind(body.id).first()) as any;
+      return { message: row.message as string, meta: JSON.parse(row.metadata_json) };
+    };
+
+    // The shipped Electron SDK sends product_type="electron" with a real
+    // platform on every minidump (clients/electron/src/common.ts). This is the
+    // payload production actually delivers, so it is the case that has to stay
+    // byte-identical — and the only one that pins the recognised-electron
+    // branch. Without it a mutation to that branch leaves the other three green.
+    const shipped = await submit("electron", "darwin");
+    expect(shipped.meta.product_type).toBe("electron");
+    expect(shipped.meta.crash_platform).toBe("darwin");
+    expect(shipped.message).toBe("Electron crash");
+
+    // A client that sends no product annotation at all must land on the same
+    // output as the shipped one.
+    const absent = await submit();
+    expect(absent.meta.product_type).toBe("electron");
+    expect(absent.meta.crash_platform).toBe("electron");
+    expect(absent.message).toBe("Electron crash");
+
+    // A value outside the closed set is treated as absent, not echoed back into
+    // the ticket title or the platform field.
+    const unknown = await submit("flutter");
+    expect(unknown.meta.product_type).toBe("electron");
+    expect(unknown.meta.crash_platform).toBe("electron");
+    expect(unknown.message).toBe("Electron crash");
+
+    // Only a deliberate, recognised value changes the output.
+    const tauri = await submit("tauri");
+    expect(tauri.meta.product_type).toBe("tauri");
+    expect(tauri.meta.crash_platform).toBe("tauri");
+    expect(tauri.message).toBe("Tauri crash");
+  });
+
   it("handlePublicMinidumpSubmit rejects an invalid client key", async () => {
     const env = makeEnv();
     const { handlePublicMinidumpSubmit } = await import("../src/routes/feedback");


### PR DESCRIPTION
## Problem

Seven places on the Crashpad minidump path hardcoded Electron, so a crash from any other product was ingested, titled and symbolicated as an Electron crash. This is the server prerequisite for the hands-tauri SDK: decide the product once at ingest, and stop naming a product downstream.

## Changes

**Ingest — derive from a closed set.** `crashProductKind()` maps the annotation to `electron | tauri`; anything absent or unrecognised is Electron. That covers `metadata.product_type`, the `crash_platform` fallback, and the ticket title.

**Existing clients are byte-identical.** The shipped Electron SDK sends `product_type: "electron"` with a real `platform` on every minidump (`clients/electron/src/common.ts`), so that exact payload is covered directly, alongside the absent and unrecognised cases.

Two of those guarantees have different strengths, and a reviewer should not have to
rely on test coverage to tell them apart:

- **"An arbitrary string can never reach the title" is structural, not merely
  tested.** The title reads `CRASH_PRODUCT_LABEL[productKind]` — a table lookup
  keyed by the derived enum, which never touches the client string. It is not
  expressible in the types for an unrecognised value to be echoed there.
- **"Absent or unrecognised means *Electron specifically*" is a value choice**,
  living in one line of `crashProductKind()`. Nothing structural pins it, so the
  tests do — which is exactly the half that back-compat depends on.

**Breakpad lane — no product at all.** It symbolicates any Crashpad minidump. The old text claimed Electron *and* told the operator to run `publish-electron --symbols`, which is the wrong command for a Tauri app — worse than silence, because it looks actionable. The product is already on the ticket as `product_type`.

The symbolication text builder is extracted to `minidumpSymbolicationText()`. That path needs a container binding, so the wording was previously unassertable — and "this text names no product" needs something that can fail.

## Operator-visible cost

Existing Electron crashes get slightly different **symbolication wording**. Ticket titles and webhooks are unaffected. The previous text was itself wrong for non-Electron products, so byte-identical preservation would have preserved a known defect.

**What is *not* closed, so the claim is not over-generalised.** `metadata` starts as
`...annotations` — every client-supplied string field, truncated to 2000 chars. That
is the design of a crash annotation bag and predates this PR. Within it:

- `product_type` **is** closed, because it is written after the spread and so
  overwrites anything the client sent under that key;
- `crash_platform` is **not** — it passes the client's `platform`/`os` annotation
  through verbatim, using the derived kind only as a fallback when absent. That is
  existing main behaviour; this PR only changed the fallback from the literal
  `"electron"` to the derived value.

This annotation bag behaviour predates this PR and is out of scope here; it is
recorded so the closedness claim above is not read more broadly than it holds.
Checked while confirming it: the console has no `dangerouslySetInnerHTML`
anywhere, so the bag renders as escaped text.

The persisted lane label changes from `electron-minidump` to `minidump`. It is only a text prefix inside `symbolicated_stack`. Verified against `origin/main` (not this branch, which has already renamed the writer): `electron-minidump` occurs exactly once, at the write site — **no reader in the repo**.

Historical rows keep their existing text, guaranteed structurally rather than by test: this PR adds no migration, so there is no rewrite path.

**Residual, stated rather than implied.** A repo grep proves no *code* reads these strings. They are persisted text, so consumers outside the repo — saved operator queries, dashboards — are invisible to it.

Two strings inside `symbolicated_stack` change, not one:

| Was | Now |
|---|---|
| `[electron-minidump]` prefix | `[minidump]` |
| `Symbolicated Electron crash (minidump-stackwalk…` | `Symbolicated minidump crash (minidump-stackwalk…` |

The failure mode is worth naming precisely, because it is not an error: **a query matching either old string keeps returning results and silently stops covering new rows.** It does not fail, does not return empty, and looks healthy — it just quietly narrows to history. That is more dangerous than a broken query, which announces itself.

So the operator-facing note is not "we changed the label". It is: *queries matching the old strings will keep returning rows but will no longer include new crashes.* Historical rows are not rewritten, so old and new coexist by design.

## Testing

Full suite **324/324** (319 + 5). Each assertion mutation-checked:

| Mutation | Reddens |
|---|---|
| Open the product set so any annotated value is echoed | closed-set ingest test |
| Break only the recognised-`electron` branch (`"electron"` → `tauri`) | shipped-payload case |
| Restore the product name in the symbolication header | "names no product" |
| Restore the product-specific command in the tip | "names no product" + "no product-specific command" |
| Replace the prose with a wildcard pseudo-command (`publish-*`) | "no product-specific command" |

Each was applied and run, not reasoned about. The recognised-`electron` mutation
is the one worth noting: before the shipped-payload case existed, it left the
full suite green — absent and unrecognised both fall back to `electron`, so
nothing observed the branch production actually takes.

Also covered: the tip appears only when symbols are missing *and* a version is known, and the stack and crash reason pass through unchanged.

## Scope

Server only. No migration, no SDK code, no client changes. The `clients/tauri` skeleton is a separate task and gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




