### PR TITLE
Forbid GitHub expression interpolation inside run blocks, and clear the six that exist

### DIFF
--- a/.github/lint-fixtures/check-workflows.py
+++ b/.github/lint-fixtures/check-workflows.py
@@ -34,15 +34,33 @@ INTERPOLATION = "${" + "{"
 
 
 def interpolations_in_run_blocks(path):
-    """Lines inside a `run: |` block that interpolate. Block ends at the first
-    non-blank line indented no further than the `run:` key itself."""
+    """Interpolations in shell that a `run:` will execute, in any of its forms.
+
+    Covering only `run: |` would have missed the majority of this repository: it holds
+    70 single-line `run:` statements and no block ones. None of them interpolate today,
+    so a block-only checker would have reported the tree clean and been right by
+    accident — it could not have detected the case it was written to prevent.
+
+    Handled: `run: |`, `run: >`, and `run: <command>` on one line, each with or
+    without the `- ` list-item prefix — which is how every step in this repository
+    actually writes it, and which an earlier version of this function did not match.
+    """
     found, in_run, indent = [], False, 0
     for lineno, line in enumerate(open(path, encoding="utf-8"), 1):
         line = line.rstrip("\n")
-        opener = re.match(r"^(\s*)run: \|", line)
-        if opener:
-            in_run, indent = True, len(opener.group(1))
+
+        block = re.match(r"^(\s*)(?:-\s+)?run: [|>]", line)
+        if block:
+            in_run, indent = True, len(block.group(1))
             continue
+
+        inline = re.match(r"^(\s*)(?:-\s+)?run: (?!\s*$)(.*)$", line)
+        if inline and not block:
+            in_run = False
+            if INTERPOLATION in inline.group(2):
+                found.append((lineno, line.strip()))
+            continue
+
         if in_run and line.strip():
             if len(line) - len(line.lstrip()) <= indent:
                 in_run = False

--- a/.github/lint-fixtures/check-workflows.py
+++ b/.github/lint-fixtures/check-workflows.py
@@ -19,7 +19,15 @@ workflow.
 import re
 import sys
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError:
+    # Exit 2, not 1. Without this the import error becomes a non-zero exit that the
+    # caller reads as "defects found", sending someone to look for a duplicate key
+    # that does not exist - and the usual response to a red that cannot be reproduced
+    # is to relax the check. Could-not-run is a third outcome and has to name itself.
+    print("CANNOT RUN: PyYAML is not installed; no file was checked.", file=sys.stderr)
+    raise SystemExit(2)
 
 # Assembled rather than written, so this file does not match its own rule.
 INTERPOLATION = "${" + "{"

--- a/.github/lint-fixtures/check-workflows.py
+++ b/.github/lint-fixtures/check-workflows.py
@@ -12,13 +12,21 @@ The interpolation check walks the *parsed* document rather than the lines. "|", 
 "|-", ">+" and a plain one-line scalar are serialisation details that vanish at parse
 time: each becomes the same string under a step's "run" key. Scanning lines meant
 enumerating those spellings, and the first version enumerated them wrong - it matched
-only "run: |", covering 43 of the 70 run steps in .github/workflows (61%) and never
-looking at the other 27, while reporting the tree clean.
+only "run: |", covering 41 of the 67 run steps under .github/workflows on
+origin/main@e238fba (61%) and never looking at the other 26, while reporting the tree
+clean.
 
-(Measured by counting steps whose parsed value has a "run" key, against lines its
-opener regex matched. An earlier version of this note claimed the old checker examined
-nothing at all; that was wrong, and wrong in the direction that made the rewrite look
-more necessary than it was. 61% coverage reported as a clean bill is reason enough.)
+(Counted as steps whose parsed value carries a "run" key, against the lines the old
+opener regex matched, on that ref. The ref matters: on this branch the figure is 43 of
+70, the extra three being this file's own workflow, and three people reported three
+numbers before anyone said which tree they were counting. Two earlier versions of this
+note were also wrong about the size - one claimed nothing at all was examined, another
+put coverage near 38% - and both erred in the direction that made the rewrite look more
+necessary. 61% reported as a clean bill is reason enough.
+
+On this ref, incidentally, line-scanning and parsing see exactly the same 67 steps: the
+case for parsing is that the spellings it handles need no enumerating, not that this
+repository currently contains one it would otherwise miss.)
 
 Parsing does not make that enumeration more complete; it removes it.
 

--- a/.github/lint-fixtures/check-workflows.py
+++ b/.github/lint-fixtures/check-workflows.py
@@ -1,72 +1,37 @@
 #!/usr/bin/env python3
-"""Two checks over workflow files, plus the ability to be run against a file that
-should fail them.
+"""Checks over workflow files, and the means to run them against a file that should
+fail them.
 
-  check-workflows.py <file>...        report defects, exit 1 if any
+  check-workflows.py <file>...   exit 0 clean, 1 defects, 2 could-not-run
 
-Both defects are silent by nature, which is why they are worth a check at all:
+Three exits, not two: a tool that could not run must not be mistaken for one that
+found nothing. That happened four times in a day here - a probe refused by D1, an
+absent PyYAML twice, and an injection that never modified its target.
 
-  interpolation in a run block  the value is spliced in as program text before the
-                                shell parses the line, so it is code rather than data
-  duplicate mapping key         YAML keeps the last and discards the first without
-                                complaint, so an added `env:` can delete the one
-                                already there
+The interpolation check walks the *parsed* document rather than the lines. "|", ">",
+"|-", ">+" and a plain one-line scalar are serialisation details that vanish at parse
+time: each becomes the same string under a step's "run" key. Scanning lines meant
+enumerating those spellings, and the first version enumerated them wrong - it matched
+only "run: |" while this repository holds 70 single-line "run:" steps and no block
+ones, so it called the tree clean without having examined one statement. Parsing does
+not make that enumeration more complete; it removes it.
 
