### PR TITLE
fix(worker): keep CORS guard type-safe

### DIFF
--- a/worker/test/cors_allow_headers.test.ts
+++ b/worker/test/cors_allow_headers.test.ts
@@ -111,7 +111,7 @@ describe("CORS keeps allowHeaders non-empty (GHSA-8j4g-w8fx-2239)", () => {
     const vulnerable = registrations
       .map(({ file, args }) => {
         const match = args.match(/allowHeaders:\s*\[([^\]]*)\]/);
-        const entries = match?.[1].split(",").map((s) => s.trim()).filter(Boolean) ?? [];
+        const entries = (match?.[1] ?? "").split(",").map((s) => s.trim()).filter(Boolean);
         if (entries.length > 0) return null;
         return `${file}: allowHeaders is ${match ? "empty" : "absent"}`;
       })
@@ -137,9 +137,12 @@ describe("CORS keeps allowHeaders non-empty (GHSA-8j4g-w8fx-2239)", () => {
     const below = MANIFESTS
       .map((manifest) => ({ manifest, range: honoRange(manifest) }))
       .filter(({ range }) => {
-        const floor = range.replace(/^[^0-9]*/, "").split(".").map(Number);
-        return !(floor[0] > 4
-          || (floor[0] === 4 && (floor[1] > 12 || (floor[1] === 12 && floor[2] >= 34))));
+        const [major = 0, minor = 0, patch = 0] = range
+          .replace(/^[^0-9]*/, "")
+          .split(".")
+          .map(Number);
+        return !(major > 4
+          || (major === 4 && (minor > 12 || (minor === 12 && patch >= 34))));
       })
       .map(({ manifest, range }) => `${manifest}: hono ${range} still permits vulnerable versions`);
     expect(below).toEqual([]);


### PR DESCRIPTION
## Summary

- default a missing `allowHeaders` capture to an empty string before splitting
- destructure the parsed Hono version floor with numeric defaults
- preserve the existing fail-closed CORS and vulnerable-version assertions

## Verification

- `pnpm --filter @botiverse/hands-worker test` (362 passed)
- generated production Worker types, then `pnpm --filter @botiverse/hands-worker build`
- `git diff --check`

This fixes the Worker TypeScript errors exposed by the production deploy workflow without changing runtime code.
