### PR TITLE
ci(android): add safe publish dry run

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -7,6 +7,11 @@ on:
         description: "SDK version to publish, for example 0.1.0"
         required: true
         default: "0.12.4"
+      dry_run:
+        description: "Publish the complete SDK to the runner-local Maven repository only."
+        required: true
+        type: boolean
+        default: true
   push:
     tags:
       - "android-sdk-v*"
@@ -69,8 +74,30 @@ jobs:
           path: clients/android/build/outputs/native-symbols/*-native-symbols.zip
           if-no-files-found: error
 
+      - name: Publish SDK dry run
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        run: gradle -p clients/android publishToMavenLocal "-PVERSION_NAME=$RESOLVED_VERSION"
+
       - name: Publish SDK to GitHub Packages
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"
+
+      - name: Summary
+        shell: bash
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          {
+            echo "### Android SDK publish"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Package | \`build.hands:hands-android-sdk\` |"
+            echo "| Version | \`${RESOLVED_VERSION}\` |"
+            echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test_android_publication_gate.sh
+++ b/scripts/test_android_publication_gate.sh
@@ -40,12 +40,24 @@ grep -Fq 'VERSION="${INPUT_VERSION}"' "${publish_workflow}" || {
 
 grep -Fq 'description: "Publish the complete SDK to the runner-local Maven repository only."' \
   "${publish_workflow}"
+dry_run_step="$(
+  sed -n \
+    '/^[[:space:]]*- name: Publish SDK dry run$/,/^[[:space:]]*- name: Publish SDK to GitHub Packages$/p' \
+    "${publish_workflow}"
+)"
+real_publish_step="$(
+  sed -n \
+    '/^[[:space:]]*- name: Publish SDK to GitHub Packages$/,/^[[:space:]]*- name: Summary$/p' \
+    "${publish_workflow}"
+)"
 grep -Fq 'if: ${{ github.event_name == '\''workflow_dispatch'\'' && inputs.dry_run }}' \
-  "${publish_workflow}"
+  <<<"${dry_run_step}"
 grep -Fq 'run: gradle -p clients/android publishToMavenLocal "-PVERSION_NAME=$RESOLVED_VERSION"' \
-  "${publish_workflow}"
+  <<<"${dry_run_step}"
 grep -Fq 'if: ${{ github.event_name != '\''workflow_dispatch'\'' || !inputs.dry_run }}' \
-  "${publish_workflow}"
+  <<<"${real_publish_step}"
+grep -Fq 'run: gradle -p clients/android publish "-PVERSION_NAME=$RESOLVED_VERSION"' \
+  <<<"${real_publish_step}"
 
 if "${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" validatePublicationVersion \
   --no-daemon --console=plain >"${work_dir}/missing-version.log" 2>&1; then

--- a/scripts/test_android_publication_gate.sh
+++ b/scripts/test_android_publication_gate.sh
@@ -38,6 +38,15 @@ grep -Fq 'VERSION="${INPUT_VERSION}"' "${publish_workflow}" || {
   exit 1
 }
 
+grep -Fq 'description: "Publish the complete SDK to the runner-local Maven repository only."' \
+  "${publish_workflow}"
+grep -Fq 'if: ${{ github.event_name == '\''workflow_dispatch'\'' && inputs.dry_run }}' \
+  "${publish_workflow}"
+grep -Fq 'run: gradle -p clients/android publishToMavenLocal "-PVERSION_NAME=$RESOLVED_VERSION"' \
+  "${publish_workflow}"
+grep -Fq 'if: ${{ github.event_name != '\''workflow_dispatch'\'' || !inputs.dry_run }}' \
+  "${publish_workflow}"
+
 if "${GRADLE_BIN}" -p "${ROOT_DIR}/clients/android" validatePublicationVersion \
   --no-daemon --console=plain >"${work_dir}/missing-version.log" 2>&1; then
   echo "publication version gate accepted a missing VERSION_NAME" >&2


### PR DESCRIPTION
## Problem

The Android SDK publish workflow has no non-mutating way to exercise its complete Maven artifact publication path.

## Changes

- add a manual `dry_run` input that defaults to `true`
- publish the complete SDK and native-symbols artifact to the runner-local Maven repository during a dry run
- keep tag pushes and explicit `dry_run=false` dispatches on the existing remote publication path
- report the resolved version and dry-run state in the job summary
- extend the existing Android publication contract check for the dry-run and real-publish branch conditions

## Verification

- workflow YAML parse
- actionlint
- shell syntax and workflow contract assertions
- `git diff --check`

The local Maven dry run validates artifact generation and publication wiring. It intentionally does not claim to validate remote registry credentials or remote registry availability.
