### PR TITLE
Write the container readback rule next to the data it applies to

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -674,6 +674,22 @@ admin.get("/api/admin/container/build", async (c) => {
     typeof parsed === "object" && parsed !== null && "build" in parsed
       ? (parsed as { build?: unknown }).build
       : undefined;
+  // How to read the response. `stamped` alone does not answer "is the old image still
+  // serving", and the shorthand is what people quote:
+  //
+  //   ok:true   status:200  stamped:false  -> the old image is serving
+  //   ok:false  status:5xx  stamped:false  -> the container answered but is unhealthy;
+  //                                           NOT MEASURED, not a statement about which
+  //                                           image is up
+  //   (unreachable container throws, so there is no `stamped` field at all)
+  //
+  // Anything other than the first line is "not measured". Separating "could not read"
+  // from "read an unstamped image" is the entire reason this endpoint exists, and the
+  // separation is undone the moment someone reads one field instead of three.
+  //
+  // `stamped:true` needs no such qualification, and deliberately does not get one for
+  // symmetry: the running image has no code that emits `build`, so a true cannot be
+  // produced by anything except a rebuilt image.
   return c.json({
     ok: res.ok,
     status: res.status,


### PR DESCRIPTION
**Comment only. No behaviour change.** 16 added lines in one file.

`/api/admin/container/build` already separates *could not read* from *read an unstamped
image*. My shorthand for it undid that separation one layer up — I wrote "before the
rollout → `stamped:false` (old image)", which holds only when the container answered
healthily.

| response | meaning |
|---|---|
| `ok:true` `status:200` `stamped:false` | the old image is serving |
| `ok:false` `status:5xx` `stamped:false` | answered but unhealthy — **not measured** |
| unreachable container | throws; there is no `stamped` field at all |

Only the first line is a statement about which image is up. Everything else is "not
measured".

Caught by @Sentinel on the shorthand rather than on the code, which is exactly the
reason for this PR: **the next person reads the summary, not the implementation**, so the
qualifier has to live where the fields are.

`stamped:true` gets no matching qualifier, deliberately — the running image has no code
that emits `build`, so a true cannot come from anywhere but a rebuilt image. The
asymmetry is correct and should not be evened out for tidiness.

## Verification

- worker `tsc --noEmit`: 0 errors
- full worker suite: 403 passed, 35 files
- diff is 16 added comment lines, no executable change