### PR TITLE
Add actionlint as a layer; measure why it cannot replace the interpolation lint

### DIFF
--- a/.github/lint-fixtures/injection-declared-input.yml
+++ b/.github/lint-fixtures/injection-declared-input.yml
@@ -1,0 +1,35 @@
+# A fixture that separates two tools' coverage. It is a REAL injection vector:
+# `anything` is declared as free text, and interpolating it into `run:` splices
+# attacker-controlled input into program text before the shell parses the line.
+#
+# check-workflows.py REDS on it - its rule is "no interpolation inside executable
+# text, full stop", precisely because a `type: choice` declaration elsewhere in a
+# file can drift without anything connecting it to the line it protects.
+#
+# actionlint (1.7.7) PASSES it - its untrusted-input rule covers a fixed list of
+# known-untrusted contexts (github.event.*.title and the like); a declared string
+# input spliced into run is not on that list. This is measured, not assumed: the
+# known-bad.yml fixture DOES go red under actionlint, but for undeclared
+# properties and a duplicate key - zero of its findings are injection detection.
+#
+# The actionlint workflow asserts this file exits 0 under actionlint. The day a
+# new actionlint version starts flagging it, that assertion goes red - and THAT
+# is the signal to reconsider retiring check-workflows.py, which until then is
+# the only control enforcing this property. Task #117 originally planned to
+# delete it once actionlint was proven red on known-bad.yml; the proof exists
+# and proves the wrong thing, so the deletion does not happen.
+#
+# Kept outside .github/workflows/ so GitHub never parses it as a live workflow.
+name: declared-input injection probe
+on:
+  workflow_dispatch:
+    inputs:
+      anything:
+        description: "free text - the declaration is the point"
+        required: true
+        type: string
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ inputs.anything }}"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -33,7 +33,11 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  # Named distinctly from workflow-lint's job on purpose: both would otherwise
+  # display as "lint" on the PR checks page, and two checks with one name is how
+  # a name-based search reads "the other one ran" as "mine ran" - measured
+  # tonight on this very repo, in the deploy-watch thread.
+  actionlint:
     runs-on: ubuntu-latest
     env:
       ACTIONLINT_VERSION: "1.7.7"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,123 @@
