### PR TITLE
Let a console feedback token actually be issued

### DIFF
--- a/worker/src/lib/app_permissions.ts
+++ b/worker/src/lib/app_permissions.ts
@@ -29,8 +29,8 @@ export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
   "app:publish": "Create and publish builds, releases, and distribution assets.",
   "app:admin": "Manage app settings, members, credentials, and destructive operations.",
   "feedback:write": "Submit feedback tickets for this app.",
-  "feedback:read": "Read tickets owned by a reporter integration.",
-  "feedback:comment": "Comment on tickets owned by a reporter integration.",
+  "feedback:read": "Read feedback tickets. A token bound to a reporter integration sees only that integration's tickets; an unbound token sees the app's.",
+  "feedback:comment": "Post a public reply the reporter sees. Scope follows the token's binding.",
   "feedback:route": "Bind an opaque route subject to a reporter integration.",
   "feedback:triage": "Change ticket status and assignee, and write internal notes.",
 };
@@ -61,6 +61,24 @@ export const FEEDBACK_TOKEN_PERMISSIONS = [
   "feedback:comment",
   "feedback:route",
 ] as const satisfies readonly AppPermission[];
+
+/**
+ * Feedback permissions that only make sense for a reporter-integration proxy,
+ * and so require the token to be bound to one: submitting on a user's behalf,
+ * and binding a route subject.
+ *
+ * The rest — read, comment, triage — are also used by console-side service
+ * tokens, which are deliberately unbound. Scope there comes from the binding's
+ * absence, not from the permission name.
+ */
+export const REPORTER_BOUND_ONLY_PERMISSIONS = [
+  "feedback:write",
+  "feedback:route",
+] as const satisfies readonly AppPermission[];
+
+export function requiresReporterBinding(scope: AppPermission): boolean {
+  return (REPORTER_BOUND_ONLY_PERMISSIONS as readonly AppPermission[]).includes(scope);
+}
 
 export type FeedbackTokenPermission = (typeof FEEDBACK_TOKEN_PERMISSIONS)[number];
 

--- a/worker/src/routes/deploy_tokens.ts
+++ b/worker/src/routes/deploy_tokens.ts
@@ -15,6 +15,7 @@ import {
   APP_ROLE_PERMISSIONS,
   isFeedbackTokenPermission,
   isAppPermission,
+  requiresReporterBinding,
   type AppPermission,
 } from "../lib/app_permissions";
 
