### PR TITLE
Stamp the container image so a rollout can be read back

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -83,6 +83,12 @@ jobs:
 
       - name: Render production Wrangler config
         working-directory: worker
+        # GITHUB_SHA is already present in every step, so this line changes nothing at
+        # runtime. It is here because the renderer now reads it to stamp the container
+        # image, and an ambient variable is an invisible dependency: someone reading
+        # either file alone cannot see that the stamp comes from here.
+        env:
+          GITHUB_SHA: ${{ github.sha }}
         run: node scripts/render-production-config.mjs --output wrangler.hands.generated.jsonc
 
       - name: Generate Worker types

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -82,6 +82,19 @@ RUN npm ci --include=dev --no-audit --no-fund
 # Copy container source
 COPY src ./src
 
+# Build stamp, so /health can answer "which build is serving" rather than only
+# "something is serving". Supplied by `image_vars` in the Worker's container config,
+# which wrangler passes as a build arg; unset outside a real deploy, and /health then
+# reports "unknown" rather than pretending to know.
+#
+# Deliberately placed after every expensive layer. GIT_SHA changes on every deploy, and
+# an ARG invalidates the cache for everything below it - declared up with the other ARGs
+# it would rebuild the Rust minidump-stackwalk, the apt layer, the Android SDK and
+# `npm ci` on every single deploy. Here it invalidates only the two lines beneath it,
+# and `COPY src` above already changes whenever the source does.
+ARG GIT_SHA=""
+ENV BUILD_SHA=$GIT_SHA
+
 EXPOSE 8080
 
 # Run via tsx (no build step needed in container; Cloudflare Containers build with Docker)

--- a/container/src/server.ts
+++ b/container/src/server.ts
@@ -55,7 +55,20 @@ interface MinidumpReport {
   crashing_thread?: { thread_index?: number; frames?: MinidumpFrame[] };
 }
 
-app.get("/health", (c) => c.json({ ok: true, service: "multi-parser" }));
+// `build` is the commit the image was built from, baked in as BUILD_SHA at image build
+// time (Dockerfile) rather than injected at runtime, so it identifies *which* build is
+// serving. Its usefulness here does not depend on the value: the image running in
+// production today has no code that emits this key at all, so the key appearing is
+// itself proof the image was rebuilt and is serving, and the key being absent means the
+// old image is still up - never "the probe did not reach the container". A rollout is
+// therefore its own before/after control.
+app.get("/health", (c) =>
+  c.json({
+    ok: true,
+    service: "multi-parser",
+    build: process.env.BUILD_SHA || "unknown",
+  }),
+);
 
 // Delta/differential update patch generation (task #246). JSON body with two
 // signed URLs `old_url` and `new_url` (both APKs in R2); the container fetches

--- a/worker/scripts/render-production-config.mjs
+++ b/worker/scripts/render-production-config.mjs
@@ -121,6 +121,26 @@ if (reporterSessionActiveKeyVersion) {
   delete config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION;
 }
 
+// Build stamp for the container image, so a rollout can be verified by reading the
+// container rather than by trusting that the workflow went green. `image_vars` is
+// wrangler's build-arg channel - its own type says "available to the image at
+// build-time only" - and the Dockerfile turns GIT_SHA into BUILD_SHA, which /health
+// reports.
+//
+// Left absent when GITHUB_SHA is unset (local renders), rather than defaulting to a
+// placeholder: a stamp that always has *some* value cannot distinguish "built by a
+// deploy" from "built by hand", and this exists precisely to make that distinguishable.
+const gitSha = (process.env.GITHUB_SHA ?? "").trim();
+const containerApp = config.containers?.find(
+  (entry) => entry.class_name === "ApkParserContainer",
+);
+if (!containerApp) {
+  throw new Error("ApkParserContainer is missing from the base config");
+}
+if (gitSha) {
+  containerApp.image_vars = { ...containerApp.image_vars, GIT_SHA: gitSha };
+}
+
 mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
 console.log(`Rendered production Wrangler config: ${outputPath}`);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -644,6 +644,46 @@ admin.onError((err, c) => {
   );
 });
 
