### PR TITLE
Restore org-member reach on the feedback write routes

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -759,18 +759,18 @@ admin.get("/api/apps/:appId/analytics/devices", requireAppRole("viewer"), handle
 admin.get("/api/apps/:appId/analytics/versions", requireAppRole("viewer"), handleVersionAnalytics);
 admin.get("/api/apps/:appId/analytics/devices/:deviceId", requireAppRole("viewer"), handleDeviceDetail);
 admin.get("/api/apps/:appId/release-health", requireAppRole("viewer"), handleReleaseHealth);
-admin.get("/api/apps/:appId/feedback", requireAppRoleOrFeedbackPermission("viewer", "feedback:read"), handleListFeedback);
+admin.get("/api/apps/:appId/feedback", requireAppRoleOrFeedbackPermission("viewer", {}, "feedback:read"), handleListFeedback);
 admin.get(
   "/api/apps/:appId/feedback/material-delta",
-  requireAppRoleOrFeedbackPermission("viewer", "feedback:read"),
+  requireAppRoleOrFeedbackPermission("viewer", {}, "feedback:read"),
   handleListFeedbackMaterialDelta,
 );
-admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRoleOrFeedbackPermission("viewer", "feedback:read"), handleGetFeedback);
-admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRoleOrFeedbackPermission("publisher", "feedback:triage"), handleUpdateFeedback);
+admin.get("/api/apps/:appId/feedback/:ticketId", requireAppRoleOrFeedbackPermission("viewer", {}, "feedback:read"), handleGetFeedback);
+admin.patch("/api/apps/:appId/feedback/:ticketId", requireAppRoleOrFeedbackPermission("publisher", { orgMinimum: "member" }, "feedback:triage"), handleUpdateFeedback);
 admin.post(
   "/api/apps/:appId/feedback/:ticketId/comments",
   // Both actions share this endpoint; handleAddFeedbackComment splits them on `internal`.
-  requireAppRoleOrFeedbackPermission("publisher", "feedback:comment", "feedback:triage"),
+  requireAppRoleOrFeedbackPermission("publisher", { orgMinimum: "member" }, "feedback:comment", "feedback:triage"),
   handleAddFeedbackComment,
 );
 admin.post("/api/apps/:appId/feedback/:ticketId/symbolicate", requireFeedbackTriageRole(), handleResymbolicateFeedback);