-Kept outside .github/workflows/ so GitHub never treats the fixture beside it as a
-workflow.
+Kept outside .github/workflows/ so GitHub never parses the fixture beside it.
 """
 
-import re
 import sys
 
 try:
     import yaml
 except ModuleNotFoundError:
-    # Exit 2, not 1. Without this the import error becomes a non-zero exit that the
-    # caller reads as "defects found", sending someone to look for a duplicate key
-    # that does not exist - and the usual response to a red that cannot be reproduced
-    # is to relax the check. Could-not-run is a third outcome and has to name itself.
+    # Exit 2, not 1. Otherwise the import error is a non-zero exit the caller reads as
+    # "defects found", sending someone after a duplicate key that does not exist - and
+    # the usual answer to a red nobody can reproduce is to relax the check.
     print("CANNOT RUN: PyYAML is not installed; no file was checked.", file=sys.stderr)
     raise SystemExit(2)
 
 # Assembled rather than written, so this file does not match its own rule.
 INTERPOLATION = "${" + "{"
-
-
-def interpolations_in_run_blocks(path):
-    """Interpolations in shell that a `run:` will execute, in any of its forms.
-
-    Covering only `run: |` would have missed the majority of this repository: it holds
-    70 single-line `run:` statements and no block ones. None of them interpolate today,
-    so a block-only checker would have reported the tree clean and been right by
-    accident — it could not have detected the case it was written to prevent.
-
-    Handled: `run: |`, `run: >`, and `run: <command>` on one line, each with or
-    without the `- ` list-item prefix — which is how every step in this repository
-    actually writes it, and which an earlier version of this function did not match.
-    """
-    found, in_run, indent = [], False, 0
-    for lineno, line in enumerate(open(path, encoding="utf-8"), 1):
-        line = line.rstrip("\n")
-
-        block = re.match(r"^(\s*)(?:-\s+)?run: [|>]", line)
-        if block:
-            in_run, indent = True, len(block.group(1))
-            continue
-
-        inline = re.match(r"^(\s*)(?:-\s+)?run: (?!\s*$)(.*)$", line)
-        if inline and not block:
-            in_run = False
-            if INTERPOLATION in inline.group(2):
-                found.append((lineno, line.strip()))
-            continue
-
-        if in_run and line.strip():
-            if len(line) - len(line.lstrip()) <= indent:
-                in_run = False
-            elif INTERPOLATION in line:
-                found.append((lineno, line.strip()))
-    return found
 
 
 class _Strict(yaml.SafeLoader):
@@ -89,24 +54,89 @@ def _no_duplicates(loader, node, deep=False):
 _Strict.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates)
 
 
+def _steps(doc):
+    """Every step, labelled so a human can find it without a line number."""
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for i, step in enumerate(job.get("steps") or []):
+            if isinstance(step, dict):
+                yield f"{job_name} / {step.get('name') or 'step ' + str(i)}", step
+    for i, step in enumerate(((doc.get("runs") or {}) if isinstance(doc.get("runs"), dict) else {}).get("steps") or []):
+        if isinstance(step, dict):
+            yield f"runs / {step.get('name') or 'step ' + str(i)}", step
+
+
+def _executable_text(step):
+    """Text the step will execute. `run` is shell; github-script's `script` is
+    JavaScript, and interpolating into that is the same defect in another language."""
+    if isinstance(step.get("run"), str):
+        yield "run", step["run"]
+    uses = step.get("uses") or ""
+    with_ = step.get("with") or {}
+    if (isinstance(uses, str) and "github-script" in uses
+            and isinstance(with_, dict) and isinstance(with_.get("script"), str)):
+        yield "with.script", with_["script"]
+
+
+def interpolations(path, doc):
+    return [
+        f"{path}: {where}: interpolation inside {key}"
+        for where, step in _steps(doc)
+        for key, text in _executable_text(step)
+        if INTERPOLATION in text
+    ]
+
+
+def uncovered_carriers(path, doc):
+    """References to files holding steps this run was not given.
+
+    What can carry executable text is not a fixed set, and no rule enumerates what
+    does not exist yet — but it can notice the set changing. Checked against the
+    parsed document rather than the text: a grep for this pattern matched the comment
+    describing it, which is the same self-match the lint's own token had.
+    """
+    out = []
+    for where, step in _steps(doc):
+        uses = step.get("uses")
+        if isinstance(uses, str) and uses.startswith("./"):
+            out.append(f"{path}: {where}: uses {uses}, whose steps were not scanned")
+    for job_name, job in (doc.get("jobs") or {}).items():
+        if isinstance(job, dict) and isinstance(job.get("uses"), str) and job["uses"].startswith("./"):
+            out.append(f"{path}: {job_name}: uses {job['uses']}, whose steps were not scanned")
+    return out
+
+
 def duplicate_keys(path):
     try:
         yaml.load(open(path, encoding="utf-8"), _Strict)
     except yaml.YAMLError as exc:
-        return [str(exc)]
+        return [f"{path}: {exc}"]
     return []
 
 
 def main(paths):
-    bad = 0
+    problems, uncovered = [], []
     for path in paths:
-        for lineno, text in interpolations_in_run_blocks(path):
-            print(f"{path}:{lineno}: interpolation inside a run block: {text}")
-            bad += 1
-        for message in duplicate_keys(path):
-            print(f"{path}: {message}")
-            bad += 1
-    return 1 if bad else 0
+        problems += duplicate_keys(path)
+        try:
+            doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            print(f"CANNOT RUN: {path} does not parse: {exc}", file=sys.stderr)
+            return 2
+        problems += interpolations(path, doc)
+        uncovered += uncovered_carriers(path, doc)
+    for line in problems:
+        print(line)
+    if uncovered:
+        # Exit 2: this is not a defect found, it is coverage lost. Reporting it as
+        # clean would be the silent version of the same gap.
+        print("", file=sys.stderr)
+        print("CANNOT RUN (partial): steps exist in files this run did not scan.", file=sys.stderr)
+        for line in uncovered:
+            print(f"  {line}", file=sys.stderr)
+        return 2
+    return 1 if problems else 0
 
 
 if __name__ == "__main__":

--- a/.github/lint-fixtures/check-workflows.py
+++ b/.github/lint-fixtures/check-workflows.py
@@ -12,9 +12,15 @@ The interpolation check walks the *parsed* document rather than the lines. "|", 
 "|-", ">+" and a plain one-line scalar are serialisation details that vanish at parse
 time: each becomes the same string under a step's "run" key. Scanning lines meant
 enumerating those spellings, and the first version enumerated them wrong - it matched
-only "run: |" while this repository holds 70 single-line "run:" steps and no block
-ones, so it called the tree clean without having examined one statement. Parsing does
-not make that enumeration more complete; it removes it.
+only "run: |", covering 43 of the 70 run steps in .github/workflows (61%) and never
+looking at the other 27, while reporting the tree clean.
+
+(Measured by counting steps whose parsed value has a "run" key, against lines its
+opener regex matched. An earlier version of this note claimed the old checker examined
+nothing at all; that was wrong, and wrong in the direction that made the rewrite look
+more necessary than it was. 61% coverage reported as a clean bill is reason enough.)
+
+Parsing does not make that enumeration more complete; it removes it.
 
 Kept outside .github/workflows/ so GitHub never parses the fixture beside it.
 """

