### PR TITLE
Ask at dispatch who is watching a pending migration

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -165,8 +165,14 @@ jobs:
             echo "to ship something unrelated - you are not being asked to take it on." >&2
             echo "" >&2
             echo "Either find the owner of the pending migration and have them dispatch," >&2
-            echo "or re-dispatch saying an owner is standing by. Nothing has been" >&2
-            echo "applied and nothing has been deployed." >&2
+            echo "or re-dispatch saying an owner is standing by." >&2
+            echo "" >&2
+            echo "No migration has been applied and no Worker has been deployed." >&2
+            echo "Scoped deliberately: the bootstrap step runs before this one and" >&2
+            echo "creates the R2 bucket when it is missing, so a stopped dispatch is" >&2
+            echo "not the same as one that never happened. This is the sentence you" >&2
+            echo "are reading to work out what state you are in, so it claims only" >&2
+            echo "what this gate actually guarantees." >&2
             exit 1
           fi
 

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -17,6 +17,14 @@ on:
         required: true
         type: boolean
         default: true
+      pending_migration_readback:
+        description: "If D1 migrations are pending, they WILL be applied to production by this deploy. Who is watching that?"
+        required: true
+        type: choice
+        options:
+          - "no owner - stop before applying anything"
+          - "an owner is standing by for the readback"
+        default: "no owner - stop before applying anything"
 
 permissions:
   contents: read
@@ -118,6 +126,51 @@ jobs:
           if ! pnpm exec wrangler r2 bucket info "${HANDS_R2_BUCKET_NAME}" >/dev/null 2>&1; then
             pnpm exec wrangler r2 bucket create "${HANDS_R2_BUCKET_NAME}"
           fi
