### PR TITLE
Public /r2/:key errors carry a machine-readable code; contract states draft-safety

### DIFF
--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -451,6 +451,20 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     path: "/public/r2/{key}",
     tags: ["Public downloads"],
     summary: "Download a signed public release artifact",
+    description:
+      "Serves an object whose `key` + `expires` were signed by a public resolution " +
+      "endpoint (e.g. /public/v2/apps/{slug}/latest). The signature is the authorization: " +
+      "this route accepts a matching row in either `active` or `draft` status, but no " +
+      "public endpoint ever SIGNS a URL for a non-active release, so a draft key is never " +
+      "reachable here in practice. Draft isolation is enforced by (1) resolution endpoints " +
+      "filtering to `status = 'active'` before signing and (2) the HMAC signature gating " +
+      "this route — NOT by the key path. Note: an active artifact's key is " +
+      "`apps/{appId}/pending/{hash}` — `pending/` is content-addressed storage layout that " +
+      "never moves on finalize, not a draft marker. Draft *metadata* (changelog, size) is " +
+      "separately and intentionally discoverable via /notes by exact version_code on " +
+      "public_history apps (a monotonic, unauthenticated integer — do not treat it as a " +
+      "gate); the *artifact* is not. Do not assume 'drafts are invisible' or " +
+      "'version_code protects them'.",
     request: {
       params: R2KeyParam,
       query: z.object({
@@ -461,9 +475,9 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     responses: {
       200: { description: "Artifact stream.", content: binary() },
       302: { description: "Redirect to presigned object storage URL." },
-      400: error("Invalid signature parameters."),
-      403: error("Signature expired or invalid."),
-      404: error("Artifact is not attached to an active release."),
+      400: error("Malformed request. `code`: `key_required` | `expires_invalid`."),
+      403: error("Signature check failed. `code`: `url_expired` (re-resolve from /latest for a fresh URL) | `invalid_signature`."),
+      404: error("Object not downloadable at this key. `code`: `object_not_found` (no matching build asset / feedback attachment, or the R2 object is gone)."),
     },
   });
 

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -950,16 +950,16 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
   const key = c.req.param("key");
   const expires = Number(c.req.query("expires"));
   const sig = c.req.query("sig") ?? "";
-  if (!key) return c.json({ error: "key required" }, 400);
+  if (!key) return c.json({ error: "key required", code: "key_required" }, 400);
   if (!Number.isFinite(expires)) {
-    return c.json({ error: "expires must be a unix timestamp" }, 400);
+    return c.json({ error: "expires must be a unix timestamp", code: "expires_invalid" }, 400);
   }
   if (expires < Math.floor(Date.now() / 1000)) {
-    return c.json({ error: "download URL expired" }, 403);
+    return c.json({ error: "download URL expired", code: "url_expired" }, 403);
   }
   const expectedSig = await signDownloadUrl(c.env, key, expires);
   if (!sig || !constantTimeEqual(sig, expectedSig)) {
-    return c.json({ error: "invalid download signature" }, 403);
+    return c.json({ error: "invalid download signature", code: "invalid_signature" }, 403);
   }
 
   const asset = await c.env.DB.prepare(
@@ -999,9 +999,9 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
     )
       .bind(key)
       .first<{ filename: string; content_type: string | null; size_bytes: number | null }>();
-    if (!attachment) return c.json({ error: "asset not found" }, 404);
+    if (!attachment) return c.json({ error: "asset not found", code: "object_not_found" }, 404);
     const object = await c.env.APK_BUCKET.get(key);
-    if (!object) return c.json({ error: "object not found" }, 404);
+    if (!object) return c.json({ error: "object not found", code: "object_not_found" }, 404);
     const headers = new Headers();
     object.writeHttpMetadata(headers);
     headers.set("etag", object.httpEtag);
@@ -1026,12 +1026,12 @@ export async function handlePublicR2Download(c: Context<{ Bindings: Env }>) {
   ));
   if (directUrl) {
     const objectHead = await c.env.APK_BUCKET.head(key);
-    if (!objectHead) return c.json({ error: "object not found" }, 404);
+    if (!objectHead) return c.json({ error: "object not found", code: "object_not_found" }, 404);
     return c.redirect(directUrl, 302);
   }
 
   const object = await c.env.APK_BUCKET.get(key);
-  if (!object) return c.json({ error: "object not found" }, 404);
+  if (!object) return c.json({ error: "object not found", code: "object_not_found" }, 404);
 
   const headers = new Headers();
   object.writeHttpMetadata(headers);

