### PR TITLE
Harden CORS against GHSA-8j4g-w8fx-2239

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,7 +197,7 @@ importers:
         version: 0.0.30
       '@hono/zod-openapi':
         specifier: ^1.4.0
-        version: 1.4.0(hono@4.12.27)(zod@4.4.3)
+        version: 1.4.0(hono@4.13.0)(zod@4.4.3)
       '@noble/hashes':
         specifier: ^1.8.0
         version: 1.8.0
@@ -205,8 +205,8 @@ importers:
         specifier: 1.0.20
         version: 1.0.20
       hono:
-        specifier: ^4.11.1
-        version: 4.12.27
+        specifier: ^4.12.34
+        version: 4.13.0
       jose:
         specifier: ^5.9.6
         version: 5.10.0
@@ -2057,6 +2057,10 @@ packages:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3594,17 +3598,17 @@ snapshots:
     dependencies:
       hono: 4.12.27
 
-  '@hono/zod-openapi@1.4.0(hono@4.12.27)(zod@4.4.3)':
+  '@hono/zod-openapi@1.4.0(hono@4.13.0)(zod@4.4.3)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.4.3)
-      '@hono/zod-validator': 0.8.0(hono@4.12.27)(zod@4.4.3)
-      hono: 4.12.27
+      '@hono/zod-validator': 0.8.0(hono@4.13.0)(zod@4.4.3)
+      hono: 4.13.0
       openapi3-ts: 4.6.0
       zod: 4.4.3
 
-  '@hono/zod-validator@0.8.0(hono@4.12.27)(zod@4.4.3)':
+  '@hono/zod-validator@0.8.0(hono@4.13.0)(zod@4.4.3)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.13.0
       zod: 4.4.3
 
   '@humanfs/core@0.19.2':
@@ -4808,6 +4812,8 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   hono@4.12.27: {}
+
+  hono@4.13.0: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/worker/package.json
+++ b/worker/package.json
@@ -22,7 +22,7 @@
     "@hono/zod-openapi": "^1.4.0",
     "@noble/hashes": "^1.8.0",
     "aws4fetch": "1.0.20",
-    "hono": "^4.11.1",
+    "hono": "^4.12.34",
     "jose": "^5.9.6",
     "qrcode-generator": "^2.0.4",
     "zod": "^4.4.3"

--- a/worker/test/cors_allow_headers.test.ts
+++ b/worker/test/cors_allow_headers.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `allowHeaders` must stay non-empty on the global CORS middleware.
+ *
+ * GHSA-8j4g-w8fx-2239: hono's CORS handler runs a regex over the request's
+ * Access-Control-Request-Headers **only when `allowHeaders` is empty or
+ * unset** — that path is quadratic and reachable without authentication, on
+ * every route, by anyone who can send a preflight.
+ *
+ * The dependency is patched, so this is not what protects us today. It exists
+ * because **the immunity comes from a configuration value, not from the shape
+ * of the code**: deleting this one array reinstates the vulnerable path
+ * everywhere, and reads like tidying up a verbose config. Nothing else in the
+ * suite would notice.
+ *
+ * Asserted against the real registration in index.ts rather than a fixture,
+ * for the reason a whole day of this went wrong yesterday: a test that builds
+ * its own config only tells you what happens if that config is used.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(fileURLToPath(new URL("../src/index.ts", import.meta.url)), "utf8");
+
+/** The global `app.use("*", cors({...}))` block, bounded by its own closing paren. */
+function globalCorsBlock(): string {
+  const at = source.indexOf("cors({");
+  expect(at, "global cors() registration not found").toBeGreaterThan(-1);
+  const end = source.indexOf("}),", at);
+  expect(end, "cors() block is not closed as expected").toBeGreaterThan(at);
+  return source.slice(at, end);
+}
+
+describe("global CORS keeps allowHeaders non-empty (GHSA-8j4g-w8fx-2239)", () => {
+  it("declares allowHeaders with at least one header", () => {
+    const block = globalCorsBlock();
+    const match = block.match(/allowHeaders:\s*\[([^\]]*)\]/);
+    expect(match, "allowHeaders is absent from the global cors() config").not.toBeNull();
+    const entries = match![1].split(",").map((s) => s.trim()).filter(Boolean);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it("still carries the headers the API actually needs", () => {
+    // Keeps the assertion honest: a non-empty array of the wrong headers would
+    // dodge the ReDoS path and break every authenticated browser request.
+    const block = globalCorsBlock();
+    expect(block).toContain("content-type");
+    expect(block).toContain("authorization");
+  });
+
+  it("resolves hono to a version at or above the advisory floor", () => {
+    const pkg = JSON.parse(
+      readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"),
+    ) as { dependencies: Record<string, string> };
+    const range = pkg.dependencies.hono;
+    const floor = range.replace(/^[^0-9]*/, "").split(".").map(Number);
+    // The range floor itself must exclude the vulnerable versions, so a fresh
+    // resolve cannot land on one — a lockfile pin alone would not do that.
+    const atLeast = floor[0] > 4
+      || (floor[0] === 4 && (floor[1] > 12 || (floor[1] === 12 && floor[2] >= 34)));
+    expect(atLeast, `hono range ${range} still permits vulnerable versions`).toBe(true);
+  });
+});


### PR DESCRIPTION
**GHSA-8j4g-w8fx-2239.** hono's CORS handler runs a quadratic regex over `Access-Control-Request-Headers` **only when `allowHeaders` is empty or unset**. That path needs no authentication and sits on every route, so anyone who can send a preflight can reach it.

**Not currently exploitable** — `allowHeaders` is non-empty at `worker/src/index.ts:429`.

## Why this needs more than a version bump

**The immunity comes from a configuration value, not from the shape of the code.** Deleting one array reinstates the vulnerable path across every route, and it reads like tidying a verbose config. Nothing in the suite would have noticed.

## Range, not just lockfile

| | Effect |
|---|---|
| lockfile pin only | fixes today's install; `^4.11.1` still permits 4.11.x and 4.12.0–4.12.33 on a fresh resolve |
| **range → `^4.12.34`** | **vulnerable versions become unreachable** |

Set to the advisory floor exactly, so patched 4.12.x releases remain available. Resolves to 4.13.0. No source change required, as the task noted.

## Assertions

Against the **real registration** in `index.ts`, not a fixture — a config a test builds itself only tells you what happens if that config is used:

1. `allowHeaders` present and non-empty;
2. it still carries `content-type` and `authorization` — *a non-empty array of the wrong headers would dodge the ReDoS path and break every authenticated browser request*, so the cheap version of this assertion is not enough;
3. the declared range excludes vulnerable versions.

## Mutation-checked three ways

| Mutation | Reddens |
|---|---|
| remove `allowHeaders` entirely | (1) and (2) |
| leave it present but `[]` — hono treats this as absent | (1) and (2) |
| revert range to `^4.11.1` | (3) |

The second is not in the task description; it is the same hazard wearing a different shape, and a guard that only catches deletion would miss it.

**362/362.** Found by @Sentinel, patrol #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