+name: actionlint
+
+# actionlint is an ADDITIONAL layer over check-workflows.py, not its replacement.
+# Task #117 planned the replacement; measurement killed it. actionlint's
+# untrusted-input rule covers a fixed list of known-untrusted contexts - a
+# declared free-text input interpolated into `run:` passes it clean (see
+# lint-fixtures/injection-declared-input.yml), and banning exactly that is why
+# check-workflows.py exists. What actionlint adds that our lint does not have:
+# expression type-checking (undeclared inputs/properties), workflow syntax
+# validation, action pinning and deprecation checks.
+#
+# Both tools self-test against a fixture built to fail before their clean result
+# is believed - "no problems found" is otherwise indistinguishable from "the
+# check never executed".
+#
+# shellcheck/pyflakes integration is disabled explicitly, not by accident: they
+# are picked up if present on the runner, they are not pinned by this workflow,
+# and the machine this was verified on does not have them - so leaving them on
+# would mean the green here and the green at verification time are different
+# claims. Enabling them is a separate, deliberate change.
+
+on:
+  pull_request:
+    paths:
+      # Wide on purpose. "Which files do these checks assert on" is a derived
+      # list that misses silently in the direction of green; the whole directory
+      # has nothing to miss. (Same reasoning, same incident, as worker-tests.)
+      - ".github/**"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_VERSION: "1.7.7"
+      # Checksum of the release tarball, verified before first use on
+      # 2026-08-10. A version pin without a checksum trusts the release asset
+      # not to change under the same tag.
+      ACTIONLINT_SHA256: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
+      KNOWN_BAD: .github/lint-fixtures/known-bad.yml
+      BLIND_SPOT: .github/lint-fixtures/injection-declared-input.yml
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pinned actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sSL -o /tmp/actionlint.tgz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tgz" | sha256sum -c -
+          tar -C /tmp -xzf /tmp/actionlint.tgz actionlint
+          /tmp/actionlint --version
+
+      - name: Self-test - actionlint must fail the known-bad fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Expected to exit non-zero; captured without a pipe so the verdict is
+          # actionlint's, not a downstream command's.
+          set +e
+          output=$(/tmp/actionlint -shellcheck= -pyflakes= "${KNOWN_BAD}" 2>&1)
+          status=$?
+          set -e
+          findings=$(grep -cE '^[^ ]+:[0-9]+:[0-9]+:' <<<"${output}" || true)
+
+          if [[ "${status}" -eq 0 ]]; then
+            echo "CANNOT RUN: actionlint passed a file written to fail it." >&2
+            echo "A clean result from it today would be worthless." >&2
+            exit 2
+          fi
+          # Exactly 4, not "at least one": 3 expression findings + 1 duplicate
+          # key, pinned to this actionlint version. Honest scope note - these
+          # prove the binary runs and detects; they are NOT injection coverage.
+          # The 3 expression hits are "property not defined" (the fixture's
+          # inputs are deliberately undeclared). Injection coverage is what the
+          # blind-spot step below shows actionlint does NOT have.
+          if [[ "${findings}" -ne 4 ]]; then
+            echo "CANNOT RUN: expected exactly 4 findings on the fixture, got ${findings}." >&2
+            echo "The tool or the fixture changed without this expectation changing." >&2
+            printf '%s\n' "${output}" >&2
+            exit 2
+          fi
+          echo "Self-test passed: actionlint reds on the fixture (4 findings; none of them injection)."
+
+      - name: Boundary - actionlint must NOT see the declared-input injection
+        shell: bash
+        run: |
+          set -euo pipefail
+          # This asserts a BLIND SPOT, on purpose. The fixture is a real
+          # injection vector that only check-workflows.py catches. If a new
+          # actionlint version starts flagging it, this step goes red - and that
+          # red is the signal to reconsider retiring check-workflows.py, not a
+          # defect in the fixture. Update the version pin and this assertion
+          # together, deliberately.
+          set +e
+          output=$(/tmp/actionlint -shellcheck= -pyflakes= "${BLIND_SPOT}" 2>&1)
+          status=$?
+          set -e
+          if [[ "${status}" -ne 0 ]]; then
+            echo "actionlint now FLAGS the declared-input injection fixture:" >&2
+            printf '%s\n' "${output}" >&2
+            echo "" >&2
+            echo "This blind spot closing is good news with a required follow-up:" >&2
+            echo "re-evaluate whether check-workflows.py is still load-bearing" >&2
+            echo "before touching either tool. Do not silence this step." >&2
+            exit 1
+          fi
+          echo "Confirmed: actionlint does not cover this vector; check-workflows.py remains the only control for it."
+
+      - name: Lint the real workflows
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(.github/workflows/*.yml .github/workflows/*.yaml)
+          echo "linting ${#files[@]} workflow files"
+          /tmp/actionlint -shellcheck= -pyflakes= "${files[@]}"
+          echo "actionlint: no findings across ${#files[@]} workflow files."

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -105,7 +105,20 @@ jobs:
           output=$(/tmp/actionlint -shellcheck= -pyflakes= "${BLIND_SPOT}" 2>&1)
           status=$?
           set -e
-          if [[ "${status}" -ne 0 ]]; then
+          if [[ "${status}" -eq 0 ]]; then
+            echo "Confirmed: actionlint does not cover this vector; check-workflows.py remains the only control for it."
+            exit 0
+          fi
+
+          # Non-zero is NOT automatically "the blind spot closed". Measured on
+          # 1.7.7: a moved/renamed fixture exits 3 ("could not read"); a fixture
+          # with broken YAML exits 1 with a [syntax-check] finding. Reporting
+          # either as closure would be a zero-discrimination red pointing at
+          # deleting the one control that covers this vector - the exact defect
+          # this PR documents in known-bad's red. A genuine injection finding
+          # is the only non-zero that means closure, and on this pinned version
+          # it is identified by its message: "potentially untrusted".
+          if grep -q "potentially untrusted" <<<"${output}"; then
             echo "actionlint now FLAGS the declared-input injection fixture:" >&2
             printf '%s\n' "${output}" >&2
             echo "" >&2
@@ -114,7 +127,12 @@ jobs:
             echo "before touching either tool. Do not silence this step." >&2
             exit 1
           fi
-          echo "Confirmed: actionlint does not cover this vector; check-workflows.py remains the only control for it."
+          echo "CANNOT RUN: the probe did not measure the blind spot." >&2
+          echo "actionlint exited ${status} on the fixture for a reason other" >&2
+          echo "than an injection finding (moved file? broken YAML?). Fix the" >&2
+          echo "probe; do not act on any tool based on this run." >&2
+          printf '%s\n' "${output}" >&2
+          exit 2
 
       - name: Lint the real workflows
         shell: bash

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -47,6 +47,12 @@ jobs:
       # (1 defect - a declared free-text input interpolated into run, which is
       # also the documented actionlint blind spot; see actionlint.yml).
       FIXTURES: .github/lint-fixtures/known-bad.yml .github/lint-fixtures/injection-declared-input.yml
+      # Expected findings PER FIXTURE, aligned with FIXTURES by position. Pinned
+      # individually, not as a sum: a total of 5 is also satisfied by known-bad
+      # drifting to 5 while the other fixture stops being detected at all - two
+      # different worlds under one number, which is exactly what the count is
+      # supposed to prevent.
+      FIXTURE_EXPECT: "4 1"
     steps:
       - uses: actions/checkout@v5
 
@@ -61,51 +67,57 @@ jobs:
         run: |
           set -uo pipefail
           read -r -a fixtures <<< "$FIXTURES"
+          read -r -a expect <<< "$FIXTURE_EXPECT"
 
-          # The checker is *expected* to exit non-zero here - that is what the fixture
-          # is for. GitHub invokes steps as `bash -e`, and `pipefail` hands that
-          # non-zero to the assignment, so the step died before the count was ever
-          # compared. Captured without a pipe, with the status taken deliberately
-          # instead of inherited.
-          set +e
-          output=$(python3 .github/lint-fixtures/check-workflows.py "${fixtures[@]}")
-          status=$?
-          set -e
-          findings=$(printf '%s' "$output" | grep -c . || true)
+          if [[ "${#fixtures[@]}" -ne "${#expect[@]}" ]]; then
+            echo "CANNOT RUN: ${#fixtures[@]} fixtures but ${#expect[@]} expectations." >&2
+            echo "The two lists drifted apart; align them before trusting this run." >&2
+            exit 2
+          fi
 
-          if [[ "$status" -eq 2 ]]; then
-            echo "CANNOT RUN: the checker could not execute." >&2
-            printf '%s\n' "$output" >&2
-            exit 2
-          fi
-          if [[ "$status" -eq 0 ]]; then
-            echo "" >&2
-            echo "CANNOT RUN: the checker passed a file written to fail it." >&2
-            echo "It is not working, so any clean result from it today is worthless." >&2
-            exit 2
-          fi
-          # Four exactly, not "at least one". A bare non-zero would still be satisfied
-          # if the fixture grew a shape the checker cannot see: the other cases would
-          # keep it red and the new blind spot would pass unnoticed. That is how the
-          # block-only version of this checker survived while missing every
-          # single-line run in the repository - a control agreeing with the thing it
-          # was meant to test.
-          if [[ "$findings" -lt 5 ]]; then
-            echo "" >&2
-            echo "CANNOT RUN: the checker reported ${findings} of the 5 defects planted" >&2
-            echo "in the fixtures, so it cannot see all of them and a clean result from" >&2
-            echo "it today would mean nothing." >&2
-            exit 2
-          fi
-          if [[ "$findings" -gt 5 ]]; then
-            echo "" >&2
-            echo "CANNOT RUN: ${findings} defects reported where 5 are expected." >&2
-            echo "The fixtures changed without the expectation changing. Update the" >&2
-            echo "count deliberately - it is the statement of what this self-test" >&2
-            echo "proves, and a number that drifts along with its input proves nothing." >&2
-            exit 2
-          fi
-          echo "Self-test passed: all 5 planted defects reported (4 interpolation forms across 2 fixtures + duplicate key)."
+          # Per fixture, not in one batch. A batch total conflates the fixtures:
+          # one drifting up while another drops to zero leaves the sum intact.
+          # The checker is *expected* to exit non-zero on each - that is what a
+          # fixture is for. GitHub invokes steps as `bash -e`, and `pipefail`
+          # hands that non-zero to the assignment, so the step died before the
+          # count was ever compared. Captured without a pipe, with the status
+          # taken deliberately instead of inherited.
+          for i in "${!fixtures[@]}"; do
+            f="${fixtures[$i]}"
+            want="${expect[$i]}"
+            set +e
+            output=$(python3 .github/lint-fixtures/check-workflows.py "$f")
+            status=$?
+            set -e
+            findings=$(printf '%s' "$output" | grep -c . || true)
+
+            if [[ "$status" -eq 2 ]]; then
+              echo "CANNOT RUN: the checker could not execute on ${f}." >&2
+              printf '%s\n' "$output" >&2
+              exit 2
+            fi
+            if [[ "$status" -eq 0 ]]; then
+              echo "" >&2
+              echo "CANNOT RUN: the checker passed ${f}, a file written to fail it." >&2
+              echo "It is not working, so any clean result from it today is worthless." >&2
+              exit 2
+            fi
+            # Exact, not "at least one". A bare non-zero would still be satisfied
+            # if the fixture grew a shape the checker cannot see: the other cases
+            # would keep it red and the new blind spot would pass unnoticed.
+            if [[ "$findings" -ne "$want" ]]; then
+              echo "" >&2
+              echo "CANNOT RUN: ${f} produced ${findings} findings where exactly ${want}" >&2
+              echo "are expected. The fixture or the checker changed without this" >&2
+              echo "expectation changing. Update the count deliberately - it is the" >&2
+              echo "statement of what this self-test proves, and a number that drifts" >&2
+              echo "along with its input proves nothing." >&2
+              printf '%s\n' "$output" >&2
+              exit 2
+            fi
+            echo "  ok  ${f}: exactly ${want} finding(s)"
+          done
+          echo "Self-test passed: every fixture failed with exactly its pinned count (4 + 1)."
 
       - name: Check every file that carries executable text
         run: |

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -43,7 +43,10 @@ jobs:
     # self-test eats a fixture the denominator still counts, and the run fails saying
     # "a file was not scanned" when the truth is "two lists disagree".
     env:
-      FIXTURES: .github/lint-fixtures/known-bad.yml
+      # Two fixtures: known-bad.yml (4 defects) and injection-declared-input.yml
+      # (1 defect - a declared free-text input interpolated into run, which is
+      # also the documented actionlint blind spot; see actionlint.yml).
+      FIXTURES: .github/lint-fixtures/known-bad.yml .github/lint-fixtures/injection-declared-input.yml
     steps:
       - uses: actions/checkout@v5
 
@@ -87,22 +90,22 @@ jobs:
           # block-only version of this checker survived while missing every
           # single-line run in the repository - a control agreeing with the thing it
           # was meant to test.
-          if [[ "$findings" -lt 4 ]]; then
+          if [[ "$findings" -lt 5 ]]; then
             echo "" >&2
-            echo "CANNOT RUN: the checker reported ${findings} of the 4 defects planted" >&2
+            echo "CANNOT RUN: the checker reported ${findings} of the 5 defects planted" >&2
             echo "in the fixtures, so it cannot see all of them and a clean result from" >&2
             echo "it today would mean nothing." >&2
             exit 2
           fi
-          if [[ "$findings" -gt 4 ]]; then
+          if [[ "$findings" -gt 5 ]]; then
             echo "" >&2
-            echo "CANNOT RUN: ${findings} defects reported where 4 are expected." >&2
+            echo "CANNOT RUN: ${findings} defects reported where 5 are expected." >&2
             echo "The fixtures changed without the expectation changing. Update the" >&2
             echo "count deliberately - it is the statement of what this self-test" >&2
             echo "proves, and a number that drifts along with its input proves nothing." >&2
             exit 2
           fi
-          echo "Self-test passed: all 4 planted defects reported (3 run forms + duplicate key)."
+          echo "Self-test passed: all 5 planted defects reported (4 interpolation forms across 2 fixtures + duplicate key)."
 
       - name: Check every file that carries executable text
         run: |


### PR DESCRIPTION
Task #117. The plan said: bring in actionlint, prove it reds on `known-bad.yml`, then
delete the temporary lint. **The proof exists and proves the wrong thing, so the deletion
does not happen.**

## The measurement that changed the task

actionlint 1.7.7, binary sha256-verified:

| target | result |
|---|---|
| real workflows | exit 0, 0 findings — green on arrival |
| `known-bad.yml` | exit 1, 4 findings — 3× *property not defined* + 1 duplicate key. **Zero injection detection.** |
| declared-input probe | input declared `type: string`, interpolated into `run:` — **actionlint passes it clean; check-workflows.py reds** |

actionlint's untrusted-input rule covers a fixed list of known-untrusted contexts
(`github.event.*.title` and friends). A declared free-text input spliced into `run:` is
not on the list — and banning exactly that is why the temporary lint exists (a
`type: choice` declaration elsewhere in the file can drift with nothing connecting it to
the line it protects). `known-bad.yml` going red under actionlint is a red with **no
discriminating power** for the property that matters.

## What this PR does instead

- **`actionlint.yml`** — pinned by version *and* checksum; self-tests against
  `known-bad.yml` demanding exactly 4 findings (scope-honest: proves the tool runs, not
  injection coverage); then lints the real workflows. shellcheck/pyflakes disabled
  explicitly — unpinned runner-dependent extras, absent on the verification machine, so a
  green with them on would be a different claim than the one tested.
- **`injection-declared-input.yml`** — the probe, kept as a fixture. The workflow asserts
  actionlint exits **0** on it: an assertion of a blind spot. If an actionlint upgrade
  starts flagging it, that step reds — and *that* is the signal to reconsider retiring
  check-workflows.py. **The retirement question now has a detector instead of a memory.**
- **`workflow-lint.yml`** — the new fixture joins `FIXTURES`, self-test expectation 4→5,
  per that file's own rule (the exclusion set is the self-test's input set).

## Verification (all sides)

- check-workflows on both fixtures: exit 1, **exactly 5** findings
- check-workflows on real workflows incl. the new one: 0
- actionlint on real workflows incl. its own file: 0
- actionlint: red on known-bad (4), green on blind-spot — both directions
- `.github` YAML denominator closed: every file is either scanned or a declared fixture

check-workflows.py stays. **Never retire a control before its replacement is proven — and
the replacement was proven *not* to cover the property.**