### PR TITLE
Assert the readback tools exist before depending on them

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -204,6 +204,24 @@ jobs:
             }
           done
 
+          # wrangler needs its own probe. The criterion for guarding a command is that
+          # its failure gets turned into a substantive conclusion, and wrangler meets
+          # it plainly: `migrations list ... || true` puts the error text into $pending,
+          # grep then fails to match, and the step reports "migrations still unapplied
+          # after a successful apply" when the truth is that wrangler never ran.
+          #
+          # The loop above cannot cover it. wrangler is never a bare command here - it
+          # is always `pnpm exec wrangler`, a workspace package rather than something
+          # on PATH - so `command -v wrangler` is false whether or not it works. The
+          # criterion was closed and correct; the mechanism for applying it had a blind
+          # spot, which is a different thing and worth naming as such.
+          pnpm exec wrangler --version >/dev/null 2>&1 || {
+            echo "CANNOT RUN: wrangler is not usable via pnpm exec." >&2
+            echo "Nothing about the database has been checked - every query below" >&2
+            echo "would report its own failure as a finding about the schema." >&2
+            exit 2
+          }
+
           q() {
             pnpm exec wrangler d1 execute "${HANDS_D1_DATABASE_NAME}" \
               --remote --json --config wrangler.hands.generated.jsonc --command "$1" \

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -188,7 +188,14 @@ jobs:
           # or anything later wrapped around this, can still tell "did not run" from
           # "ran and found something". The third state survives as a convention where
           # it cannot survive as an exit.
-          for tool in jq node pnpm; do
+          # The set to guard is not "every command used" - that is an open list nobody
+          # can keep - but the ones whose failure an `if` turns into a substantive
+          # conclusion. A missing diff makes the structure comparison report "remote
+          # structure differs"; a missing grep makes the pending-migration test report
+          # "migrations still unapplied". Both would be a defect announced where the
+          # truth is a tool that was never there. cat, sort, wc and the rest fail
+          # loudly without being mapped onto a verdict, so they are left out.
+          for tool in jq node pnpm diff grep; do
             command -v "$tool" >/dev/null || {
               echo "CANNOT RUN: ${tool} is not on this runner." >&2
               echo "Nothing about the database has been checked. This is not a pass" >&2
@@ -426,7 +433,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for tool in curl jq; do
+          for tool in curl jq; do  # both feed an `if` below
             command -v "$tool" >/dev/null || {
               echo "CANNOT RUN: ${tool} is not on this runner; no runtime check happened." >&2
               exit 2

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -177,12 +177,23 @@ jobs:
           # in the log from the database being wrong - and the more total that failure
           # looks, the more it reads like a real finding rather than a broken probe.
           # "Could not run" is a third outcome and has to say its own name.
+          # Mapped to a failure, and the reason is written down because the reason is
+          # what expires: a missing tool here is *unexpected*, so stopping is right.
+          # Where "could not run" is an expected outcome the correct mapping is the
+          # other one - the pragma check below was reported-and-allowed until it had
+          # been measured, and became a failure only once a refusal stopped being
+          # plausible. If that changes, this mapping should be revisited, not defended.
+          #
+          # exit 2 rather than 1: CI sees only non-zero, but a human reading the log,
+          # or anything later wrapped around this, can still tell "did not run" from
+          # "ran and found something". The third state survives as a convention where
+          # it cannot survive as an exit.
           for tool in jq node pnpm; do
             command -v "$tool" >/dev/null || {
               echo "CANNOT RUN: ${tool} is not on this runner." >&2
               echo "Nothing about the database has been checked. This is not a pass" >&2
               echo "and not a failure of the migration - the readback did not execute." >&2
-              exit 1
+              exit 2
             }
           done
 
@@ -418,7 +429,7 @@ jobs:
           for tool in curl jq; do
             command -v "$tool" >/dev/null || {
               echo "CANNOT RUN: ${tool} is not on this runner; no runtime check happened." >&2
-              exit 1
+              exit 2
             }
           done
 

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -172,6 +172,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Assert the tools exist before anything depends on them. Without this, an
+          # absent jq makes every check below exit non-zero, which is indistinguishable
+          # in the log from the database being wrong - and the more total that failure
+          # looks, the more it reads like a real finding rather than a broken probe.
+          # "Could not run" is a third outcome and has to say its own name.
+          for tool in jq node pnpm; do
+            command -v "$tool" >/dev/null || {
+              echo "CANNOT RUN: ${tool} is not on this runner." >&2
+              echo "Nothing about the database has been checked. This is not a pass" >&2
+              echo "and not a failure of the migration - the readback did not execute." >&2
+              exit 1
+            }
+          done
+
           q() {
             pnpm exec wrangler d1 execute "${HANDS_D1_DATABASE_NAME}" \
               --remote --json --config wrangler.hands.generated.jsonc --command "$1" \
@@ -401,6 +415,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          for tool in curl jq; do
+            command -v "$tool" >/dev/null || {
+              echo "CANNOT RUN: ${tool} is not on this runner; no runtime check happened." >&2
+              exit 1
+            }
+          done
+
           if [[ -z "${PROBE_PATH:-}" ]]; then
             echo "No runtime check: repository variable HANDS_READBACK_PROBE_PATH is unset."
             echo "It should name a public path whose handler reads build_assets, so this"


### PR DESCRIPTION
## Problem

The readback depends on `jq`, `node` and `pnpm`, and the runtime probe on `curl` and `jq`. If one is missing, every check exits non-zero — which in the log is indistinguishable from the database being wrong.

Both failure modes seen today had that shape. A `CREATE TEMP TABLE` probe refused by D1 left its assertion unevaluated, and the end state looked exactly like a guard correctly blocking. A review of a production matrix came back entirely red because the reviewer's machine had no `jq`, and that looked exactly like every assertion correctly failing. Same fold — "could not run" posted into the same exit as a real result — and which disguise it takes is luck.

The direction that lands is not neutral either. A check that fails *completely* reads as a bigger finding than one that fails partially, so it is likelier to be believed and acted on rather than re-examined.

## Changes

Assert the tools exist first, and say plainly when they do not:

```
CANNOT RUN: jq is not on this runner.
Nothing about the database has been checked. This is not a pass
and not a failure of the migration - the readback did not execute.
```

Three outcomes rather than two: pass, fail, and could-not-run, with the third naming itself.

## Testing

This happened to be verifiable for real rather than by simulation: the machine it was written on has no `jq`. Running the readback step there produces the message above and exits 1, instead of fourteen database findings.

`ubuntu-latest` does ship `jq` today, so this is precautionary — but "it is present today" is the same class of assumption as the `type: choice` that made an interpolation safe until someone changed the input type. It costs one line and removes an entire category of misleading output.
