### PR TITLE
chore(npm): add package authors

### DIFF
--- a/clients/electron/package.json
+++ b/clients/electron/package.json
@@ -2,6 +2,10 @@
   "name": "@botiverse/hands-electron",
   "version": "0.2.1",
   "description": "Hands crash reporting for Electron apps — main + renderer, Crashpad minidumps auto-uploaded and symbolicated server-side.",
+  "author": {
+    "name": "jiacheng",
+    "email": "jiacheng@botiverse.dev"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,10 @@
   "name": "@botiverse/hands-cli",
   "version": "0.5.14",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
+  "author": {
+    "name": "jiacheng",
+    "email": "jiacheng@botiverse.dev"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/feedback-react/package.json
+++ b/packages/feedback-react/package.json
@@ -2,6 +2,10 @@
   "name": "@botiverse/hands-feedback-react",
   "version": "0.1.0",
   "description": "Embeddable reporter-facing Hands feedback inbox components.",
+  "author": {
+    "name": "jiacheng",
+    "email": "jiacheng@botiverse.dev"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,6 +2,10 @@
   "name": "@botiverse/hands-node",
   "version": "0.1.0",
   "description": "Hands logging, redaction, and policy-governed log collection for Node.js.",
+  "author": {
+    "name": "jiacheng",
+    "email": "jiacheng@botiverse.dev"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- add canonical author metadata to the four published npm package manifests
- leave package publishing workflows unchanged

This is a minimal replacement for #387.

## Verification

- parsed all four manifests and checked the exact author object
- ran `npm pack --dry-run --ignore-scripts` for all four packages
- ran `git diff --check`