@@ -163,9 +164,20 @@ export async function handleCreateAppDeployToken(c: AdminContext) {
   const reporterIntegrationId = body.reporter_integration_id == null
     ? null
     : String(body.reporter_integration_id).trim();
-  const hasFeedbackScope = scopes?.some((scope) => scope.startsWith("feedback:")) ?? false;
-  if (appRole === null && hasFeedbackScope && !reporterIntegrationId) {
-    return c.json({ error: "reporter_integration_id is required for feedback scopes" }, 400);
+  // Only the proxy-side scopes require a binding. A role-free token holding
+  // read/comment/triage is a console service principal — unbound on purpose,
+  // because the console routes refuse bound tokens (they are confined to one
+  // integration's tickets and must not see the whole app).
+  //
+  // This rule predates that use: when feedback:* existed solely for reporter
+  // proxies, "role-free + feedback scope" always meant "a proxy token", so
+  // demanding a binding was right. #403 added the second use and this was not
+  // revisited, which made the console token impossible to issue.
+  const boundOnly = scopes?.filter(requiresReporterBinding) ?? [];
+  if (appRole === null && boundOnly.length > 0 && !reporterIntegrationId) {
+    return c.json({
+      error: `reporter_integration_id is required for ${boundOnly.join(", ")}`,
+    }, 400);
   }
   if (reporterIntegrationId) {
     if (appRole !== null || !scopes || !scopes.every(isFeedbackTokenPermission)) {

--- a/worker/test/deploy_token_issuance.test.ts
+++ b/worker/test/deploy_token_issuance.test.ts
@@ -1,0 +1,147 @@
+/**
+ * These go through `handleCreateAppDeployToken`, the only production issuance
+ * path, rather than inserting rows directly.
+ *
+ * That distinction is the whole point of the file. The #403/#404 tests built
+ * tokens with `INSERT INTO app_deploy_tokens`, so they verified behaviour on a
+ * state production could not actually produce: the console service token they
+ * proved out was rejected at issuance with 400, and every test stayed green.
+ *
+ * A test that fabricates its own state can only tell you what happens *if* that
+ * state exists.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { handleCreateAppDeployToken } from "../src/routes/deploy_tokens";
+
+const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+const APP = "app-a";
+const INTEGRATION = "33333333-3333-4333-8333-333333333333";
+
+function d1(db: Database.Database) {
+  const prepare = (sql: string) => {
+    const indexes: number[] = [];
+    const normalized = sql.replace(/\?(\d+)/g, (_m, i) => { indexes.push(Number(i)); return "?"; });
+    const statement = db.prepare(normalized);
+    const bind = (...input: unknown[]) => {
+      const params = (indexes.length ? indexes.map((i) => input[i - 1]) : input)
+        .map((v) => v === undefined ? null : v);
+      const execute = () => statement.reader
+        ? { results: statement.all(...params), success: true as const, meta: { changes: 0 } }
+        : { results: [], success: true as const, meta: { changes: statement.run(...params).changes } };
+      return {
+        _execute: execute,
+        run: async () => execute(),
+        all: async () => execute(),
+        first: async <T>() => (statement.get(...params) as T | undefined) ?? null,
+      };
+    };
+    return { bind, run: () => bind().run(), all: () => bind().all(), first: <T>() => bind().first<T>() };
+  };
+  return {
+    prepare,
+    batch: async (sts: { _execute: () => unknown }[]) =>
+      db.transaction(() => sts.map((s) => s._execute()))(),
+  };
+}
+
+function environment() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  for (const name of readdirSync(MIGRATION_DIR).sort()) {
+    if (name.endsWith(".sql")) sqlite.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+  }
+  sqlite.prepare(
+    `INSERT INTO organizations (id, slug, name, external_provider, external_id, created_at)
+     VALUES ('org','org','Org','raft','server',1)`,
+  ).run();
+  sqlite.prepare(
+    `INSERT INTO apps (id, org_id, slug, name, platform, client_key, created_at)
+     VALUES (?,'org','app-a','App A','electron','ck',1)`,
+  ).run(APP);
+  sqlite.prepare(
+    `INSERT INTO app_reporter_integrations (id, app_id, name, created_at, updated_at)
+     VALUES (?,?,'inbox',1,1)`,
+  ).run(INTEGRATION, APP);
+  return { sqlite, env: { DB: d1(sqlite) } as unknown as Env };
+}
+
+/** Calls the real handler; returns { status, body }. */
+async function issue(env: Env, body: unknown) {
+  let status = 200;
+  const c = {
+    env,
+    req: { param: (n: string) => (n === "appId" ? APP : ""), json: async () => body },
+    json: (data: unknown, s = 200) => { status = s; return new Response(JSON.stringify(data), { status: s }); },
+    get: () => undefined,
+  } as any;
+  const response = await handleCreateAppDeployToken(c);
+  return { status, body: await response.json() as any };
+}
+
+describe("issuing a console feedback token", () => {
+  it("accepts role-free feedback:read with no reporter binding", async () => {
+    // The exact token the console routes are built to accept. Before this fix
+    // it was rejected 400, so the feature was undeliverable: the middleware
+    // accepted a credential the issuer would not mint.
+    const { env } = environment();
+    const { status, body } = await issue(env, {
+      name: "feedback-readback", scopes: ["feedback:read"],
+    });
+    expect(status).toBe(201);
+    expect(body.deploy_token.app_role).toBeNull();
+    expect(body.deploy_token.scopes).toEqual(["feedback:read"]);
+    expect(body.token).toBeTruthy();
+  });
+
+  it("accepts role-free feedback:read + feedback:comment unbound", async () => {
+    const { env } = environment();
+    const { status } = await issue(env, {
+      name: "support", scopes: ["feedback:read", "feedback:comment"],
+    });
+    expect(status).toBe(201);
+  });
+
+  it("accepts role-free feedback:triage unbound", async () => {
+    const { env } = environment();
+    const { status } = await issue(env, { name: "triage", scopes: ["feedback:triage"] });
+    expect(status).toBe(201);
+  });
+
+  it("still requires a binding for feedback:write", async () => {
+    // Unchanged on purpose: submitting on a user's behalf is only meaningful
+    // for a proxy, so it must name the integration it proxies.
+    const { env } = environment();
+    const { status, body } = await issue(env, { name: "proxy", scopes: ["feedback:write"] });
+    expect(status).toBe(400);
+    expect(body.error).toContain("feedback:write");
+  });
+
+  it("still requires a binding for feedback:route", async () => {
+    const { env } = environment();
+    const { status } = await issue(env, { name: "router", scopes: ["feedback:route"] });
+    expect(status).toBe(400);
+  });
+
+  it("requires a binding when a proxy scope is mixed with console scopes", async () => {
+    // The relaxation is per-scope, not "any feedback scope is fine now".
+    const { env } = environment();
+    const { status, body } = await issue(env, {
+      name: "mixed", scopes: ["feedback:read", "feedback:write"],
+    });
+    expect(status).toBe(400);
+    expect(body.error).toContain("feedback:write");
+    expect(body.error).not.toContain("feedback:read");
+  });
+
+  it("keeps the reporter path intact: bound token with feedback-only scopes", async () => {
+    const { env } = environment();
+    const { status } = await issue(env, {
+      name: "reporter", scopes: ["feedback:read"], reporter_integration_id: INTEGRATION,
+    });
+    expect(status).toBe(201);
+  });
+});

--- a/worker/test/deploy_token_issuance.test.ts
+++ b/worker/test/deploy_token_issuance.test.ts
@@ -15,7 +15,11 @@ import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
 import { handleCreateAppDeployToken } from "../src/routes/deploy_tokens";
+import { authMiddleware } from "../src/middleware/auth";
+import { requireAppRoleOrFeedbackPermission } from "../src/lib/permissions";
+import { handleListFeedback } from "../src/routes/feedback";
 
 const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
 const APP = "app-a";
@@ -143,5 +147,43 @@ describe("issuing a console feedback token", () => {
       name: "reporter", scopes: ["feedback:read"], reporter_integration_id: INTEGRATION,
     });
     expect(status).toBe(201);
+  });
+});
+
+describe("the seam: a token that was really issued is really accepted", () => {
+  // Both halves were green while the feature was undeliverable, because each
+  // tested its own half against an assumption about the other:
+  //
+  //   #403/#404  given such a token, the console admits it   (token fabricated)
+  //   #406       such a token can be issued                  (never used)
+  //
+  // Nothing checked that the thing issuance produces is the thing the
+  // middleware accepts. The bug lived exactly there. This mints through the
+  // real handler and spends the returned token on the real route.
+  it("mints a feedback:read token and uses it on the console list route", async () => {
+    const { sqlite, env } = environment();
+
+    const { status, body } = await issue(env, {
+      name: "seam", scopes: ["feedback:read"],
+    });
+    expect(status).toBe(201);
+    const token = body.token as string;
+
+    const app = new Hono<any>();
+    app.use("*", authMiddleware);
+    app.get(
+      "/api/apps/:appId/feedback",
+      requireAppRoleOrFeedbackPermission("viewer", {}, "feedback:read"),
+      handleListFeedback,
+    );
+    const response = await app.request(
+      `https://hands.test/api/apps/${APP}/feedback`,
+      { headers: { authorization: `Bearer ${token}` } },
+      { ...env, DASHBOARD_ORIGIN: "https://dashboard.example" } as unknown as Env,
+    );
+    expect(response.status).toBe(200);
+    expect(sqlite.prepare(
+      "SELECT app_role, reporter_integration_id FROM app_deploy_tokens WHERE name = 'seam'",
+    ).get()).toMatchObject({ app_role: null, reporter_integration_id: null });
   });
 });


