### PR TITLE
Check every cors() registration, and raise container's hono floor

### DIFF
--- a/container/package.json
+++ b/container/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
-    "hono": "^4.11.1"
+    "hono": "^4.12.34"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,10 +105,10 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        version: 1.19.14(hono@4.13.0)
       hono:
-        specifier: ^4.11.1
-        version: 4.12.27
+        specifier: ^4.12.34
+        version: 4.13.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
@@ -2053,10 +2053,6 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
-    engines: {node: '>=16.9.0'}
-
   hono@4.13.0:
     resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
@@ -3594,9 +3590,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@1.19.14(hono@4.13.0)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.13.0
 
   '@hono/zod-openapi@1.4.0(hono@4.13.0)(zod@4.4.3)':
     dependencies:
@@ -4810,8 +4806,6 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
-
-  hono@4.12.27: {}
 
   hono@4.13.0: {}
 

--- a/worker/test/cors_allow_headers.test.ts
+++ b/worker/test/cors_allow_headers.test.ts
@@ -1,64 +1,147 @@
 /**
- * `allowHeaders` must stay non-empty on the global CORS middleware.
+ * Every `cors()` registration must declare a non-empty `allowHeaders`.
  *
  * GHSA-8j4g-w8fx-2239: hono's CORS handler runs a regex over the request's
  * Access-Control-Request-Headers **only when `allowHeaders` is empty or
  * unset** — that path is quadratic and reachable without authentication, on
- * every route, by anyone who can send a preflight.
+ * every route it is mounted on, by anyone who can send a preflight.
  *
  * The dependency is patched, so this is not what protects us today. It exists
  * because **the immunity comes from a configuration value, not from the shape
- * of the code**: deleting this one array reinstates the vulnerable path
- * everywhere, and reads like tidying up a verbose config. Nothing else in the
- * suite would notice.
+ * of the code**: deleting one array reinstates the vulnerable path, and reads
+ * like tidying up a verbose config. Nothing else in the suite would notice.
  *
- * Asserted against the real registration in index.ts rather than a fixture,
- * for the reason a whole day of this went wrong yesterday: a test that builds
- * its own config only tells you what happens if that config is used.
+ * Checks **every** registration in both packages that depend on hono, not the
+ * first one in one file. The earlier version anchored to `indexOf("cors({")`
+ * and passed green with a second, empty registration sitting beside the good
+ * one. A guard that only sees the call site it was written against is a guard
+ * against edits nobody makes.
+ *
+ * container has no `cors()` today and its own suite does not run here, so its
+ * source is scanned from this side: "we have not called it yet" is the same
+ * brittle immunity this file exists to replace.
  */
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const source = readFileSync(fileURLToPath(new URL("../src/index.ts", import.meta.url)), "utf8");
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const SOURCE_DIRS = ["worker/src", "container/src"];
+const MANIFESTS = ["worker/package.json", "container/package.json"];
 
-/** The global `app.use("*", cors({...}))` block, bounded by its own closing paren. */
-function globalCorsBlock(): string {
-  const at = source.indexOf("cors({");
-  expect(at, "global cors() registration not found").toBeGreaterThan(-1);
-  const end = source.indexOf("}),", at);
-  expect(end, "cors() block is not closed as expected").toBeGreaterThan(at);
-  return source.slice(at, end);
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (at: string) => {
+    for (const entry of readdirSync(at, { withFileTypes: true })) {
+      const full = join(at, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".ts")) out.push(full);
+    }
+  };
+  walk(join(ROOT, dir));
+  return out;
 }
 