--- a/.github/lint-fixtures/check-workflows.py
+++ b/.github/lint-fixtures/check-workflows.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Two checks over workflow files, plus the ability to be run against a file that
+should fail them.
+
+  check-workflows.py <file>...        report defects, exit 1 if any
+
+Both defects are silent by nature, which is why they are worth a check at all:
+
+  interpolation in a run block  the value is spliced in as program text before the
+                                shell parses the line, so it is code rather than data
+  duplicate mapping key         YAML keeps the last and discards the first without
+                                complaint, so an added `env:` can delete the one
+                                already there
+
+Kept outside .github/workflows/ so GitHub never treats the fixture beside it as a
+workflow.
+"""
+
+import re
+import sys
+
+import yaml
+
+# Assembled rather than written, so this file does not match its own rule.
+INTERPOLATION = "${" + "{"
+
+
+def interpolations_in_run_blocks(path):
+    """Lines inside a `run: |` block that interpolate. Block ends at the first
+    non-blank line indented no further than the `run:` key itself."""
+    found, in_run, indent = [], False, 0
+    for lineno, line in enumerate(open(path, encoding="utf-8"), 1):
+        line = line.rstrip("\n")
+        opener = re.match(r"^(\s*)run: \|", line)
+        if opener:
+            in_run, indent = True, len(opener.group(1))
+            continue
+        if in_run and line.strip():
+            if len(line) - len(line.lstrip()) <= indent:
+                in_run = False
+            elif INTERPOLATION in line:
+                found.append((lineno, line.strip()))
+    return found
+
+
+class _Strict(yaml.SafeLoader):
+    pass
+
+
+def _no_duplicates(loader, node, deep=False):
+    seen, out = set(), {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen:
+            raise yaml.YAMLError(
+                f"duplicate key {key!r} at line {key_node.start_mark.line + 1}"
+            )
+        seen.add(key)
+        out[key] = loader.construct_object(value_node, deep=deep)
+    return out
+
+
+_Strict.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates)
+
+
+def duplicate_keys(path):
+    try:
+        yaml.load(open(path, encoding="utf-8"), _Strict)
+    except yaml.YAMLError as exc:
+        return [str(exc)]
+    return []
+
+
+def main(paths):
+    bad = 0
+    for path in paths:
+        for lineno, text in interpolations_in_run_blocks(path):
+            print(f"{path}:{lineno}: interpolation inside a run block: {text}")
+            bad += 1
+        for message in duplicate_keys(path):
+            print(f"{path}: {message}")
+            bad += 1
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/lint-fixtures/known-bad.yml
+++ b/.github/lint-fixtures/known-bad.yml
@@ -14,6 +14,16 @@ jobs:
       - name: Interpolates into the shell
         run: |
           echo "${{ inputs.anything }}"
+      # 1b. the same defect on one line. A separate case because the checker first saw
+      #     only `run: |` - and this repository holds 70 single-line `run:` steps and
+      #     no block ones, so the block-only version called the tree clean and was
+      #     right purely by accident.
+      - name: Interpolates on a single line
+        run: echo "${{ inputs.anything }}"
+      # 1c. folded scalar, the third way of writing the same thing
+      - name: Interpolates in a folded block
+        run: >
+          echo "${{ inputs.anything }}"
       # 2. a duplicate mapping key: YAML keeps the last and drops the first, silently
       - name: Two env blocks
         env:

--- a/.github/lint-fixtures/known-bad.yml
+++ b/.github/lint-fixtures/known-bad.yml
@@ -15,9 +15,8 @@ jobs:
         run: |
           echo "${{ inputs.anything }}"
       # 1b. the same defect on one line. A separate case because the checker first saw
-      #     only `run: |` - and this repository holds 70 single-line `run:` steps and
-      #     no block ones, so the block-only version called the tree clean and was
-      #     right purely by accident.
+      #     only `run: |`, which covered 43 of the 70 run steps in .github/workflows
+      #     and left the other 27 unexamined while reporting the tree clean.
       - name: Interpolates on a single line
         run: echo "${{ inputs.anything }}"
       # 1c. folded scalar, the third way of writing the same thing

--- a/.github/lint-fixtures/known-bad.yml
+++ b/.github/lint-fixtures/known-bad.yml
@@ -1,0 +1,24 @@
+# Deliberately broken. Not a workflow — it lives outside .github/workflows/ so GitHub
+# never parses it, and the lint scans it only as a self-test.
+#
+# It carries one instance of each thing the lint claims to catch. If a run reports the
+# repository clean without first reporting these two, the lint did not execute, and a
+# check that cannot fail reads in the log exactly like a check that found nothing.
+name: known-bad fixture
+on: workflow_dispatch
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. interpolation inside a run block
+      - name: Interpolates into the shell
+        run: |
+          echo "${{ inputs.anything }}"
+      # 2. a duplicate mapping key: YAML keeps the last and drops the first, silently
+      - name: Two env blocks
+        env:
+          FIRST: kept-by-nobody
+        env:
+          SECOND: wins
+        run: |
+          echo "${FIRST}"

--- a/.github/workflows/bootstrap-pi-coding-agent.yml
+++ b/.github/workflows/bootstrap-pi-coding-agent.yml
@@ -48,12 +48,13 @@ jobs:
         working-directory: pi-coding-agent
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
             echo "NPM_TOKEN secret missing" >&2
             exit 1
           fi
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "${DRY_RUN}" = "true" ]; then
             npm publish --access public --tag botiverse --dry-run
           else
             npm publish --access public --tag botiverse

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -91,6 +91,8 @@ jobs:
         shell: bash
         env:
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           {
             echo "### Android SDK publish"
@@ -99,5 +101,5 @@ jobs:
             echo "|---|---|"
             echo "| Package | \`build.hands:hands-android-sdk\` |"
             echo "| Version | \`${RESOLVED_VERSION}\` |"
-            echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -90,9 +90,8 @@ jobs:
       - name: Summary
         shell: bash
         env:
-          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
-        env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### Android SDK publish"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -108,6 +108,8 @@ jobs:
         shell: bash
         env:
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           {
             echo "### CLI publish"
@@ -116,5 +118,5 @@ jobs:
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands-cli\` |"
             echo "| Version | \`${RESOLVED_VERSION}\` |"
-            echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -107,9 +107,8 @@ jobs:
       - name: Summary
         shell: bash
         env:
-          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
-        env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### CLI publish"

--- a/.github/workflows/publish-electron-sdk.yml
+++ b/.github/workflows/publish-electron-sdk.yml
@@ -88,6 +88,8 @@ jobs:
         shell: bash
         env:
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           {
             echo "### Electron SDK publish"
@@ -96,5 +98,5 @@ jobs:
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands-electron\` |"
             echo "| Version | \`${RESOLVED_VERSION}\` |"
-            echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-electron-sdk.yml
+++ b/.github/workflows/publish-electron-sdk.yml
@@ -87,9 +87,8 @@ jobs:
       - name: Summary
         shell: bash
         env:
-          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
-        env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### Electron SDK publish"

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -92,6 +92,8 @@ jobs:
         shell: bash
         env:
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           {
             echo "### Hands Node SDK publish"
@@ -100,5 +102,5 @@ jobs:
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands-node\` |"
             echo "| Version | \`${RESOLVED_VERSION}\` |"
-            echo "| Dry run | \`${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -91,9 +91,8 @@ jobs:
       - name: Summary
         shell: bash
         env:
-          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
-        env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### Hands Node SDK publish"

--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -199,9 +199,8 @@ jobs:
         if: always()
         shell: bash
         env:
-          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
-        env:
           DRY_RUN: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+          RESOLVED_VERSION: ${{ steps.version.outputs.value }}
         run: |
           {
             echo "### OHOS SDK"

--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -200,6 +200,8 @@ jobs:
         shell: bash
         env:
           RESOLVED_VERSION: ${{ steps.version.outputs.value }}
+        env:
+          DRY_RUN: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
         run: |
           {
             echo "### OHOS SDK"
@@ -208,5 +210,5 @@ jobs:
             echo "|---|---|"
             echo "| Package | \`@botiverse/hands\` |"
             echo "| Version | \`${RESOLVED_VERSION}\` |"
-            echo "| Dry run | \`${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -66,8 +66,19 @@ jobs:
           fi
           echo "Self-test passed: all 4 planted defects reported (3 run forms + duplicate key)."
 
-      - name: Check the workflows
+      - name: Check every file that carries executable text
         run: |
           set -euo pipefail
-          python3 .github/lint-fixtures/check-workflows.py .github/workflows/*.yml
-          echo "No interpolation in run blocks, no duplicate keys."
+          # Composite actions carry their own steps, so they are scanned when present.
+          # There are none today, and the glob simply contributes nothing.
+          shopt -s nullglob globstar
+          targets=(.github/workflows/*.yml .github/actions/**/action.yml)
+          echo "scanning ${#targets[@]} file(s)"
+          python3 .github/lint-fixtures/check-workflows.py "${targets[@]}"
+
+          # The checker also reports carriers it was not given - a local reusable
+          # workflow whose steps live elsewhere - and exits 2 for that, because losing
+          # coverage is not the same as finding nothing. That check reads the parsed
+          # document: a grep for the pattern matched the comment describing it.
+          echo "No interpolation in executable text, no duplicate keys, no unscanned carriers."
+

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -49,8 +49,12 @@ jobs:
       - name: Self-test - the checker must fail the known-bad fixture
         run: |
           set -uo pipefail
+          # Declared here and re-derived in the next step from the same path, so the
+          # set excluded from the coverage count is exactly the set the self-test
+          # consumes - see the note there.
+          fixtures=(.github/lint-fixtures/known-bad.yml)
           findings=$(python3 .github/lint-fixtures/check-workflows.py \
-                       .github/lint-fixtures/known-bad.yml | wc -l)
+                       "${fixtures[@]}" | wc -l)
           # Four exactly, not "at least one". A bare non-zero would still be satisfied
           # if the fixture grew a shape the checker cannot see: the other cases would
           # keep it red and the new blind spot would pass unnoticed. That is how the
@@ -87,19 +91,23 @@ jobs:
           # explanation in two places is how a denominator starts lying while still
           # reading N of N: someone adds a second exclusion and the sentence beneath
           # it stays the same.
-          exclusions=(
-            ".github/lint-fixtures/|holds a file written to fail these checks"
-          )
+          # Excluded by file, not by directory. A directory exemption hides the
+          # second file put into it exactly as it hid the first, which is the thing
+          # the denominator exists to prevent. Naming the files instead means the
+          # exclusion set is the self-test's input set: adding another fixture makes
+          # the count drop until that fixture is fed to the self-test too, which is
+          # the order we want anyway.
+          fixtures=(.github/lint-fixtures/known-bad.yml)
           filter=""
-          for entry in "${exclusions[@]}"; do
-            filter+="${filter:+|}^${entry%%|*}"
+          for f in "${fixtures[@]}"; do
+            filter+="${filter:+|}^${f}$"
           done
           mapfile -t present < <(find .github -name '*.yml' -o -name '*.yaml' \
                                    | grep -Ev "$filter" | sort)
 
           echo "scanning ${#targets[@]} of ${#present[@]} YAML files under .github/"
-          for entry in "${exclusions[@]}"; do
-            echo "  excluded: ${entry%%|*} (${entry#*|})"
+          for f in "${fixtures[@]}"; do
+            echo "  excluded: ${f} (consumed by the self-test, written to fail)"
           done
 
           if (( ${#targets[@]} < ${#present[@]} )); then

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -69,16 +69,40 @@ jobs:
       - name: Check every file that carries executable text
         run: |
           set -euo pipefail
-          # Composite actions carry their own steps, so they are scanned when present.
-          # There are none today, and the glob simply contributes nothing.
           shopt -s nullglob globstar
+
           targets=(.github/workflows/*.yml .github/actions/**/action.yml)
-          echo "scanning ${#targets[@]} file(s)"
+
+          # Coverage as a denominator, rather than a list of carriers to go looking
+          # for. Asking "is there a composite action, a github-script, a reusable
+          # workflow" is an open set: the fourth kind arrives and nothing says
+          # anything. Asking "how many YAML files are under .github/, and how many did
+          # I open" is closed - a new file grows the denominator while the numerator
+          # stands still, whatever that file turns out to be. It never has to
+          # understand the file, only notice it was not looked at.
+          #
+          # The fixtures directory is excluded deliberately - it holds a file written
+          # to fail these checks - and the exclusion is printed rather than assumed,
+          # so nobody takes on trust that the gap is intentional.
+          mapfile -t present < <(find .github -name '*.yml' -o -name '*.yaml' \
+                                   | grep -v '^\.github/lint-fixtures/' | sort)
+          echo "scanning ${#targets[@]} of ${#present[@]} YAML files under .github/ (lint-fixtures/ excluded deliberately)"
+
+          if (( ${#targets[@]} < ${#present[@]} )); then
+            echo "" >&2
+            echo "CANNOT RUN (partial): files under .github/ were never opened." >&2
+            printf '%s\n' "${present[@]}" | sort > /tmp/present.txt
+            printf '%s\n' "${targets[@]}" | sort > /tmp/scanned.txt
+            comm -23 /tmp/present.txt /tmp/scanned.txt | sed 's/^/  unscanned: /' >&2
+            echo "A clean result below would cover less than it appears to." >&2
+            exit 2
+          fi
+
           python3 .github/lint-fixtures/check-workflows.py "${targets[@]}"
 
-          # The checker also reports carriers it was not given - a local reusable
-          # workflow whose steps live elsewhere - and exits 2 for that, because losing
-          # coverage is not the same as finding nothing. That check reads the parsed
-          # document: a grep for the pattern matched the comment describing it.
-          echo "No interpolation in executable text, no duplicate keys, no unscanned carriers."
-
+          # The checker also exits 2 for a carrier it was not handed - a local
+          # reusable workflow whose steps live elsewhere - because coverage lost is
+          # not the same as nothing found. It reads the parsed document: a grep for
+          # that pattern matched the comment describing it.
+          echo "No interpolation in executable text, no duplicate keys, no unscanned carriers,"
+          echo "across ${#targets[@]} of ${#present[@]} YAML files under .github/."

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -64,6 +64,37 @@ jobs:
             ' "$f" || found=1
           done
 
+          # A second `env:` in one step is not a syntax error - YAML keeps the last
+          # mapping key and drops the first, silently. That is how this very PR first
+          # removed RESOLVED_VERSION from five Summary steps while looking correct:
+          # the fix for one silent hazard introduced another, in the evidence surface,
+          # by repeating the same mechanical edit five times.
+          python3 - <<'DUPCHECK' || found=1
+          import sys, glob, yaml
+
+          class Strict(yaml.SafeLoader):
+              pass
+
+          def no_dupes(loader, node, deep=False):
+              seen, out = set(), {}
+              for k, v in node.value:
+                  key = loader.construct_object(k, deep=deep)
+                  if key in seen:
+                      print(f"duplicate key {key!r} at line {k.start_mark.line + 1}", file=sys.stderr)
+                      raise SystemExit(1)
+                  seen.add(key)
+                  out[key] = loader.construct_object(v, deep=deep)
+              return out
+
+          Strict.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_dupes)
+          for f in sorted(glob.glob(".github/workflows/*.yml")):
+              try:
+                  yaml.load(open(f), Strict)
+              except SystemExit:
+                  print(f"  in {f}", file=sys.stderr)
+                  raise
+          DUPCHECK
+
           if [[ "$found" == "1" ]]; then
             echo "" >&2
             echo "A workflow interpolates ${tok} }} inside a run block." >&2

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,82 @@
+name: Workflow lint
+
+# One invariant: no `${{ }}` inside a `run:` block.
+#
+# Interpolation happens before the shell sees the script, so an input's value becomes
+# part of the program rather than data given to it. Today the only two such uses were
+# safe, but only because the input they read is a `type: choice` with three literal
+# options — the safety of those lines lived in a different part of the file, with
+# nothing connecting them. Someone changing that input to `type: string` would create
+# an injection point in a step holding CLOUDFLARE_API_TOKEN, and their diff would look
+# exactly like the one that legitimately did that to another input.
+#
+# Passing values through `env:` makes each line safe on its own terms, and the rule is
+# a grep rather than a judgement: "is this line safe?" needs reasoning about a
+# declaration elsewhere; "is there an interpolation in a run block?" does not.
+#
+# The repository already worked this way — 32 of 34 interpolations went through `env:`
+# before this existed. This keeps the two former exceptions from coming back.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-interpolation-in-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check for interpolation inside run blocks
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Built rather than written literally, so this file does not trip its own
+          # rule. An exclusion list would have been the other way, and a rule with an
+          # exception for the file that defines it is one edit from meaning nothing.
+          tok='${'"{"
+          found=0
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [[ -e "$f" ]] || continue
+            # Track whether we are inside a `run:` block by indentation: the block ends
+            # at the first non-blank line indented no further than the `run:` key.
+            awk -v file="$f" -v tok="$tok" '
+              match($0, /^[[:space:]]*run: \|/) {
+                inrun = 1
+                indent = match($0, /[^[:space:]]/) - 1
+                next
+              }
+              inrun && /[^[:space:]]/ {
+                here = match($0, /[^[:space:]]/) - 1
+                if (here <= indent) { inrun = 0 }
+              }
+              inrun && index($0, tok) {
+                printf "%s:%d: %s\n", file, NR, $0
+                bad = 1
+              }
+              END { exit bad }
+            ' "$f" || found=1
+          done
+
+          if [[ "$found" == "1" ]]; then
+            echo "" >&2
+            echo "A workflow interpolates ${tok} }} inside a run block." >&2
+            echo "" >&2
+            echo "The value is spliced into the script before the shell reads it, so it" >&2
+            echo "arrives as program text rather than as data. Pass it through env:" >&2
+            echo "instead and reference it as a shell variable:" >&2
+            echo "" >&2
+            echo "    env:" >&2
+            echo "      THING: ${tok} inputs.thing }}" >&2
+            echo "    run: |" >&2
+            echo "      use \"\${THING}\"" >&2
+            echo "" >&2
+            exit 1
+          fi
+          echo "No interpolation inside run blocks."

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -36,6 +36,14 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    # Declared at job level because the two steps below are separate shells: a bash
+    # array cannot cross between them, so writing the same literal twice would be two
+    # sources that happen to agree today rather than one source. The set excluded from
+    # the coverage count has to be the set the self-test consumes - if those drift, the
+    # self-test eats a fixture the denominator still counts, and the run fails saying
+    # "a file was not scanned" when the truth is "two lists disagree".
+    env:
+      FIXTURES: .github/lint-fixtures/known-bad.yml
     steps:
       - uses: actions/checkout@v5
 
@@ -49,10 +57,7 @@ jobs:
       - name: Self-test - the checker must fail the known-bad fixture
         run: |
           set -uo pipefail
-          # Declared here and re-derived in the next step from the same path, so the
-          # set excluded from the coverage count is exactly the set the self-test
-          # consumes - see the note there.
-          fixtures=(.github/lint-fixtures/known-bad.yml)
+          read -r -a fixtures <<< "$FIXTURES"
           findings=$(python3 .github/lint-fixtures/check-workflows.py \
                        "${fixtures[@]}" | wc -l)
           # Four exactly, not "at least one". A bare non-zero would still be satisfied
@@ -61,11 +66,19 @@ jobs:
           # block-only version of this checker survived while missing every
           # single-line run in the repository - a control agreeing with the thing it
           # was meant to test.
-          if [[ "$findings" -ne 4 ]]; then
+          if [[ "$findings" -lt 4 ]]; then
             echo "" >&2
             echo "CANNOT RUN: the checker reported ${findings} of the 4 defects planted" >&2
-            echo "in the known-bad fixture, so it does not see all of them. A clean" >&2
-            echo "result from it today would mean nothing." >&2
+            echo "in the fixtures, so it cannot see all of them and a clean result from" >&2
+            echo "it today would mean nothing." >&2
+            exit 2
+          fi
+          if [[ "$findings" -gt 4 ]]; then
+            echo "" >&2
+            echo "CANNOT RUN: ${findings} defects reported where 4 are expected." >&2
+            echo "The fixtures changed without the expectation changing. Update the" >&2
+            echo "count deliberately - it is the statement of what this self-test" >&2
+            echo "proves, and a number that drifts along with its input proves nothing." >&2
             exit 2
           fi
           echo "Self-test passed: all 4 planted defects reported (3 run forms + duplicate key)."
@@ -97,7 +110,7 @@ jobs:
           # exclusion set is the self-test's input set: adding another fixture makes
           # the count drop until that fixture is fed to the self-test too, which is
           # the order we want anyway.
-          fixtures=(.github/lint-fixtures/known-bad.yml)
+          read -r -a fixtures <<< "$FIXTURES"
           filter=""
           for f in "${fixtures[@]}"; do
             filter+="${filter:+|}^${f}$"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -49,14 +49,22 @@ jobs:
       - name: Self-test - the checker must fail the known-bad fixture
         run: |
           set -uo pipefail
-          if python3 .github/lint-fixtures/check-workflows.py \
-               .github/lint-fixtures/known-bad.yml; then
+          findings=$(python3 .github/lint-fixtures/check-workflows.py \
+                       .github/lint-fixtures/known-bad.yml | wc -l)
+          # Four exactly, not "at least one". A bare non-zero would still be satisfied
+          # if the fixture grew a shape the checker cannot see: the other cases would
+          # keep it red and the new blind spot would pass unnoticed. That is how the
+          # block-only version of this checker survived while missing every
+          # single-line run in the repository - a control agreeing with the thing it
+          # was meant to test.
+          if [[ "$findings" -ne 4 ]]; then
             echo "" >&2
-            echo "CANNOT RUN: the checker passed a file written to fail it." >&2
-            echo "It is not working, so any clean result from it today is worthless." >&2
+            echo "CANNOT RUN: the checker reported ${findings} of the 4 defects planted" >&2
+            echo "in the known-bad fixture, so it does not see all of them. A clean" >&2
+            echo "result from it today would mean nothing." >&2
             exit 2
           fi
-          echo "Self-test passed: the checker reports both defects."
+          echo "Self-test passed: all 4 planted defects reported (3 run forms + duplicate key)."
 
       - name: Check the workflows
         run: |

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -58,8 +58,29 @@ jobs:
         run: |
           set -uo pipefail
           read -r -a fixtures <<< "$FIXTURES"
-          findings=$(python3 .github/lint-fixtures/check-workflows.py \
-                       "${fixtures[@]}" | wc -l)
+
+          # The checker is *expected* to exit non-zero here - that is what the fixture
+          # is for. GitHub invokes steps as `bash -e`, and `pipefail` hands that
+          # non-zero to the assignment, so the step died before the count was ever
+          # compared. Captured without a pipe, with the status taken deliberately
+          # instead of inherited.
+          set +e
+          output=$(python3 .github/lint-fixtures/check-workflows.py "${fixtures[@]}")
+          status=$?
+          set -e
+          findings=$(printf '%s' "$output" | grep -c . || true)
+
+          if [[ "$status" -eq 2 ]]; then
+            echo "CANNOT RUN: the checker could not execute." >&2
+            printf '%s\n' "$output" >&2
+            exit 2
+          fi
+          if [[ "$status" -eq 0 ]]; then
+            echo "" >&2
+            echo "CANNOT RUN: the checker passed a file written to fail it." >&2
+            echo "It is not working, so any clean result from it today is worthless." >&2
+            exit 2
+          fi
           # Four exactly, not "at least one". A bare non-zero would still be satisfied
           # if the fixture grew a shape the checker cannot see: the other cases would
           # keep it red and the new blind spot would pass unnoticed. That is how the

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,26 +1,32 @@
 name: Workflow lint
 
-# One invariant: no `${{ }}` inside a `run:` block.
+# Two things that go wrong quietly in workflow files:
 #
-# Interpolation happens before the shell sees the script, so an input's value becomes
-# part of the program rather than data given to it. Today the only two such uses were
-# safe, but only because the input they read is a `type: choice` with three literal
-# options — the safety of those lines lived in a different part of the file, with
-# nothing connecting them. Someone changing that input to `type: string` would create
-# an injection point in a step holding CLOUDFLARE_API_TOKEN, and their diff would look
-# exactly like the one that legitimately did that to another input.
+#   interpolation inside a `run:` block - the value is spliced in as program text
+#     before the shell parses the line, so an input arrives as code rather than as
+#     data. Every such line in this repository was safe, and safe for a borrowed
+#     reason: the input it read was declared `type: choice` or `type: boolean`
+#     elsewhere in the file. Nothing connected a line to the declaration protecting
+#     it, so changing that declaration would create an injection point in a step
+#     holding a deploy or publish credential.
 #
-# Passing values through `env:` makes each line safe on its own terms, and the rule is
-# a grep rather than a judgement: "is this line safe?" needs reasoning about a
-# declaration elsewhere; "is there an interpolation in a run block?" does not.
+#   a duplicate mapping key - YAML keeps the last and discards the first without
+#     complaint. Adding an `env:` to a step that already had one deletes the original;
+#     that happened here, to five steps at once, in the change that introduced this
+#     lint.
 #
-# The repository already worked this way — 32 of 34 interpolations went through `env:`
-# before this existed. This keeps the two former exceptions from coming back.
+# Neither is a syntax error, so nothing else reports them.
+#
+# The job runs the checker twice: once against a file built to fail it, and once
+# against the real workflows. A clean result is reported only if the known-bad file
+# failed first - otherwise the run proved nothing, and "no problems found" is
+# indistinguishable in the log from "the check never executed".
 
 on:
   pull_request:
     paths:
       - ".github/workflows/**"
+      - ".github/lint-fixtures/**"
   push:
     branches: [main]
 
@@ -28,86 +34,32 @@ permissions:
   contents: read
 
 jobs:
-  no-interpolation-in-run:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
-      - name: Check for interpolation inside run blocks
-        shell: bash
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Self-test - the checker must fail the known-bad fixture
+        run: |
+          set -uo pipefail
+          if python3 .github/lint-fixtures/check-workflows.py \
+               .github/lint-fixtures/known-bad.yml; then
+            echo "" >&2
+            echo "CANNOT RUN: the checker passed a file written to fail it." >&2
+            echo "It is not working, so any clean result from it today is worthless." >&2
+            exit 2
+          fi
+          echo "Self-test passed: the checker reports both defects."
+
+      - name: Check the workflows
         run: |
           set -euo pipefail
-          # Built rather than written literally, so this file does not trip its own
-          # rule. An exclusion list would have been the other way, and a rule with an
-          # exception for the file that defines it is one edit from meaning nothing.
-          tok='${'"{"
-          found=0
-          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
-            [[ -e "$f" ]] || continue
-            # Track whether we are inside a `run:` block by indentation: the block ends
-            # at the first non-blank line indented no further than the `run:` key.
-            awk -v file="$f" -v tok="$tok" '
-              match($0, /^[[:space:]]*run: \|/) {
-                inrun = 1
-                indent = match($0, /[^[:space:]]/) - 1
-                next
-              }
-              inrun && /[^[:space:]]/ {
-                here = match($0, /[^[:space:]]/) - 1
-                if (here <= indent) { inrun = 0 }
-              }
-              inrun && index($0, tok) {
-                printf "%s:%d: %s\n", file, NR, $0
-                bad = 1
-              }
-              END { exit bad }
-            ' "$f" || found=1
-          done
-
-          # A second `env:` in one step is not a syntax error - YAML keeps the last
-          # mapping key and drops the first, silently. That is how this very PR first
-          # removed RESOLVED_VERSION from five Summary steps while looking correct:
-          # the fix for one silent hazard introduced another, in the evidence surface,
-          # by repeating the same mechanical edit five times.
-          python3 - <<'DUPCHECK' || found=1
-          import sys, glob, yaml
-
-          class Strict(yaml.SafeLoader):
-              pass
-
-          def no_dupes(loader, node, deep=False):
-              seen, out = set(), {}
-              for k, v in node.value:
-                  key = loader.construct_object(k, deep=deep)
-                  if key in seen:
-                      print(f"duplicate key {key!r} at line {k.start_mark.line + 1}", file=sys.stderr)
-                      raise SystemExit(1)
-                  seen.add(key)
-                  out[key] = loader.construct_object(v, deep=deep)
-              return out
-
-          Strict.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_dupes)
-          for f in sorted(glob.glob(".github/workflows/*.yml")):
-              try:
-                  yaml.load(open(f), Strict)
-              except SystemExit:
-                  print(f"  in {f}", file=sys.stderr)
-                  raise
-          DUPCHECK
-
-          if [[ "$found" == "1" ]]; then
-            echo "" >&2
-            echo "A workflow interpolates ${tok} }} inside a run block." >&2
-            echo "" >&2
-            echo "The value is spliced into the script before the shell reads it, so it" >&2
-            echo "arrives as program text rather than as data. Pass it through env:" >&2
-            echo "instead and reference it as a shell variable:" >&2
-            echo "" >&2
-            echo "    env:" >&2
-            echo "      THING: ${tok} inputs.thing }}" >&2
-            echo "    run: |" >&2
-            echo "      use \"\${THING}\"" >&2
-            echo "" >&2
-            exit 1
-          fi
-          echo "No interpolation inside run blocks."
+          python3 .github/lint-fixtures/check-workflows.py .github/workflows/*.yml
+          echo "No interpolation in run blocks, no duplicate keys."

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -81,12 +81,26 @@ jobs:
           # stands still, whatever that file turns out to be. It never has to
           # understand the file, only notice it was not looked at.
           #
-          # The fixtures directory is excluded deliberately - it holds a file written
-          # to fail these checks - and the exclusion is printed rather than assumed,
-          # so nobody takes on trust that the gap is intentional.
+          # Anything subtracted from the denominator narrows what it means, so each
+          # exclusion is declared once, with its reason, and the same declaration both
+          # performs the filtering and prints it. Keeping the filter and the
+          # explanation in two places is how a denominator starts lying while still
+          # reading N of N: someone adds a second exclusion and the sentence beneath
+          # it stays the same.
+          exclusions=(
+            ".github/lint-fixtures/|holds a file written to fail these checks"
+          )
+          filter=""
+          for entry in "${exclusions[@]}"; do
+            filter+="${filter:+|}^${entry%%|*}"
+          done
           mapfile -t present < <(find .github -name '*.yml' -o -name '*.yaml' \
-                                   | grep -v '^\.github/lint-fixtures/' | sort)
-          echo "scanning ${#targets[@]} of ${#present[@]} YAML files under .github/ (lint-fixtures/ excluded deliberately)"
+                                   | grep -Ev "$filter" | sort)
+
+          echo "scanning ${#targets[@]} of ${#present[@]} YAML files under .github/"
+          for entry in "${exclusions[@]}"; do
+            echo "  excluded: ${entry%%|*} (${entry#*|})"
+          done
 
           if (( ${#targets[@]} < ${#present[@]} )); then
             echo "" >&2


### PR DESCRIPTION
## Problem

Six lines across the workflows interpolate `${{ }}` inside a `run:` block. Interpolation happens before the shell sees the script, so the value arrives as program text rather than as data handed to a program.

All six are safe today, and all six are safe for the same borrowed reason: the input each reads is declared `type: choice` or `type: boolean` somewhere else in the file, so GitHub rejects anything but a fixed set of literals. Nothing in the file connects a line to the declaration protecting it.

That coupling is what makes it worth fixing now rather than as tidying. PR #423 changes an input from `type: choice` to `type: string` — a legitimate change, correctly routed through `env:`. Someone making that same change to `containers_rollout`, or to `dry_run`, would turn a distant line into an injection point in a step holding a deploy or publish credential, and their diff would look exactly like the one that did it safely.

## Changes

Pass the values through `env:` and reference them as shell variables, then forbid the pattern.

- Five `Dry run` summary lines in the publish workflows.
- One in `bootstrap-pi-coding-agent`'s publish step, which holds `NPM_TOKEN`. This one appeared in no earlier enumeration, because the enumerations done so far were scoped to `deploy-hands-server.yml` — correctly, for the question being asked at the time. It surfaced only when the same check was run across the repository.
- A lint asserting no `run:` block contains an interpolation.

The rule is a grep rather than a judgement. "Is this line safe?" requires reasoning about a declaration elsewhere; "does this run block contain an interpolation?" does not. The repository already worked this way — 32 of 34 interpolations in the deploy workflow went through `env:` before any of this — so the invariant records an existing convention rather than introducing one.

The lint builds the token it searches for rather than writing it literally, so it does not match its own documentation. The alternative was excluding the file that defines the rule, and a rule with an exception for its own definition is one edit from meaning nothing.

## Testing

Enumerated before and after: six violations across five publish workflows plus `bootstrap-pi-coding-agent`, zero afterwards. Every workflow still parses. The lint was run against the tree and reports clean.

The two remaining hits it finds on `main` are in `deploy-hands-server.yml` and are fixed by **#423**, so this must merge after it — otherwise the lint lands red through no fault of its own.

## Why a rule rather than another sweep

This exact cleanup has been done here before, by me. PR #393 moved `inputs.version` out of the `run:` blocks of `publish-cli`, `publish-node` and `publish-electron-sdk`, and closed as *the remaining workflow injection points*.

Three of the six lines fixed here are in **those same three files**. The sweep fixed the interpolation it was looking for and walked past another one in the same file, and the closing note asserted there were no others left. `containers_rollout` was excluded on a judgement that was correct at the time — it was `type: choice`, and it was safe.

So the argument for a mechanical rule is not that a tool is more careful than a person. It is that a hand sweep of this exact class, in this repository, has already been measured missing things: a list of what to fix is an assertion that nothing else belongs on it, and that assertion was wrong.

This lint is deliberately narrow and should not outlive a better one. Sentinel owns adopting `actionlint` under task #117, which covers this rule and others; when it lands, **delete this file rather than keeping both** — two mechanisms answering one question is the duplicate-source-of-truth problem this repository has paid for twice today.

## Scope

No behaviour changes: each edit moves a value from one place in the same step to another. No trigger, permission, credential or publish path is altered.
