### PR TITLE
Let reporters close their own feedback tickets

### DIFF
--- a/docs/public/feedback-react.md
+++ b/docs/public/feedback-react.md
@@ -231,6 +231,7 @@ Proxy these Hands operations behind your own authenticated, same-origin API:
 | Read ticket | `GET /api/apps/:appId/reporter-feedback/:ticketId?comment_limit=50&comment_cursor=...` |
 | Create ticket | `POST /public/v2/apps/:appSlug/feedback` as multipart, then read the returned ticket id |
 | Reply | `POST /api/apps/:appId/reporter-feedback/:ticketId/comments` as JSON or multipart |
+| Close owned ticket | `POST /api/apps/:appId/reporter-feedback/:ticketId/close` |
 | Download attachment | `GET /api/apps/:appId/reporter-feedback/:ticketId/attachments/:attachmentId` |
 
 Generate one UUID `submission_id` for each new ticket draft or reply and keep

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -351,6 +351,7 @@ Trusted server proxies can list and continue only their own reporters' tickets:
 GET  /api/apps/:appId/reporter-feedback
 GET  /api/apps/:appId/reporter-feedback/:ticketId
 POST /api/apps/:appId/reporter-feedback/:ticketId/comments
+POST /api/apps/:appId/reporter-feedback/:ticketId/close
 GET  /api/apps/:appId/reporter-feedback/:ticketId/attachments/:attachmentId
 Authorization: Bearer qvdt_...
 X-Hands-Reporter-Id: <stable opaque value>

