### PR TITLE
Run the worker test suite on pull requests

### DIFF
--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -18,6 +18,17 @@ on:
       - "migrations/**"
       - "packages/**"
       - ".github/workflows/worker-tests.yml"
+      # The root files this job actually reads, enumerated rather than guessed:
+      # pnpm/action-setup takes packageManager from the root package.json; the pnpm
+      # cache and `install --frozen-lockfile` read the lockfile, the workspace file
+      # and that same package.json; worker/tsconfig.json extends tsconfig.base.json.
+      # There is no root .npmrc, .nvmrc, .node-version, .pnpmfile.cjs or patches/, so
+      # the set is closed at these. A lockfile-only CVE bump and a strict-mode flip in
+      # tsconfig.base.json are both real changes that would otherwise skip this job.
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "tsconfig*.json"
   # No paths filter here, deliberately. Two lists are two things to keep in step, and
   # the first was already out of step: this file itself was missing from the push
   # list, so a change to the workflow could merge without main ever running it. The

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -51,9 +51,13 @@ jobs:
         working-directory: worker
         run: pnpm test
 
-      # The suite covers migrations against the real chain, so a migration that cannot
-      # be applied twice, or that disagrees with the schema the files describe, fails
-      # here rather than during a production deploy.
-      - name: Type-check
-        working-directory: worker
-        run: pnpm build
+      # The type-check is deliberately not run here. `tsc` needs
+      # worker-configuration.d.ts, which `wrangler types` generates from the rendered
+      # production config, and that renderer validates its inputs against the real
+      # checked-in route -- it refuses placeholder values by design. Making it accept
+      # them to satisfy CI would weaken a production guard to buy a convenience, so
+      # the type-check stays where the real config exists: the deploy workflow runs it
+      # before every deploy.
+      #
+      # Naming the gap rather than leaving it implied: a type error can still reach
+      # main and will surface at deploy time.

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -1,0 +1,59 @@
+name: Worker tests
+
+# Nothing ran the worker test suite. Every test result quoted in a review was a
+# number someone produced locally, and a local run is evidence about whatever tree it
+# happened to be sitting on — which is not necessarily the commit under review. That
+# is not hypothetical: a migration fix was destroyed by a `git checkout --` during a
+# mutation run, the following commit captured only its test, and the suite result
+# reported against that commit had been produced minutes earlier from a working tree
+# that no longer existed. A reviewer caught it by reading the Git object.
+#
+# A run here is bound to the commit by construction, so nobody has to be trusted about
+# which tree they were on, and nobody has to remember to check.
+
+on:
+  pull_request:
+    paths:
+      - "worker/**"
+      - "migrations/**"
+      - "packages/**"
+      - ".github/workflows/worker-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "worker/**"
+      - "migrations/**"
+      - "packages/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: worker-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run the worker test suite
+        working-directory: worker
+        run: pnpm test
+
+      # The suite covers migrations against the real chain, so a migration that cannot
+      # be applied twice, or that disagrees with the schema the files describe, fails
+      # here rather than during a production deploy.
+      - name: Type-check
+        working-directory: worker
+        run: pnpm build

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -18,12 +18,14 @@ on:
       - "migrations/**"
       - "packages/**"
       - ".github/workflows/worker-tests.yml"
+  # No paths filter here, deliberately. Two lists are two things to keep in step, and
+  # the first was already out of step: this file itself was missing from the push
+  # list, so a change to the workflow could merge without main ever running it. The
+  # distinction a paths filter encodes — which changes are worth testing — is not one
+  # the property here cares about, which is only that the tree on main was tested.
+  # Pushes to main are essentially merges, so the extra runs are few and cheap.
   push:
     branches: [main]
-    paths:
-      - "worker/**"
-      - "migrations/**"
-      - "packages/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

No workflow runs the worker test suite — not on pull requests, not on `main`, not anywhere. `grep -l "vitest\|pnpm test" .github/workflows/*` returns nothing.

So every test result quoted in a review is a number someone produced on their own machine. A local run is evidence about whatever tree it happened to be sitting on, which is not necessarily the commit under review, and a reviewer has no way to tell the difference.

That is not a theoretical gap; it was reached today. During a mutation run on PR #420, `git checkout --` restored a file whose fix was still uncommitted, destroying it. The commit that followed captured only the test. The suite result reported against that commit had been produced minutes earlier, from a working tree that no longer existed. It was caught because a reviewer read the migration out of the Git object rather than trusting the number.

## Changes

Run `pnpm test` and the type-check on pull requests touching `worker/`, `migrations/` or `packages/`, and on pushes to `main`.

A run here is bound to the commit by construction. Nobody has to be trusted about which tree they were on, and nobody has to remember to check — which matters more than it sounds, because this class of mistake does not present as "I forgot to run the tests". It presents as "I ran them and they passed".

## Testing

Checked out the defective commit into a worktree and ran the suite against it:

```
× migration 0062 — keeps the discriminator's sentinel out of reach of any declared value
  Tests  1 failed | 27 passed (28)
```

So this workflow would have failed that commit automatically, on the exact test whose expectation the missing fix violated. On the corrected commit the same suite is 393/393.

## Notes

The suite covers migrations against the real 0001→N chain, so a migration that cannot apply over existing rows, or that disagrees with the schema its files describe, fails here rather than during a production deploy. That is the same property PR #421 asserts against the live database after an apply; this is the cheaper half, before merge.

This does not make the mutation-testing discipline unnecessary — a mutation still has to be run by a person deciding what to break. It removes the part that was being taken on trust: which tree the resulting number came from.
