### PR TITLE
Remove reporter-session supply-side config; keep the environment as the deploy branch gate

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -38,6 +38,19 @@ concurrency:
 
 jobs:
   deploy:
+    # Removing this line, or this environment, is a security change - not cleanup.
+    # The name refers to a retired feature. The function it serves does not.
+    #
+    # This job deploys production: it applies D1 migrations, writes production
+    # secrets, and publishes the Worker. The trigger is `workflow_dispatch`, and a
+    # dispatch runs the workflow file from whichever ref is selected. This
+    # environment's deployment branch policy is what confines that to main.
+    #
+    # Do not substitute a job-level `if: github.ref == 'refs/heads/main'`. It looks
+    # equivalent and is a downgrade: an `if:` lives in the workflow file on the
+    # dispatched ref, so the branch being deployed can remove it in the same commit
+    # that would exploit it. The branch policy is enforced by GitHub outside the
+    # file, where the deployed branch cannot reach it.
     environment: reporter-session-production
     runs-on: ubuntu-latest
     env:
@@ -53,8 +66,6 @@ jobs:
       HANDS_RAFT_API_ORIGIN: ${{ vars.HANDS_RAFT_API_ORIGIN }}
       HANDS_RAFT_CLIENT_ID: ${{ vars.HANDS_RAFT_CLIENT_ID }}
       HANDS_FLAGSHIP_APP_ID: ${{ vars.HANDS_FLAGSHIP_APP_ID }}
-      HANDS_FEEDBACK_REPORTER_SESSION_ENABLED: ${{ vars.HANDS_FEEDBACK_REPORTER_SESSION_ENABLED }}
-      HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION: ${{ vars.HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION }}
     steps:
       - uses: actions/checkout@v6
 
@@ -69,23 +80,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Validate reporter-session rollout inputs
-        env:
-          FEEDBACK_REPORTER_SESSION_KEYS: ${{ secrets.HANDS_FEEDBACK_REPORTER_SESSION_KEYS }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${HANDS_FEEDBACK_REPORTER_SESSION_ENABLED:-false}" == "true" ]]; then
-            if [[ -z "${HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION:-}" ]]; then
-              echo "Missing repository variable HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION." >&2
-              exit 1
-            fi
-            if [[ -z "${FEEDBACK_REPORTER_SESSION_KEYS:-}" ]]; then
-              echo "Missing GitHub secret HANDS_FEEDBACK_REPORTER_SESSION_KEYS." >&2
-              exit 1
-            fi
-          fi
 
       - name: Render production Wrangler config
         working-directory: worker
@@ -595,7 +589,6 @@ jobs:
           ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
           AGC_CRED_ENC_KEY: ${{ secrets.HANDS_AGC_CRED_ENC_KEY }}
           FEEDBACK_AUDIT_HMAC_KEY: ${{ secrets.HANDS_FEEDBACK_AUDIT_HMAC_KEY }}
-          FEEDBACK_REPORTER_SESSION_KEYS: ${{ secrets.HANDS_FEEDBACK_REPORTER_SESSION_KEYS }}
           R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
           # Optional: R2 S3-API credentials enable direct-to-R2 presigned downloads
           # (bandwidth bypasses the Worker). When unset, downloads fall back to the
@@ -635,12 +628,6 @@ jobs:
           printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${AGC_CRED_ENC_KEY}" | pnpm exec wrangler secret put AGC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${FEEDBACK_AUDIT_HMAC_KEY}" | pnpm exec wrangler secret put FEEDBACK_AUDIT_HMAC_KEY --config "${config}"
-          # Provision the keyring while the feature remains disabled, then flip
-          # the repository flag in a separate deploy. This avoids an enabled
-          # Worker version ever depending on a keyring that has not been bound.
-          if [[ -n "${FEEDBACK_REPORTER_SESSION_KEYS:-}" ]]; then
-            printf '%s' "${FEEDBACK_REPORTER_SESSION_KEYS}" | pnpm exec wrangler secret put FEEDBACK_REPORTER_SESSION_KEYS --config "${config}"
-          fi
           printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
           # Optional R2 S3-API credentials (only put when configured).
           if [[ -n "${R2_S3_ACCESS_KEY_ID:-}" ]]; then


### PR DESCRIPTION
Step 3 of the reporter-session teardown. Steps 1 and 2 removed the keyring from
the GitHub environment and from the production Worker; this removes the config
that fed it.

## Removed

- `Validate reporter-session rollout inputs` step — checked a keyring that no longer exists
- two `HANDS_FEEDBACK_REPORTER_SESSION_*` job env lines
- `FEEDBACK_REPORTER_SESSION_KEYS` step env and the conditional `wrangler secret put` behind it

## Deliberately NOT removed: `environment: reporter-session-production`

The name refers to the retired feature. The function it serves does not: this
job applies D1 migrations to production, writes production secrets and publishes
the Worker, the trigger is `workflow_dispatch`, a dispatch runs the workflow file
from whichever ref is selected, and this environment's deployment branch policy
is what confines that to main.

The original scope for this step said to delete it. The reason it stays is now a
comment above the line, where the next person cleaning this up will read it —
including why a job-level `if: github.ref == 'refs/heads/main'` is not a
substitute: an `if:` lives in the workflow file on the dispatched ref, so the
branch being deployed can remove it. The branch policy is enforced outside the file.

## This is not inert — measured, not reasoned

I predicted the removal was a no-op by reading the renderer. Wrong. Rendering the
production config three ways:

```
today (ENABLED=false, ACTIVE_KEY_VERSION=staging-v1)  vs  after this PR (neither set)
  -     "FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION": "staging-v1"
positive control (ENABLED=true) — proves the diff can see these vars at all
  +     "FEEDBACK_REPORTER_SESSION_ENABLED": "true",
  +     "FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION": "staging-v1"
```

So the deployed config carries `ACTIVE_KEY_VERSION="staging-v1"` today and this
drops it. `ENABLED` keeps its value — the renderer defaults it to `"false"` and
the repository variable was already `"false"`.

Safe at runtime: both are optional-typed in `reporter_sessions.ts` (`?.trim() ?? ""`),
and the path reading the version is behind `FEEDBACK_REPORTER_SESSION_ENABLED === "true"`.

## Verification

- workflow lint: self-test 4/4 planted defects, real files exit 0
- job still parses with `environment` bound, 16 steps
- no residual `reporter-session` references under `.github/` except the environment line and its comment

## Order

The two repository variables (`...ENABLED`, `...ACTIVE_KEY_VERSION`) are deleted
**after** this merges — while these lines exist, the variables are still read.