### PR TITLE
Add the schema for build-asset direct upload

### DIFF
--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -1,40 +1,75 @@
 -- Direct upload for release build assets: declare -> R2 staging PUT -> complete.
--- Additive only. Existing rows keep NULL ingest state and stay on the legacy gate;
--- nothing is backfilled to 'ready', because "this row existed" and "this row passed
--- the new verifier" are different claims and only the first one is true of them.
+--
+-- build_assets is rebuilt rather than altered. The UNIQUE from 0010 is a table
+-- constraint, and SQLite cannot drop one in place; leaving it would keep rejecting a
+-- QA artifact and a release installable that share a shape, which is exactly what
+-- artifact_kind scoping is meant to allow.
 
--- Per-build protocol selection. Explicit at creation, immutable after; NULL = legacy.
--- Deliberately not inferred from created_at: a timestamp is not a declaration.
+-- Per-build protocol selection: explicit at creation, immutable after, NULL = legacy.
+-- Not inferred from created_at, because a timestamp is not a declaration.
 ALTER TABLE builds ADD COLUMN asset_ingest_protocol_version INTEGER;
 
--- The required slot set the draft gate evaluates, frozen with the protocol version.
--- Kept separate from required_targets_json: external targets and asset slots are two
--- contracts, and sharing a column makes a mismatch in either look like the other.
+-- The set the draft gate evaluates. Separate from required_targets_json: external
+-- targets and asset slots are two contracts, and one column would make a mismatch in
+-- either look like a mismatch in the other.
 ALTER TABLE builds ADD COLUMN required_asset_slots_json TEXT;
 
--- Canonical slot identity. The 0010 index cannot serve: arch/variant are NULLable and
--- SQLite treats NULLs as distinct, so it never enforced one-row-per-slot for assets
--- without them; and it predates artifact_kind (0020), so a QA artifact and a release
--- installable in the same shape collide. Sentinels are outside the input domain.
--- The CHECK is what makes '-' a sentinel rather than a guess: it may only appear
--- when the underlying column is NULL, so a literal '-' input cannot masquerade as
--- "no arch" and merge two distinct slots into one.
-ALTER TABLE build_assets ADD COLUMN slot_arch TEXT NOT NULL DEFAULT '-'
-  CHECK (slot_arch <> '-' OR arch IS NULL);
-ALTER TABLE build_assets ADD COLUMN slot_variant TEXT NOT NULL DEFAULT '-'
-  CHECK (slot_variant <> '-' OR variant IS NULL);
+-- Lets the replay ledger reference (app_id, build_id) as a pair, so a key cannot be
+-- presented against a build belonging to another app.
+CREATE UNIQUE INDEX idx_builds_app_scope ON builds(app_id, id);
 
-UPDATE build_assets
-   SET slot_arch = COALESCE(arch, '-'),
-       slot_variant = COALESCE(variant, '-');
+ALTER TABLE build_assets RENAME TO build_assets_legacy;
 
--- Fails closed if duplicate slots already exist. That failure is the census: the old
--- index permitted duplicate NULL-slot rows for its entire life, so they may be real.
+CREATE TABLE build_assets (
+  id                      TEXT PRIMARY KEY,
+  build_id                TEXT NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+  platform                TEXT NOT NULL,
+  -- The sentinel is kept out of the input domain at the source, so a literal '-'
+  -- can never occupy the slot that means "no arch" and merge two distinct slots.
+  arch                    TEXT CHECK (arch IS NULL OR arch <> '-'),
+  variant                 TEXT CHECK (variant IS NULL OR variant <> '-'),
+  filetype                TEXT NOT NULL,
+  r2_key                  TEXT NOT NULL,
+  file_hash               TEXT NOT NULL,
+  size_bytes              INTEGER NOT NULL,
+  signature               TEXT,
+  signing_credential_id   TEXT REFERENCES signing_credentials(id) ON DELETE SET NULL,
+  metadata_json           TEXT NOT NULL DEFAULT '{}',
+  download_count          INTEGER NOT NULL DEFAULT 0,
+  created_at              INTEGER NOT NULL,
+  artifact_kind           TEXT NOT NULL DEFAULT 'installable',
+  -- Generated, not caller-supplied: a writer cannot set a slot value that disagrees
+  -- with the column it normalizes, and existing INSERTs need no change.
+  slot_arch    TEXT GENERATED ALWAYS AS (COALESCE(arch, '-')) VIRTUAL,
+  slot_variant TEXT GENERATED ALWAYS AS (COALESCE(variant, '-')) VIRTUAL
+);
+
+INSERT INTO build_assets (
+  id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
+  signature, signing_credential_id, metadata_json, download_count, created_at,
+  artifact_kind
+)
+SELECT
+  id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
+  signature, signing_credential_id, metadata_json, download_count, created_at,
+  artifact_kind
+FROM build_assets_legacy;
+
+DROP TABLE build_assets_legacy;
+
+CREATE INDEX idx_build_assets_build ON build_assets(build_id);
+CREATE INDEX idx_build_assets_signing
+  ON build_assets(signing_credential_id) WHERE signing_credential_id IS NOT NULL;
+
+-- Canonical slot: closed (no NULLs) and kind-scoped. Fails closed if duplicates
+-- already exist; the old index permitted them for its whole life.
 CREATE UNIQUE INDEX idx_build_assets_canonical_slot
   ON build_assets(build_id, artifact_kind, platform, slot_arch, slot_variant, filetype);
 
