### PR TITLE
Publish Android SDK to Raft Artifacts

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -80,12 +80,18 @@ jobs:
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: gradle -p clients/android publishToMavenLocal "-PVERSION_NAME=$RESOLVED_VERSION"
 
-      - name: Publish SDK to GitHub Packages
+      - name: Publish SDK to Maven repositories
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RAFT_ARTIFACTS_TOKEN: ${{ secrets.RAFT_ARTIFACTS_TOKEN }}
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
-        run: gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"
+        run: |
+          [[ -n "${RAFT_ARTIFACTS_TOKEN}" ]] || {
+            echo "RAFT_ARTIFACTS_TOKEN is required for Android SDK publication" >&2
+            exit 1
+          }
+          gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"
 
       - name: Summary
         shell: bash

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -9,9 +9,22 @@ queued on-device and retried after network or process failures; set
 
 ## Coordinates
 
-Two ways to consume the SDK. **JitPack needs no token** — prefer it unless you
-already have GitHub Packages set up. (GitHub Packages' Maven registry requires a
-`read:packages` token for every request, even though the package is public.)
+The canonical `build.hands:hands-android-sdk` publication is public on Raft
+Artifacts and needs no download token. JitPack remains available as a
+source-build fallback. GitHub Packages requires a `read:packages` token for
+every request even though the package is public.
+
+### Raft Artifacts (preferred, no token)
+
+```kotlin
+repositories {
+    maven { url = uri("https://maven.artifacts.botiverse.dev") }
+}
+
+dependencies {
+    implementation("build.hands:hands-android-sdk:0.12.4")
+}
+```
 
 ### JitPack (no token)
 

--- a/clients/android/build.gradle.kts
+++ b/clients/android/build.gradle.kts
@@ -200,6 +200,18 @@ afterEvaluate {
 
         repositories {
             maven {
+                name = "RaftArtifacts"
+                url = uri("https://maven.artifacts.botiverse.dev")
+                credentials {
+                    // The registry intentionally ignores the Basic username;
+                    // keep a stable label here so build diagnostics identify
+                    // which credential class was expected without printing it.
+                    username = "hands-ci"
+                    password = System.getenv("RAFT_ARTIFACTS_TOKEN")
+                }
+            }
+
+            maven {
                 name = "GitHubPackages"
                 val repository = System.getenv("GITHUB_REPOSITORY") ?: "botiverse/hands"
                 url = uri("https://maven.pkg.github.com/$repository")

--- a/scripts/test_android_publication_gate.sh
+++ b/scripts/test_android_publication_gate.sh
@@ -42,12 +42,12 @@ grep -Fq 'description: "Publish the complete SDK to the runner-local Maven repos
   "${publish_workflow}"
 dry_run_step="$(
   sed -n \
-    '/^[[:space:]]*- name: Publish SDK dry run$/,/^[[:space:]]*- name: Publish SDK to GitHub Packages$/p' \
+    '/^[[:space:]]*- name: Publish SDK dry run$/,/^[[:space:]]*- name: Publish SDK to Maven repositories$/p' \
     "${publish_workflow}"
 )"
 real_publish_step="$(
   sed -n \
-    '/^[[:space:]]*- name: Publish SDK to GitHub Packages$/,/^[[:space:]]*- name: Summary$/p' \
+    '/^[[:space:]]*- name: Publish SDK to Maven repositories$/,/^[[:space:]]*- name: Summary$/p' \
     "${publish_workflow}"
 )"
 grep -Fq 'if: ${{ github.event_name == '\''workflow_dispatch'\'' && inputs.dry_run }}' \
@@ -56,7 +56,7 @@ grep -Fq 'run: gradle -p clients/android publishToMavenLocal "-PVERSION_NAME=$RE
   <<<"${dry_run_step}"
 grep -Fq 'if: ${{ github.event_name != '\''workflow_dispatch'\'' || !inputs.dry_run }}' \
   <<<"${real_publish_step}"
-grep -Fq 'run: gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"' \
+grep -Fq 'gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"' \
   <<<"${real_publish_step}"
 
 if "${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" validatePublicationVersion \
@@ -94,6 +94,19 @@ grep -Fq ":publishReleasePublicationToMavenLocal SKIPPED" \
   "${work_dir}/local.log"
 grep -Fq ":publishReleasePublicationToGitHubPackagesRepository SKIPPED" \
   "${work_dir}/remote.log"
+grep -Fq ":publishReleasePublicationToRaftArtifactsRepository SKIPPED" \
+  "${work_dir}/remote.log"
+
+grep -Fq 'RAFT_ARTIFACTS_TOKEN: ${{ secrets.RAFT_ARTIFACTS_TOKEN }}' \
+  <<<"${real_publish_step}" || {
+  echo "publish workflow does not bind the Raft Artifacts credential" >&2
+  exit 1
+}
+grep -Fq 'RAFT_ARTIFACTS_TOKEN is required for Android SDK publication' \
+  <<<"${real_publish_step}" || {
+  echo "publish workflow can silently skip a missing Raft Artifacts credential" >&2
+  exit 1
+}
 
 "${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" packageReleaseNativeSymbols \
   --no-daemon --console=plain -PVERSION_NAME="${SDK_VERSION}" \


### PR DESCRIPTION
## Problem

The Hands Android SDK is published only to GitHub Packages, which requires a GitHub token even for public consumption.

## Changes

- add `https://maven.artifacts.botiverse.dev` as a publication target for `build.hands:hands-android-sdk`
- require the repository-scoped publication credential in the release workflow instead of silently skipping the target
- extend the publication gate to prove the Raft Artifacts task is in the remote publication graph
- document anonymous public consumption from Raft Artifacts

## Follow-up

Run one prerelease publication and resolve it from a clean Gradle cache before using this target for the next SDK release.

## Testing

- `bash -n scripts/test_android_publication_gate.sh`
- workflow YAML parse
- `git diff --check`
- hosted Android publication gate and prerelease publish will run on this exact branch