+// Container build readback. The deploy pipeline has no container probe at all: it passes
+// --containers-rollout and prints the value, so "the workflow went green" has been the
+// only evidence that a rebuilt image is serving. This route is the instrument for the
+// container-side criterion - read it before and after a rollout.
+//
+// `build` comes from the container's own /health. On the image running today that key
+// does not exist, so *key absent* means the old image is still serving and *key present*
+// means the new one is - the old image cannot fabricate a key its code never emits, which
+// rules out "the probe passed but hit the old image".
+//
+// Admin-gated on purpose. The exact deployed commit narrows a public repository's tree to
+// one revision for anyone asking which known issues currently apply, and this readback is
+// run by operators, not by clients.
+admin.get("/api/admin/container/build", async (c) => {
+  const container = await getRandom(c.env.APK_PARSER, 1);
+  const res = await container.fetch(new Request("http://container/health"));
+  const body = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    // Surface the raw body rather than a parse error: a container that answers with
+    // something unparseable is a different failure from one that does not answer, and
+    // collapsing them is how "no result" starts reading like "clean result".
+    return c.json({ ok: false, status: res.status, raw: body.slice(0, 512) }, 502);
+  }
+  const build =
+    typeof parsed === "object" && parsed !== null && "build" in parsed
+      ? (parsed as { build?: unknown }).build
+      : undefined;
+  return c.json({
+    ok: res.ok,
+    status: res.status,
+    // null, not omitted: an absent key here would be indistinguishable from this route
+    // having failed to read one, which is the exact confusion the stamp exists to end.
+    build: typeof build === "string" ? build : null,
+    stamped: typeof build === "string",
+  });
+});
+
 admin.get("/api/orgs", handleListOrgs);
 admin.get("/api/orgs/:orgId/members", requireOrgRole("orgId", "viewer"), handleListOrgMembers);
 admin.patch("/api/orgs/:orgId/members/:accountId", requireOrgRole("orgId", "admin"), handleUpdateOrgMember);


### PR DESCRIPTION
Implements the instrument for task #97's container-side readback criterion.

## The gap

The deploy passes `--containers-rollout` and prints the value in the job summary.
There is no container probe anywhere in the pipeline, so "the workflow went green"
has been the only evidence that a rebuilt image is serving — which is precisely
what the container readback criterion rules out. **The criterion existed; the
instrument did not.**

## Shape

| file | change |
|---|---|
| `container/Dockerfile` | `ARG GIT_SHA` → `ENV BUILD_SHA` |
| `container/src/server.ts` | `/health` reports `build` |
| `worker/scripts/render-production-config.mjs` | sets `containers[].image_vars.GIT_SHA` from `GITHUB_SHA` |
| `worker/src/index.ts` | `GET /api/admin/container/build` reads it back |
| `.github/workflows/deploy-hands-server.yml` | passes `GITHUB_SHA` explicitly |

## Why it is self-controlling

The image running in production contains no code that emits a `build` key.

```
key present  => the image was rebuilt and is serving   (the old image cannot fake it)
key absent   => the old image is still serving         (never "the probe missed")
```

So **the next rollout is its own before/after control** — no extra deploy is needed
to establish a baseline, and no deploy is being requested by this PR.

## Decisions worth reviewing

**Build-time, not runtime.** A runtime value could only answer "some build made after
the instrument landed"; a build-time value answers *which* build. `image_vars` is
wrangler's build-arg channel — its own types say *"available to the image at build-time
only"* — and it exists in **4.105.0**, the version the lockfile resolves and the deploy
uses. (Checked against 4.105.0 specifically: an unreferenced 4.118.0 also sits in the
pnpm store, and reading types from that one would have proven nothing about the deploy.)

**ARG placement is load-bearing.** `GIT_SHA` changes every deploy and an `ARG`
invalidates every layer below it. Declared beside the other ARGs it would rebuild the
Rust minidump-stackwalk, the apt layer, the Android SDK and `npm ci` on *every* deploy.
Placed after `COPY src` it invalidates two trivial lines, and `COPY src` already changes
whenever the source does.

**No placeholder when unstamped.** With `GITHUB_SHA` unset the renderer omits
`image_vars` entirely. A stamp that always carries some value cannot separate "built by
a deploy" from "built by hand".

**Readback is admin-gated.** The exact deployed commit narrows a public repository to
one revision for anyone asking which known issues apply, and this is run by operators.
It returns `build: null` with `stamped: false` rather than omitting the key, so a failed
read cannot be misread as an unstamped image.

## Verification

- worker `tsc --noEmit`: **0 errors**, against a **0-error baseline** on clean main
  (the checked-out `worker-configuration.d.ts` was stale and failed identically on main;
  regenerated before comparing, so this is a like-for-like result)
- container `npm run build` (`tsc --noEmit`): **0 errors**, baseline **0**
- workflow lint: self-test 4/4, real files exit 0; `environment:` still bound
- renderer rendered both ways — the only diff is the `image_vars` block, and the
  no-SHA render contains **0** occurrences of `image_vars`/`GIT_SHA`

**Not verified:** the image build. No Docker on the machine I work from, so the
Dockerfile change is unbuilt. The two added lines are trivial syntax, but that is an
argument, not a test — worth a reviewer's eye.

## Rollout

Rides the next natural container rollout. This PR requests no deploy.