--- One row per upload attempt. Cleanup finds staging objects here by exact key; it is
--- never inferred and never prefix-scanned.
+-- Lets the replay ledger reference (build_id, asset_id) as a pair.
+CREATE UNIQUE INDEX idx_build_assets_build_scope ON build_assets(build_id, id);
+
+-- One row per upload attempt; cleanup finds staging objects here by exact key.
 CREATE TABLE build_asset_ingest_attempt (
   asset_id             TEXT    NOT NULL REFERENCES build_assets(id) ON DELETE CASCADE,
   attempt              INTEGER NOT NULL,
@@ -59,10 +94,13 @@ CREATE TABLE build_asset_ingest_attempt (
 CREATE INDEX idx_build_asset_ingest_attempt_sweep
   ON build_asset_ingest_attempt(state, upload_expires_at);
 
--- One row per (attempt, lease generation). Written BEFORE the R2 create-once write is
--- issued, so an object that exists is always discoverable by exact key even if the
--- process dies between the write and any later update. Identity columns are immutable;
--- lifecycle columns move only by named CAS.
+-- One row per (attempt, lease generation), written BEFORE the R2 create-once write is
+-- issued, so an object that exists is discoverable by exact key even if the process
+-- dies immediately after writing it.
+--
+-- Deliberately no foreign key: a tombstone is permanent, and the row that records its
+-- exact key must outlive the asset. A cascade here would delete the only record of an
+-- object that still exists.
 CREATE TABLE build_asset_ingest_seal (
   asset_id         TEXT    NOT NULL,
   attempt          INTEGER NOT NULL,
@@ -72,24 +110,24 @@ CREATE TABLE build_asset_ingest_seal (
   sealed_at        INTEGER,
   outcome          TEXT CHECK (outcome IN ('committed', 'superseded', 'cleaned')),
   cleanup_receipt  TEXT,
-  PRIMARY KEY (asset_id, attempt, lease_generation),
-  FOREIGN KEY (asset_id, attempt)
-    REFERENCES build_asset_ingest_attempt(asset_id, attempt) ON DELETE CASCADE
+  PRIMARY KEY (asset_id, attempt, lease_generation)
 );
 
 CREATE INDEX idx_build_asset_ingest_seal_open
   ON build_asset_ingest_seal(outcome, intent_at);
 
--- Replay keys are request-scoped, not identity. One asset accumulates several keys
--- when CI reruns, so a single column on build_assets cannot hold them.
+-- Replay keys are request-scoped, not identity. Composite references keep a key from
+-- naming a build in another app, or an asset in another build.
 CREATE TABLE build_asset_ingest_replay (
-  app_id          TEXT    NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
-  build_id        TEXT    NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+  app_id          TEXT    NOT NULL,
+  build_id        TEXT    NOT NULL,
   idempotency_key TEXT    NOT NULL,
-  asset_id        TEXT    NOT NULL REFERENCES build_assets(id) ON DELETE CASCADE,
+  asset_id        TEXT    NOT NULL,
   request_digest  TEXT    NOT NULL,
   created_at      INTEGER NOT NULL,
-  PRIMARY KEY (app_id, build_id, idempotency_key)
+  PRIMARY KEY (app_id, build_id, idempotency_key),
+  FOREIGN KEY (app_id, build_id) REFERENCES builds(app_id, id) ON DELETE CASCADE,
+  FOREIGN KEY (build_id, asset_id) REFERENCES build_assets(build_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_build_asset_ingest_replay_asset

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -1,0 +1,96 @@
+-- Direct upload for release build assets: declare -> R2 staging PUT -> complete.
+-- Additive only. Existing rows keep NULL ingest state and stay on the legacy gate;
+-- nothing is backfilled to 'ready', because "this row existed" and "this row passed
+-- the new verifier" are different claims and only the first one is true of them.
+
+-- Per-build protocol selection. Explicit at creation, immutable after; NULL = legacy.
+-- Deliberately not inferred from created_at: a timestamp is not a declaration.
+ALTER TABLE builds ADD COLUMN asset_ingest_protocol_version INTEGER;
+
+-- The required slot set the draft gate evaluates, frozen with the protocol version.
+-- Kept separate from required_targets_json: external targets and asset slots are two
+-- contracts, and sharing a column makes a mismatch in either look like the other.
+ALTER TABLE builds ADD COLUMN required_asset_slots_json TEXT;
+
+-- Canonical slot identity. The 0010 index cannot serve: arch/variant are NULLable and
+-- SQLite treats NULLs as distinct, so it never enforced one-row-per-slot for assets
+-- without them; and it predates artifact_kind (0020), so a QA artifact and a release
+-- installable in the same shape collide. Sentinels are outside the input domain.
+-- The CHECK is what makes '-' a sentinel rather than a guess: it may only appear
+-- when the underlying column is NULL, so a literal '-' input cannot masquerade as
+-- "no arch" and merge two distinct slots into one.
+ALTER TABLE build_assets ADD COLUMN slot_arch TEXT NOT NULL DEFAULT '-'
+  CHECK (slot_arch <> '-' OR arch IS NULL);
+ALTER TABLE build_assets ADD COLUMN slot_variant TEXT NOT NULL DEFAULT '-'
+  CHECK (slot_variant <> '-' OR variant IS NULL);
+
+UPDATE build_assets
+   SET slot_arch = COALESCE(arch, '-'),
+       slot_variant = COALESCE(variant, '-');
+
+-- Fails closed if duplicate slots already exist. That failure is the census: the old
+-- index permitted duplicate NULL-slot rows for its entire life, so they may be real.
+CREATE UNIQUE INDEX idx_build_assets_canonical_slot
+  ON build_assets(build_id, artifact_kind, platform, slot_arch, slot_variant, filetype);
+
+-- One row per upload attempt. Cleanup finds staging objects here by exact key; it is
+-- never inferred and never prefix-scanned.
+CREATE TABLE build_asset_ingest_attempt (
+  asset_id             TEXT    NOT NULL REFERENCES build_assets(id) ON DELETE CASCADE,
+  attempt              INTEGER NOT NULL,
+  declared_sha256      TEXT    NOT NULL,
+  declared_size        INTEGER NOT NULL CHECK (declared_size > 0),
+  staging_key          TEXT    NOT NULL,
+  -- NULL until a lease generation wins: the final key embeds the generation, and no
+  -- generation exists until the cron claims the work.
+  committed_final_key  TEXT,
+  upload_expires_at    INTEGER NOT NULL,
+  state                TEXT    NOT NULL
+    CHECK (state IN ('pending', 'verifying', 'ready', 'failed', 'expired')),
+  verifier_lease_id         TEXT,
+  verifier_lease_expires_at INTEGER,
+  cleanup_state        TEXT    NOT NULL DEFAULT 'live'
+    CHECK (cleanup_state IN ('live', 'tombstoned', 'expired')),
+  cleanup_receipt      TEXT,
+  created_at           INTEGER NOT NULL,
+  PRIMARY KEY (asset_id, attempt)
+);
+
+CREATE INDEX idx_build_asset_ingest_attempt_sweep
+  ON build_asset_ingest_attempt(state, upload_expires_at);
+
+-- One row per (attempt, lease generation). Written BEFORE the R2 create-once write is
+-- issued, so an object that exists is always discoverable by exact key even if the
+-- process dies between the write and any later update. Identity columns are immutable;
+-- lifecycle columns move only by named CAS.
+CREATE TABLE build_asset_ingest_seal (
+  asset_id         TEXT    NOT NULL,
+  attempt          INTEGER NOT NULL,
+  lease_generation INTEGER NOT NULL,
+  final_key        TEXT    NOT NULL,
+  intent_at        INTEGER NOT NULL,
+  sealed_at        INTEGER,
+  outcome          TEXT CHECK (outcome IN ('committed', 'superseded', 'cleaned')),
+  cleanup_receipt  TEXT,
+  PRIMARY KEY (asset_id, attempt, lease_generation),
+  FOREIGN KEY (asset_id, attempt)
+    REFERENCES build_asset_ingest_attempt(asset_id, attempt) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_build_asset_ingest_seal_open
+  ON build_asset_ingest_seal(outcome, intent_at);
+
+-- Replay keys are request-scoped, not identity. One asset accumulates several keys
+-- when CI reruns, so a single column on build_assets cannot hold them.
+CREATE TABLE build_asset_ingest_replay (
+  app_id          TEXT    NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  build_id        TEXT    NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+  idempotency_key TEXT    NOT NULL,
+  asset_id        TEXT    NOT NULL REFERENCES build_assets(id) ON DELETE CASCADE,
+  request_digest  TEXT    NOT NULL,
+  created_at      INTEGER NOT NULL,
+  PRIMARY KEY (app_id, build_id, idempotency_key)
+);
+
+CREATE INDEX idx_build_asset_ingest_replay_asset
+  ON build_asset_ingest_replay(asset_id);

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -116,6 +116,20 @@ CREATE TABLE build_asset_ingest_seal (
 CREATE INDEX idx_build_asset_ingest_seal_open
   ON build_asset_ingest_seal(outcome, intent_at);
 
+-- Dropping the foreign key kept the ledger alive past its asset, but it also removed
+-- the check that a seal names a real attempt when it is written. A trigger restores
+-- that at INSERT only: a seal for an attempt that never existed is refused, while a
+-- legitimate one still outlives the asset it belonged to.
+CREATE TRIGGER build_asset_ingest_seal_requires_attempt
+BEFORE INSERT ON build_asset_ingest_seal
+WHEN NOT EXISTS (
+  SELECT 1 FROM build_asset_ingest_attempt
+   WHERE asset_id = NEW.asset_id AND attempt = NEW.attempt
+)
+BEGIN
+  SELECT RAISE(ABORT, 'seal ledger row must name an existing attempt');
+END;
+
 -- Replay keys are request-scoped, not identity. Composite references keep a key from
 -- naming a build in another app, or an asset in another build.
 CREATE TABLE build_asset_ingest_replay (

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -137,8 +137,25 @@ END;
 CREATE TRIGGER build_asset_ingest_seal_identity_immutable
 BEFORE UPDATE OF asset_id, attempt, lease_generation, final_key, intent_at
   ON build_asset_ingest_seal
+-- Fires on a changed value, not on the column appearing in a SET list, so an
+-- idempotent or full-row write that leaves identity alone is not refused.
+WHEN NEW.asset_id         IS NOT OLD.asset_id
+  OR NEW.attempt          IS NOT OLD.attempt
+  OR NEW.lease_generation IS NOT OLD.lease_generation
+  OR NEW.final_key        IS NOT OLD.final_key
+  OR NEW.intent_at        IS NOT OLD.intent_at
 BEGIN
   SELECT RAISE(ABORT, 'seal ledger identity is immutable');
+END;
+
+-- Guarding DELETE alone left a two-step route out: move `outcome` off 'cleaned',
+-- then delete. `cleaned` is therefore terminal. Entering it stays allowed, and so
+-- does writing a cleanup_receipt afterwards — only leaving it is refused.
+CREATE TRIGGER build_asset_ingest_seal_cleaned_is_terminal
+BEFORE UPDATE OF outcome ON build_asset_ingest_seal
+WHEN OLD.outcome = 'cleaned' AND NEW.outcome IS NOT OLD.outcome
+BEGIN
+  SELECT RAISE(ABORT, 'a tombstoned seal ledger row cannot leave the cleaned state');
 END;
 
 -- A tombstoned generation's row records the exact key of an object that still

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -130,6 +130,27 @@ BEGIN
   SELECT RAISE(ABORT, 'seal ledger row must name an existing attempt');
 END;
 
+-- "Identity columns are immutable" was a statement about intent, not a rule SQLite
+-- enforces: it permits UPDATE of a primary key, so a legitimate seal could be
+-- retargeted to a fictitious attempt and its exact tombstone key lost. Identity is
+-- frozen here; the lifecycle columns still move by CAS.
+CREATE TRIGGER build_asset_ingest_seal_identity_immutable
+BEFORE UPDATE OF asset_id, attempt, lease_generation, final_key, intent_at
+  ON build_asset_ingest_seal
+BEGIN
+  SELECT RAISE(ABORT, 'seal ledger identity is immutable');
+END;
+
+-- A tombstoned generation's row records the exact key of an object that still
+-- exists and is never removed. Retention may reap rows that were never tombstoned;
+-- it may not reap the ones that make a permanent object discoverable.
+CREATE TRIGGER build_asset_ingest_seal_cleaned_is_permanent
+BEFORE DELETE ON build_asset_ingest_seal
+WHEN OLD.outcome = 'cleaned'
+BEGIN
+  SELECT RAISE(ABORT, 'a tombstoned seal ledger row is permanent');
+END;
+
 -- Replay keys are request-scoped, not identity. Composite references keep a key from
 -- naming a build in another app, or an asset in another build.
 CREATE TABLE build_asset_ingest_replay (

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Migration 0062 — direct upload for release build assets.
+ *
+ * Asserts against the real migration file, applied over the real prior migrations,
+ * so what is proven is the schema production will get rather than a fixture.
+ *
+ * The properties here are the ones the frozen design leans on. Each has a
+ * counterexample that was live before this migration, and each fails if the
+ * corresponding line of SQL is removed.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+const MIGRATION = "0062_build_asset_direct_upload.sql";
+
+function database(includeMigration = true) {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  for (const name of readdirSync(MIGRATION_DIR).sort()) {
+    if (!name.endsWith(".sql")) continue;
+    if (name === MIGRATION && !includeMigration) continue;
+    db.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+  }
+  db.prepare(
+    "INSERT INTO apps (id, slug, name, platform, created_at) VALUES ('app-i', 'app-i', 'Ingest', 'android', 1)",
+  ).run();
+  db.prepare(
+    `INSERT INTO builds (id, app_id, version_name, version_code, created_at, updated_at)
+     VALUES ('build-i', 'app-i', '1.0.0', 1, 1, 1)`,
+  ).run();
+  return db;
+}
+
+/** Insert a build asset in a given slot. Mirrors how production writes the row. */
+function insertAsset(
+  db: Database.Database,
+  id: string,
+  opts: { arch?: string | null; variant?: string | null; kind?: string } = {},
+) {
+  const arch = opts.arch ?? null;
+  const variant = opts.variant ?? null;
+  db.prepare(
+    `INSERT INTO build_assets
+       (id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
+        artifact_kind, created_at, slot_arch, slot_variant)
+     VALUES (?, 'build-i', 'android', ?, ?, 'apk', 'k', 'h', 1, ?, 1, ?, ?)`,
+  ).run(id, arch, variant, opts.kind ?? "installable", arch ?? "-", variant ?? "-");
+}
+
+describe("migration 0062 — build asset direct upload", () => {
+  it("replays the defect: before 0062 the slot index admits duplicate NULL slots", () => {
+    const db = database(false);
+    const insert = (id: string) =>
+      db.prepare(
+        `INSERT INTO build_assets
+           (id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
+            artifact_kind, created_at)
+         VALUES (?, 'build-i', 'android', NULL, NULL, 'apk', 'k', 'h', 1, 'installable', 1)`,
+      ).run(id);
+    insert("dup-1");
+    // The 0010 index looks like one-row-per-slot and never was, for any asset
+    // without arch/variant: SQLite treats NULLs as distinct.
+    expect(() => insert("dup-2")).not.toThrow();
+  });
+
+  it("closes the slot: duplicate slots are rejected once normalized", () => {
+    const db = database();
+    insertAsset(db, "a-1");
+    expect(() => insertAsset(db, "a-2")).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it("scopes the slot by artifact_kind so QA and release do not collide", () => {
+    const db = database();
+    insertAsset(db, "rel-1");
+    // Before 0062 this was rejected: the index predated artifact_kind, so a QA
+    // artifact and a release installable fought over one slot.
+    expect(() => insertAsset(db, "qa-1", { kind: "ios-simulator-qa" })).not.toThrow();
+  });
+
+  it("keeps the sentinel out of the input domain", () => {
+    const db = database();
+    // A literal "-" arch must not be able to occupy the slot that means "no arch",
+    // or two distinct slots silently become one.
+    expect(() =>
+      db.prepare(
+        `INSERT INTO build_assets
+           (id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
+            artifact_kind, created_at, slot_arch, slot_variant)
+         VALUES ('sentinel', 'build-i', 'android', '-', NULL, 'apk', 'k', 'h', 1,
+                 'installable', 1, '-', '-')`,
+      ).run(),
+    ).toThrow(/CHECK constraint failed/);
+  });
+
+  it("leaves existing builds on the legacy gate rather than backfilling them", () => {
+    const db = database();
+    const row = db.prepare(
+      "SELECT asset_ingest_protocol_version AS v, required_asset_slots_json AS s FROM builds WHERE id = 'build-i'",
+    ).get() as { v: number | null; s: string | null };
+    // "this build existed" and "this build's assets passed the new verifier" are
+    // different claims; a backfill would forge the second from the first.
+    expect(row.v).toBeNull();
+    expect(row.s).toBeNull();
+  });
+
+  it("gives every attempt and every seal generation its own discoverable row", () => {
+    const db = database();
+    insertAsset(db, "a-1");
+    const attempt = db.prepare(
+      `INSERT INTO build_asset_ingest_attempt
+         (asset_id, attempt, declared_sha256, declared_size, staging_key,
+          upload_expires_at, state, cleanup_state, created_at)
+       VALUES ('a-1', ?, 'sha', 10, ?, 99, 'pending', 'live', 1)`,
+    );
+    attempt.run(1, "staging-1");
+    attempt.run(2, "staging-2");
+    expect(() => attempt.run(1, "staging-1-again")).toThrow(/UNIQUE constraint failed/);
+
+    const seal = db.prepare(
+      `INSERT INTO build_asset_ingest_seal
+         (asset_id, attempt, lease_generation, final_key, intent_at)
+       VALUES ('a-1', 1, ?, ?, 1)`,
+    );
+    seal.run(1, "final-a1-g1");
+    // A second lease generation on the same attempt keeps its own row, so the
+    // object a superseded verifier sealed stays findable by exact key.
+    seal.run(2, "final-a1-g2");
+    expect(() => seal.run(1, "final-a1-g1-again")).toThrow(/UNIQUE constraint failed/);
+    expect(
+      db.prepare("SELECT COUNT(*) AS n FROM build_asset_ingest_seal WHERE asset_id = 'a-1'").get(),
+    ).toEqual({ n: 2 });
+  });
+
+  it("scopes replay keys per app and build, and lets one asset hold several", () => {
+    const db = database();
+    insertAsset(db, "a-1");
+    const replay = db.prepare(
+      `INSERT INTO build_asset_ingest_replay
+         (app_id, build_id, idempotency_key, asset_id, request_digest, created_at)
+       VALUES ('app-i', 'build-i', ?, 'a-1', 'digest', 1)`,
+    );
+    replay.run("key-1");
+    // A CI rerun with a fresh key reuses the asset; a single column could not have
+    // held both keys, which is why this is a table.
+    replay.run("key-2");
+    expect(() => replay.run("key-1")).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it("refuses states and cleanup states outside the frozen sets", () => {
+    const db = database();
+    insertAsset(db, "a-1");
+    const withState = (state: string) =>
+      db.prepare(
+        `INSERT INTO build_asset_ingest_attempt
+           (asset_id, attempt, declared_sha256, declared_size, staging_key,
+            upload_expires_at, state, cleanup_state, created_at)
+         VALUES ('a-1', 99, 'sha', 10, 'k', 99, ?, 'live', 1)`,
+      ).run(state);
+    expect(() => withState("done")).toThrow(/CHECK constraint failed/);
+  });
+});

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -203,6 +203,64 @@ describe("migration 0062 — build asset direct upload", () => {
     expect(db.prepare("SELECT COUNT(*) AS n FROM build_asset_ingest_seal").get()).toEqual({ n: 1 });
   });
 
+  it("freezes seal identity against UPDATE while lifecycle columns still move", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
+    db.exec(`
+      INSERT INTO build_asset_ingest_attempt
+        (asset_id, attempt, declared_sha256, declared_size, staging_key,
+         upload_expires_at, state, cleanup_state, created_at)
+      VALUES ('as1', 1, 'sha', 10, 'staging-1', 99, 'verifying', 'live', 1);
+      INSERT INTO build_asset_ingest_seal
+        (asset_id, attempt, lease_generation, final_key, intent_at)
+      VALUES ('as1', 1, 1, 'final-real', 1);
+    `);
+    // "Identity is immutable" was intent, not a rule: SQLite permits UPDATE of a
+    // primary key, so a legitimate seal could be retargeted at a fictitious attempt
+    // and the exact key of a real object lost.
+    for (const set of [
+      "asset_id = 'missing'",
+      "attempt = 99",
+      "lease_generation = 7",
+      "final_key = 'arbitrary'",
+      "intent_at = 2",
+    ]) {
+      expect(() => db.prepare(`UPDATE build_asset_ingest_seal SET ${set}`).run())
+        .toThrow(/identity is immutable/);
+    }
+    // The lifecycle columns must still advance, or the ledger cannot record outcomes.
+    expect(() =>
+      db.prepare(
+        "UPDATE build_asset_ingest_seal SET sealed_at = 5, outcome = 'committed', cleanup_receipt = 'r'",
+      ).run(),
+    ).not.toThrow();
+  });
+
+  it("keeps a tombstoned seal row permanently, while others stay reapable", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
+    db.exec(`
+      INSERT INTO build_asset_ingest_attempt
+        (asset_id, attempt, declared_sha256, declared_size, staging_key,
+         upload_expires_at, state, cleanup_state, created_at)
+      VALUES ('as1', 1, 'sha', 10, 's1', 99, 'failed', 'tombstoned', 1),
+             ('as1', 2, 'sha', 10, 's2', 99, 'failed', 'live', 1);
+      INSERT INTO build_asset_ingest_seal
+        (asset_id, attempt, lease_generation, final_key, intent_at, outcome)
+      VALUES ('as1', 1, 1, 'final-cleaned', 1, 'cleaned'),
+             ('as1', 2, 1, 'final-superseded', 1, 'superseded');
+    `);
+    // A cleaned row records the exact key of a tombstone that is never removed;
+    // deleting it would make a permanent object undiscoverable.
+    expect(() =>
+      db.prepare("DELETE FROM build_asset_ingest_seal WHERE outcome = 'cleaned'").run(),
+    ).toThrow(/permanent/);
+    // Retention may still reap rows that were never tombstoned.
+    expect(() =>
+      db.prepare("DELETE FROM build_asset_ingest_seal WHERE outcome = 'superseded'").run(),
+    ).not.toThrow();
+  });
+
   it("gives each attempt and each lease generation its own row", () => {
     const db = database({ seedBeforeMigration: seedApps });
     insertAsset(db, "as1", { arch: "arm64" });

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -234,6 +234,72 @@ describe("migration 0062 — build asset direct upload", () => {
         "UPDATE build_asset_ingest_seal SET sealed_at = 5, outcome = 'committed', cleanup_receipt = 'r'",
       ).run(),
     ).not.toThrow();
+    // The rule is "identity may not change", not "identity may not be named". A
+    // full-row or retried write that restates the same identity is not a rewrite,
+    // and refusing it would push callers into hand-built column lists.
+    expect(() =>
+      db.prepare(`
+        UPDATE build_asset_ingest_seal
+           SET asset_id = asset_id, attempt = attempt, lease_generation = lease_generation,
+               final_key = final_key, intent_at = intent_at, sealed_at = 6
+      `).run(),
+    ).not.toThrow();
+    expect(
+      db.prepare("SELECT final_key, sealed_at FROM build_asset_ingest_seal").get(),
+    ).toEqual({ final_key: "final-real", sealed_at: 6 });
+  });
+
+  it("cannot escape permanence by moving `outcome` off cleaned and then deleting", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
+    db.exec(`
+      INSERT INTO build_asset_ingest_attempt
+        (asset_id, attempt, declared_sha256, declared_size, staging_key,
+         upload_expires_at, state, cleanup_state, created_at)
+      VALUES ('as1', 1, 'sha', 10, 's1', 99, 'failed', 'tombstoned', 1);
+      INSERT INTO build_asset_ingest_seal
+        (asset_id, attempt, lease_generation, final_key, intent_at, outcome)
+      VALUES ('as1', 1, 1, 'final-cleaned', 1, 'cleaned');
+    `);
+    // Guarding DELETE alone is not permanence: the delete guard reads `outcome`, so
+    // whoever can write `outcome` can unlock the delete in two statements.
+    for (const next of ["'superseded'", "'committed'", "NULL"]) {
+      expect(() =>
+        db.prepare(`UPDATE build_asset_ingest_seal SET outcome = ${next}`).run(),
+      ).toThrow(/cannot leave the cleaned state/);
+    }
+    expect(
+      db.prepare("SELECT outcome FROM build_asset_ingest_seal").pluck().get(),
+    ).toBe("cleaned");
+    // Terminal means no exit, not frozen: a cleanup receipt still lands afterwards,
+    // and restating the same outcome is not a transition.
+    expect(() =>
+      db.prepare(
+        "UPDATE build_asset_ingest_seal SET outcome = 'cleaned', cleanup_receipt = 'r2-tombstone-etag'",
+      ).run(),
+    ).not.toThrow();
+    // And entering cleaned from any other state stays open.
+    db.exec(`
+      INSERT INTO build_asset_ingest_attempt
+        (asset_id, attempt, declared_sha256, declared_size, staging_key,
+         upload_expires_at, state, cleanup_state, created_at)
+      VALUES ('as1', 2, 'sha', 10, 's2', 99, 'failed', 'live', 1);
+      INSERT INTO build_asset_ingest_seal
+        (asset_id, attempt, lease_generation, final_key, intent_at, outcome)
+      VALUES ('as1', 2, 1, 'final-2', 1, 'superseded');
+    `);
+    expect(() =>
+      db.prepare(
+        "UPDATE build_asset_ingest_seal SET outcome = 'cleaned' WHERE attempt = 2",
+      ).run(),
+    ).not.toThrow();
+    // The consequence: after the whole sequence the exact key of every tombstone is
+    // still discoverable, which is the only reason the ledger exists.
+    expect(() => db.prepare("DELETE FROM build_asset_ingest_seal").run())
+      .toThrow(/permanent/);
+    expect(
+      db.prepare("SELECT COUNT(*) FROM build_asset_ingest_seal").pluck().get(),
+    ).toBe(2);
   });
 
   it("keeps a tombstoned seal row permanently, while others stay reapable", () => {

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -63,17 +63,31 @@ function insertAsset(
 }
 
 describe("migration 0062 — build asset direct upload", () => {
-  it("applies over rows that already exist with a non-NULL arch", () => {
-    // Every real database has these. A revision of this migration added a defaulted
-    // column with a CHECK, which fails on exactly them.
-    expect(() =>
-      database({
-        seedBeforeMigration: (db) => {
-          seedApps(db);
-          insertAsset(db, "pre", { arch: "arm64", variant: "release" });
-        },
-      }),
-    ).not.toThrow();
+  it("applies over rows that already exist, and carries every one of them across", () => {
+    // Every real database has rows with a non-NULL arch. A revision of this migration
+    // added a defaulted column with a CHECK, which fails on exactly them.
+    //
+    // Asserting "did not throw" is not enough: build_assets is rebuilt here, and a
+    // rebuild that dropped every row would satisfy that and nothing else.
+    const db = database({
+      seedBeforeMigration: (db) => {
+        seedApps(db);
+        insertAsset(db, "pre-a", { arch: "arm64", variant: "release" });
+        insertAsset(db, "pre-b", { arch: "x86" });
+        insertAsset(db, "pre-c");
+        db.prepare("UPDATE build_assets SET metadata_json = '{\"kept\":1}', download_count = 7").run();
+      },
+    });
+    const rows = db.prepare(
+      `SELECT id, r2_key, file_hash, size_bytes, metadata_json, download_count,
+              slot_arch, slot_variant
+         FROM build_assets ORDER BY id`,
+    ).all();
+    expect(rows).toEqual([
+      { id: "pre-a", r2_key: "k", file_hash: "h", size_bytes: 1, metadata_json: '{"kept":1}', download_count: 7, slot_arch: "arm64", slot_variant: "release" },
+      { id: "pre-b", r2_key: "k", file_hash: "h", size_bytes: 1, metadata_json: '{"kept":1}', download_count: 7, slot_arch: "x86", slot_variant: "-" },
+      { id: "pre-c", r2_key: "k", file_hash: "h", size_bytes: 1, metadata_json: '{"kept":1}', download_count: 7, slot_arch: "-", slot_variant: "-" },
+    ]);
   });
 
   it("leaves existing writers alone: a legacy INSERT with no slot columns still works", () => {

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -63,31 +63,75 @@ function insertAsset(
 }
 
 describe("migration 0062 — build asset direct upload", () => {
-  it("applies over rows that already exist, and carries every one of them across", () => {
-    // Every real database has rows with a non-NULL arch. A revision of this migration
-    // added a defaulted column with a CHECK, which fails on exactly them.
-    //
-    // Asserting "did not throw" is not enough: build_assets is rebuilt here, and a
-    // rebuild that dropped every row would satisfy that and nothing else.
+  it("carries every column, index and foreign key across the rebuild", () => {
+    // build_assets is rebuilt, so "did not throw" proves nothing: a copy that dropped
+    // rows, or mapped a column to the wrong position, would satisfy it. Every one of
+    // the 15 pre-existing columns is seeded with a distinct non-default value so a
+    // mis-mapping cannot hide behind a default.
     const db = database({
       seedBeforeMigration: (db) => {
         seedApps(db);
-        insertAsset(db, "pre-a", { arch: "arm64", variant: "release" });
+        db.prepare(
+          `INSERT INTO signing_credentials
+             (id, owner_type, owner_id, platform, kind, label, encrypted_blob,
+              created_at, updated_at)
+           VALUES ('cred-1', 'app', 'app-a', 'android', 'keystore', 'c', 'x', 1, 1)`,
+        ).run();
+        db.prepare(
+          `INSERT INTO build_assets
+             (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+              size_bytes, signature, signing_credential_id, metadata_json,
+              download_count, created_at, artifact_kind)
+           VALUES ('pre-a', 'build-a', 'harmony', 'arm64', 'release', 'hap',
+                   'r2/key/a', 'sha-a', 4242, 'sig-a', 'cred-1', '{"kept":true}',
+                   77, 1700000001, 'installable')`,
+        ).run();
         insertAsset(db, "pre-b", { arch: "x86" });
-        insertAsset(db, "pre-c");
-        db.prepare("UPDATE build_assets SET metadata_json = '{\"kept\":1}', download_count = 7").run();
       },
     });
-    const rows = db.prepare(
-      `SELECT id, r2_key, file_hash, size_bytes, metadata_json, download_count,
-              slot_arch, slot_variant
-         FROM build_assets ORDER BY id`,
-    ).all();
-    expect(rows).toEqual([
-      { id: "pre-a", r2_key: "k", file_hash: "h", size_bytes: 1, metadata_json: '{"kept":1}', download_count: 7, slot_arch: "arm64", slot_variant: "release" },
-      { id: "pre-b", r2_key: "k", file_hash: "h", size_bytes: 1, metadata_json: '{"kept":1}', download_count: 7, slot_arch: "x86", slot_variant: "-" },
-      { id: "pre-c", r2_key: "k", file_hash: "h", size_bytes: 1, metadata_json: '{"kept":1}', download_count: 7, slot_arch: "-", slot_variant: "-" },
+
+    expect(
+      db.prepare("SELECT * FROM build_assets WHERE id = 'pre-a'").get(),
+    ).toEqual({
+      id: "pre-a", build_id: "build-a", platform: "harmony", arch: "arm64",
+      variant: "release", filetype: "hap", r2_key: "r2/key/a", file_hash: "sha-a",
+      size_bytes: 4242, signature: "sig-a", signing_credential_id: "cred-1",
+      metadata_json: '{"kept":true}', download_count: 77, created_at: 1700000001,
+      artifact_kind: "installable", slot_arch: "arm64", slot_variant: "release",
+    });
+    expect(
+      db.prepare("SELECT COUNT(*) AS n FROM build_assets").get(),
+    ).toEqual({ n: 2 });
+
+    // The indexes and foreign keys the old table carried must still be there.
+    const indexes = db.prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'build_assets'
+         AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+    ).all().map((r) => (r as { name: string }).name);
+    expect(indexes).toContain("idx_build_assets_build");
+    expect(indexes).toContain("idx_build_assets_signing");
+    expect(
+      db.prepare("SELECT \"table\", \"from\" FROM pragma_foreign_key_list('build_assets') ORDER BY \"from\"").all(),
+    ).toEqual([
+      { table: "builds", from: "build_id" },
+      { table: "signing_credentials", from: "signing_credential_id" },
     ]);
+    expect(db.pragma("foreign_key_check")).toEqual([]);
+  });
+
+  it("refuses a seal row that names an attempt which never existed", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
+    // Dropping the FK let the ledger outlive its asset; it also removed the check
+    // that a seal names something real when written. The trigger restores that at
+    // INSERT only.
+    expect(() =>
+      db.prepare(
+        `INSERT INTO build_asset_ingest_seal
+           (asset_id, attempt, lease_generation, final_key, intent_at)
+         VALUES ('no-such-asset', 99, 1, 'final-x', 1)`,
+      ).run(),
+    ).toThrow(/must name an existing attempt/);
   });
 
   it("leaves existing writers alone: a legacy INSERT with no slot columns still works", () => {

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -1,12 +1,15 @@
 /**
  * Migration 0062 — direct upload for release build assets.
  *
- * Asserts against the real migration file, applied over the real prior migrations,
- * so what is proven is the schema production will get rather than a fixture.
+ * Applied over the real prior migrations, and — importantly — over rows that already
+ * exist. An earlier revision of this suite created the database empty and only then
+ * inserted, so a CHECK that fails on pre-existing non-NULL data passed here and would
+ * have failed on every real deployment. `seedBeforeMigration` exists so that fixture
+ * cannot be convenient again.
  *
- * The properties here are the ones the frozen design leans on. Each has a
- * counterexample that was live before this migration, and each fails if the
- * corresponding line of SQL is removed.
+ * The kind-scoping case likewise uses a NON-NULL arch. With NULLs it passed for the
+ * wrong reason: SQLite treats NULLs as distinct, so the old table constraint could
+ * never fire and the test proved nothing about artifact_kind.
  */
 
 import { readdirSync, readFileSync } from "node:fs";
@@ -17,149 +20,180 @@ import { describe, expect, it } from "vitest";
 const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
 const MIGRATION = "0062_build_asset_direct_upload.sql";
 
-function database(includeMigration = true) {
+type Seed = (db: Database.Database) => void;
+
+/** Apply every migration; optionally insert rows *before* 0062 runs. */
+function database(opts: { seedBeforeMigration?: Seed; includeMigration?: boolean } = {}) {
+  const include = opts.includeMigration ?? true;
   const db = new Database(":memory:");
   db.pragma("foreign_keys = ON");
   for (const name of readdirSync(MIGRATION_DIR).sort()) {
     if (!name.endsWith(".sql")) continue;
-    if (name === MIGRATION && !includeMigration) continue;
+    if (name === MIGRATION) {
+      if (!include) continue;
+      opts.seedBeforeMigration?.(db);
+    }
     db.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
   }
-  db.prepare(
-    "INSERT INTO apps (id, slug, name, platform, created_at) VALUES ('app-i', 'app-i', 'Ingest', 'android', 1)",
-  ).run();
-  db.prepare(
-    `INSERT INTO builds (id, app_id, version_name, version_code, created_at, updated_at)
-     VALUES ('build-i', 'app-i', '1.0.0', 1, 1, 1)`,
-  ).run();
+  if (!include) opts.seedBeforeMigration?.(db);
   return db;
 }
 
-/** Insert a build asset in a given slot. Mirrors how production writes the row. */
+function seedApps(db: Database.Database) {
+  db.exec(`
+    INSERT INTO apps (id, slug, name, platform, created_at) VALUES
+      ('app-a', 'app-a', 'A', 'android', 1), ('app-b', 'app-b', 'B', 'android', 1);
+    INSERT INTO builds (id, app_id, version_name, version_code, created_at, updated_at) VALUES
+      ('build-a', 'app-a', '1.0.0', 1, 1, 1), ('build-b', 'app-b', '1.0.0', 1, 1, 1);
+  `);
+}
+
+/** A legacy-shaped INSERT: no slot columns, exactly as existing writers issue it. */
 function insertAsset(
   db: Database.Database,
   id: string,
-  opts: { arch?: string | null; variant?: string | null; kind?: string } = {},
+  o: { build?: string; arch?: string | null; variant?: string | null; kind?: string } = {},
 ) {
-  const arch = opts.arch ?? null;
-  const variant = opts.variant ?? null;
   db.prepare(
     `INSERT INTO build_assets
        (id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
-        artifact_kind, created_at, slot_arch, slot_variant)
-     VALUES (?, 'build-i', 'android', ?, ?, 'apk', 'k', 'h', 1, ?, 1, ?, ?)`,
-  ).run(id, arch, variant, opts.kind ?? "installable", arch ?? "-", variant ?? "-");
+        artifact_kind, created_at)
+     VALUES (?, ?, 'android', ?, ?, 'apk', 'k', 'h', 1, ?, 1)`,
+  ).run(id, o.build ?? "build-a", o.arch ?? null, o.variant ?? null, o.kind ?? "installable");
 }
 
 describe("migration 0062 — build asset direct upload", () => {
-  it("replays the defect: before 0062 the slot index admits duplicate NULL slots", () => {
-    const db = database(false);
-    const insert = (id: string) =>
-      db.prepare(
-        `INSERT INTO build_assets
-           (id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
-            artifact_kind, created_at)
-         VALUES (?, 'build-i', 'android', NULL, NULL, 'apk', 'k', 'h', 1, 'installable', 1)`,
-      ).run(id);
-    insert("dup-1");
-    // The 0010 index looks like one-row-per-slot and never was, for any asset
-    // without arch/variant: SQLite treats NULLs as distinct.
-    expect(() => insert("dup-2")).not.toThrow();
+  it("applies over rows that already exist with a non-NULL arch", () => {
+    // Every real database has these. A revision of this migration added a defaulted
+    // column with a CHECK, which fails on exactly them.
+    expect(() =>
+      database({
+        seedBeforeMigration: (db) => {
+          seedApps(db);
+          insertAsset(db, "pre", { arch: "arm64", variant: "release" });
+        },
+      }),
+    ).not.toThrow();
   });
 
-  it("closes the slot: duplicate slots are rejected once normalized", () => {
-    const db = database();
-    insertAsset(db, "a-1");
-    expect(() => insertAsset(db, "a-2")).toThrow(/UNIQUE constraint failed/);
+  it("leaves existing writers alone: a legacy INSERT with no slot columns still works", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    expect(() => insertAsset(db, "legacy", { arch: "x86", variant: "release" })).not.toThrow();
   });
 
-  it("scopes the slot by artifact_kind so QA and release do not collide", () => {
-    const db = database();
-    insertAsset(db, "rel-1");
-    // Before 0062 this was rejected: the index predated artifact_kind, so a QA
-    // artifact and a release installable fought over one slot.
-    expect(() => insertAsset(db, "qa-1", { kind: "ios-simulator-qa" })).not.toThrow();
+  it("scopes the slot by artifact_kind at a NON-NULL arch", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "rel", { arch: "arm64", variant: "release" });
+    // Rejected before 0062: the 0010 table constraint omitted artifact_kind.
+    expect(() =>
+      insertAsset(db, "qa", { arch: "arm64", variant: "release", kind: "ios-simulator-qa" }),
+    ).not.toThrow();
+  });
+
+  it("rejects a duplicate canonical slot, including when arch and variant are NULL", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "n1");
+    expect(() => insertAsset(db, "n2")).toThrow(/UNIQUE constraint failed/);
+    insertAsset(db, "a1", { arch: "arm64" });
+    expect(() => insertAsset(db, "a2", { arch: "arm64" })).toThrow(/UNIQUE constraint failed/);
   });
 
   it("keeps the sentinel out of the input domain", () => {
-    const db = database();
-    // A literal "-" arch must not be able to occupy the slot that means "no arch",
-    // or two distinct slots silently become one.
+    const db = database({ seedBeforeMigration: seedApps });
+    expect(() => insertAsset(db, "sent", { arch: "-" })).toThrow(/CHECK constraint failed/);
+  });
+
+  it("derives the slot columns so a writer cannot disagree with them", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    // Generated columns: a caller supplying its own slot value — which would let two
+    // rows share a raw slot while appearing distinct — is refused by SQLite itself.
     expect(() =>
       db.prepare(
         `INSERT INTO build_assets
-           (id, build_id, platform, arch, variant, filetype, r2_key, file_hash, size_bytes,
-            artifact_kind, created_at, slot_arch, slot_variant)
-         VALUES ('sentinel', 'build-i', 'android', '-', NULL, 'apk', 'k', 'h', 1,
-                 'installable', 1, '-', '-')`,
+           (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+            size_bytes, artifact_kind, created_at, slot_arch)
+         VALUES ('forced', 'build-a', 'android', 'arm64', NULL, 'apk', 'k', 'h', 1,
+                 'installable', 1, 'x86')`,
       ).run(),
-    ).toThrow(/CHECK constraint failed/);
+    ).toThrow(/generated column/i);
   });
 
-  it("leaves existing builds on the legacy gate rather than backfilling them", () => {
-    const db = database();
+  it("does not backfill existing builds onto the new gate", () => {
+    const db = database({ seedBeforeMigration: seedApps });
     const row = db.prepare(
-      "SELECT asset_ingest_protocol_version AS v, required_asset_slots_json AS s FROM builds WHERE id = 'build-i'",
+      "SELECT asset_ingest_protocol_version AS v, required_asset_slots_json AS s FROM builds WHERE id = 'build-a'",
     ).get() as { v: number | null; s: string | null };
-    // "this build existed" and "this build's assets passed the new verifier" are
-    // different claims; a backfill would forge the second from the first.
     expect(row.v).toBeNull();
     expect(row.s).toBeNull();
   });
 
-  it("gives every attempt and every seal generation its own discoverable row", () => {
-    const db = database();
-    insertAsset(db, "a-1");
+  it("keeps the seal ledger when its asset is deleted", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
+    db.exec(`
+      INSERT INTO build_asset_ingest_attempt
+        (asset_id, attempt, declared_sha256, declared_size, staging_key,
+         upload_expires_at, state, cleanup_state, created_at)
+      VALUES ('as1', 1, 'sha', 10, 'staging-1', 99, 'ready', 'tombstoned', 1);
+      INSERT INTO build_asset_ingest_seal
+        (asset_id, attempt, lease_generation, final_key, intent_at, outcome)
+      VALUES ('as1', 1, 1, 'final-as1-g1', 1, 'cleaned');
+    `);
+    db.prepare("DELETE FROM build_assets WHERE id = 'as1'").run();
+    // A tombstone is permanent, so the row recording its exact key must outlive the
+    // asset. A cascade here would delete the only record of an object that exists.
+    expect(db.prepare("SELECT COUNT(*) AS n FROM build_asset_ingest_seal").get()).toEqual({ n: 1 });
+  });
+
+  it("gives each attempt and each lease generation its own row", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
     const attempt = db.prepare(
       `INSERT INTO build_asset_ingest_attempt
          (asset_id, attempt, declared_sha256, declared_size, staging_key,
           upload_expires_at, state, cleanup_state, created_at)
-       VALUES ('a-1', ?, 'sha', 10, ?, 99, 'pending', 'live', 1)`,
+       VALUES ('as1', ?, 'sha', 10, ?, 99, 'pending', 'live', 1)`,
     );
     attempt.run(1, "staging-1");
     attempt.run(2, "staging-2");
-    expect(() => attempt.run(1, "staging-1-again")).toThrow(/UNIQUE constraint failed/);
-
     const seal = db.prepare(
       `INSERT INTO build_asset_ingest_seal
          (asset_id, attempt, lease_generation, final_key, intent_at)
-       VALUES ('a-1', 1, ?, ?, 1)`,
+       VALUES ('as1', 1, ?, ?, 1)`,
     );
-    seal.run(1, "final-a1-g1");
-    // A second lease generation on the same attempt keeps its own row, so the
-    // object a superseded verifier sealed stays findable by exact key.
-    seal.run(2, "final-a1-g2");
-    expect(() => seal.run(1, "final-a1-g1-again")).toThrow(/UNIQUE constraint failed/);
-    expect(
-      db.prepare("SELECT COUNT(*) AS n FROM build_asset_ingest_seal WHERE asset_id = 'a-1'").get(),
-    ).toEqual({ n: 2 });
+    seal.run(1, "final-g1");
+    seal.run(2, "final-g2");
+    expect(() => seal.run(1, "final-g1-again")).toThrow(/UNIQUE constraint failed/);
   });
 
-  it("scopes replay keys per app and build, and lets one asset hold several", () => {
-    const db = database();
-    insertAsset(db, "a-1");
+  it("refuses a replay key that names a build or asset outside its own scope", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as-a", { build: "build-a", arch: "arm64" });
     const replay = db.prepare(
       `INSERT INTO build_asset_ingest_replay
          (app_id, build_id, idempotency_key, asset_id, request_digest, created_at)
-       VALUES ('app-i', 'build-i', ?, 'a-1', 'digest', 1)`,
+       VALUES (?, ?, ?, ?, 'digest', 1)`,
     );
-    replay.run("key-1");
-    // A CI rerun with a fresh key reuses the asset; a single column could not have
-    // held both keys, which is why this is a table.
-    replay.run("key-2");
-    expect(() => replay.run("key-1")).toThrow(/UNIQUE constraint failed/);
+    replay.run("app-a", "build-a", "key-1", "as-a");
+    // One asset may hold several keys — a CI rerun with a new key reuses it.
+    expect(() => replay.run("app-a", "build-a", "key-2", "as-a")).not.toThrow();
+    expect(() => replay.run("app-a", "build-a", "key-1", "as-a")).toThrow(/UNIQUE constraint/);
+    // Another app's build must not be able to name this app's asset.
+    expect(() => replay.run("app-b", "build-b", "key-x", "as-a")).toThrow(/FOREIGN KEY/);
+    // Nor may a build be claimed under the wrong app.
+    expect(() => replay.run("app-b", "build-a", "key-y", "as-a")).toThrow(/FOREIGN KEY/);
   });
 
-  it("refuses states and cleanup states outside the frozen sets", () => {
-    const db = database();
-    insertAsset(db, "a-1");
-    const withState = (state: string) =>
+  it("refuses states outside the frozen set", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    insertAsset(db, "as1", { arch: "arm64" });
+    expect(() =>
       db.prepare(
         `INSERT INTO build_asset_ingest_attempt
            (asset_id, attempt, declared_sha256, declared_size, staging_key,
             upload_expires_at, state, cleanup_state, created_at)
-         VALUES ('a-1', 99, 'sha', 10, 'k', 99, ?, 'live', 1)`,
-      ).run(state);
-    expect(() => withState("done")).toThrow(/CHECK constraint failed/);
+         VALUES ('as1', 9, 'sha', 10, 'k', 99, 'done', 'live', 1)`,
+      ).run(),
+    ).toThrow(/CHECK constraint failed/);
   });
 });


### PR DESCRIPTION
## Problem

Release build assets upload through a Worker multipart endpoint that reads the whole
file into memory (`worker/src/routes/upload.ts:42,58`). There is no declare/complete
protocol, no upload state, no staging key and no expiry, so a large artifact cannot be
uploaded directly to R2 and an interrupted upload cannot be resumed idempotently.

The table those assets live in also cannot express identity. `UNIQUE (build_id,
platform, arch, variant, filetype)` from migration 0010 is **too loose and too tight
at once**:

- `arch` and `variant` are nullable and SQLite treats NULLs as distinct, so
  `('b1','android',NULL,NULL,'apk')` inserts twice. One-row-per-slot never held for
  any asset without an arch or variant.
- the index predates `artifact_kind` (0020) and omits it, so a QA artifact and a
  release installable in the same shape collide and the second is rejected.

## Changes

Schema only. No route, verifier or reaper reads any of it yet.

- `builds.asset_ingest_protocol_version` — explicit at creation, immutable after,
  NULL meaning legacy. Not inferred from `created_at`: a timestamp is not a
  declaration.
- `builds.required_asset_slots_json` — the set the draft gate will evaluate. Kept
  separate from `required_targets_json`; sharing one column would make a mismatch in
  either contract look like a mismatch in the other.
- **`build_assets` is rebuilt, not altered.** The 0010 `UNIQUE` is a table constraint
  and SQLite cannot drop one in place; leaving it kept rejecting a QA artifact and a
  release installable that share a shape. The rebuild also allows generated columns.
- `slot_arch` / `slot_variant` — **generated**, so a writer cannot supply a slot value
  that disagrees with the column it normalizes, and existing INSERTs need no change.
  The sentinel is kept out of the input domain by a CHECK on `arch`/`variant`
  themselves.
- `idx_build_assets_canonical_slot` — closed and kind-scoped.
- `build_asset_ingest_attempt` — one row per attempt; cleanup finds staging objects
  here by exact key.
- `build_asset_ingest_seal` — one row per `(attempt, lease_generation)`, written
  **before** the R2 create-once write is issued. Identity columns immutable,
  lifecycle columns move by CAS only. **No foreign key:** a tombstone is permanent,
  so the row recording its exact key must outlive the asset. A `BEFORE INSERT`
  trigger keeps the one property the key was providing — a seal must name an attempt
  that exists — without restoring the cascade that would delete it. Three further
  triggers enforce what the design states rather than assuming it, because each
  sentence above was at some point true of the design and false of the schema:
  identity columns cannot be changed to a **different** value by `UPDATE` (SQLite
  permits updating a primary key; restating the same identity is not a change, so
  full-row writes still pass); `cleaned` is terminal, since a permanence rule that
  reads a writable column is only as strong as the write path to it; and a row whose
  outcome is `cleaned` cannot be deleted, because it records the exact key of a
  tombstone that is never removed.
- `build_asset_ingest_replay` — composite references bind `(app_id, build_id)` and
  `(build_id, asset_id)` together, so a key cannot name a build in another app or an
  asset in another build.
Existing rows are not backfilled to `ready`: *this row existed* and *this row passed
the new verifier* are different claims, and only the first is true of them.

## Follow-up

- **Two read-only pre-checks must run before this is applied.** Both failure modes
  are fail-closed at migration time, so these only buy learning without a failed
  deploy. They are separate questions and a single query conflates them:

  ```sql
  -- 1. real duplicate slots -> CREATE UNIQUE INDEX would fail.
  -- Group by raw columns: SQLite groups NULLs together here, unlike a unique index.
  SELECT build_id, artifact_kind, platform, arch, variant, filetype, COUNT(*) n
    FROM build_assets GROUP BY 1,2,3,4,5,6 HAVING n > 1;

  -- 2. rows already holding the sentinel literal -> the UPDATE + CHECK would fail.
  SELECT id, arch, variant FROM build_assets WHERE arch = '-' OR variant = '-';
  ```

  Grouping by `COALESCE(arch,'-')` would be wrong: historical rows are not yet
  covered by the new CHECK, so a literal `-` would merge with NULL and report a
  duplicate that does not exist.
- Routes, verifier, reaper, CLI and the draft-gate switch follow as separate changes,
  so each mutation test names the behaviour it guards.

## Testing

15 tests against the real migration applied over the real prior migrations — and,
where it matters, over rows seeded **before** the migration runs. An earlier revision
built the database empty and inserted afterwards, so a CHECK that fails on
pre-existing non-NULL rows passed here while being guaranteed to fail on any real
database.

The kind-scoping case uses a non-NULL arch for the same reason: with NULLs it passed
for the wrong reason, since NULL-distinctness kept the old table constraint from
firing at all.

Each assertion was checked by removing what makes it true:

| Mutation | Result |
|---|---|
| keep the 0010 `UNIQUE` alongside the new index | 1 red |
| make the slot columns plain instead of generated | 2 red |
| drop the sentinel CHECK on `arch` | 1 red |
| cascade the seal ledger from the asset | 1 red |
| drop the seal parent trigger | 1 red |
| drop the identity-immutability trigger | 1 red |
| drop the tombstone-permanence trigger | 1 red |
| drop the `cleaned`-is-terminal trigger | 1 red (`cleaned → superseded → DELETE`) |
| narrow that trigger to `NEW.outcome = 'superseded'` | 1 red — an enumerated exit list is not terminality |
| revert the identity trigger to firing on the column being named | 1 red (`SET asset_id = asset_id` must pass) |
| widen the identity trigger to every `UPDATE` | 1 red (lifecycle CAS must still work) |
| split the replay composite keys into single-column FKs | 1 red |
| copy zero rows in the rebuild | 1 red |
| map two columns to the wrong positions in the copy | 1 red |
| drop `idx_build_assets_signing` from the rebuild | 1 red |
| drop the `signing_credentials` FK from the rebuild | 1 red |

Full worker suite 380/380.




---

### Round 5 — two review findings closed

**Permanence was guarded on `DELETE` only, and that guard reads `outcome`.** So
anyone who could write `outcome` could leave in two statements — `cleaned →
superseded`, then `DELETE` — taking with them the only record of a permanent
tombstone's exact key. Guarding the exit as well as the door: `cleaned` is now
terminal. Entering it is unchanged, and a `cleanup_receipt` still lands afterwards;
only leaving is refused. The lesson generalises past this row: **a guard whose
predicate reads a mutable column is only as strong as the write path to that
column.**

**The identity trigger fired on the column being named, not on its value changing**,
so `SET asset_id = asset_id` was rejected and any full-row or retried write was
blocked. Narrowed to `NEW IS NOT OLD`, as asked.

exact `0f81bbb81f42a0988d78b955c6e746fabc736a7a` · tree `e9bd017a3bc4574a16beb98554557ccf401b523a` · base `8b15193d` · 15 migration tests · worker suite 380/380