+
+      # A deploy applies whatever migrations are pending, whatever the deploy was for.
+      # Somebody dispatching this to ship an admin asset has no reason to know that,
+      # and nothing in the process tells them: the obligation to watch the first apply
+      # of a migration rides on an action they started for another purpose. Until the
+      # automated readback exists, the dispatch form is the only surface that travels
+      # with the action, so the question is asked there.
+      #
+      # This stays quiet when nothing is pending, which is almost every deploy. It only
+      # speaks up in the case it is about, and it stops before the apply rather than
+      # after it.
+      - name: Check who is watching a pending migration
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+          READBACK_OWNER: ${{ inputs.pending_migration_readback }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pending=$(pnpm exec wrangler d1 migrations list "${HANDS_D1_DATABASE_NAME}" \
+            --remote --config wrangler.hands.generated.jsonc 2>&1 || true)
+
+          if grep -qi "no migrations to apply" <<<"$pending"; then
+            echo "No migrations pending; this deploy changes no schema."
+            exit 0
+          fi
+
+          echo "Migrations pending, and this deploy will apply them to production:"
+          echo "$pending"
+
+          if [[ "${READBACK_OWNER}" != "an owner is standing by for the readback" ]]; then
+            echo "" >&2
+            echo "Stopping before the apply." >&2
+            echo "" >&2
+            echo "This deploy would change the production database, and the dispatch" >&2
+            echo "said nobody is watching. That is the right answer when you came here" >&2
+            echo "to ship something unrelated - you are not being asked to take it on." >&2
+            echo "" >&2
+            echo "Either find the owner of the pending migration and have them dispatch," >&2
+            echo "or re-dispatch saying an owner is standing by. Nothing has been" >&2
+            echo "applied and nothing has been deployed." >&2
+            exit 1
+          fi
+
+          echo "Readback owner acknowledged at dispatch; continuing."
 
       - name: Apply Hands D1 migrations
         working-directory: worker

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -18,13 +18,16 @@ on:
         type: boolean
         default: true
       pending_migration_readback:
-        description: "If D1 migrations are pending, they WILL be applied to production by this deploy. Who is watching that?"
+        # A checkbox saying "someone is watching" is self-certifying: anyone can tick
+        # it and nobody can tell afterwards whether they did. Asking for the id of the
+        # owner's reply makes the same claim checkable — the readback can look it up,
+        # confirm who wrote it and confirm it predates the dispatch. It does not stop
+        # a fabricated id, but that is a traceable false statement rather than a
+        # careless click.
+        description: "If D1 migrations are pending they WILL be applied to production. Paste the message id of the owner's 'I am present' reply in #proj-hands:3308eb65, or leave as none."
         required: true
-        type: choice
-        options:
-          - "no owner - stop before applying anything"
-          - "an owner is standing by for the readback"
-        default: "no owner - stop before applying anything"
+        type: string
+        default: "none"
 
 permissions:
   contents: read
@@ -156,7 +159,11 @@ jobs:
           echo "Migrations pending, and this deploy will apply them to production:"
           echo "$pending"
 
-          if [[ "${READBACK_OWNER}" != "an owner is standing by for the readback" ]]; then
+          # Shape only: an 8-character short id or a full UUID. Whether it is really
+          # the owner's reply is for the readback to check against Raft, which this
+          # runner cannot reach — so the gate refuses what is obviously not an id and
+          # prints what it was given, rather than pretending to have verified it.
+          if [[ ! "${READBACK_OWNER}" =~ ^[0-9a-fA-F]{8}(-[0-9a-fA-F-]{27,})?$ ]]; then
             echo "" >&2
             echo "Stopping before the apply." >&2
             echo "" >&2
@@ -164,8 +171,11 @@ jobs:
             echo "said nobody is watching. That is the right answer when you came here" >&2
             echo "to ship something unrelated - you are not being asked to take it on." >&2
             echo "" >&2
-            echo "Either find the owner of the pending migration and have them dispatch," >&2
-            echo "or re-dispatch saying an owner is standing by." >&2
+            echo "Got: '${READBACK_OWNER}'" >&2
+            echo "" >&2
+            echo "Ask the migration's owner in #proj-hands:3308eb65 and wait for their" >&2
+            echo "reply, then re-dispatch with that reply's message id. Their answer is" >&2
+            echo "the handshake - naming them is not." >&2
             echo "" >&2
             echo "No migration has been applied and no Worker has been deployed." >&2
             echo "Scoped deliberately: the bootstrap step runs before this one and" >&2
@@ -176,7 +186,9 @@ jobs:
             exit 1
           fi
 
-          echo "Readback owner acknowledged at dispatch; continuing."
+          echo "Handshake reference given at dispatch: ${READBACK_OWNER}"
+          echo "The readback owner verifies this id exists, is their own reply, and"
+          echo "predates this run. This step has only checked that it is id-shaped." 
 
       - name: Apply Hands D1 migrations
         working-directory: worker

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -209,12 +209,13 @@ jobs:
         working-directory: worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+          ROLLOUT: ${{ inputs.containers_rollout }}
         shell: bash
         run: |
           set -euo pipefail
           pnpm exec wrangler deploy \
             --config wrangler.hands.generated.jsonc \
-            --containers-rollout "${{ inputs.containers_rollout }}"
+            --containers-rollout "${ROLLOUT}"
 
       - name: Configure Hands Worker secrets
         working-directory: worker
@@ -282,6 +283,8 @@ jobs:
 
       - name: Summary
         shell: bash
+        env:
+          ROLLOUT: ${{ inputs.containers_rollout }}
         run: |
           {
             echo "### Hands server deploy"
@@ -290,5 +293,5 @@ jobs:
             echo "|---|---|"
             echo "| Ref | \`${GITHUB_REF_NAME}\` |"
             echo "| SHA | \`${GITHUB_SHA}\` |"
-            echo "| Containers rollout | \`${{ inputs.containers_rollout }}\` |"
+            echo "| Containers rollout | \`${ROLLOUT}\` |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

This workflow applies whatever D1 migrations are pending, and that step has no condition on it. Somebody dispatching a deploy to ship an admin asset changes the production database as a side effect, and nothing in the process tells them so.

That matters right now because `0062` is merged and unapplied, so the next dispatch — for any reason, by anyone — applies it.

The shape of the obligation is the real problem. A hold says *don't dispatch*: a null action, satisfied by doing nothing, and missing it takes a deliberate mistake. What replaced it says *if you dispatch, have someone check the result*: a positive duty riding on an action somebody else started for an unrelated purpose. Missing that requires only not knowing, and not knowing is the default state.

## Changes

Ask at dispatch, because until the automated readback exists the dispatch form is the only surface that travels with the action. It is what the person pressing the button necessarily reads.

A required input asks who is watching, defaulting to "no owner". Before the apply step, if migrations are pending and the answer is still "no owner", the run stops — before anything is applied and before the Worker is deployed.

It stays silent when nothing is pending, which is nearly every deploy, so it speaks only in the case it is about. And "no owner" is the correct answer for someone who came to ship something unrelated; the message says so, and tells them to find the migration's owner rather than adopt the duty themselves.

## Testing

Both answers against both states, with the wrangler call stubbed:

| pending | answer | result |
| --- | --- | --- |
| nothing | no owner | proceeds |
| nothing | owner standing by | proceeds |
| `0063` | no owner | **stops before the apply** |
| `0063` | owner standing by | proceeds |

Step order asserted from the parsed workflow: the check precedes `Apply Hands D1 migrations`, which precedes `Deploy Hands Worker and admin assets`.

One note on the testing itself: the first run of this harness reported that a deploy with nothing pending would be blocked. That was the harness, not the workflow — the YAML parser re-indents a block scalar, so the string substitution stubbing the wrangler call silently matched nothing and the script fell through to its failure path. The substitution now asserts it applied.

## Scope

This is a question at dispatch time, not a readback. It does not check that a migration worked; PR #421 does that, by asserting the database state between apply and deploy. This is the smaller thing that can exist before then.

Sentinel, who raised it, also asked not to be counted as the person watching: his patrol enumerates deploy runs daily, so a first apply is found within about 17 hours. That is detection, not supervision.