@@ -778,7 +778,7 @@ admin.get(
   "/api/apps/:appId/feedback/:ticketId/attachments/:attachmentId",
   // An attachment is the substance of most crash reports; reading a ticket
   // without being able to fetch its screenshot is not "read feedback".
-  requireAppRoleOrFeedbackPermission("viewer", "feedback:read"),
+  requireAppRoleOrFeedbackPermission("viewer", {}, "feedback:read"),
   handleDownloadFeedbackAttachment,
 );
 admin.get("/api/apps/:appId/releases/:releaseId/shares", requireAppRole("viewer"), handleListReleaseShares);

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -403,6 +403,7 @@ export function requireAppRole(minimum: AppRole): MiddlewareHandler<RoleContext>
  */
 export function requireAppRoleOrFeedbackPermission(
   minimum: AppRole,
+  options: { orgMinimum?: OrgRole },
   ...permissions: AppPermission[]
 ): MiddlewareHandler<RoleContext> {
   return async (c, next) => {
@@ -422,7 +423,10 @@ export function requireAppRoleOrFeedbackPermission(
       await next();
       return;
     }
-    const allowed = await ensureAppRole(c, appId, minimum);
+    // The role branch must retain exactly the reach the guard it replaced had.
+    // requireFeedbackTriageRole passed { orgMinimum: "member" }; dropping that
+    // silently removed org-level members from routes they could always use.
+    const allowed = await ensureAppRole(c, appId, minimum, options);
     if (!allowed.ok) return allowed.response;
     await next();
   };

--- a/worker/test/feedback_token_console_access.test.ts
+++ b/worker/test/feedback_token_console_access.test.ts
@@ -129,12 +129,12 @@ function app() {
   mini.use("*", authMiddleware);
   mini.get(
     "/api/apps/:appId/feedback",
-    requireAppRoleOrFeedbackPermission("viewer", "feedback:read"),
+    requireAppRoleOrFeedbackPermission("viewer", {}, "feedback:read"),
     handleListFeedback,
   );
   mini.post(
     "/api/apps/:appId/feedback/:ticketId/comments",
-    requireAppRoleOrFeedbackPermission("publisher", "feedback:comment", "feedback:triage"),
+    requireAppRoleOrFeedbackPermission("publisher", { orgMinimum: "member" }, "feedback:comment", "feedback:triage"),
     handleAddFeedbackComment,
   );
   return mini;
@@ -179,6 +179,37 @@ describe("the tested wiring is the shipped wiring", () => {
     const next = indexSource.indexOf("admin.", at);
     return indexSource.slice(at, next === -1 ? indexSource.length : next);
   };
+
+  // The routes that replaced requireFeedbackTriageRole must keep its org reach.
+  // That guard passed { orgMinimum: "member" }; the replacement dropped it and
+  // silently locked org-level members out of internal notes in production.
+  //
+  // Structural, and I want the limit on record: it asserts the option is passed,
+  // not that an org member can actually write. The behavioural version needs the
+  // human session harness these tests do not build. This catches the exact
+  // regression that shipped; it does not prove the org path end to end.
+  // Walks back from the path to its own `admin.<verb>(`, so it works whether the
+  // registration is written on one line or several — the earlier attempt assumed
+  // single-line and silently matched nothing.
+  // Scan registrations of THIS verb and take the one whose path matches. Looking
+  // up the path first is wrong: GET and PATCH share "/…/feedback/:ticketId", so
+  // indexOf lands on whichever appears first in the file.
+  const writeRegistration = (verb: string, route: string) => {
+    const marker = "admin." + verb + "(";
+    for (let at = indexSource.indexOf(marker); at !== -1; at = indexSource.indexOf(marker, at + 1)) {
+      const next = indexSource.indexOf("admin.", at + marker.length);
+      const block = indexSource.slice(at, next === -1 ? indexSource.length : next);
+      if (block.includes('"' + route + '"')) return block;
+    }
+    throw new Error(`no ${verb.toUpperCase()} registration for ${route}`);
+  };
+
+  it.each([
+    ["post", "/api/apps/:appId/feedback/:ticketId/comments"],
+    ["patch", "/api/apps/:appId/feedback/:ticketId"],
+  ])("keeps org-member reach on %s %s", (verb, route) => {
+    expect(writeRegistration(verb, route)).toContain('orgMinimum: "member"');
+  });
 
   it.each([
     ["/api/apps/:appId/feedback", "feedback:read"],
@@ -249,7 +280,7 @@ describe("console feedback access for role-free tokens", () => {
     mini.use("*", authMiddleware);
     mini.get(
       "/api/apps/:appId/releases",
-      requireAppRoleOrFeedbackPermission("publisher", "app:publish"),
+      requireAppRoleOrFeedbackPermission("publisher", {}, "app:publish"),
       (c) => c.json({ ok: true }),
     );
     const response = await mini.request(


### PR DESCRIPTION
**Production regression from #404.** Org-level members lost the ability to write internal notes and change status/assignee. Reported by @DiRenJie, whose feedback patrol was blocked; deployed exact `2cfb1e5d` confirmed live at 09:17, so this was reaching real users.

## Cause

`requireFeedbackTriageRole()` passed `{ orgMinimum: "member" }` to `ensureAppRole`, letting an **org-level** member through. The middleware that replaced it in #404 called `ensureAppRole(c, appId, minimum)` — **without that option.**

I replaced a guard and carried over its *minimum role* but not its *org reach*.

## Fix

`orgMinimum` is now an explicit parameter, passed on exactly the two routes that previously had it:

| Route | Option |
|---|---|
| `PATCH .../feedback/:ticketId` | `{ orgMinimum: "member" }` — restored |
| `POST .../feedback/:ticketId/comments` | `{ orgMinimum: "member" }` — restored |
| the three read routes | `{}` — they never had it |

Direction was tightening only, so no permission was widened: an **availability** regression, not a security one.

## Why every test passed

The suite covers the token path in three directions — read-only, comment-only, triage — and **no role path at all**. Every assertion was about tokens, so replacing the role branch's behaviour changed nothing any test observed.

That is the same shape as the other misses on this branch: I verified the thing I was building and not the thing I was standing on.

## Guard

Both write registrations must carry `orgMinimum`. Mutation-checked against **the exact regression that shipped** — removing it from both routes reddens both.

**Its limit, on the record:** this is structural. It asserts the option is passed, not that an org member can actually write. The behavioural version needs the human session harness these tests do not build, and I did not hold a production fix to construct one.

351/351. Typecheck back at the 720 baseline (I had left one un-migrated call site in my own test file — the suite stayed green because vitest does not typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Post-deploy verification — the canonical list

Deployed `49f6dc55` at 10:24 (run `30805467948`). **Point at this list; do not restate it.** Each time it was restated in chat, an item was dropped — twice, and both times it was ②, the one nobody reported.

## Precondition for every check

**The verifier must be a member of the org that owns the app under test** — not merely "a member of some org."

`getEffectiveRole` resolves membership against *the app's* org. I hit a 403 testing `raft-android` from an account in a different org and briefly mis-reported it as the fix having failed. A read may still return 200 via a server-level viewer grant, so **read-succeeds/write-fails is exactly what a non-member looks like** and is not evidence of a regression.

## The three checks

| # | Check | Expected | Needs |
|---|---|---|---|
| ① | org member → `POST .../feedback/:ticketId/comments` with `internal=true` | **201** | member of the app's org |
| ② | org member → `PATCH .../feedback/:ticketId` (status/assignee) | **200** | member of the app's org |
| ③ | role-free token holding only `feedback:read` → `GET .../feedback` / `POST .../comments` | **200 / 403** | the temporary token |

① is the reported symptom (`orgMinimum` lost in #403). **② was never reported** and was broken too (`orgMinimum` lost in #404) — it is the item that keeps falling off restated lists. ③ confirms this fix did not break the token path, since it edits the middleware serving both.

**Receipt rule:** record what actually ran. If ③ has no token, write "①② verified, ③ not run" — never "fix verified."

## Result (2026-08-03), and what each check does *not* prove

Verified by @DiRenJie, a member of the app's own org:

| # | Result | Proves | Does **not** prove |
|---|---|---|---|
| ① | **VERIFIED 10:50** — 201 on Android `6aa9a254` + OHOS `13cd9aa7`, readback `internal=1` | authorisation **and** the row persists correctly | — |
| ② | **VERIFIED 10:50** — idempotent PATCH (same values) → 200, `changed=false` | **the write permission is restored** | that a real change persists — by construction it made none |
| ③ | **VERIFIED 13:47** — `GET .../feedback` 200 (real ticket returned); `POST .../comments` 403 `INSUFFICIENT_APP_ROLE`, refused before any write | the console routes admit a role-free `feedback:read` token for reads and refuse it for writes | — |

**All three verified. The incident receipt is closed.** Outage 09:17→10:26, ~69 minutes.

Additionally, unprompted by this checklist, @Gogo confirmed **cross-app fail-closed**: the same token against a different app returns 403 `scoped_token_app_boundary`. Not one of the three checks — recorded because it was actually run.

> **This table is the record.** Every time these three were restated from memory in chat, an item was lost — four times, and three of those were an item that had already been verified. Point here.

**② is "write permission restored", not "write verified."** Writing the existing values back proves the request passed authorisation without touching the ticket or the audit trail — the right tool for checking a permission gate at zero state cost. It cannot speak to persistence, and ① is what covers that half. Do not cite ② alone as evidence the write path works.

Sufficient here because the regression was in authorisation, not in the write path.