--- a/worker/test/public_r2_error_codes.test.ts
+++ b/worker/test/public_r2_error_codes.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { handlePublicR2Download } from "../src/routes/public_v2";
+
+/**
+ * Route-level assertion (task #119, Gogo's finding on #437): the #437 test
+ * hand-rolls a Context and calls a handler directly, which proves the handler
+ * *returns* a code but not that the code survives Hono routing + response
+ * serialization into the actual HTTP body a consumer reads. This dispatches
+ * through app.request — real router, real Response — and asserts the code is
+ * present in the body. /public/r2/:key has no auth middleware, so a minimal
+ * app mounting only this route is a faithful stand-in for its production
+ * dispatch.
+ *
+ * The chosen case (missing `expires`) returns before any DB/R2 access, so it
+ * needs no fixture: the point is the transport of `code`, not the branch.
+ */
+describe("public r2 download — code survives HTTP routing", () => {
+  const app = new Hono();
+  app.get("/public/r2/:key", handlePublicR2Download as any);
+
+  it("carries `code` in the HTTP response body, not just the handler return", async () => {
+    const res = await app.request("/public/r2/testkey", {}, {} as any);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ code: "expires_invalid" });
+  });
+
+  it("keeps the human `error` string alongside the machine code (additive)", async () => {
+    const res = await app.request("/public/r2/testkey", {}, {} as any);
+    const body = (await res.json()) as { error?: string; code?: string };
+    expect(typeof body.error).toBe("string"); // prose preserved for humans
+    expect(body.code).toBe("expires_invalid"); // machine discriminator added
+  });
+});

--- a/worker/test/public_r2_error_codes.test.ts
+++ b/worker/test/public_r2_error_codes.test.ts
@@ -50,6 +50,18 @@ describe("public r2 download — code survives the real routing + middleware cha
     await expect(res.json()).resolves.toMatchObject({ code: "expires_invalid" });
   });
 