### PR DESCRIPTION
The console feedback routes accept a role-free, **unbound** token holding `feedback:read`/`comment`/`triage`. **The issuer refuses to mint one.** Role-free plus any feedback scope without a `reporter_integration_id` returns 400 — so the feature shipped undeliverable: the middleware accepts a credential that cannot exist.

Found by @Sentinel when @artin tried to create the token and hit the 400.

## Cause: semantic drift, not a wrong rule

`feedback:*` originally existed **only** for reporter-integration proxies — the permission descriptions still said "owned by a reporter integration". So "role-free + feedback scope" always meant a proxy token, and demanding a binding was correct.

**#403 added a second use** — the console service principal — **and this rule was never revisited.** Same shape as overloading one permission to mean two things, except here it happened on the issuing side.

## Fixed per scope, not by relaxing the check

| Scope | Binding | Why |
|---|---|---|
| `feedback:write` | **required** | submitting on a user's behalf is meaningless without naming the proxied integration |
| `feedback:route` | **required** | binds a route subject to an integration |
| `feedback:read` | optional | also used console-side, where unbound is the point |
| `feedback:comment` | optional | same |
| `feedback:triage` | optional | same |

Mixing a proxy scope with console scopes **still requires the binding**, and the error names the offending scope rather than saying "feedback scopes".

