### PR TITLE
fix(feedback): preserve close action shadow gutter

### DIFF
--- a/packages/feedback-react/src/provider.test.tsx
+++ b/packages/feedback-react/src/provider.test.tsx
@@ -159,6 +159,9 @@ describe("FeedbackProvider", () => {
       /\.hands-feedback-detail \.hands-feedback-middle[^}]*overflow:\s*hidden/,
     );
     expect(css).toMatch(
+      /\.hands-feedback-close[^}]*padding:\s*0 4px 4px 0/,
+    );
+    expect(css).toMatch(
       /\.hands-feedback-conversation[^}]*flex:\s*1[^}]*overflow-y:\s*auto/,
     );
     expect(css).toMatch(

--- a/packages/feedback-react/src/styles.css
+++ b/packages/feedback-react/src/styles.css
@@ -278,6 +278,7 @@
   gap: 8px;
   justify-content: flex-end;
   margin-top: 12px;
+  padding: 0 4px 4px 0;
 }
 .hands-feedback-composer {
   background: var(--hf-bg);


### PR DESCRIPTION
## Summary

- reserve the brutal-theme button shadow gutter at the bottom and right of the ticket-close confirmation row
- keep the existing bounded conversation overflow behavior
- add a source contract so the gutter cannot be removed silently

## Verification

- `pnpm --filter @botiverse/hands-feedback-react test` (34 passed)
- `pnpm --filter @botiverse/hands-feedback-react build`
- `git diff --check`