-describe("global CORS keeps allowHeaders non-empty (GHSA-8j4g-w8fx-2239)", () => {
-  it("declares allowHeaders with at least one header", () => {
-    const block = globalCorsBlock();
-    const match = block.match(/allowHeaders:\s*\[([^\]]*)\]/);
-    expect(match, "allowHeaders is absent from the global cors() config").not.toBeNull();
-    const entries = match![1].split(",").map((s) => s.trim()).filter(Boolean);
-    expect(entries.length).toBeGreaterThan(0);
+/**
+ * Slice from just after `(` to its matching `)`, skipping strings and comments.
+ *
+ * Matched rather than searched for a closing delimiter, so a registration is
+ * read to its real end whatever its formatting — the previous version cut at
+ * the first `}),` and would stop early on a nested object.
+ */
+function balanced(source: string, open: number): string {
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "/" && source[i + 1] === "/") {
+      const nl = source.indexOf("\n", i);
+      if (nl === -1) break;
+      i = nl;
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "*") {
+      i = source.indexOf("*/", i) + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i += 1;
+      while (i < source.length && source[i] !== ch) i += source[i] === "\\" ? 2 : 1;
+      continue;
+    }
+    if (ch === "(") depth += 1;
+    else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unterminated cors( at offset ${open}`);
+}
+
+/** Every `cors(...)` call's arguments. Bare `cors()` yields "" — the unset case. */
+function corsRegistrations(): Array<{ file: string; args: string }> {
+  const found: Array<{ file: string; args: string }> = [];
+  for (const dir of SOURCE_DIRS) {
+    for (const file of sourceFiles(dir)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(/\bcors\s*\(/g)) {
+        const open = match.index! + match[0].length - 1;
+        found.push({ file: file.slice(ROOT.length), args: balanced(source, open) });
+      }
+    }
+  }
+  return found;
+}
+
+function honoRange(manifest: string): string {
+  const pkg = JSON.parse(readFileSync(join(ROOT, manifest), "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  return pkg.dependencies?.hono ?? "";
+}
+
+describe("CORS keeps allowHeaders non-empty (GHSA-8j4g-w8fx-2239)", () => {
+  it("declares a non-empty allowHeaders on every registration", () => {
+    const registrations = corsRegistrations();
+    // Guards the guard: if the scan stops finding anything — renamed import,
+    // moved file — the loop below would pass vacuously and prove nothing.
+    expect(registrations.length, "no cors() registration found to check").toBeGreaterThan(0);
+
+    const vulnerable = registrations
+      .map(({ file, args }) => {
+        const match = args.match(/allowHeaders:\s*\[([^\]]*)\]/);
+        const entries = match?.[1].split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+        if (entries.length > 0) return null;
+        return `${file}: allowHeaders is ${match ? "empty" : "absent"}`;
+      })
+      .filter(Boolean);
+    expect(vulnerable).toEqual([]);
   });
 
   it("still carries the headers the API actually needs", () => {
     // Keeps the assertion honest: a non-empty array of the wrong headers would
     // dodge the ReDoS path and break every authenticated browser request.
-    const block = globalCorsBlock();
-    expect(block).toContain("content-type");
-    expect(block).toContain("authorization");
+    const withHeaders = corsRegistrations().filter(({ args }) => args.includes("allowHeaders"));
+    expect(withHeaders.length).toBeGreaterThan(0);
+    for (const { file, args } of withHeaders) {
+      expect(args, `${file}: allowHeaders lost content-type`).toContain("content-type");
+      expect(args, `${file}: allowHeaders lost authorization`).toContain("authorization");
+    }
   });
 
-  it("resolves hono to a version at or above the advisory floor", () => {
-    const pkg = JSON.parse(
-      readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"),
-    ) as { dependencies: Record<string, string> };
-    const range = pkg.dependencies.hono;
-    const floor = range.replace(/^[^0-9]*/, "").split(".").map(Number);
-    // The range floor itself must exclude the vulnerable versions, so a fresh
-    // resolve cannot land on one — a lockfile pin alone would not do that.
-    const atLeast = floor[0] > 4
-      || (floor[0] === 4 && (floor[1] > 12 || (floor[1] === 12 && floor[2] >= 34)));
-    expect(atLeast, `hono range ${range} still permits vulnerable versions`).toBe(true);
+  it("declares a hono range that excludes the vulnerable versions", () => {
+    // The range floor, not the lockfile: a pin fixes the current install, while
+    // a range starting below the advisory lets a fresh resolve land back on a
+    // vulnerable version. Checked in every package that depends on hono.
+    const below = MANIFESTS
+      .map((manifest) => ({ manifest, range: honoRange(manifest) }))
+      .filter(({ range }) => {
+        const floor = range.replace(/^[^0-9]*/, "").split(".").map(Number);
+        return !(floor[0] > 4
+          || (floor[0] === 4 && (floor[1] > 12 || (floor[1] === 12 && floor[2] >= 34))));
+      })
+      .map(({ manifest, range }) => `${manifest}: hono ${range} still permits vulnerable versions`);
+    expect(below).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes the two residuals from @Sentinel's review of #407.

## Residual two — the guard only saw the first registration

`globalCorsBlock()` anchored to `indexOf("cors({")`. **A second registration beside the good one passed green** while carrying the vulnerable empty array — Sentinel demonstrated it.

Now scans **every** `cors(` occurrence in both hono-dependent packages, matching parentheses instead of searching for a closing delimiter, so a registration is read to its real end whatever its formatting. Bare `cors()` is reported too: **unset and empty reach the same path in hono**, and clearing an array looks more innocent than deleting a line.

## Residual one — container was inside the affected range

`container` resolved to **4.12.27**. It runs a real hono server (`container/src/server.ts:36`, `:577`) and has **no `cors()` call today**, so it cannot be hit — but that is immunity from *not having called it*, which is the exact shape this guard exists to remove. Raised to the advisory floor `^4.12.34`, matching worker. Its source is scanned from the worker suite because its own runner (`tsx --test`, one file) does not cover it.

## Mutations

| Mutation | Result |
|---|---|
| second `cors({ allowHeaders: [] })` | ① ② red — **the case the previous guard passed** |
| bare `cors()` | ① ② red |
| revert either package's range | ③ red, **naming which package** |

**362/362.**

## One thing this does not do

There is no pull-request CI that runs this suite. `deploy-hands-server.yml` is `workflow_dispatch` only, and its checks are behind a `run_checks` input. **These assertions fire at deploy time, not at review time** — worth knowing before relying on "a test will catch it." Raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
