### PR TITLE
Add feedback:triage so handling a ticket does not require release rights

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -766,8 +766,13 @@ admin.get(
   handleListFeedbackMaterialDelta,
 );
 admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRoleOrFeedbackPermission("viewer", "feedback:read"), handleGetFeedback);
-admin.patch("/api/apps/:appId/feedback/:ticketId", requireFeedbackTriageRole(), handleUpdateFeedback);
-admin.post("/api/apps/:appId/feedback/:ticketId/comments", requireAppRoleOrFeedbackPermission("publisher", "feedback:comment"), handleAddFeedbackComment);
+admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRoleOrFeedbackPermission("publisher", "feedback:triage"), handleUpdateFeedback);
+admin.post(
+  "/api/apps/:appId/feedback/:ticketId/comments",
+  // Both actions share this endpoint; handleAddFeedbackComment splits them on `internal`.
+  requireAppRoleOrFeedbackPermission("publisher", "feedback:comment", "feedback:triage"),
+  handleAddFeedbackComment,
+);
 admin.post("/api/apps/:appId/feedback/:ticketId/symbolicate", requireFeedbackTriageRole(), handleResymbolicateFeedback);
 admin.get(
   "/api/apps/:appId/feedback/:ticketId/attachments/:attachmentId",

--- a/worker/src/lib/app_permissions.ts
+++ b/worker/src/lib/app_permissions.ts
@@ -8,6 +8,7 @@ export const APP_PERMISSIONS = [
   "feedback:read",
   "feedback:comment",
   "feedback:route",
+  "feedback:triage",
 ] as const;
 
 export type AppPermission = (typeof APP_PERMISSIONS)[number];
@@ -20,6 +21,7 @@ export const APP_PERMISSION_LABELS: Record<AppPermission, string> = {
   "feedback:read": "Reporter feedback read",
   "feedback:comment": "Reporter feedback comment",
   "feedback:route": "Reporter route binding",
+  "feedback:triage": "Feedback triage",
 };
 
 export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
@@ -30,6 +32,7 @@ export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
   "feedback:read": "Read tickets owned by a reporter integration.",
   "feedback:comment": "Comment on tickets owned by a reporter integration.",
   "feedback:route": "Bind an opaque route subject to a reporter integration.",
+  "feedback:triage": "Change ticket status and assignee, and write internal notes.",
 };
 
 export const APP_ROLE_PERMISSIONS: Record<AppRole, readonly AppPermission[]> = {
@@ -49,6 +52,7 @@ export const APP_PERMISSION_MINIMUM_ROLE: Partial<Record<AppPermission, AppRole>
   "app:publish": "publisher",
   "app:admin": "admin",
   "feedback:write": "publisher",
+  "feedback:triage": "publisher",
 };
 
 export const FEEDBACK_TOKEN_PERMISSIONS = [

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -403,7 +403,7 @@ export function requireAppRole(minimum: AppRole): MiddlewareHandler<RoleContext>
  */
 export function requireAppRoleOrFeedbackPermission(
   minimum: AppRole,
-  permission: AppPermission,
+  ...permissions: AppPermission[]
 ): MiddlewareHandler<RoleContext> {
   return async (c, next) => {
     const appId = c.req.param("appId");
@@ -414,9 +414,11 @@ export function requireAppRoleOrFeedbackPermission(
       && token.app_id === appId
       && token.app_role === null
       && token.reporter_integration_id === null
-      && resolveDeployTokenPermissions(token).has(permission)
+      && permissions.some((permission) => resolveDeployTokenPermissions(token).has(permission))
     ) {
-      c.set("feedback_scoped_token", true);
+      // Which permission admitted them matters downstream: the comments endpoint
+      // serves both public replies and internal notes.
+      c.set("feedback_token_permissions", resolveDeployTokenPermissions(token));
       await next();
       return;
     }

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Context, MiddlewareHandler } from "hono";
+import type { AppPermission } from "../lib/app_permissions";
 import { getCookie } from "hono/cookie";
 import {
   loadDeployToken,
@@ -56,9 +57,10 @@ export type AdminEnv = {
     org_id?: string;
     org_role?: "owner" | "admin" | "member" | "viewer";
     // Set when a console feedback route admitted a role-free deploy token on a
-    // feedback permission rather than a role. Such a caller may read tickets and
-    // reply to the reporter, but has no staff-side handling rights.
-    feedback_scoped_token?: true;
+    // feedback permission rather than a role. Holds that token's resolved
+    // permissions, because one endpoint serves two actions: replying to the
+    // reporter needs feedback:comment, an internal note needs feedback:triage.
+    feedback_token_permissions?: ReadonlySet<AppPermission>;
   };
 };
 

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -15,6 +15,7 @@ import { generateSignedR2Url } from "./public_v2";
 import { dashboardOrigin, requestOrigin } from "../lib/origin";
 import { loadDeployToken } from "../lib/deploy_tokens";
 import { isFeedbackOnlyToken, REPORTER_ID_PATTERN } from "../lib/reporter_auth";
+import type { AppPermission } from "../lib/app_permissions";
 import { buildFeedbackCommentEvent, buildFeedbackStatusEvent } from "../lib/feedback_events";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
@@ -2347,8 +2348,19 @@ export async function handleAddFeedbackComment(c: AdminContext) {
   const isInternal = body.internal === true;
   // A role-free feedback token may reply to the reporter, not write staff-only
   // notes. Checked here rather than in middleware because it depends on the body.
-  if (isInternal && c.get("feedback_scoped_token")) {
-    return c.json({ error: "internal notes require the publisher role" }, 403);
+  const tokenPermissions = c.get("feedback_token_permissions");
+  if (tokenPermissions) {
+    const needed: AppPermission = isInternal ? "feedback:triage" : "feedback:comment";
+    if (!tokenPermissions.has(needed)) {
+      return c.json(
+        {
+          error: isInternal
+            ? "internal notes require feedback:triage or the publisher role"
+            : "replying requires feedback:comment or the publisher role",
+        },
+        403,
+      );
+    }
   }
   const ticket = await c.env.DB.prepare(
     `SELECT t.id, t.reporter_integration_id, t.reporter_id, a.org_id,

--- a/worker/test/feedback_token_console_access.test.ts
+++ b/worker/test/feedback_token_console_access.test.ts
@@ -134,7 +134,7 @@ function app() {
   );
   mini.post(
     "/api/apps/:appId/feedback/:ticketId/comments",
-    requireAppRoleOrFeedbackPermission("publisher", "feedback:comment"),
+    requireAppRoleOrFeedbackPermission("publisher", "feedback:comment", "feedback:triage"),
     handleAddFeedbackComment,
   );
   return mini;
@@ -186,6 +186,7 @@ describe("the tested wiring is the shipped wiring", () => {
     ["/api/apps/:appId/feedback/:ticketId", "feedback:read"],
     ["/api/apps/:appId/feedback/:ticketId/attachments/:attachmentId", "feedback:read"],
     ["/api/apps/:appId/feedback/:ticketId/comments", "feedback:comment"],
+    ["/api/apps/:appId/feedback/:ticketId/comments", "feedback:triage"],
   ])("registers %s so a feedback token can use it (%s)", (route, permission) => {
     expect(registrationFor(route)).toContain('"' + permission + '"');
   });
@@ -283,6 +284,44 @@ describe("the two grants are independently usable", () => {
       name: "commenter", role: null, scopes: '["feedback:comment"]',
     });
     expect((await list(app(), token, env)).status).toBe(403);
+  });
+});
+
+describe("triage and reply are separate grants, not a hierarchy", () => {
+  const triage = (sqlite: Database.Database) => issueToken(sqlite, {
+    name: "triage", role: null, scopes: '["feedback:read","feedback:triage"]',
+  });
+
+  it("lets a triage token write an internal note", async () => {
+    const { sqlite, env } = environment();
+    const response = await comment(app(), await triage(sqlite), env, {
+      body: "staff only", internal: true,
+    });
+    expect(response.status).toBe(201);
+    expect(sqlite.prepare(
+      "SELECT internal FROM feedback_comments WHERE ticket_id = ?",
+    ).get(TICKET)).toMatchObject({ internal: 1 });
+  });
+
+  it("does NOT let a triage token speak to the customer", async () => {
+    // Handling a ticket internally does not imply permission to send the user
+    // text in our name. Neither grant implies the other.
+    const { sqlite, env } = environment();
+    const response = await comment(app(), await triage(sqlite), env, { body: "hello user" });
+    expect(response.status).toBe(403);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM feedback_comments").get())
+      .toMatchObject({ n: 0 });
+  });
+
+  it("does NOT let a comment token write an internal note", async () => {
+    const { sqlite, env } = environment();
+    const token = await issueToken(sqlite, {
+      name: "commenter", role: null, scopes: '["feedback:comment"]',
+    });
+    const response = await comment(app(), token, env, { body: "note", internal: true });
+    expect(response.status).toBe(403);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM feedback_comments").get())
+      .toMatchObject({ n: 0 });
   });
 });
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2640,12 +2640,22 @@ describe("quiver Hono app — auth + dispatch", () => {
       "feedback:read",
       "feedback:comment",
       "feedback:route",
+      "feedback:triage",
     ]);
     expect(body.permissions.find((entry: any) => entry.permission === "app:read").label)
       .toBe("App read");
     expect(body.roles.find((entry: any) => entry.role === "viewer").permissions).toEqual(["app:read"]);
     expect(body.roles.find((entry: any) => entry.role === "publisher").permissions).toContain("feedback:write");
     expect(body.roles.find((entry: any) => entry.role === "admin").permissions).toContain("app:admin");
+
+    // feedback:triage must be grantable only by explicit scope. Putting it in a
+    // role bundle is the natural next edit — "admins can do everything" — and it
+    // would destroy the whole reason for the permission: that nobody holds it
+    // unless someone decided to grant it. Separating triage from publisher is
+    // undone the moment publisher carries it again.
+    for (const role of body.roles) {
+      expect(role.permissions).not.toContain("feedback:triage");
+    }
   });
 
   it("loads app-scoped deploy tokens and updates last_used_at", async () => {


### PR DESCRIPTION
Stacked on **#403** (branched from it, so the diff shown includes it until #403 lands).

## Why

Changing a ticket's status or assignee, and writing internal notes, required the `publisher` role — whose real meaning is *can ship a release*. Doing support work meant being able to publish production builds. Same conflation #403 removed from reading and replying, on the other side of the endpoint.

## What changed

| Action | Was | Now |
|---|---|---|
| `PATCH .../feedback/:ticketId` (status, assignee) | `publisher` | `publisher` **or** `feedback:triage` |
| Internal note (`internal: true` on the comments route) | `publisher` | `publisher` **or** `feedback:triage` |
| Public reply (`internal` absent/false) | unchanged from #403 | `publisher` **or** `feedback:comment` |
| `POST .../symbolicate` | `publisher` | **unchanged** |

Existing publishers are unaffected — they still pass on the role branch.

**Symbolicate deliberately stays on the role.** It re-runs a processing job and is not one of the three actions this permission was asked for; folding it in would be scope the grant was never given.

## Triage and reply are separate grants, not a hierarchy

A triage token **cannot** speak to the customer; a reply token **cannot** write staff-only notes. Handling a ticket internally does not imply permission to talk to the user, so neither implies the other. Both live on one endpoint separated by a request field, so the split is in the handler and the middleware admits either.

## The constraint this rests on

**`feedback:triage` is absent from `APP_ROLE_PERMISSIONS`.** Adding it there is the natural next edit — *"admins can do everything"* — and it would destroy the entire reason for the permission: that nobody holds it unless someone decided to grant it. Separating triage from publisher is undone the moment publisher carries it again.

The registry test now fails if **any** role bundle gains it, so that edit cannot be made quietly. It appears only in `APP_PERMISSION_MINIMUM_ROLE` (who may *grant* it), which does not create automatic holders.

## Harness drift, caught while writing this

These tests build their own mini-app, so they can pass while `index.ts` is wired differently — which happened: the harness accepted only `feedback:comment` on the comments route after production already accepted `feedback:triage`, and **every test stayed green**. A new block asserts the shipped registrations carry the permissions the tests assume.

**339/339.** Typecheck unchanged against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
