### PR TITLE
ci: one-shot bootstrap publish for pi-coding-agent (Raft 779)

### DIFF
--- a/.github/workflows/bootstrap-pi-coding-agent.yml
+++ b/.github/workflows/bootstrap-pi-coding-agent.yml
@@ -1,0 +1,60 @@
+name: bootstrap-pi-coding-agent
+
+# One-shot bootstrap for @botiverse/pi-coding-agent@0.83.0-botiverse.0 (Raft #779).
+# Uses existing repo NPM_TOKEN; remove this workflow after successful publish.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run only"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mirror package
+        uses: actions/checkout@v4
+        with:
+          repository: botiverse/pi-coding-agent
+          ref: main
+          path: pi-coding-agent
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify package identity
+        working-directory: pi-coding-agent
+        run: |
+          node -e '
+            const p = require("./package.json");
+            if (p.name !== "@botiverse/pi-coding-agent") throw new Error("bad name " + p.name);
+            if (p.version !== "0.83.0-botiverse.0") throw new Error("bad version " + p.version);
+            console.log("ok", p.name, p.version);
+          '
+          test -f dist/core/extensions/loader.js
+          grep -q isNodeSeaBinary dist/core/extensions/loader.js
+          grep -q useVirtualModulesForExtensions dist/core/extensions/loader.js
+          echo "SEA loader markers present"
+
+      - name: Publish
+        working-directory: pi-coding-agent
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN secret missing" >&2
+            exit 1
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm publish --access public --tag botiverse --dry-run
+          else
+            npm publish --access public --tag botiverse
+          fi


### PR DESCRIPTION
Temporary workflow_dispatch to publish botiverse/pi-coding-agent 0.83.0-botiverse.0 via this repo NPM_TOKEN. Delete after success.