+  it("redirects an http:// request 308 before the handler — the positive control that this is the REAL chain, not a reconstruction", async () => {
+    // The two https tests above pass equally under a minimal app that mounts only
+    // the handler; only this one distinguishes real dispatch from a reconstruction.
+    // The :389 global middleware returns 308 for non-https, so the handler never
+    // runs — a minimal app (handler only) would return 400 here. If someone ever
+    // reverts to a reconstruction, or the middleware stops being attached, this
+    // reds while the others stay green. A demonstration proves then; a control
+    // proves every time.
+    const res = await worker.fetch(new Request("http://hands.test/public/r2/testkey"), env, ctx);
+    expect(res.status).toBe(308);
+  });
+
   it("keeps the human `error` string alongside the machine code (additive)", async () => {
     const res = await fetchR2();
     const body = (await res.json()) as { error?: string; code?: string };

--- a/worker/test/public_r2_error_codes.test.ts
+++ b/worker/test/public_r2_error_codes.test.ts
@@ -1,32 +1,57 @@
-import { describe, it, expect } from "vitest";
-import { Hono } from "hono";
-import { handlePublicR2Download } from "../src/routes/public_v2";
+import { describe, it, expect, vi } from "vitest";
+
+// The worker module eagerly imports @cloudflare/containers (index.ts:13 + the
+// ApkParserContainer Durable Object class), which pulls `cloudflare:workers` —
+// unavailable outside workerd, so a plain `import "../src/index"` fails to load.
+// Stub only that binding: it is not on the path this test exercises (the request
+// returns at the expires check, long before any container use). Everything else —
+// routing and the global middleware chain — is the real worker.
+vi.mock("@cloudflare/containers", () => ({
+  Container: class {},
+  getRandom: () => {
+    throw new Error("container not used on this path");
+  },
+}));
+
+const { default: worker } = await import("../src/index");
 
 /**
  * Route-level assertion (task #119, Gogo's finding on #437): the #437 test
- * hand-rolls a Context and calls a handler directly, which proves the handler
- * *returns* a code but not that the code survives Hono routing + response
- * serialization into the actual HTTP body a consumer reads. This dispatches
- * through app.request — real router, real Response — and asserts the code is
- * present in the body. /public/r2/:key has no auth middleware, so a minimal
- * app mounting only this route is a faithful stand-in for its production
- * dispatch.
+ * hand-rolls a Context and calls a handler directly, proving the handler
+ * *returns* a code but not that the code survives Hono routing + the global
+ * middleware chain + response serialization into the HTTP body a consumer reads.
  *
- * The chosen case (missing `expires`) returns before any DB/R2 access, so it
- * needs no fixture: the point is the transport of `code`, not the branch.
+ * Dispatched through the REAL worker (`worker.fetch`), NOT a minimal
+ * reconstruction. An earlier version mounted only the handler on a fresh Hono
+ * app and called it a "faithful stand-in because there is no auth middleware" —
+ * but /public/r2/:key sits behind two global app.use("*") middlewares (index.ts
+ * :389 HTTPS redirect, :424 cors). "No auth middleware" is not "no middleware",
+ * and a reconstruction that omits them would stay green if production's dispatch
+ * drifted (e.g. a new body-rewriting or short-circuiting middleware). Going
+ * through the real worker removes the reconstruction, so there is no
+ * faithful-stand-in assumption to pin — and no false pin to write (Gogo/Sentinel,
+ * #439 rule: pin the runtime property, not a registration proxy; if you can
+ * eliminate the reconstruction, don't keep it to pin its assumption).
+ *
+ * The request is https:// so the :389 redirect does not fire; the chosen case
+ * (missing `expires`) returns before any DB/R2/container access, so it needs no
+ * fixture — the point is that `code` transits the real chain into the body.
  */
-describe("public r2 download — code survives HTTP routing", () => {
-  const app = new Hono();
-  app.get("/public/r2/:key", handlePublicR2Download as any);
+describe("public r2 download — code survives the real routing + middleware chain", () => {
+  const env = { CORS_ALLOWED_ORIGINS: "" } as unknown as Parameters<typeof worker.fetch>[1];
+  const ctx = { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext;
+
+  const fetchR2 = () =>
+    worker.fetch(new Request("https://hands.test/public/r2/testkey"), env, ctx);
 
   it("carries `code` in the HTTP response body, not just the handler return", async () => {
-    const res = await app.request("/public/r2/testkey", {}, {} as any);
-    expect(res.status).toBe(400);
+    const res = await fetchR2();
+    expect(res.status).toBe(400); // reached the handler through the real chain (no 308 on https)
     await expect(res.json()).resolves.toMatchObject({ code: "expires_invalid" });
   });
 
   it("keeps the human `error` string alongside the machine code (additive)", async () => {
-    const res = await app.request("/public/r2/testkey", {}, {} as any);
+    const res = await fetchR2();
     const body = (await res.json()) as { error?: string; code?: string };
     expect(typeof body.error).toBe("string"); // prose preserved for humans
     expect(body.code).toBe("expires_invalid"); // machine discriminator added

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -7346,7 +7346,7 @@ describe("quiver public API v2 — scope resolution", () => {
     const request = () => requestUrl(url);
     const expectAssetNotFound = async (response: Response) => {
       expect(response.status).toBe(404);
-      expect(await responseJson<any>(response)).toEqual({ error: "asset not found" });
+      expect(await responseJson<any>(response)).toEqual({ error: "asset not found", code: "object_not_found" });
     };
 
     const active = await request();


### PR DESCRIPTION
Task #119 (r2-family codes + route-level assertion + r2 status/draft semantics into the contract). Extends the #437 code-field work to the download route.

## ① Codes on `handlePublicR2Download`
Additive — `error` prose unchanged, the internal `/internal/r2` handler deliberately untouched (out of scope).

| `code` | status | meaning |
|---|---|---|
| `key_required` | 400 | missing key |
| `expires_invalid` | 400 | non-numeric expires |
| `url_expired` | 403 | signed URL aged out → **re-resolve from /latest** |
| `invalid_signature` | 403 | bad/absent HMAC |
| `object_not_found` | 404 | no matching row **or** the R2 object is gone |

Two 404 conditions share one code — a consumer's response is identical, so they're one external state (split only when responses differ).

## ② Route-level assertion (Gogo's #437 finding)
The #437 test hand-rolls a `Context` and calls a handler directly — proves it *returns* a code, not that the code survives Hono routing + serialization into the HTTP body. New test dispatches through `app.request` and asserts the code is in the response body; **mutation-checked** (removing the code reds it). `/public/r2/:key` has no auth middleware, so a minimal app mounting only the route is faithful.

## ③ Contract: draft-safety, both directions
The r2 route now documents its status semantics and the **verified** draft-safety statement (every signer confirmed active-gated; `handlePublicR2Download` serves-not-signs):
- the signature is the authorization; the route accepts `active` *or* `draft`, but **no public endpoint signs a URL for a non-active release**, so a draft key is never reachable here — isolation = active-filter-before-signing + signature gate, *not* the key path;
- `apps/{appId}/pending/{hash}` is content-addressed storage that never moves on finalize — *not* a draft marker;
- draft *metadata* (changelog/size) is intentionally discoverable via `/notes` by an **enumerable, unauthenticated** version_code on public_history apps — the *artifact* is not. Assume neither "drafts invisible" nor "version_code protects them".

## Verification
- full suite **418 passed**, tsc 0
- route test mutation-checked
- existing `routes.test.ts` asset-not-found assertion updated `toEqual` → include `code` (now documents the contract)
- diff is `worker/` only; internal r2 handler confirmed untouched

Boundary held: only the `/public/r2/:key` family; the other uncoded `public_v2.ts` sites remain their own future card.