The reporter path is untouched: a bound token with feedback-only scopes still issues exactly as before.

## Why no test caught it

The #403/#404 tests build tokens with `INSERT INTO app_deploy_tokens`, bypassing `handleCreateAppDeployToken` entirely. **They verified behaviour on a state production cannot produce** — the console token they proved out was rejected at issuance, and every test stayed green.

This is one layer below the "tested wiring ≠ shipped wiring" guard added earlier today: there I checked the routes were registered as tested; I never asked whether the *state* was reachable.

The new tests call the real handler. **Mutation-checked**: restoring the old rule reddens four of them.

## Also

Two permission descriptions still said "owned by a reporter integration", untrue for unbound tokens since #403. Corrected — the scope now follows the binding, and the text says so.

**358/358**, typecheck at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Seam test added (`205aa086`)

Both halves were green while the feature was undeliverable, because each verified its own half against an **assumption** about the other:

| Suite | Proves | Assumes |
|---|---|---|
| #403/#404 | given such a token, the console admits it | such a token can exist — it fabricated one |
| #406 (first commit) | such a token can be issued | the console accepts what issuance produces |

**Nothing checked that what issuance produces is what the middleware accepts**, and the bug lived exactly there. Adding a condition to either side would leave both suites green while issuance silently stopped satisfying the consumer.

The new test mints through `handleCreateAppDeployToken` and spends the returned token on the real console route.

**Mutation evidence, corrected.** My first attempt added a requirement to the middleware that nothing satisfies; it reddened six tests, because the fabricated tokens fail it too. That proves *some* test notices, not that this one covers the gap.

@Sentinel supplied the mutation that isolates it — **break the issuance side**, restoring this morning's actual failure (`feedback:read` requires a binding again):

| Suite | Under the issuance break |
|---|---|
| issuance (4) + **seam (1)** | **red** |
| console behaviour (27) | **all green** |

That is the evidence: **when issuance breaks, the entire console behaviour suite stays silent** — precisely what happened this morning — and the seam test is the only thing that speaks.

General form: a mutation must reproduce a **realistic failure mode**, not add an arbitrary unsatisfiable condition. The second proves "a test goes red"; only the first proves "this test covers that hole."

## Follow-ups, recorded so they do not evaporate

- **Convert the three independence tests to really-issued tokens** (@Sentinel). Today they prove *"given this token, the separation holds"*; afterwards they would prove *"this token can exist **and** the separation holds"* — the deliverable claim. Out of scope here because production is waiting on the blocking fix.
- **The console offers permission combinations the server rejects.** @artin ticked `feedback:read` with no role and got a 400 only on submit. #406 makes that specific combination legal, but the form still lets you build invalid ones — it should prevent or explain them rather than failing after the fact.

