### PR TITLE
Assert migration 0062's preconditions before it rewrites anything

### DIFF
--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM (
     FROM build_assets
    GROUP BY build_id, artifact_kind, platform,
             COALESCE(arch, '-'), COALESCE(variant, '-'),
-            COALESCE(CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-'),
+            COALESCE('v' || CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-'),
             filetype
   HAVING COUNT(*) > 1
 );
@@ -136,8 +136,13 @@ CREATE TABLE build_assets (
   -- part of the identity whether or not the schema says so. Leaving it out folded
   -- every patch for a build into one slot and would have rejected the second prior
   -- that delta.ts and the CLI both write today.
+  -- Real values carry a prefix so none of them can ever equal the sentinel. arch and
+  -- variant needed a CHECK to keep '-' out of their domain; that is not available
+  -- here, because the value lives inside metadata_json where no column constraint
+  -- reaches it. Making the two ranges disjoint by construction removes the need:
+  -- a patch declaring from_version_code '-' becomes 'v-', not '-'.
   slot_from_version TEXT GENERATED ALWAYS AS (
-    COALESCE(CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-')
+    COALESCE('v' || CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-')
   ) VIRTUAL
 );
 

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -27,6 +27,23 @@
 -- already committed while the INSERT has not, so the table survives the abort; a
 -- second attempt would then die on "table already exists" and report the wrong
 -- problem entirely. A guard that breaks the retry is worse than no guard.
+-- Order matters here too. If an earlier attempt left a renamed table behind, the two
+-- guards below would run against the *empty* replacement, count zero violations and
+-- report green -- a clean bill of health for a database that is already broken. This
+-- one runs first so that state is named instead of measured. It also refuses a plain
+-- re-run after a successful apply, where the retained copy is expected to exist: the
+-- RENAME would fail there anyway, but with "table already exists", which describes
+-- the symptom rather than the situation.
+DROP TABLE IF EXISTS _preflight_0062_prior;
+CREATE TABLE _preflight_0062_prior (
+  prior_attempt INTEGER NOT NULL CONSTRAINT
+    "0062 preflight failed: build_assets_legacy already exists, so this database has either applied 0062 already or been left half way through an earlier attempt. The checks below would read the replacement table and pass on an empty one. Establish which case this is before re-applying."
+    CHECK (prior_attempt = 0)
+);
+INSERT INTO _preflight_0062_prior
+SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'build_assets_legacy';
+DROP TABLE _preflight_0062_prior;
+
 DROP TABLE IF EXISTS _preflight_0062_sentinel;
 CREATE TABLE _preflight_0062_sentinel (
   offending_rows INTEGER NOT NULL CONSTRAINT

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -59,7 +59,7 @@ DROP TABLE _preflight_0062_prior;
 DROP TABLE IF EXISTS _preflight_0062_sentinel;
 CREATE TABLE _preflight_0062_sentinel (
   offending_rows INTEGER NOT NULL CONSTRAINT
-    "0062 preflight failed: build_assets has rows whose arch or variant is the literal '-'. The rebuilt table reserves '-' as the NULL sentinel and rejects it as a value. Resolve those rows, then re-apply: this aborts before the rebuild starts, so build_assets and builds are untouched."
+    "0062 preflight failed: build_assets has rows whose arch or variant is the literal '-'. The rebuilt table reserves '-' as the NULL sentinel and rejects it as a value. Resolve those rows, then re-apply. This check sits ahead of the rebuild, but whether the statements after it ran depends on how your executor treats a failed statement -- read the database state back before retrying rather than assuming nothing happened."
     CHECK (offending_rows = 0)
 );
 INSERT INTO _preflight_0062_sentinel
@@ -77,7 +77,7 @@ DROP TABLE _preflight_0062_sentinel;
 DROP TABLE IF EXISTS _preflight_0062_slot;
 CREATE TABLE _preflight_0062_slot (
   colliding_slots INTEGER NOT NULL CONSTRAINT
-    "0062 preflight failed: build_assets already has two or more rows sharing a canonical slot (build_id, artifact_kind, platform, arch, variant, filetype) once NULL is normalised. The rebuilt table makes that slot unique. Resolve the duplicates, then re-apply: this aborts before the rebuild starts, so build_assets and builds are untouched."
+    "0062 preflight failed: build_assets already has two or more rows sharing a canonical slot (build_id, artifact_kind, platform, arch, variant, filetype) once NULL is normalised. The rebuilt table makes that slot unique. Resolve the duplicates, then re-apply. This check sits ahead of the rebuild, but whether the statements after it ran depends on how your executor treats a failed statement -- read the database state back before retrying rather than assuming nothing happened."
     CHECK (colliding_slots = 0)
 );
 INSERT INTO _preflight_0062_slot
@@ -86,7 +86,10 @@ SELECT COUNT(*) FROM (
     FROM build_assets
    GROUP BY build_id, artifact_kind, platform,
             COALESCE(arch, '-'), COALESCE(variant, '-'),
-            COALESCE('v' || CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-'),
+            COALESCE(
+      CASE WHEN artifact_kind = 'delta-patch'
+           THEN 'v' || CAST(CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) AS TEXT)
+      END, '-'),
             filetype
   HAVING COUNT(*) > 1
 );
@@ -136,13 +139,25 @@ CREATE TABLE build_assets (
   -- part of the identity whether or not the schema says so. Leaving it out folded
   -- every patch for a build into one slot and would have rejected the second prior
   -- that delta.ts and the CLI both write today.
-  -- Real values carry a prefix so none of them can ever equal the sentinel. arch and
-  -- variant needed a CHECK to keep '-' out of their domain; that is not available
-  -- here, because the value lives inside metadata_json where no column constraint
-  -- reaches it. Making the two ranges disjoint by construction removes the need:
-  -- a patch declaring from_version_code '-' becomes 'v-', not '-'.
+  -- Scoped to delta patches, because this describes *their* identity. Applied to
+  -- every kind it stopped being a discriminator and became a bypass: any caller able
+  -- to write metadata_json could add an irrelevant from_version_code and escape the
+  -- canonical constraint entirely.
+  --
+  -- Coerced through INTEGER because that is what the reader does. public_v2.ts
+  -- selects with `CAST(json_extract(...) AS INTEGER) = ?`, so 1 and 1.0 are one prior
+  -- to it; keyed as text they were two slots here, both matched that query, and it
+  -- takes LIMIT 1 — the client's download would have depended on scan order. The
+  -- identity of a row is whatever the query that consumes it treats as identical.
+  --
+  -- Declared values carry a prefix so none can equal the sentinel. arch and variant
+  -- keep '-' out of their domain with a CHECK; no column constraint reaches inside
+  -- metadata_json, so the ranges are made disjoint by construction instead.
   slot_from_version TEXT GENERATED ALWAYS AS (
-    COALESCE('v' || CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-')
+    COALESCE(
+      CASE WHEN artifact_kind = 'delta-patch'
+           THEN 'v' || CAST(CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) AS TEXT)
+      END, '-')
   ) VIRTUAL
 );
 

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -55,7 +55,10 @@ SELECT COUNT(*) FROM build_assets WHERE arch = '-' OR variant = '-';
 DROP TABLE _preflight_0062_sentinel;
 
 -- Ordering matters between the two guards, not just before the DDL. This one
--- normalises with COALESCE because the index it protects normalises the same way,
+-- normalises exactly as the index it protects normalises -- including the delta
+-- discriminator, because a guard that groups more coarsely than its index reports
+-- duplicates that the index would happily accept, and would block a migration over
+-- data that is entirely correct. It must mirror the expression, not approximate it.
 -- so a literal '-' and a NULL genuinely would collide there. That also means this
 -- query cannot distinguish them -- which is safe only because the guard above has
 -- already established there are no literal '-' rows left to confuse it.
@@ -70,7 +73,9 @@ SELECT COUNT(*) FROM (
   SELECT 1
     FROM build_assets
    GROUP BY build_id, artifact_kind, platform,
-            COALESCE(arch, '-'), COALESCE(variant, '-'), filetype
+            COALESCE(arch, '-'), COALESCE(variant, '-'),
+            COALESCE(CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-'),
+            filetype
   HAVING COUNT(*) > 1
 );
 DROP TABLE _preflight_0062_slot;
@@ -112,7 +117,16 @@ CREATE TABLE build_assets (
   -- Generated, not caller-supplied: a writer cannot set a slot value that disagrees
   -- with the column it normalizes, and existing INSERTs need no change.
   slot_arch    TEXT GENERATED ALWAYS AS (COALESCE(arch, '-')) VIRTUAL,
-  slot_variant TEXT GENERATED ALWAYS AS (COALESCE(variant, '-')) VIRTUAL
+  slot_variant TEXT GENERATED ALWAYS AS (COALESCE(variant, '-')) VIRTUAL,
+  -- A delta patch is identified by which prior version it patches from. That lives in
+  -- metadata_json, and the public download path selects on it
+  -- (public_v2.ts, `json_extract(metadata_json, '$.from_version_code')`), so it is
+  -- part of the identity whether or not the schema says so. Leaving it out folded
+  -- every patch for a build into one slot and would have rejected the second prior
+  -- that delta.ts and the CLI both write today.
+  slot_from_version TEXT GENERATED ALWAYS AS (
+    COALESCE(CAST(json_extract(metadata_json, '$.from_version_code') AS TEXT), '-')
+  ) VIRTUAL
 );
 
 INSERT INTO build_assets (
@@ -153,7 +167,8 @@ CREATE INDEX idx_build_assets_signing
 -- Canonical slot: closed (no NULLs) and kind-scoped. Fails closed if duplicates
 -- already exist; the old index permitted them for its whole life.
 CREATE UNIQUE INDEX idx_build_assets_canonical_slot
-  ON build_assets(build_id, artifact_kind, platform, slot_arch, slot_variant, filetype);
+  ON build_assets(build_id, artifact_kind, platform, slot_arch, slot_variant,
+                  slot_from_version, filetype);
 
 -- Lets the replay ledger reference (build_id, asset_id) as a pair.
 CREATE UNIQUE INDEX idx_build_assets_build_scope ON build_assets(build_id, id);

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -13,12 +13,24 @@
 -- rows that collide once the slot is normalised, which the new UNIQUE index forbids.
 -- Both are legal under today's schema, so neither can be assumed absent.
 --
--- Placement is the whole point. `wrangler d1 migrations apply --remote` posts this
--- file to D1 as one `/query` string, and wrangler documents rollback only for the
--- separate `--file` import path -- so whether a failure half way down leaves a
--- renamed old table beside an empty new one is not something this file should have
--- to know. Asserting first makes the question moot: a violation aborts before the
--- RENAME, and the database is untouched either way.
+-- `wrangler d1 migrations apply --remote` posts this file to D1 as one `/query`
+-- string, and wrangler documents rollback only for the separate `--file` import
+-- path. What a failure half way down leaves behind therefore depends on how the
+-- executor treats a failed statement, which is not documented on this path.
+--
+-- What placing the checks first does and does not buy, stated exactly, because an
+-- earlier version of this comment claimed more than it delivers:
+--
+--   executor stops at the first error   the checks abort before the RENAME and
+--                                       nothing here has run
+--   executor rolls the batch back       the same, by a different route
+--   executor continues past errors      the checks abort nothing. The rebuild runs
+--                                       and leaves an empty replacement -- measured,
+--                                       not supposed
+--
+-- So this is a probability reduction, not a guarantee. The guarantee is further
+-- down and independent of all three: build_assets_legacy is not dropped, so the
+-- rows survive whichever executor we turn out to have.
 --
 -- A bare RAISE() is trigger-only in SQLite, so the abort is a named CHECK; SQLite
 -- puts the constraint name in the error, which is what the operator will read.
@@ -150,9 +162,15 @@ FROM build_assets_legacy;
 -- unrecoverable; keeping it makes the worst outcome an empty table beside an intact
 -- copy of its rows.
 --
--- A follow-up migration drops it, once a rebuild has been observed to succeed against
--- production data. That is the point at which "it worked" is evidence rather than
--- expectation.
+-- Keeping it is not free: it is a full copy of the table including signature,
+-- signing_credential_id, r2_key and metadata_json, maintained by nothing and tracked
+-- by no later migration. The reason to keep it expires the moment the rebuild is
+-- known to have worked against production data, and what is left after that is only
+-- the copy's own risk.
+--
+-- So the removal is owned rather than hoped for: task #115, which drops it once the
+-- first production apply has succeeded and its readback is green, and which asserts
+-- the rebuilt table is no smaller before deleting the only copy.
 --
 -- Its indexes came with it through the RENAME and still hold the names the new table
 -- needs, so they are dropped by name here. Dropping an index costs nothing that

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -5,6 +5,60 @@
 -- QA artifact and a release installable that share a shape, which is exactly what
 -- artifact_kind scoping is meant to allow.
 
+-- ---------------------------------------------------------------------------
+-- Preflight. Runs before anything destructive, on purpose.
+--
+-- Two properties of the existing data can make the rebuild below fail: a row whose
+-- arch or variant is already the literal '-', which the new CHECK forbids, and two
+-- rows that collide once the slot is normalised, which the new UNIQUE index forbids.
+-- Both are legal under today's schema, so neither can be assumed absent.
+--
+-- Placement is the whole point. `wrangler d1 migrations apply --remote` posts this
+-- file to D1 as one `/query` string, and wrangler documents rollback only for the
+-- separate `--file` import path -- so whether a failure half way down leaves a
+-- renamed old table beside an empty new one is not something this file should have
+-- to know. Asserting first makes the question moot: a violation aborts before the
+-- RENAME, and the database is untouched either way.
+--
+-- A bare RAISE() is trigger-only in SQLite, so the abort is a named CHECK; SQLite
+-- puts the constraint name in the error, which is what the operator will read.
+--
+-- Each guard drops its own scratch table first. When a guard fires, its CREATE has
+-- already committed while the INSERT has not, so the table survives the abort; a
+-- second attempt would then die on "table already exists" and report the wrong
+-- problem entirely. A guard that breaks the retry is worse than no guard.
+DROP TABLE IF EXISTS _preflight_0062_sentinel;
+CREATE TABLE _preflight_0062_sentinel (
+  offending_rows INTEGER NOT NULL CONSTRAINT
+    "0062 preflight failed: build_assets has rows whose arch or variant is the literal '-'. The rebuilt table reserves '-' as the NULL sentinel and rejects it as a value. Resolve those rows, then re-apply: this aborts before the rebuild starts, so build_assets and builds are untouched."
+    CHECK (offending_rows = 0)
+);
+INSERT INTO _preflight_0062_sentinel
+SELECT COUNT(*) FROM build_assets WHERE arch = '-' OR variant = '-';
+DROP TABLE _preflight_0062_sentinel;
+
+-- Ordering matters between the two guards, not just before the DDL. This one
+-- normalises with COALESCE because the index it protects normalises the same way,
+-- so a literal '-' and a NULL genuinely would collide there. That also means this
+-- query cannot distinguish them -- which is safe only because the guard above has
+-- already established there are no literal '-' rows left to confuse it.
+DROP TABLE IF EXISTS _preflight_0062_slot;
+CREATE TABLE _preflight_0062_slot (
+  colliding_slots INTEGER NOT NULL CONSTRAINT
+    "0062 preflight failed: build_assets already has two or more rows sharing a canonical slot (build_id, artifact_kind, platform, arch, variant, filetype) once NULL is normalised. The rebuilt table makes that slot unique. Resolve the duplicates, then re-apply: this aborts before the rebuild starts, so build_assets and builds are untouched."
+    CHECK (colliding_slots = 0)
+);
+INSERT INTO _preflight_0062_slot
+SELECT COUNT(*) FROM (
+  SELECT 1
+    FROM build_assets
+   GROUP BY build_id, artifact_kind, platform,
+            COALESCE(arch, '-'), COALESCE(variant, '-'), filetype
+  HAVING COUNT(*) > 1
+);
+DROP TABLE _preflight_0062_slot;
+-- ---------------------------------------------------------------------------
+
 -- Per-build protocol selection: explicit at creation, immutable after, NULL = legacy.
 -- Not inferred from created_at, because a timestamp is not a declaration.
 ALTER TABLE builds ADD COLUMN asset_ingest_protocol_version INTEGER;

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -168,9 +168,11 @@ FROM build_assets_legacy;
 -- known to have worked against production data, and what is left after that is only
 -- the copy's own risk.
 --
--- So the removal is owned rather than hoped for: task #115, which drops it once the
--- first production apply has succeeded and its readback is green, and which asserts
--- the rebuilt table is no smaller before deleting the only copy.
+-- So the removal is owned rather than hoped for: task #114, which drops it once the
+-- first production apply has succeeded and its readback is green. Deleting it is
+-- itself irreversible, so its owner gates execution on a separate authorisation and
+-- on a retained export taken first -- the export being both the way back and the only
+-- thing that could later verify the deletion value by value.
 --
 -- Its indexes came with it through the RENAME and still hold the names the new table
 -- needs, so they are dropped by name here. Dropping an index costs nothing that

--- a/migrations/sql/0062_build_asset_direct_upload.sql
+++ b/migrations/sql/0062_build_asset_direct_upload.sql
@@ -109,7 +109,25 @@ SELECT
   artifact_kind
 FROM build_assets_legacy;
 
-DROP TABLE build_assets_legacy;
+-- build_assets_legacy is deliberately NOT dropped here.
+--
+-- The preflight above reduces the chance of the copy failing; this reduces what it
+-- costs if it fails anyway. Both are needed because they cover different things, and
+-- this one holds in a case the preflight does not: if D1 executes the rest of a batch
+-- after a statement fails, the assertion aborts nothing and the rebuild proceeds
+-- regardless. Dropping the original in the same breath would make that case
+-- unrecoverable; keeping it makes the worst outcome an empty table beside an intact
+-- copy of its rows.
+--
+-- A follow-up migration drops it, once a rebuild has been observed to succeed against
+-- production data. That is the point at which "it worked" is evidence rather than
+-- expectation.
+--
+-- Its indexes came with it through the RENAME and still hold the names the new table
+-- needs, so they are dropped by name here. Dropping an index costs nothing that
+-- matters for recovery: the rows are what has to survive, and they do.
+DROP INDEX idx_build_assets_build;
+DROP INDEX idx_build_assets_signing;
 
 CREATE INDEX idx_build_assets_build ON build_assets(build_id);
 CREATE INDEX idx_build_assets_signing

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -182,6 +182,37 @@ describe("migration 0062 — build asset direct upload", () => {
     expect(db.prepare("SELECT COUNT(*) FROM build_assets").pluck().get()).toBe(2);
   });
 
+  it("keeps the discriminator's sentinel out of reach of any declared value", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    const patch = (id: string, metadata: string) =>
+      db
+        .prepare(
+          `INSERT INTO build_assets
+             (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+              size_bytes, artifact_kind, metadata_json, created_at)
+           VALUES (?, 'build-a', 'android', 'arm64', NULL, 'patch', ?, 'h', 1,
+                   'delta-patch', ?, 1)`,
+        )
+        .run(id, id, metadata);
+
+    // arch and variant keep '-' out of their domain with a CHECK. No column
+    // constraint reaches inside metadata_json, so instead the two ranges are made
+    // disjoint: a declared value is always prefixed and the sentinel never is. The
+    // first version of this column coalesced to a bare '-' and a patch declaring '-'
+    // collided with an asset that has no discriminator at all.
+    expect(() => patch("none", "{}")).not.toThrow();
+    expect(() => patch("dash", JSON.stringify({ from_version_code: "-" }))).not.toThrow();
+    expect(
+      db.prepare("SELECT slot_from_version FROM build_assets ORDER BY id").pluck().all(),
+    ).toEqual(["v-", "-"]);
+
+    // The same prior written as a number and as a string is one prior, so one slot.
+    expect(() => patch("n", JSON.stringify({ from_version_code: 7 }))).not.toThrow();
+    expect(() => patch("s", JSON.stringify({ from_version_code: "7" }))).toThrow(
+      /UNIQUE constraint failed/,
+    );
+  });
+
   it("does not let the discriminator loosen assets that have none", () => {
     const db = database({ seedBeforeMigration: seedApps });
     // Everything except a delta patch lacks from_version_code, normalises to the same

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -468,6 +468,41 @@ describe("migration 0062 — preflight", () => {
     expect(tables(db)).toContain("build_asset_ingest_seal");
   });
 
+  it("keeps the original rows recoverable after a successful rebuild", () => {
+    const db = database({
+      seedBeforeMigration: (d) => {
+        seedApps(d);
+        insertAsset(d, "as1", { arch: "arm64" });
+        insertAsset(d, "as2", { arch: "x86_64" });
+      },
+    });
+    // The preflight lowers the chance of the copy failing; this lowers the cost when
+    // it fails anyway. If D1 runs the rest of a batch after a statement fails, the
+    // assertion stops nothing — and dropping the source table in the same breath
+    // would turn a recoverable outage into a permanent loss.
+    expect(tables(db)).toContain("build_assets_legacy");
+    // "Recoverable" is a claim about content, not about a table still being listed:
+    // every column of every row must still be readable from the retained copy.
+    const columns = (t: string) =>
+      (db.pragma(`table_info(${t})`) as { name: string }[]).map((c) => c.name);
+    const carried = columns("build_assets_legacy");
+    expect(carried).toHaveLength(15);
+    expect(columns("build_assets")).toEqual(expect.arrayContaining(carried));
+    const list = carried.join(", ");
+    expect(db.prepare(`SELECT ${list} FROM build_assets_legacy ORDER BY id`).all()).toEqual(
+      db.prepare(`SELECT ${list} FROM build_assets ORDER BY id`).all(),
+    );
+    // The index names the rebuild reuses must have ended up on the new table; they
+    // travelled with the old one through the RENAME and were dropped by name.
+    const owner = (i: string) =>
+      db
+        .prepare("SELECT tbl_name FROM sqlite_master WHERE type = 'index' AND name = ?")
+        .pluck()
+        .get(i);
+    expect(owner("idx_build_assets_build")).toBe("build_assets");
+    expect(owner("idx_build_assets_signing")).toBe("build_assets");
+  });
+
   it("leaves no scratch table behind on a clean apply", () => {
     const { db, error } = attempt((d) => {
       seedApps(d);

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -454,6 +454,25 @@ describe("migration 0062 — preflight", () => {
     expect(db.prepare("SELECT COUNT(*) FROM build_assets_legacy").pluck().get()).toBe(1);
   });
 
+  it("names the half-applied state even when the data checks also have something to say", () => {
+    const { error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: "arm64" });
+      d.exec(`
+        ALTER TABLE build_assets RENAME TO build_assets_legacy;
+        CREATE TABLE build_assets (id TEXT PRIMARY KEY, build_id TEXT, platform TEXT,
+          arch TEXT, variant TEXT, filetype TEXT, artifact_kind TEXT);
+        INSERT INTO build_assets VALUES ('as2', 'build-a', 'android', '-', NULL, 'apk', 'installable');
+      `);
+    });
+    // Here both the prior-attempt guard and the sentinel guard have something to say,
+    // so the order decides which problem the operator is told about. "Resolve those
+    // rows" is a true statement and the wrong instruction: they are a consequence of a
+    // migration that stopped half way, and fixing them would not address that.
+    expect(error?.message).toMatch(/build_assets_legacy already exists/);
+    expect(error?.message).not.toMatch(/literal '-'/);
+  });
+
   it("refuses to start when a row already holds the literal '-' sentinel", () => {
     const { db, error } = attempt((d) => {
       seedApps(d);

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -434,6 +434,26 @@ describe("migration 0062 — preflight", () => {
     expect(hasColumn(db, "builds", "asset_ingest_protocol_version")).toBe(false);
   }
 
+  it("refuses to start on a half-applied database, where the checks would read empty", () => {
+    const { db, error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: "-" });
+      // Exactly the wreckage the other guards cannot see: the rename happened, the
+      // replacement is empty, and the offending row is now out of their reach. Both
+      // would count zero and pass, certifying a database that is already broken.
+      d.exec(`
+        ALTER TABLE build_assets RENAME TO build_assets_legacy;
+        CREATE TABLE build_assets (id TEXT PRIMARY KEY, build_id TEXT, platform TEXT,
+          arch TEXT, variant TEXT, filetype TEXT, artifact_kind TEXT);
+      `);
+    });
+    expect(error?.message).toMatch(/0062 preflight failed: build_assets_legacy already exists/);
+    // Not "table build_assets_legacy already exists" from the RENAME further down,
+    // which reports the symptom and leaves the operator to work out the situation.
+    expect(error?.message).not.toMatch(/^table build_assets_legacy already exists/);
+    expect(db.prepare("SELECT COUNT(*) FROM build_assets_legacy").pluck().get()).toBe(1);
+  });
+
   it("refuses to start when a row already holds the literal '-' sentinel", () => {
     const { db, error } = attempt((d) => {
       seedApps(d);

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -470,6 +470,77 @@ describe("migration 0062 — preflight", () => {
     expect(hasColumn(db, "builds", "asset_ingest_protocol_version")).toBe(false);
   }
 
+  /**
+   * Split into statements, keeping trigger bodies whole — `BEGIN ... END;` contains
+   * semicolons that do not end a statement.
+   */
+  function statements(sql: string) {
+    const out: string[] = [];
+    let buf = "";
+    let depth = 0;
+    for (const line of sql.split("\n")) {
+      if (/\bBEGIN\b/.test(line) && !/^\s*--/.test(line)) depth += 1;
+      buf += line + "\n";
+      if (/^\s*END;/.test(line)) depth -= 1;
+      if (depth === 0 && /;\s*$/.test(line) && !/^\s*--/.test(line)) {
+        if (buf.trim()) out.push(buf);
+        buf = "";
+      }
+    }
+    if (buf.trim()) out.push(buf);
+    return out;
+  }
+
+  /** An executor that carries on after a failed statement, which D1 may or may not be. */
+  function applyIgnoringErrors(db: Database.Database, sql: string) {
+    const errors: string[] = [];
+    for (const stmt of statements(sql)) {
+      try {
+        db.exec(stmt);
+      } catch (e) {
+        errors.push((e as Error).message);
+      }
+    }
+    return errors;
+  }
+
+  it("does not stop a continuing executor — the retained copy is what saves the data", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    for (const name of readdirSync(MIGRATION_DIR).sort()) {
+      if (!name.endsWith(".sql") || name === MIGRATION) continue;
+      db.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+    }
+    seedApps(db);
+    insertAsset(db, "as1", { arch: "-" });
+
+    const errors = applyIgnoringErrors(db, readFileSync(`${MIGRATION_DIR}${MIGRATION}`, "utf8"));
+
+    // The guard fired and was ignored. Claiming the preflight makes the executor
+    // question moot was wrong, and this is the case that makes it wrong: the rebuild
+    // ran anyway and the replacement is empty.
+    expect(errors.join("\n")).toMatch(/0062 preflight failed/);
+    const names = tables(db);
+    expect(names).toContain("build_assets_legacy");
+    expect(db.prepare("SELECT COUNT(*) FROM build_assets").pluck().get()).toBe(0);
+
+    // And this is what holds regardless of which executor we have. The row is still
+    // readable, so the outcome is an outage someone can undo rather than a deletion.
+    expect(db.prepare("SELECT COUNT(*) FROM build_assets_legacy").pluck().get()).toBe(1);
+    expect(db.prepare("SELECT arch FROM build_assets_legacy").pluck().get()).toBe("-");
+  });
+
+  it("stops a stop-at-first-error executor before anything is renamed", () => {
+    // The other half of the same question, kept next to it so neither reads as the
+    // general case. better-sqlite3's exec stops at the first error.
+    const { db, error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: "-" });
+    });
+    expect(error?.message).toMatch(/0062 preflight failed/);
+    expect(tables(db)).not.toContain("build_assets_legacy");
+  });
+
   it("refuses to start on a half-applied database, where the checks would read empty", () => {
     const { db, error } = attempt((d) => {
       seedApps(d);

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -379,3 +379,101 @@ describe("migration 0062 — build asset direct upload", () => {
     ).toThrow(/CHECK constraint failed/);
   });
 });
+
+
+/**
+ * The preflight guards.
+ *
+ * `wrangler d1 migrations apply --remote` posts this file to D1 as a single `/query`
+ * string, and wrangler documents rollback only for the separate `--file` import path.
+ * Rather than depend on an atomicity guarantee nobody here can read back, 0062 asserts
+ * its preconditions before the first destructive statement.
+ *
+ * `db.exec` matches the pessimistic reading — it stops at the first error and does not
+ * wrap the batch in a transaction — so whatever ran before the abort really is left
+ * behind here. That is the point: these tests assert what survives, not what threw.
+ */
+describe("migration 0062 — preflight", () => {
+  /** Prior migrations, then a seed, then 0062 — returning the database either way. */
+  function attempt(seed: Seed) {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    for (const name of readdirSync(MIGRATION_DIR).sort()) {
+      if (!name.endsWith(".sql")) continue;
+      if (name === MIGRATION) break;
+      db.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+    }
+    seed(db);
+    let error: Error | null = null;
+    try {
+      db.exec(readFileSync(`${MIGRATION_DIR}${MIGRATION}`, "utf8"));
+    } catch (e) {
+      error = e as Error;
+    }
+    return { db, error };
+  }
+
+  const tables = (db: Database.Database) =>
+    db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .pluck()
+      .all() as string[];
+
+  const hasColumn = (db: Database.Database, table: string, column: string) =>
+    (db.pragma(`table_info(${table})`) as { name: string }[]).some((c) => c.name === column);
+
+  /** The consequence both guards exist for: the rebuild never started. */
+  function expectUntouched(db: Database.Database, rows: number) {
+    const names = tables(db);
+    expect(names).toContain("build_assets");
+    expect(names).not.toContain("build_assets_legacy");
+    expect(names.filter((n) => n.includes("ingest"))).toEqual([]);
+    expect(db.prepare("SELECT COUNT(*) FROM build_assets").pluck().get()).toBe(rows);
+    // The first statements of 0062 proper are `ALTER TABLE builds`; if the guards sit
+    // where they belong, even those have not run.
+    expect(hasColumn(db, "builds", "asset_ingest_protocol_version")).toBe(false);
+  }
+
+  it("refuses to start when a row already holds the literal '-' sentinel", () => {
+    const { db, error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: "-" });
+    });
+    expect(error?.message).toMatch(/0062 preflight failed: .*literal '-'/);
+    expectUntouched(db, 1);
+  });
+
+  it("refuses to start when two rows already share a normalised slot", () => {
+    const { db, error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: null });
+      insertAsset(d, "as2", { arch: null });
+    });
+    expect(error?.message).toMatch(/0062 preflight failed: .*canonical slot/);
+    expectUntouched(db, 2);
+  });
+
+  it("still applies once the offending data is resolved", () => {
+    const { db, error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: "-" });
+    });
+    expect(error).not.toBeNull();
+    // A guard that fires leaves its scratch table behind — its CREATE committed, its
+    // INSERT did not. If the retry did not drop it first, the second attempt would die
+    // on "table already exists" and report a problem the operator does not have.
+    expect(tables(db).some((n) => n.startsWith("_preflight_0062"))).toBe(true);
+    db.prepare("UPDATE build_assets SET arch = NULL").run();
+    expect(() => db.exec(readFileSync(`${MIGRATION_DIR}${MIGRATION}`, "utf8"))).not.toThrow();
+    expect(tables(db)).toContain("build_asset_ingest_seal");
+  });
+
+  it("leaves no scratch table behind on a clean apply", () => {
+    const { db, error } = attempt((d) => {
+      seedApps(d);
+      insertAsset(d, "as1", { arch: "arm64" });
+    });
+    expect(error).toBeNull();
+    expect(tables(db).filter((n) => n.startsWith("_preflight"))).toEqual([]);
+  });
+});

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -98,6 +98,9 @@ describe("migration 0062 — build asset direct upload", () => {
       size_bytes: 4242, signature: "sig-a", signing_credential_id: "cred-1",
       metadata_json: '{"kept":true}', download_count: 77, created_at: 1700000001,
       artifact_kind: "installable", slot_arch: "arm64", slot_variant: "release",
+      // No from_version_code in metadata, so the delta discriminator normalises to
+      // the sentinel and this row's slot is unchanged by its introduction.
+      slot_from_version: "-",
     });
     expect(
       db.prepare("SELECT COUNT(*) AS n FROM build_assets").get(),
@@ -154,6 +157,39 @@ describe("migration 0062 — build asset direct upload", () => {
     expect(() => insertAsset(db, "n2")).toThrow(/UNIQUE constraint failed/);
     insertAsset(db, "a1", { arch: "arm64" });
     expect(() => insertAsset(db, "a2", { arch: "arm64" })).toThrow(/UNIQUE constraint failed/);
+  });
+
+  it("gives each delta patch its own slot, keyed by the prior it patches from", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    const patch = (id: string, from: number | null) =>
+      db
+        .prepare(
+          `INSERT INTO build_assets
+             (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+              size_bytes, artifact_kind, metadata_json, created_at)
+           VALUES (?, 'build-a', 'android', 'arm64', NULL, 'patch', ?, 'h', 1,
+                   'delta-patch', ?, 1)`,
+        )
+        .run(id, id, from === null ? "{}" : JSON.stringify({ from_version_code: from }));
+
+    // delta.ts and the CLI both write one patch per prior version, and the public
+    // download path selects on from_version_code. It is part of the identity whether
+    // or not the schema says so; a slot that omits it folds every patch for a build
+    // into one and rejects the second prior.
+    expect(() => patch("d1", 1)).not.toThrow();
+    expect(() => patch("d2", 2)).not.toThrow();
+    expect(() => patch("d3", 2)).toThrow(/UNIQUE constraint failed/);
+    expect(db.prepare("SELECT COUNT(*) FROM build_assets").pluck().get()).toBe(2);
+  });
+
+  it("does not let the discriminator loosen assets that have none", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    // Everything except a delta patch lacks from_version_code, normalises to the same
+    // sentinel, and must stay as constrained as it was.
+    insertAsset(db, "i1", { arch: "arm64", kind: "app-icon" });
+    expect(() => insertAsset(db, "i2", { arch: "arm64", kind: "app-icon" })).toThrow(
+      /UNIQUE constraint failed/,
+    );
   });
 
   it("keeps the sentinel out of the input domain", () => {
@@ -480,6 +516,25 @@ describe("migration 0062 — preflight", () => {
     });
     expect(error?.message).toMatch(/0062 preflight failed: .*literal '-'/);
     expectUntouched(db, 1);
+  });
+
+  it("does not block a migration over legitimate multi-prior delta patches", () => {
+    const { error } = attempt((d) => {
+      seedApps(d);
+      for (const [id, from] of [["d1", 1], ["d2", 2]] as const) {
+        d.prepare(
+          `INSERT INTO build_assets
+             (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+              size_bytes, artifact_kind, metadata_json, created_at)
+           VALUES (?, 'build-a', 'android', 'arm64', NULL, 'patch', ?, 'h', 1,
+                   'delta-patch', ?, 1)`,
+        ).run(id, id, JSON.stringify({ from_version_code: from }));
+      }
+    });
+    // A guard that groups more coarsely than the index it protects reports duplicates
+    // the index would accept, and refuses to migrate a database that is entirely
+    // correct. Mirroring the expression is the requirement; approximating it is not.
+    expect(error).toBeNull();
   });
 
   it("refuses to start when two rows already share a normalised slot", () => {

--- a/worker/test/build_asset_direct_upload_migration.test.ts
+++ b/worker/test/build_asset_direct_upload_migration.test.ts
@@ -182,6 +182,41 @@ describe("migration 0062 — build asset direct upload", () => {
     expect(db.prepare("SELECT COUNT(*) FROM build_assets").pluck().get()).toBe(2);
   });
 
+  it("agrees with the reader about which values are the same prior", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    const patch = (id: string, from: unknown) =>
+      db
+        .prepare(
+          `INSERT INTO build_assets
+             (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+              size_bytes, artifact_kind, metadata_json, created_at)
+           VALUES (?, 'build-a', 'android', 'arm64', NULL, 'patch', ?, 'h', 1,
+                   'delta-patch', ?, 1)`,
+        )
+        .run(id, id, JSON.stringify({ from_version_code: from }));
+
+    expect(() => patch("p1", 1)).not.toThrow();
+    // public_v2.ts matches with CAST(... AS INTEGER), so these are the same prior to
+    // the reader. Keyed as text they were two rows, its query matched both, and it
+    // takes LIMIT 1 — which patch a client received would have depended on scan order.
+    expect(() => patch("p1_0", 1.0)).toThrow(/UNIQUE constraint failed/);
+    expect(() => patch("p1_str", "1")).toThrow(/UNIQUE constraint failed/);
+    expect(() => patch("p2", 2)).not.toThrow();
+
+    // The reader's own query, run verbatim: exactly one row can answer for prior 1.
+    const forPrior = (v: number) =>
+      db
+        .prepare(
+          `SELECT id FROM build_assets
+            WHERE artifact_kind = 'delta-patch'
+              AND CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) = ?`,
+        )
+        .pluck()
+        .all(v);
+    expect(forPrior(1)).toEqual(["p1"]);
+    expect(forPrior(2)).toEqual(["p2"]);
+  });
+
   it("keeps the discriminator's sentinel out of reach of any declared value", () => {
     const db = database({ seedBeforeMigration: seedApps });
     const patch = (id: string, metadata: string) =>
@@ -202,13 +237,37 @@ describe("migration 0062 — build asset direct upload", () => {
     // collided with an asset that has no discriminator at all.
     expect(() => patch("none", "{}")).not.toThrow();
     expect(() => patch("dash", JSON.stringify({ from_version_code: "-" }))).not.toThrow();
+    // '-' coerces to 0 like any non-numeric text, and the prefix keeps it clear of
+    // the sentinel either way. The reader coerces identically, so it agrees.
     expect(
       db.prepare("SELECT slot_from_version FROM build_assets ORDER BY id").pluck().all(),
-    ).toEqual(["v-", "-"]);
+    ).toEqual(["v0", "-"]);
 
     // The same prior written as a number and as a string is one prior, so one slot.
     expect(() => patch("n", JSON.stringify({ from_version_code: 7 }))).not.toThrow();
     expect(() => patch("s", JSON.stringify({ from_version_code: "7" }))).toThrow(
+      /UNIQUE constraint failed/,
+    );
+  });
+
+  it("does not let a non-delta asset buy a new slot with an irrelevant metadata key", () => {
+    const db = database({ seedBeforeMigration: seedApps });
+    const put = (id: string, metadata: string) =>
+      db
+        .prepare(
+          `INSERT INTO build_assets
+             (id, build_id, platform, arch, variant, filetype, r2_key, file_hash,
+              size_bytes, artifact_kind, metadata_json, created_at)
+           VALUES (?, 'build-a', 'android', 'arm64', 'release', 'apk', ?, 'h', 1,
+                   'installable', ?, 1)`,
+        )
+        .run(id, id, metadata);
+    // Every slot column identical, non-NULL throughout, differing only by a key that
+    // has no meaning for this kind. Scoped to every kind, the discriminator turned
+    // into an escape hatch: anyone able to write metadata_json could dodge the
+    // canonical constraint by adding a field.
+    expect(() => put("a", "{}")).not.toThrow();
+    expect(() => put("b", JSON.stringify({ from_version_code: 1 }))).toThrow(
       /UNIQUE constraint failed/,
     );
   });
@@ -551,6 +610,11 @@ describe("migration 0062 — preflight", () => {
     // question moot was wrong, and this is the case that makes it wrong: the rebuild
     // ran anyway and the replacement is empty.
     expect(errors.join("\n")).toMatch(/0062 preflight failed/);
+    // The constraint name IS the operator-facing message, and this is the executor
+    // under which it is read. An earlier revision told them build_assets and builds
+    // were untouched; at that exact moment the rebuild was continuing behind the
+    // error. What the message says has to survive the case that produces it.
+    expect(errors.join("\n")).not.toMatch(/untouched|nothing has been changed|no changes were made/i);
     const names = tables(db);
     expect(names).toContain("build_assets_legacy");
     expect(db.prepare("SELECT COUNT(*) FROM build_assets").pluck().get()).toBe(0);


### PR DESCRIPTION
## Problem

`0062` rebuilds `build_assets`: it renames the old table aside, creates the replacement with a `CHECK` and a `UNIQUE` index the old one did not have, copies the rows across, and drops the original. Two properties of data that is legal under today's schema make that copy fail:

- a row whose `arch` or `variant` is already the literal `-`, which the replacement reserves as the NULL sentinel and rejects as a value;
- two rows that collide once the slot is normalised, which the replacement's unique index forbids.

Neither can be assumed absent, because nothing has ever prevented them.

What turns that from a failed migration into an incident is how the migration reaches the database. `wrangler d1 migrations apply --remote` reads the file, appends its bookkeeping `INSERT`, and posts the whole thing to D1 as a single `/query` string. Wrangler 4.105.0 — the version this repository's lockfile pins, and the one the deploy job installs with `--frozen-lockfile` — prints a rollback guarantee — *"if the execution fails to complete, your DB will return to its original state"* — only on the separate `--file` import path. Its absence here is not proof of anything, but it does mean the safety of a mid-file failure is a property we would be assuming rather than reading back. If the batch is not atomic, a violation lands after the rename and leaves a renamed old table beside an empty new one.

## Changes

Assert three preconditions at the top of `0062`, before the first `ALTER`.

The first is that no `build_assets_legacy` already exists. It runs ahead of the other two because on a database left half way through an earlier attempt they would read the empty replacement, count zero violations and report green — a clean bill of health for a database that is already broken. Where the replacement does hold something they object to, both have a case, and whichever runs first is what the operator is told; "resolve those rows" is true and useless when the rows are a consequence of a migration that stopped part way.

This is deliberately not a census. A census is a snapshot, and rows can change between reading it and applying the migration; the guard is evaluated inside the same batch as the statements it protects, so there is no window.

Two details worth naming:

- **`RAISE()` is trigger-only in SQLite**, so each guard is a `CREATE TABLE` with a named `CHECK` and an `INSERT` of the offending count. SQLite puts the constraint name in the error, so the name *is* the operator-facing message, including what to do next.
- **The scratch tables are ordinary tables, not `TEMP` ones.** D1 refuses `CREATE TEMP TABLE` outright (`not authorized: SQLITE_AUTH`), so the obvious shape for a throwaway assertion is unavailable.
- **Each guard drops its scratch table first.** When a guard fires its `CREATE` has committed and its `INSERT` has not, so the table survives the abort. Without the drop, the retry would die on `table already exists` and report a problem the operator does not have.

## Testing

Asserting what survives rather than what threw — `db.exec` stops at the first error without wrapping the batch in a transaction, which is the pessimistic reading of how D1 might behave:

- a pre-existing `-` row aborts, and `build_assets` still exists unrenamed with its rows, no `build_assets_legacy`, no ingest tables, and `builds` has not even gained its new columns;
- a pre-existing normalised-slot collision aborts the same way;
- after the offending data is resolved, a second attempt applies cleanly over the scratch table the first attempt left behind;
- a half-applied database is refused by name rather than by the `RENAME` failing later with `table already exists`, and is still refused when the data checks also have something to say;
- a clean apply leaves no scratch table;
- two delta patches from different priors both store, and a second patch for the same prior does not — including when that prior is written `1` in one row and `1.0` or `"1"` in another, checked against the reader's own query, which can then match exactly one row;
- a non-delta asset with every slot column identical and non-NULL cannot buy a second slot by carrying a `from_version_code` it has no use for — rejected by the current schema and by the previous one, so nothing was loosened;
- the preflight does not block a database holding legitimate multi-prior patches;
- **both executor behaviours are tested**: a stop-at-first-error executor is halted before the `RENAME`, and a continuing executor is not — the latter asserts the empty replacement and the intact retained copy, so a stop-only fixture cannot stand in for unknown semantics;
- after a successful rebuild the retained copy still holds every column of every row, equal to the rebuilt table, and both reused index names belong to the new table rather than the old one.

| mutation | result |
| --- | --- |
| move both guards below the rename | 3 red |
| drop the sentinel guard | 2 red |
| drop the slot-collision guard | 1 red |
| remove the retry-safety `DROP TABLE IF EXISTS` | 1 red |
| restore `DROP TABLE build_assets_legacy` | 1 red |
| drop the prior-attempt guard | 1 red |
| move the prior-attempt guard below the data checks | 1 red — ordering decides which problem is reported |
| drop `slot_from_version` from the unique index | 2 red — multi-prior patches, and the preflight then blocking them |
| apply the discriminator to every kind, not just `delta-patch` | 1 red — a non-delta asset buys a second slot with an irrelevant metadata key |
| key the discriminator as `TEXT` instead of coercing to `INTEGER` | 1 red — `1` and `1.0` stop colliding while the reader still treats them as one prior |
| coarsen the preflight to every kind, leaving the column correct | 1 red |
| revert the preflight to `TEXT`, leaving the column correct | 1 red |
| restore the `untouched` wording in the operator-facing `CHECK` names | 1 red — under a continuing executor that message is read while the rebuild proceeds |

Full worker suite 395/395.

### Keeping the source table

The preflight lowers the probability of a failed copy. Not dropping `build_assets_legacy` lowers the cost of one, and it holds in a case the preflight does not.

Asserting before the destructive statements only helps if a failed statement actually prevents the ones after it. That is a separate property from atomicity, and wrangler documents neither on this path.

Stated exactly, because an earlier revision of this description claimed more than it delivers:

| executor behaviour | what the preflight achieves |
| --- | --- |
| stops at the first error | aborts before the `RENAME`; nothing has run |
| rolls the batch back | the same, by another route |
| continues past errors | **nothing.** The rebuild proceeds and leaves an empty replacement |

The third row is measured, not hypothesised — run with an executor that continues, the guard fires, is ignored, and the rebuild completes over an empty table. Measured separately against a throw-away D1 on wrangler 4.105.0, that case does not arise; but that is a version-scoped observation rather than a contract.

So the preflight reduces the probability of a bad apply. **The guarantee is the retained source table**, which holds under all three behaviours: the worst outcome is an empty table beside an intact copy of its rows rather than a table that is gone.

The old indexes travelled with the table through the `RENAME` and still hold the names the rebuild needs, so they are dropped by name.

Retaining it is not free. `build_assets_legacy` is a full copy including `signature`, `signing_credential_id`, `r2_key` and `metadata_json`, maintained by nothing and tracked by no later migration, and the reason to keep it expires as soon as the rebuild is known to have worked. Its removal is therefore owned rather than hoped for: **task #114**, owned by the deploy lane, drops it once the first production apply has succeeded and its readback is green. Deleting it is itself irreversible, so its owner gates execution on a separate authorisation and on a retained export taken beforehand — the export being both the way back and the only thing that could afterwards verify the deletion value by value.

### The canonical slot has to match who actually writes

A delta patch is identified by the prior version it patches from. `delta.ts` and the CLI both write one patch per prior, and the public download path selects on `json_extract(metadata_json, '$.from_version_code')`. The slot as first specified omitted it, folding every patch for a build into one: two patches store on the current schema and the second is rejected under the first version of this migration.

That is a defect in the design rather than the migration — the slot was specified without enumerating who writes to `build_assets`. A generated column carries the discriminator into the constrained identity, with two limits that are the point rather than details:

**It applies to `delta-patch` and nothing else.** Applied to every artifact kind it stopped being a discriminator and became a bypass: any caller able to write `metadata_json` could add an irrelevant `from_version_code` and escape the canonical constraint. Every other kind normalises to the sentinel regardless of what its metadata contains, so it stays exactly as constrained as before — asserted, or the change would be a quiet loosening.

**It coerces through `CAST(... AS INTEGER)`, because that is what the reader does.** `public_v2.ts` selects patches with `CAST(json_extract(metadata_json, '$.from_version_code') AS INTEGER) = ?`, so `1` and `1.0` are one prior to it. Keyed as text they were two slots here; its query matched both rows and takes `LIMIT 1`, which means the patch a client downloaded would have depended on scan order. A row's identity is whatever the query consuming it treats as identical.

The preflight had to follow. Grouping more coarsely than the index it protects reports duplicates the index would accept, and would have refused to migrate a database whose multi-prior patches are entirely correct.

## Follow-up

- Drop `build_assets_legacy` in a later migration, after a successful production rebuild.
- Rollback behaviour was measured at wrangler `4.105.0`, per-migration-file granularity. The declared range is `^4.88.0`, so a lockfile bump silently invalidates it and nobody is notified.