--- a/packages/feedback-react/src/components.tsx
+++ b/packages/feedback-react/src/components.tsx
@@ -396,6 +396,7 @@ export type FeedbackTicketProps = {
   draft?: string;
   onDraftChange?: (value: string) => void;
   onReadSuccess?: (ticketId: string) => void;
+  onTicketUpdated?: (ticket: FeedbackTicketSummary) => void;
 };
 
 export function FeedbackTicket({
@@ -405,6 +406,7 @@ export function FeedbackTicket({
   draft,
   onDraftChange,
   onReadSuccess,
+  onTicketUpdated,
 }: FeedbackTicketProps) {
   const { formatDate, formatFileSize, message, reportUnread, transport } =
     useHandsFeedback();
@@ -416,6 +418,8 @@ export function FeedbackTicket({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [sending, setSending] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [confirmingClose, setConfirmingClose] = useState(false);
   const [replyAttachments, setReplyAttachments] = useState<PendingAttachment[]>(
     [],
   );
@@ -444,6 +448,8 @@ export function FeedbackTicket({
     actionController.current = null;
     commentSubmission.current = null;
     setSending(false);
+    setClosing(false);
+    setConfirmingClose(false);
     setReplyAttachments([]);
   }, [ticketId, transport]);
 
@@ -594,6 +600,32 @@ export function FeedbackTicket({
       }
     } finally {
       if (!controller.signal.aborted) setSending(false);
+    }
+  };
+
+  const closeTicket = async () => {
+    if (!detail || !transport.closeTicket || closing) return;
+    setClosing(true);
+    setActionError(null);
+    actionController.current?.abort();
+    const controller = new AbortController();
+    actionController.current = controller;
+    try {
+      const result = await transport.closeTicket({ ticketId, signal: controller.signal });
+      if (controller.signal.aborted) return;
+      reportUnread({ total: result.unreadTotal, source: "close" });
+      setDetail(result);
+      setConfirmingClose(false);
+      onTicketUpdated?.(result.ticket);
+      setAnnouncement(message("ticketClosed"));
+    } catch (cause) {
+      if (!controller.signal.aborted) {
+        const safe = safeError(cause);
+        setActionError(safe);
+        setAnnouncement(safe);
+      }
+    } finally {
+      if (!controller.signal.aborted) setClosing(false);
     }
   };
 
@@ -765,10 +797,32 @@ export function FeedbackTicket({
                   : message("loadMoreReplies")}
               </Button>
             )}
+            {transport.closeTicket && detail.ticket.status !== "closed" && (
+              <div className="hands-feedback-close">
+                {confirmingClose ? (
+                  <>
+                    <span>{message("closeTicketConfirm")}</span>
+                    <Button variant="outline" disabled={closing} onClick={() => setConfirmingClose(false)}>
+                      {message("cancel")}
+                    </Button>
+                    <Button disabled={closing} onClick={() => void closeTicket()}>
+                      {message("closeTicket")}
+                    </Button>
+                  </>
+                ) : (
+                  <Button variant="outline" onClick={() => setConfirmingClose(true)}>
+                    {message("closeTicket")}
+                  </Button>
+                )}
+              </div>
+            )}
+            {detail.ticket.status === "closed" && (
+              <p className="hands-feedback-muted">{message("closedDescription")}</p>
+            )}
           </>
         )}
       </div>
-      {detail && (
+      {detail && detail.ticket.status !== "closed" && (
         <div className="hands-feedback-composer">
           <label
             className="hands-feedback-sr-only"
@@ -1280,6 +1334,7 @@ export function FeedbackWorkspace({
             setDrafts((current) => ({ ...current, [route.ticketId!]: value }))
           }
           onReadSuccess={setReadTicketId}
+          onTicketUpdated={setCreatedTicket}
           onBack={back}
           {...(onOpenAttachment ? { onOpenAttachment } : {})}
         />

--- a/packages/feedback-react/src/locale.ts
+++ b/packages/feedback-react/src/locale.ts
@@ -16,6 +16,9 @@ export type FeedbackMessageKey =
   | "attachImage"
   | "back"
   | "cancel"
+  | "closeTicket"
+  | "closeTicketConfirm"
+  | "closedDescription"
   | "conversation"
   | "emptyBody"
   | "emptyTitle"
@@ -57,6 +60,7 @@ export type FeedbackMessageKey =
   | "team"
   | "feedbackCreated"
   | "replySent"
+  | "ticketClosed"
   | "ticketUpdated"
   | "ticketHeading"
   | "unreadCount"
@@ -82,6 +86,9 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     attachImage: "Attach image",
     back: "Back",
     cancel: "Cancel",
+    closeTicket: "Close ticket",
+    closeTicketConfirm: "Close this ticket?",
+    closedDescription: "This ticket is closed. The team can reopen it if more information is needed.",
     conversation: "Conversation",
     emptyBody: "Send your first idea or report a problem.",
     emptyTitle: "No feedback yet",
@@ -124,6 +131,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     team: "Team",
     feedbackCreated: "Feedback created",
     replySent: "Reply sent",
+    ticketClosed: "Ticket closed",
     ticketUpdated: "Ticket updated",
     ticketHeading: "Feedback ticket",
     unreadCount: "{count} unread",
@@ -145,6 +153,9 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     attachImage: "添加图片",
     back: "返回",
     cancel: "取消",
+    closeTicket: "关闭工单",
+    closeTicketConfirm: "确定关闭这个工单吗？",
+    closedDescription: "该工单已关闭。如需更多信息，团队可以重新打开。",
     conversation: "对话",
     emptyBody: "提交第一个想法或问题。",
     emptyTitle: "暂无反馈",
@@ -186,6 +197,7 @@ const messages: Record<FeedbackLocale, FeedbackMessages> = {
     team: "团队",
     feedbackCreated: "反馈已创建",
     replySent: "回复已发送",
+    ticketClosed: "工单已关闭",
     ticketUpdated: "工单已更新",
     ticketHeading: "反馈工单",
     unreadCount: "{count} 条未读",

--- a/packages/feedback-react/src/provider.dom.test.tsx
+++ b/packages/feedback-react/src/provider.dom.test.tsx
@@ -66,6 +66,40 @@ function transport(): HandsFeedbackTransport {
 }
 
 describe("FeedbackWorkspace browser behavior", () => {
+  it("confirms and closes only through an available host capability", async () => {
+    const adapter = transport();
+    const closedDetail: FeedbackTicketDetail = {
+      ...detail,
+      ticket: {
+        ...detail.ticket,
+        status: "closed",
+        updatedAt: 4,
+      },
+    };
+    adapter.closeTicket = vi.fn(async () => closedDetail);
+    render(
+      <FeedbackProvider transport={adapter} locale="zh-CN">
+        <FeedbackWorkspace />
+      </FeedbackProvider>,
+    );
+
+    fireEvent.click(await screen.findByText(ticket.message));
+    fireEvent.click(await screen.findByRole("button", { name: "关闭工单" }));
+    expect(screen.getByText("确定关闭这个工单吗？")).toBeTruthy();
+    expect(adapter.closeTicket).not.toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole("button", { name: "关闭工单" }).at(-1)!);
+
+    await waitFor(() => expect(adapter.closeTicket).toHaveBeenCalledTimes(1));
+    expect(adapter.closeTicket).toHaveBeenCalledWith(expect.objectContaining({
+      ticketId: ticket.id,
+      signal: expect.any(AbortSignal),
+    }));
+    expect(await screen.findByText("该工单已关闭。如需更多信息，团队可以重新打开。")).toBeTruthy();
+    expect(screen.queryByLabelText("回复")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+    await waitFor(() => expect(screen.getByText("已关闭")).toBeTruthy());
+  });
+
   it("supports host copy and date localization overrides through one provider contract", async () => {
     const adapter = transport();
     adapter.getTicket = vi.fn(async () => ({

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -271,6 +271,14 @@
   margin: 8px auto;
   position: sticky;
 }
+.hands-feedback-close {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
 .hands-feedback-composer {
   background: var(--hf-bg);
   border: 2px solid var(--hf-border-strong);

--- a/packages/feedback-react/src/types.ts
+++ b/packages/feedback-react/src/types.ts
@@ -91,11 +91,16 @@ export type HandsFeedbackTransport = {
   addComment(
     input: AddFeedbackCommentInput & { signal: AbortSignal },
   ): Promise<FeedbackTicketDetail>;
+  /** Optional until the host exposes the reporter-owned close endpoint. */
+  closeTicket?(input: {
+    ticketId: string;
+    signal: AbortSignal;
+  }): Promise<FeedbackTicketDetail>;
 };
 
 export type FeedbackUnreadChange = {
   total: number;
-  source: "list" | "detail" | "create" | "comment";
+  source: "list" | "detail" | "create" | "comment" | "close";
 };
 
 export type FeedbackTransportErrorCode =

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -108,6 +108,7 @@ import {
 } from "./routes/reporter_integrations";
 import {
   handleAddReporterComment,
+  handleCloseReporterFeedback,
   handleDownloadReporterAttachment,
   handleGetReporterFeedback,
   handleListReporterFeedback,
@@ -575,6 +576,7 @@ app.post("/api/apps/:appId/reporter-feedback/session", handleMintReporterSession
 app.put("/api/apps/:appId/reporter-feedback/route-subject", handleBindReporterRouteSubject);
 app.get("/api/apps/:appId/reporter-feedback/:ticketId", handleGetReporterFeedback);
 app.post("/api/apps/:appId/reporter-feedback/:ticketId/comments", handleAddReporterComment);
+app.post("/api/apps/:appId/reporter-feedback/:ticketId/close", handleCloseReporterFeedback);
 app.get(
   "/api/apps/:appId/reporter-feedback/:ticketId/attachments/:attachmentId",
   handleDownloadReporterAttachment,

--- a/worker/src/openapi/feedback.ts
+++ b/worker/src/openapi/feedback.ts
@@ -214,6 +214,25 @@ export function registerFeedbackRoutes(registry: OpenApiRegistry) {
   });
 
   register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/reporter-feedback/{ticketId}/close",
+    tags: ["Reporter Feedback"],
+    summary: "Close a reporter-owned feedback ticket",
+    description: "Idempotently moves only the authenticated reporter's ticket to the closed state. This route cannot reopen tickets or change assignees.",
+    security: auth,
+    request: { params: AppTicketParams, headers: ReporterHeaders },
+    responses: {
+      200: success("Ticket closed or already closed.", GenericObject),
+      400: error("Missing or malformed reporter id."),
+      401: error("Missing or invalid bearer token."),
+      403: error("Invalid reporter integration grant."),
+      404: error("Ticket is not owned by this reporter integration."),
+      409: error("Ticket changed concurrently; retry."),
+      429: error("Reporter rate limit exceeded."),
+    },
+  });
+
+  register(registry, {
     method: "get",
     path: "/api/apps/{appId}/reporter-feedback/{ticketId}/attachments/{attachmentId}",
     tags: ["Reporter Feedback"],

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -2430,7 +2430,7 @@ export async function handleAddFeedbackComment(c: AdminContext) {
   return c.json({ id, ticket_id: ticketId, created_at: now }, 201);
 }
 
-function feedbackReporterEventStatements(
+export function feedbackReporterEventStatements(
   db: D1Database,
   input: {
     eventType: "feedback:comment_created" | "feedback:status_changed";

--- a/worker/src/routes/reporter_feedback.ts
+++ b/worker/src/routes/reporter_feedback.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { authenticateReporter, type ReporterPrincipal } from "../lib/reporter_auth";
 import { computeReporterAuditHash } from "../lib/reporter_audit";
 import { buildFeedbackCommentEvent } from "../lib/feedback_events";
+import { feedbackReporterEventStatements } from "./feedback";
 
 type ReporterContext = Context<{ Bindings: Env }>;
 
@@ -22,7 +23,7 @@ type ReporterEnv = Env & {
   FEEDBACK_AUDIT_KEY_VERSION?: string;
 };
 
-type Endpoint = "list" | "detail" | "attachment" | "comment";
+type Endpoint = "list" | "detail" | "attachment" | "comment" | "close";
 
 function timingDuration(start: number, end: number): string {
   return Math.max(0, end - start).toFixed(1);
@@ -39,6 +40,7 @@ const LIMITS: Record<Endpoint, { reporter: number; integration: number; windowMs
   detail: { reporter: 120, integration: 1_200, windowMs: 60_000 },
   attachment: { reporter: 120, integration: 1_200, windowMs: 3_600_000 },
   comment: { reporter: 30, integration: 300, windowMs: 3_600_000 },
+  close: { reporter: 30, integration: 300, windowMs: 3_600_000 },
 };
 
 function fullUuid(value: string | undefined): string | null {
@@ -899,6 +901,106 @@ export async function handleAddReporterComment(c: ReporterContext) {
   const committedAt = performance.now();
   setCommentTiming(committedAt);
   return c.json({ id: commentId, ticket_id: ticketId, created_at: now, idempotent_replay: false }, 201);
+}
+
+/**
+ * Close one ticket owned by the authenticated reporter.
+ *
+ * This deliberately reuses feedback:comment: both operations are bounded
+ * mutations of the same reporter-owned conversation. The route cannot set an
+ * arbitrary status, change the assignee, reopen a ticket, or address another
+ * reporter's ticket.
+ */
+export async function handleCloseReporterFeedback(c: ReporterContext) {
+  const authorized = await authorize(c, "feedback:comment", "close");
+  if (!authorized.ok) return authorized.response;
+  const ticketId = fullUuid(c.req.param("ticketId"));
+  if (!ticketId) return ticketNotFound(c);
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const ticket = await c.env.DB.prepare(
+      `SELECT t.status, a.org_id
+       FROM feedback_tickets t
+       JOIN apps a ON a.id = t.app_id
+       WHERE t.id = ?1 AND t.app_id = ?2
+         AND t.reporter_integration_id = ?3 AND t.reporter_id = ?4`,
+    ).bind(
+      ticketId,
+      authorized.principal.appId,
+      authorized.principal.integrationId,
+      authorized.principal.reporterId,
+    ).first<{ status: string; org_id: string | null }>();
+    if (!ticket) return ticketNotFound(c);
+    if (ticket.status === "closed") {
+      return c.json({ id: ticketId, status: "closed", updated_at: null, changed: false });
+    }
+
+    const now = Date.now();
+    const auditId = crypto.randomUUID();
+    const auditPayload = JSON.stringify({
+      ticket_id: ticketId,
+      previous_status: ticket.status,
+      status: "closed",
+      reporter_hash: authorized.pseudonym.hash,
+      audit_key_version: authorized.pseudonym.version,
+    });
+    const statements: D1PreparedStatement[] = [
+      c.env.DB.prepare(
+        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+         SELECT ?1, ?2, 'feedback.reporter_close', ?3, ?4, ?5
+         FROM feedback_tickets
+         WHERE id = ?6 AND app_id = ?2 AND reporter_integration_id = ?7
+           AND reporter_id = ?8 AND status = ?9`,
+      ).bind(
+        auditId,
+        authorized.principal.appId,
+        `reporter:${authorized.pseudonym.hash}`,
+        auditPayload,
+        now,
+        ticketId,
+        authorized.principal.integrationId,
+        authorized.principal.reporterId,
+        ticket.status,
+      ),
+      c.env.DB.prepare(
+        `UPDATE feedback_tickets
+         SET status = 'closed', updated_at = ?1
+         WHERE id = ?2 AND app_id = ?3 AND reporter_integration_id = ?4
+           AND reporter_id = ?5 AND status = ?6
+           AND EXISTS (SELECT 1 FROM audit_logs WHERE id = ?7)`,
+      ).bind(
+        now,
+        ticketId,
+        authorized.principal.appId,
+        authorized.principal.integrationId,
+        authorized.principal.reporterId,
+        ticket.status,
+        auditId,
+      ),
+    ];
+    if (ticket.org_id) {
+      statements.push(...feedbackReporterEventStatements(c.env.DB, {
+        eventType: "feedback:status_changed",
+        orgId: ticket.org_id,
+        appId: authorized.principal.appId,
+        ticketId,
+        reporterIntegrationId: authorized.principal.integrationId,
+        reporterId: authorized.principal.reporterId,
+        createdAt: now,
+        previousStatus: ticket.status,
+        status: "closed",
+        claimAuditId: auditId,
+      }));
+    }
+    await c.env.DB.batch(statements);
+    const won = await c.env.DB.prepare("SELECT id FROM audit_logs WHERE id = ?1")
+      .bind(auditId)
+      .first();
+    if (won) {
+      return c.json({ id: ticketId, status: "closed", updated_at: now, changed: true });
+    }
+  }
+  return c.json({ error: "feedback ticket changed concurrently; retry" }, 409);
 }
 
 export async function handleDownloadReporterAttachment(c: ReporterContext) {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -11404,6 +11404,7 @@ describe("Hands iOS simulator QA artifacts", () => {
     const { generateDeployToken, hashDeployToken } = await import("../src/lib/deploy_tokens");
     const {
       handleAddReporterComment,
+      handleCloseReporterFeedback,
       cleanupReporterFeedbackData,
       handleDownloadReporterAttachment,
       handleGetReporterFeedback,
@@ -11418,23 +11419,38 @@ describe("Hands iOS simulator QA artifacts", () => {
     const ticketB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const credentialA = generateDeployToken();
     const credentialB = generateDeployToken();
+    const credentialComment = generateDeployToken();
+    const credentialRead = generateDeployToken();
     await env.DB.prepare(
       `INSERT INTO app_reporter_integrations
        (id, app_id, name, created_at, updated_at)
        VALUES (?1, 'app-ios', 'A', ?3, ?3), (?2, 'app-ios', 'B', ?3, ?3)`,
     ).bind(integrationA, integrationB, now).run();
-    const insertToken = async (id: string, credential: { token: string; token_prefix: string }, integrationId: string) => {
+    const insertToken = async (
+      id: string,
+      credential: { token: string; token_prefix: string },
+      integrationId: string,
+      scopes = '["feedback:write","feedback:read","feedback:comment","feedback:route"]',
+    ) => {
       await env.DB.prepare(
         `INSERT INTO app_deploy_tokens
          (id, app_id, name, token_prefix, token_hash, app_role, scopes_json,
           created_by_actor, created_at, reporter_integration_id)
          VALUES (?1, 'app-ios', ?1, ?2, ?3, NULL,
-                 '["feedback:write","feedback:read","feedback:comment","feedback:route"]',
-                 'test', ?4, ?5)`,
-      ).bind(id, credential.token_prefix, await hashDeployToken(credential.token), now, integrationId).run();
+                 ?4, 'test', ?5, ?6)`,
+      ).bind(
+        id,
+        credential.token_prefix,
+        await hashDeployToken(credential.token),
+        scopes,
+        now,
+        integrationId,
+      ).run();
     };
     await insertToken("token-a", credentialA, integrationA);
     await insertToken("token-b", credentialB, integrationB);
+    await insertToken("token-comment", credentialComment, integrationA, '["feedback:comment"]');
+    await insertToken("token-read", credentialRead, integrationA, '["feedback:read"]');
     await env.DB.prepare(
       `INSERT INTO feedback_tickets
        (id, app_id, kind, status, message, metadata_json, reporter_id,
@@ -11460,7 +11476,7 @@ describe("Hands iOS simulator QA artifacts", () => {
     ).bind(integrationA, now).run();
 
     const context = (
-      handler: "list" | "detail" | "comment",
+      handler: "list" | "detail" | "comment" | "close",
       credential: string | null,
       ticketId?: string,
       commentBody?: { body: string; submission_id: string } | FormData,
@@ -11588,6 +11604,58 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect((await env.DB.prepare(
       "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'feedback.reporter_comment'",
     ).first() as any).count).toBe(1);
+
+    // Closing is a one-way, reporter-owned conversation mutation. It uses the
+    // comment capability, preserves every other ticket field, and emits one
+    // status event/audit even under an exact concurrent retry.
+    expect((await handleCloseReporterFeedback(context(
+      "close", credentialRead.token, ticketA,
+    ))).status).toBe(403);
+    expect((await handleCloseReporterFeedback(context(
+      "close", credentialB.token, ticketA,
+    ))).status).toBe(404);
+    await env.DB.prepare("UPDATE feedback_tickets SET assignee = 'staff:test' WHERE id = ?1")
+      .bind(ticketA).run();
+    const closeResponses = await Promise.all([
+      handleCloseReporterFeedback(context("close", credentialComment.token, ticketA)),
+      handleCloseReporterFeedback(context("close", credentialComment.token, ticketA)),
+    ]);
+    const closeBodies = await Promise.all(closeResponses.map((response) => response.json() as Promise<any>));
+    expect(closeBodies.map((body) => body.changed).sort()).toEqual([false, true]);
+    expect(await env.DB.prepare(
+      "SELECT status, assignee FROM feedback_tickets WHERE id = ?1",
+    ).bind(ticketA).first()).toEqual({ status: "closed", assignee: "staff:test" });
+    expect((await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'feedback.reporter_close'",
+    ).first() as any).count).toBe(1);
+    const closeAudit = await env.DB.prepare(
+      "SELECT actor, payload FROM audit_logs WHERE action = 'feedback.reporter_close'",
+    ).first() as { actor: string; payload: string } | null;
+    expect(closeAudit?.actor).toMatch(/^reporter:[0-9a-f]{64}$/);
+    expect(JSON.parse(closeAudit!.payload)).toMatchObject({
+      ticket_id: ticketA,
+      previous_status: "open",
+      status: "closed",
+    });
+    const closeEvents = await env.DB.prepare(
+      `SELECT payload_json FROM feedback_events
+       WHERE ticket_id = ?1 AND event_type = 'feedback:status_changed'`,
+    ).bind(ticketA).all() as any;
+    expect(closeEvents.results).toHaveLength(1);
+    expect(JSON.parse(closeEvents.results[0].payload_json).payload).toMatchObject({
+      ticket_id: ticketA,
+      previous_status: "open",
+      status: "closed",
+      reporter_integration_id: integrationA,
+      reporter_id: reporterId,
+    });
+    await env.DB.prepare(
+      "DELETE FROM feedback_events WHERE ticket_id = ?1 AND event_type = 'feedback:status_changed'",
+    ).bind(ticketA).run();
+    await env.DB.prepare("DELETE FROM audit_logs WHERE action = 'feedback.reporter_close'").run();
+    await env.DB.prepare(
+      "UPDATE feedback_tickets SET status = 'open', assignee = NULL WHERE id = ?1",
+    ).bind(ticketA).run();
 
     const { computeReporterAuditHash } = await import("../src/lib/reporter_audit");
     await expect(computeReporterAuditHash({


### PR DESCRIPTION
## Summary

- add an idempotent reporter endpoint that can only move the authenticated reporter's own ticket to `closed`
- preserve assignee and all other ticket fields while recording one audit entry and one status-change event under concurrent retries
- expose an optional close capability in the feedback React transport, with English and Chinese confirmation/closed states and immediate list synchronization
- document the reporter close endpoint in the public API guides

The close endpoint uses the existing reporter conversation-write capability. It cannot select an arbitrary status, reopen a ticket, change its assignee, or address a ticket outside the exact app/integration/reporter ownership tuple.

## Verification

- Worker test suite: 359 passed
- feedback React tests: 34 passed
- feedback React typecheck and build
- Worker shim typecheck
- `git diff --check`
