### PR TITLE
Say that feedback:comment can also close a reporter's ticket

### DIFF
--- a/docs/public/permissions.md
+++ b/docs/public/permissions.md
@@ -103,7 +103,7 @@ reached by holding the role.
 | `app:admin` | Carried by `admin`; settings, members, credentials, destructive operations | Console entry on its own; anything in another app |
 | `feedback:write` | **File a ticket on a user's behalf** from a trusted server proxy. Requires a reporter-integration binding | **Any staff-side handling. This is not a support or triage permission.** |
 | `feedback:read` | Read tickets, their detail, attachments and the material-delta feed. Scope follows the token's binding | Any write |
-| `feedback:comment` | Post a **public reply** the reporter sees | Internal notes; status or assignee |
+| `feedback:comment` | Post a **public reply** the reporter sees. A **bound** token may also **close** that reporter's own ticket | Internal notes; assignee; reopening; any other status change |
 | `feedback:triage` | Change status and assignee, write **internal notes** | Replying to the reporter |
 | `feedback:route` | Bind an opaque route subject to a reporter integration. Requires a reporter-integration binding | Reading or writing ticket content |
 
@@ -132,7 +132,8 @@ unreadable or corrupt grant fails closed.
   `feedback:write`, **bound to an active reporter integration**. Issuance refuses
   this permission on an unbound token, so the binding is not optional.
 - **A reporter integration** — no role, `feedback:read` and `feedback:comment`,
-  bound to the integration.
+  bound to the integration. **Note that `feedback:comment` also lets it close a
+  reporter's own ticket** — see the permission table.
 - **Support automation that reads and answers feedback** — no role,
   `feedback:read` + `feedback:comment`, **unbound**. It cannot publish, change
   status, or write internal notes.

--- a/docs/rbac-permissions.md
+++ b/docs/rbac-permissions.md
@@ -20,7 +20,7 @@ The initial registry is:
 | `app:admin` | Manage app settings, members, credentials, and destructive operations. |
 | `feedback:write` | Submit feedback tickets for the app. |
 | `feedback:read` | Token-only: read tickets owned by a reporter integration. |
-| `feedback:comment` | Token-only: comment on tickets owned by a reporter integration. |
+| `feedback:comment` | Token-only: comment on, and close, tickets owned by a reporter integration. |
 | `feedback:route` | Token-only: bind an opaque immutable route subject for webhook routing. |
 
 App roles are centrally defined bundles:

--- a/worker/src/lib/app_permissions.ts
+++ b/worker/src/lib/app_permissions.ts
@@ -30,7 +30,7 @@ export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
   "app:admin": "Manage app settings, members, credentials, and destructive operations.",
   "feedback:write": "Submit feedback tickets for this app.",
   "feedback:read": "Read feedback tickets. A token bound to a reporter integration sees only that integration's tickets; an unbound token sees the app's.",
-  "feedback:comment": "Post a public reply the reporter sees. Scope follows the token's binding.",
+  "feedback:comment": "Post a public reply the reporter sees, and — for a token bound to a reporter integration — close that reporter's own ticket. Scope follows the token's binding.",
   "feedback:route": "Bind an opaque route subject to a reporter integration.",
   "feedback:triage": "Change ticket status and assignee, and write internal notes.",
 };


### PR DESCRIPTION
The reporter-close route authorises with `feedback:comment` (`reporter_feedback.ts:915`), so a token **bound to a reporter integration** can close that reporter's own ticket. Every text describing the permission still said it only posts a public reply — and the public page went further, listing "status or assignee" among the things it does **not** grant, which closing a ticket is.

## Three carriers, all stale, in three languages

| | Said | Problem |
|---|---|---|
| `worker/src/lib/app_permissions.ts:33` | "Post a public reply the reporter sees." | what someone reads **when choosing what to grant** |
| `docs/public/permissions.md:106` | "Does not grant: … status or assignee" | **actively false**, and published |
| `docs/rbac-permissions.md:23` | "Token-only: comment on tickets…" | incomplete |

Corrected together, because fixing one leaves anyone consulting another misinformed. Also flagged on the reporter-integration recipe, where a reader picking a grant would otherwise acquire close authority without seeing it mentioned.

## Deliberately bounded wording

The route **closes only**: it cannot reopen, cannot set an arbitrary status, cannot change the assignee, and cannot reach another reporter's ticket. The text says *close* rather than *change status* so it does not read as broader than the route permits.

## Why this is worth a PR rather than a footnote

**#408 did not add a permission — it changed the meaning of an existing one.** Adding a permission forces someone to write a description; changing what one means does not, so every description of it expires silently and simultaneously. This is the third consequence of that single change, after the SQL `CHECK` that did not follow the TypeScript union (a production 500) and the review that was skipped because the PR landed outside the patrol window.

Found by @Sentinel, who swept for the other carriers after I reported the public page.

Docs and one description constant. No behaviour change; 362/362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
