### PR TITLE
Say that a bound token acts for any reporter in its integration

### DIFF
--- a/docs/public/permissions.md
+++ b/docs/public/permissions.md
@@ -48,6 +48,12 @@ outright on the console endpoints above. An *unbound* token holding the same
 reach. The permission says what you may do; the binding says what you may do it
 to.
 
+**Within its integration a bound token is not narrowed any further.** The caller
+states which reporter it is acting for, so the same token can reply on — and
+close — **any** ticket that integration owns, not one reporter's. This is a
+property of the binding, so it applies equally to `feedback:comment` and to the
+close it authorises.
+
 ## Roles
 
 | Role | Intended for | Who can hold it | Also carries |
@@ -103,7 +109,7 @@ reached by holding the role.
 | `app:admin` | Carried by `admin`; settings, members, credentials, destructive operations | Console entry on its own; anything in another app |
 | `feedback:write` | **File a ticket on a user's behalf** from a trusted server proxy. Requires a reporter-integration binding | **Any staff-side handling. This is not a support or triage permission.** |
 | `feedback:read` | Read tickets, their detail, attachments and the material-delta feed. Scope follows the token's binding | Any write |
-| `feedback:comment` | Post a **public reply** the reporter sees. A **bound** token may also **close** that reporter's own ticket | Internal notes; assignee; reopening; any other status change |
+| `feedback:comment` | Post a **public reply** the reporter sees. A **bound** token may also **close** a ticket its integration owns | Internal notes; assignee; reopening; any other status change |
 | `feedback:triage` | Change status and assignee, write **internal notes** | Replying to the reporter |
 | `feedback:route` | Bind an opaque route subject to a reporter integration. Requires a reporter-integration binding | Reading or writing ticket content |
 
@@ -132,8 +138,9 @@ unreadable or corrupt grant fails closed.
   `feedback:write`, **bound to an active reporter integration**. Issuance refuses
   this permission on an unbound token, so the binding is not optional.
 - **A reporter integration** — no role, `feedback:read` and `feedback:comment`,
-  bound to the integration. **Note that `feedback:comment` also lets it close a
-  reporter's own ticket** — see the permission table.
+  bound to the integration. **Note that `feedback:comment` also lets it close
+  tickets** — for any reporter the integration owns, not one. See the permission
+  table.
 - **Support automation that reads and answers feedback** — no role,
   `feedback:read` + `feedback:comment`, **unbound**. It cannot publish, change
   status, or write internal notes.

--- a/worker/src/lib/app_permissions.ts
+++ b/worker/src/lib/app_permissions.ts
@@ -30,7 +30,7 @@ export const APP_PERMISSION_DESCRIPTIONS: Record<AppPermission, string> = {
   "app:admin": "Manage app settings, members, credentials, and destructive operations.",
   "feedback:write": "Submit feedback tickets for this app.",
   "feedback:read": "Read feedback tickets. A token bound to a reporter integration sees only that integration's tickets; an unbound token sees the app's.",
-  "feedback:comment": "Post a public reply the reporter sees, and — for a token bound to a reporter integration — close that reporter's own ticket. Scope follows the token's binding.",
+  "feedback:comment": "Post a public reply the reporter sees, and — for a token bound to a reporter integration — close any ticket its integration owns. Scope follows the token's binding.",
   "feedback:route": "Bind an opaque route subject to a reporter integration.",
   "feedback:triage": "Change ticket status and assignee, and write internal notes.",
 };


### PR DESCRIPTION
The permission table implied a bound token was tied to one reporter — it said close applies to *"that reporter's own ticket"*. A proxy **states which reporter it is acting for**, so the same token can reply on and close **any** ticket the integration owns.

That is an **understatement**, which is the more dangerous direction: whoever issues the token reads the blast radius as one reporter when it is the whole integration.

## Said once, in the binding paragraph — not on the close row

`feedback:comment` has always had this property; close merely inherits it. Spelling it out **only** for close would invent a contrast between the two rows and read as a deliberate design difference, when their reach is identical.

So the sentence lives with *"the binding decides the scope"*, where it belongs — the scope comes from the binding, not from either action.

Raised by @Sentinel, who caught that fixing only the instance would create a new false implication. Verified both paths use the same `authorize(c, "feedback:comment", …)` (`reporter_feedback.ts:680` and `:915`).

Docs only; no behaviour change. Admin build green, 16 docs pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)