### PR TITLE
Add separately deployed Hands admin observability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Hands production observability is a separately deployed operations surface.
+/.github/CODEOWNERS @bytemain
+/admin-worker/ @bytemain
+/worker/src/observability_data.ts @bytemain
+/worker/src/observability_rpc.ts @bytemain
+/.github/workflows/deploy-hands-admin.yml @bytemain

--- a/.github/workflows/deploy-hands-admin.yml
+++ b/.github/workflows/deploy-hands-admin.yml
@@ -1,0 +1,60 @@
+name: Deploy Hands Admin
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hands-admin-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment: hands-admin-production
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+      HANDS_ADMIN_WORKER_NAME: ${{ vars.HANDS_ADMIN_WORKER_NAME }}
+      HANDS_ADMIN_DOMAIN: ${{ vars.HANDS_ADMIN_DOMAIN }}
+      HANDS_ADMIN_AUDIT_DB_NAME: ${{ vars.HANDS_ADMIN_AUDIT_DB_NAME }}
+      HANDS_ADMIN_AUDIT_DB_ID: ${{ vars.HANDS_ADMIN_AUDIT_DB_ID }}
+      HANDS_WORKER_NAME: ${{ vars.HANDS_WORKER_NAME }}
+      HANDS_RAFT_ORIGIN: ${{ vars.HANDS_RAFT_ORIGIN }}
+      HANDS_RAFT_API_ORIGIN: ${{ vars.HANDS_RAFT_API_ORIGIN }}
+      HANDS_ADMIN_RAFT_CLIENT_ID: ${{ vars.HANDS_ADMIN_RAFT_CLIENT_ID }}
+      HANDS_ADMIN_ALLOWED_SERVER_IDS: ${{ vars.HANDS_ADMIN_ALLOWED_SERVER_IDS }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with: { version: 9.12.0 }
+      - uses: actions/setup-node@v6
+        with: { node-version: "22", cache: "pnpm" }
+      - run: pnpm install --frozen-lockfile
+      - name: Validate
+        run: |
+          pnpm --filter @botiverse/hands-worker build
+          pnpm --filter @botiverse/hands-worker test -- observability_rpc.test.ts
+          pnpm --filter @botiverse/hands-admin-worker build
+          pnpm --filter @botiverse/hands-admin-worker test
+      - name: Render production config
+        working-directory: admin-worker
+        run: node scripts/render-production-config.mjs --output wrangler.generated.jsonc
+      - name: Apply audit migrations
+        working-directory: admin-worker
+        run: pnpm exec wrangler d1 migrations apply "${HANDS_ADMIN_AUDIT_DB_NAME}" --remote --config wrangler.generated.jsonc
+      - name: Configure secrets
+        working-directory: admin-worker
+        shell: bash
+        env:
+          RAFT_CLIENT_SECRET: ${{ secrets.HANDS_ADMIN_RAFT_CLIENT_SECRET }}
+          SESSION_SECRET: ${{ secrets.HANDS_ADMIN_SESSION_SECRET }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$RAFT_CLIENT_SECRET" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config wrangler.generated.jsonc
+          printf '%s' "$SESSION_SECRET" | pnpm exec wrangler secret put SESSION_SECRET --config wrangler.generated.jsonc
+      - name: Deploy
+        working-directory: admin-worker
+        run: pnpm exec wrangler deploy --config wrangler.generated.jsonc

--- a/admin-worker/README.md
+++ b/admin-worker/README.md
@@ -1,0 +1,9 @@
+# Hands Admin Worker
+
+Separately deployed, staff-only observability UI for Hands.
+
+- No Hands D1 or R2 binding. Product data is available only through the main Worker's named `HandsObservability.getOverview()` RPC method.
+- Login with Raft is enforced server-side. An encrypted HttpOnly session carries the Raft token, and every sensitive request re-reads userinfo and rechecks the explicit server allowlist plus owner/admin role.
+- The RPC response is a closed aggregate schema: counts, bytes, enums, and timestamps only.
+- Every view is written to this Worker's separate audit D1 database.
+- Secrets and production identifiers are injected at deploy time, never committed.

--- a/admin-worker/migrations/0001_audit.sql
+++ b/admin-worker/migrations/0001_audit.sql
@@ -1,0 +1,8 @@
+CREATE TABLE access_audit (
+  id TEXT PRIMARY KEY,
+  actor_subject TEXT NOT NULL,
+  server_id TEXT NOT NULL,
+  action TEXT NOT NULL CHECK (action = 'overview.view'),
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX idx_access_audit_created ON access_audit(created_at DESC);

--- a/admin-worker/package.json
+++ b/admin-worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@botiverse/hands-admin-worker",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": { "hono": "^4.12.34", "jose": "^5.9.6" },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250101.0",
+    "jsonc-parser": "^3.3.1",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.8",
+    "wrangler": "^4.88.0"
+  }
+}

--- a/admin-worker/scripts/render-production-config.mjs
+++ b/admin-worker/scripts/render-production-config.mjs
@@ -1,0 +1,40 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "jsonc-parser";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const outputIndex = process.argv.indexOf("--output");
+const output = resolve(root, outputIndex >= 0 ? process.argv[outputIndex + 1] : "wrangler.generated.jsonc");
+const required = (name) => {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment value ${name}`);
+  return value;
+};
+const uuid = (name) => {
+  const value = required(name);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) throw new Error(`${name} must be a UUID`);
+  return value;
+};
+const domain = (name) => {
+  const value = required(name).toLowerCase();
+  if (!/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i.test(value)) throw new Error(`${name} must be a hostname`);
+  return value;
+};
+
+const config = parse(readFileSync(resolve(root, "wrangler.jsonc"), "utf8"));
+config.name = required("HANDS_ADMIN_WORKER_NAME");
+config.routes = [{ pattern: domain("HANDS_ADMIN_DOMAIN"), custom_domain: true }];
+config.services[0].service = required("HANDS_WORKER_NAME");
+config.d1_databases[0].database_name = required("HANDS_ADMIN_AUDIT_DB_NAME");
+config.d1_databases[0].database_id = uuid("HANDS_ADMIN_AUDIT_DB_ID");
+config.vars = {
+  RAFT_ORIGIN: required("HANDS_RAFT_ORIGIN"),
+  RAFT_API_ORIGIN: required("HANDS_RAFT_API_ORIGIN"),
+  RAFT_CLIENT_ID: required("HANDS_ADMIN_RAFT_CLIENT_ID"),
+  RAFT_ALLOWED_SERVER_IDS: required("HANDS_ADMIN_ALLOWED_SERVER_IDS"),
+};
+mkdirSync(dirname(output), { recursive: true });
+writeFileSync(output, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+console.log(`Rendered production Wrangler config: ${output}`);

--- a/admin-worker/src/auth.ts
+++ b/admin-worker/src/auth.ts
@@ -1,0 +1,85 @@
+import { EncryptJWT, jwtDecrypt } from "jose";
+import type { Context, MiddlewareHandler } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import type { AdminWorkerEnv } from "./env";
+
+const SESSION = "hands_admin_session";
+const STATE = "hands_admin_oauth_state";
+export type AdminSession = { sub: string; server_id: string; role: string; name: string; access_token: string };
+type Userinfo = { sub: string; server_id: string; server_role?: string; name?: string; preferred_username?: string };
+const key = (secret: string) => new TextEncoder().encode(secret);
+type AdminAppEnv = { Bindings: AdminWorkerEnv; Variables: { session: AdminSession } };
+
+async function readSession(c: Context<AdminAppEnv>) {
+  const token = getCookie(c, SESSION);
+  if (!token) return null;
+  try {
+    const verified = await jwtDecrypt(token, key(c.env.SESSION_SECRET), { keyManagementAlgorithms: ["dir"], contentEncryptionAlgorithms: ["A256GCM"] });
+    return verified.payload as unknown as AdminSession;
+  } catch { return null; }
+}
+
+export const requireAdmin: MiddlewareHandler<{ Bindings: AdminWorkerEnv; Variables: { session: AdminSession } }> =
+  async (c, next) => {
+    const session = await readSession(c);
+    if (!session) {
+      return c.req.path.startsWith("/api/")
+        ? c.json({ error: "unauthorized", code: "AUTH_REQUIRED" }, 401)
+        : c.redirect("/login", 302);
+    }
+    const response = await fetch(new URL("/api/oauth/userinfo", c.env.RAFT_API_ORIGIN), {
+      headers: { authorization: `Bearer ${session.access_token}` },
+    });
+    if (!response.ok) {
+      return c.req.path.startsWith("/api/")
+        ? c.json({ error: "unauthorized", code: "AUTH_EXPIRED" }, 401)
+        : c.redirect("/login", 302);
+    }
+    const user = await response.json<Userinfo>();
+    const allowed = c.env.RAFT_ALLOWED_SERVER_IDS.split(",").map((value) => value.trim()).filter(Boolean);
+    const role = (user.server_role ?? "").toLowerCase();
+    if (user.sub !== session.sub || !allowed.includes(user.server_id) || !["owner", "admin"].includes(role)) {
+      return c.text("Hands staff access required", 403);
+    }
+    c.set("session", { ...session, server_id: user.server_id, role, name: user.name ?? user.preferred_username ?? user.sub });
+    await next();
+  };
+
+export async function login(c: Context<{ Bindings: AdminWorkerEnv }>) {
+  const state = crypto.randomUUID();
+  setCookie(c, STATE, state, { httpOnly: true, secure: true, sameSite: "Lax", maxAge: 600, path: "/" });
+  const callback = new URL("/auth/callback", c.req.url).toString();
+  const url = new URL("/oauth/authorize", c.env.RAFT_ORIGIN);
+  for (const [name, value] of Object.entries({ response_type: "code", client_id: c.env.RAFT_CLIENT_ID, redirect_uri: callback, scope: "openid profile", state })) url.searchParams.set(name, value);
+  return c.redirect(url.toString(), 302);
+}
+
+export async function callback(c: Context<{ Bindings: AdminWorkerEnv }>) {
+  const code = c.req.query("code");
+  const state = c.req.query("state");
+  if (!code || !state || state !== getCookie(c, STATE)) return c.text("Invalid OAuth state", 400);
+  deleteCookie(c, STATE, { path: "/" });
+  const redirectUri = new URL("/auth/callback", c.req.url).toString();
+  const tokenResponse = await fetch(new URL("/api/oauth/token", c.env.RAFT_API_ORIGIN), {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Basic ${btoa(`${c.env.RAFT_CLIENT_ID}:${c.env.RAFT_CLIENT_SECRET}`)}` },
+    body: JSON.stringify({ grant_type: "authorization_code", code, redirect_uri: redirectUri }),
+  });
+  if (!tokenResponse.ok) return c.text("Raft token exchange failed", 502);
+  const { access_token } = await tokenResponse.json<{ access_token: string }>();
+  const userResponse = await fetch(new URL("/api/oauth/userinfo", c.env.RAFT_API_ORIGIN), { headers: { authorization: `Bearer ${access_token}` } });
+  if (!userResponse.ok) return c.text("Raft user lookup failed", 502);
+  const user = await userResponse.json<Userinfo>();
+  const allowed = c.env.RAFT_ALLOWED_SERVER_IDS.split(",").map((v) => v.trim()).filter(Boolean);
+  const role = (user.server_role ?? "").toLowerCase();
+  if (!allowed.includes(user.server_id) || !["owner", "admin"].includes(role)) return c.text("Hands staff access required", 403);
+  const token = await new EncryptJWT({ sub: user.sub, server_id: user.server_id, role, name: user.name ?? user.preferred_username ?? user.sub, access_token })
+    .setProtectedHeader({ alg: "dir", enc: "A256GCM" }).setIssuedAt().setExpirationTime("8h").encrypt(key(c.env.SESSION_SECRET));
+  setCookie(c, SESSION, token, { httpOnly: true, secure: true, sameSite: "Lax", maxAge: 28_800, path: "/" });
+  return c.redirect("/", 302);
+}
+
+export function logout(c: Context<{ Bindings: AdminWorkerEnv }>) {
+  deleteCookie(c, SESSION, { path: "/" });
+  return c.redirect("/", 302);
+}

--- a/admin-worker/src/env.ts
+++ b/admin-worker/src/env.ts
@@ -1,0 +1,29 @@
+export type HandsObservabilityOverview = {
+  measured_at: number;
+  summary: { users: number; organizations: number; apps: number; active_apps: number; builds: number; releases: number };
+  users_by_type: Array<{ type: string; count: number }>;
+  apps_by_platform: Array<{ type: string; count: number }>;
+  builds_by_product_type: Array<{ type: string; count: number }>;
+  releases_by_status: Array<{ status: string; count: number }>;
+  releases_by_week: Array<{ week: string; count: number }>;
+  storage: {
+    r2: { object_count: number; size_bytes: number };
+    registered: { object_count: number; size_bytes: number };
+    note: string;
+  };
+};
+
+export interface HandsObservabilityService {
+  getOverview(): Promise<HandsObservabilityOverview>;
+}
+
+export interface AdminWorkerEnv {
+  HANDS_OBSERVABILITY: HandsObservabilityService;
+  AUDIT_DB: D1Database;
+  RAFT_ORIGIN: string;
+  RAFT_API_ORIGIN: string;
+  RAFT_CLIENT_ID: string;
+  RAFT_CLIENT_SECRET: string;
+  RAFT_ALLOWED_SERVER_IDS: string;
+  SESSION_SECRET: string;
+}

--- a/admin-worker/src/index.ts
+++ b/admin-worker/src/index.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { callback, login, logout, requireAdmin, type AdminSession } from "./auth";
+import type { AdminWorkerEnv } from "./env";
+
+export const app = new Hono<{ Bindings: AdminWorkerEnv; Variables: { session: AdminSession } }>();
+type AdminContext = Context<{ Bindings: AdminWorkerEnv; Variables: { session: AdminSession } }>;
+app.get("/health", (c) => c.json({ ok: true }));
+app.get("/login", login);
+app.get("/auth/callback", callback);
+app.post("/logout", logout);
+app.use("/", requireAdmin);
+app.use("/api/*", requireAdmin);
+
+async function overview(c: AdminContext) {
+  const session = c.get("session");
+  const data = await c.env.HANDS_OBSERVABILITY.getOverview();
+  await c.env.AUDIT_DB.prepare(
+    "INSERT INTO access_audit (id, actor_subject, server_id, action, created_at) VALUES (?1, ?2, ?3, 'overview.view', ?4)",
+  ).bind(crypto.randomUUID(), session.sub, session.server_id, Date.now()).run();
+  return data;
+}
+
+app.get("/api/overview", async (c) => c.json(await overview(c)));
+
+const esc = (value: unknown) => String(value).replace(/[&<>"']/g, (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch]!);
+const bytes = (value: number) => { const units = ["B", "KB", "MB", "GB", "TB"]; let n = value, i = 0; while (n >= 1024 && i < 4) { n /= 1024; i++; } return `${n.toFixed(i ? 1 : 0)} ${units[i]}`; };
+
+app.get("/", async (c) => {
+  const data = await overview(c);
+  const session = c.get("session");
+  const cards = [["Users", data.summary.users], ["Organizations", data.summary.organizations], ["Projects", data.summary.apps], ["Active projects", data.summary.active_apps], ["Builds", data.summary.builds], ["Releases", data.summary.releases], ["R2 storage", bytes(data.storage.r2.size_bytes)], ["R2 objects", data.storage.r2.object_count]];
+  const rows = (items: Array<{ type?: string; status?: string; count: number }>) => items.map((item) => `<tr><td>${esc(item.type ?? item.status)}</td><td>${item.count}</td></tr>`).join("");
+  return c.html(`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Hands Admin</title><style>:root{font-family:Inter,system-ui;color:#0f172a;background:#f8fafc}body{margin:0}.shell{max-width:1180px;margin:auto;padding:40px 24px}header{display:flex;justify-content:space-between;align-items:end;gap:24px}h1{font-size:34px;margin:5px 0}.eyebrow{color:#0284c7;font-size:12px;font-weight:700;letter-spacing:.16em;text-transform:uppercase}.muted{color:#64748b}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:14px;margin:28px 0}.card,.panel{background:white;border:1px solid #e2e8f0;border-radius:14px;padding:20px}.value{font-size:30px;font-weight:650;margin-top:8px}.panels{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:18px}h2{font-size:15px}table{border-collapse:collapse;width:100%;font-size:14px}td{padding:9px 0;border-top:1px solid #f1f5f9}td:last-child{text-align:right;font-weight:600}button{border:1px solid #cbd5e1;border-radius:8px;background:white;padding:8px 12px}</style></head><body><div class="shell"><header><div><div class="eyebrow">Hands admin</div><h1>Observability</h1><div class="muted">Global, read-only product and storage inventory.</div></div><form method="post" action="/logout"><button>Sign out ${esc(session.name)}</button></form></header><div class="grid">${cards.map(([label,value]) => `<div class="card"><div class="muted">${label}</div><div class="value">${value}</div></div>`).join("")}</div><p class="muted">${esc(data.storage.note)} Measured ${new Date(data.measured_at).toISOString()}.</p><div class="panels"><section class="panel"><h2>Users by type</h2><table>${rows(data.users_by_type)}</table></section><section class="panel"><h2>Projects by platform</h2><table>${rows(data.apps_by_platform)}</table></section><section class="panel"><h2>Builds by product type</h2><table>${rows(data.builds_by_product_type)}</table></section><section class="panel"><h2>Releases by status</h2><table>${rows(data.releases_by_status)}</table></section></div></div></body></html>`);
+});
+
+export default app;

--- a/admin-worker/test/access.test.ts
+++ b/admin-worker/test/access.test.ts
@@ -1,24 +1,65 @@
 import { describe, expect, it, vi } from "vitest";
+import { EncryptJWT } from "jose";
 import { app } from "../src/index";
+
+const SESSION_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function sessionCookie() {
+  const value = await new EncryptJWT({
+    sub: "user-1",
+    server_id: "server-1",
+    role: "owner",
+    name: "Reviewer",
+    access_token: "access-token",
+  }).setProtectedHeader({ alg: "dir", enc: "A256GCM" }).setIssuedAt().setExpirationTime("8h")
+    .encrypt(new TextEncoder().encode(SESSION_SECRET));
+  return `hands_admin_session=${value}`;
+}
+
+function env(getOverview: ReturnType<typeof vi.fn>, prepare: ReturnType<typeof vi.fn>) {
+  return {
+    HANDS_OBSERVABILITY: { getOverview },
+    AUDIT_DB: { prepare },
+    SESSION_SECRET,
+    RAFT_ALLOWED_SERVER_IDS: "server-1",
+    RAFT_CLIENT_ID: "client",
+    RAFT_CLIENT_SECRET: "secret",
+    RAFT_ORIGIN: "https://app.raft.build",
+    RAFT_API_ORIGIN: "https://api.raft.build",
+  } as never;
+}
 
 describe("Hands admin access gate", () => {
   it("rejects an unauthenticated overview before calling product RPC or audit storage", async () => {
     const getOverview = vi.fn();
     const prepare = vi.fn();
-    const response = await app.request("https://admin.example/api/overview", {}, {
-      HANDS_OBSERVABILITY: { getOverview },
-      AUDIT_DB: { prepare },
-      SESSION_SECRET: "test-secret",
-      RAFT_ALLOWED_SERVER_IDS: "server-1",
-      RAFT_CLIENT_ID: "client",
-      RAFT_CLIENT_SECRET: "secret",
-      RAFT_ORIGIN: "https://app.raft.build",
-      RAFT_API_ORIGIN: "https://api.raft.build",
-    } as never);
+    const response = await app.request("https://admin.example/api/overview", {}, env(getOverview, prepare));
 
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "unauthorized", code: "AUTH_REQUIRED" });
     expect(getOverview).not.toHaveBeenCalled();
     expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a non-admin role", { sub: "user-1", server_id: "server-1", server_role: "member" }],
+    ["a server outside the allowlist", { sub: "user-1", server_id: "server-2", server_role: "owner" }],
+  ])("rejects %s before calling product RPC or audit storage", async (_name, userinfo) => {
+    const getOverview = vi.fn();
+    const prepare = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify(userinfo), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+
+    const response = await app.request("https://admin.example/api/overview", {
+      headers: { cookie: await sessionCookie() },
+    }, env(getOverview, prepare));
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Hands staff access required");
+    expect(getOverview).not.toHaveBeenCalled();
+    expect(prepare).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 });

--- a/admin-worker/test/access.test.ts
+++ b/admin-worker/test/access.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { app } from "../src/index";
+
+describe("Hands admin access gate", () => {
+  it("rejects an unauthenticated overview before calling product RPC or audit storage", async () => {
+    const getOverview = vi.fn();
+    const prepare = vi.fn();
+    const response = await app.request("https://admin.example/api/overview", {}, {
+      HANDS_OBSERVABILITY: { getOverview },
+      AUDIT_DB: { prepare },
+      SESSION_SECRET: "test-secret",
+      RAFT_ALLOWED_SERVER_IDS: "server-1",
+      RAFT_CLIENT_ID: "client",
+      RAFT_CLIENT_SECRET: "secret",
+      RAFT_ORIGIN: "https://app.raft.build",
+      RAFT_API_ORIGIN: "https://api.raft.build",
+    } as never);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "unauthorized", code: "AUTH_REQUIRED" });
+    expect(getOverview).not.toHaveBeenCalled();
+    expect(prepare).not.toHaveBeenCalled();
+  });
+});

--- a/admin-worker/tsconfig.json
+++ b/admin-worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/admin-worker/wrangler.jsonc
+++ b/admin-worker/wrangler.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "hands-admin",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-10-08",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": { "enabled": true },
+  "preview_urls": false,
+  "services": [
+    { "binding": "HANDS_OBSERVABILITY", "service": "local-hands-worker", "entrypoint": "HandsObservability" }
+  ],
+  "d1_databases": [
+    {
+      "binding": "AUDIT_DB",
+      "database_name": "hands-admin-audit-local",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "migrations"
+    }
+  ],
+  "vars": {
+    "RAFT_ORIGIN": "https://app.raft.build",
+    "RAFT_API_ORIGIN": "https://api.raft.build"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,31 @@ importers:
         specifier: ^4.88.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
 
+  admin-worker:
+    dependencies:
+      hono:
+        specifier: ^4.12.34
+        version: 4.13.0
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250101.0
+        version: 4.20260626.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
+      wrangler:
+        specifier: ^4.88.0
+        version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
+
   clients/electron:
     dependencies:
       electron:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "worker"
   - "container"
   - "admin"
+  - "admin-worker"
   - "migrations"
   - "packages/*"
   - "clients/electron"

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,6 +15,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { publicDocAssetPaths } from "./lib/public_docs";
+export { HandsObservability } from "./observability_rpc";
 
 import { authMiddleware, currentActor } from "./middleware/auth";
 import {

--- a/worker/src/observability_data.ts
+++ b/worker/src/observability_data.ts
@@ -1,0 +1,41 @@
+export type CountByType = { type: string; count: number };
+export type HandsObservabilityOverview = {
+  measured_at: number;
+  summary: { users: number; organizations: number; apps: number; active_apps: number; builds: number; releases: number };
+  users_by_type: CountByType[];
+  apps_by_platform: CountByType[];
+  builds_by_product_type: CountByType[];
+  releases_by_status: Array<{ status: string; count: number }>;
+  releases_by_week: Array<{ week: string; count: number }>;
+  storage: { r2: { object_count: number; size_bytes: number }; registered: { object_count: number; size_bytes: number }; note: string };
+};
+
+async function measureR2(bucket: R2Bucket) {
+  let cursor: string | undefined, objectCount = 0, sizeBytes = 0;
+  do {
+    const page = await bucket.list(cursor ? { cursor, limit: 1000 } : { limit: 1000 });
+    for (const object of page.objects) { objectCount += 1; sizeBytes += object.size; }
+    cursor = page.truncated ? page.cursor : undefined;
+  } while (cursor);
+  return { object_count: objectCount, size_bytes: sizeBytes };
+}
+
+export async function getHandsObservabilityOverview(env: Env): Promise<HandsObservabilityOverview> {
+  const [summary, users, platforms, productTypes, statuses, weeks, registered, r2] = await Promise.all([
+    env.DB.prepare(`SELECT (SELECT COUNT(*) FROM raft_accounts) AS users, (SELECT COUNT(*) FROM organizations WHERE archived = 0) AS organizations, (SELECT COUNT(*) FROM apps) AS apps, (SELECT COUNT(*) FROM apps WHERE archived = 0) AS active_apps, (SELECT COUNT(*) FROM builds) AS builds, (SELECT COUNT(*) FROM releases) AS releases`).first<HandsObservabilityOverview["summary"]>(),
+    env.DB.prepare(`SELECT principal_type AS type, COUNT(*) AS count FROM raft_accounts GROUP BY principal_type ORDER BY count DESC, type ASC`).all<CountByType>(),
+    env.DB.prepare(`SELECT platform AS type, COUNT(*) AS count FROM apps GROUP BY platform ORDER BY count DESC, type ASC`).all<CountByType>(),
+    env.DB.prepare(`SELECT product_type AS type, COUNT(*) AS count FROM builds GROUP BY product_type ORDER BY count DESC, type ASC`).all<CountByType>(),
+    env.DB.prepare(`SELECT status, COUNT(*) AS count FROM releases GROUP BY status ORDER BY count DESC, status ASC`).all<{ status: string; count: number }>(),
+    env.DB.prepare(`SELECT strftime('%Y-%W', created_at / 1000, 'unixepoch') AS week, COUNT(*) AS count FROM releases WHERE created_at >= (strftime('%s', 'now', '-12 weeks') * 1000) GROUP BY week ORDER BY week ASC`).all<{ week: string; count: number }>(),
+    env.DB.prepare(`SELECT COUNT(*) AS object_count, COALESCE(SUM(size_bytes), 0) AS size_bytes FROM (SELECT r2_key, MAX(size_bytes) AS size_bytes FROM (SELECT r2_key, size_bytes FROM build_assets UNION ALL SELECT r2_key, size_bytes FROM feedback_attachments) GROUP BY r2_key)`).first<{ object_count: number; size_bytes: number }>(),
+    measureR2(env.APK_BUCKET),
+  ]);
+  return {
+    measured_at: Date.now(),
+    summary: summary ?? { users: 0, organizations: 0, apps: 0, active_apps: 0, builds: 0, releases: 0 },
+    users_by_type: users.results, apps_by_platform: platforms.results, builds_by_product_type: productTypes.results,
+    releases_by_status: statuses.results, releases_by_week: weeks.results,
+    storage: { r2, registered: registered ?? { object_count: 0, size_bytes: 0 }, note: "R2 is measured from the bucket. Registered storage is deduplicated D1 metadata for build and feedback objects and can differ from R2." },
+  };
+}

--- a/worker/src/observability_rpc.ts
+++ b/worker/src/observability_rpc.ts
@@ -1,10 +1,33 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { getHandsObservabilityOverview } from "./observability_data";
 
+const OVERVIEW_CACHE_TTL_MS = 60_000;
+let cachedOverview: { expiresAt: number; value: Awaited<ReturnType<typeof getHandsObservabilityOverview>> } | undefined;
+let pendingOverview: Promise<Awaited<ReturnType<typeof getHandsObservabilityOverview>>> | undefined;
+
+export async function getCachedHandsObservabilityOverview(env: Env) {
+  const now = Date.now();
+  if (cachedOverview && cachedOverview.expiresAt > now) return cachedOverview.value;
+  if (pendingOverview) return pendingOverview;
+
+  pendingOverview = getHandsObservabilityOverview(env).then((value) => {
+    cachedOverview = { expiresAt: Date.now() + OVERVIEW_CACHE_TTL_MS, value };
+    return value;
+  }).finally(() => {
+    pendingOverview = undefined;
+  });
+  return pendingOverview;
+}
+
+export function resetHandsObservabilityCacheForTest() {
+  cachedOverview = undefined;
+  pendingOverview = undefined;
+}
+
 // This service-binding entrypoint deliberately exposes one named aggregate method.
 // It does not accept SQL, object prefixes, identifiers, or arbitrary operations.
 export class HandsObservability extends WorkerEntrypoint<Env> {
   getOverview() {
-    return getHandsObservabilityOverview(this.env);
+    return getCachedHandsObservabilityOverview(this.env);
   }
 }

--- a/worker/src/observability_rpc.ts
+++ b/worker/src/observability_rpc.ts
@@ -1,0 +1,10 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { getHandsObservabilityOverview } from "./observability_data";
+
+// This service-binding entrypoint deliberately exposes one named aggregate method.
+// It does not accept SQL, object prefixes, identifiers, or arbitrary operations.
+export class HandsObservability extends WorkerEntrypoint<Env> {
+  getOverview() {
+    return getHandsObservabilityOverview(this.env);
+  }
+}

--- a/worker/test/cloudflare_workers_stub.ts
+++ b/worker/test/cloudflare_workers_stub.ts
@@ -1,0 +1,8 @@
+// Node-only test substitute for the Workers RPC base class. Production builds
+// continue to resolve the native `cloudflare:workers` module.
+export class WorkerEntrypoint<Environment> {
+  env: Environment;
+  constructor(context: { env: Environment }) {
+    this.env = context.env;
+  }
+}

--- a/worker/test/observability_rpc.test.ts
+++ b/worker/test/observability_rpc.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getHandsObservabilityOverview } from "../src/observability_data";
+import { getCachedHandsObservabilityOverview, resetHandsObservabilityCacheForTest } from "../src/observability_rpc";
+
+afterEach(() => {
+  resetHandsObservabilityCacheForTest();
+  vi.useRealTimers();
+});
 
 describe("Hands observability RPC", () => {
   it("returns only aggregate rows and measures all R2 pages", async () => {
@@ -33,5 +39,33 @@ describe("Hands observability RPC", () => {
       "measured_at", "summary", "users_by_type", "apps_by_platform",
       "builds_by_product_type", "releases_by_status", "releases_by_week", "storage",
     ]);
+  });
+
+  it("caches the expensive bucket measurement for a short TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-12T15:00:00Z"));
+    let query = 0;
+    const rows = [
+      { users: 1, organizations: 1, apps: 1, active_apps: 1, builds: 1, releases: 1 },
+      [], [], [], [], [],
+      { object_count: 1, size_bytes: 5 },
+    ];
+    const DB = {
+      prepare: () => ({
+        first: async () => rows[query++ % rows.length],
+        all: async () => ({ results: rows[query++ % rows.length] }),
+      }),
+    };
+    const list = vi.fn(async () => ({ objects: [{ key: "private/key", size: 5 }], truncated: false }));
+    const env = { DB, APK_BUCKET: { list } } as never;
+
+    const first = await getCachedHandsObservabilityOverview(env);
+    const second = await getCachedHandsObservabilityOverview(env);
+    expect(second).toBe(first);
+    expect(list).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60_001);
+    await getCachedHandsObservabilityOverview(env);
+    expect(list).toHaveBeenCalledTimes(2);
   });
 });

--- a/worker/test/observability_rpc.test.ts
+++ b/worker/test/observability_rpc.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getHandsObservabilityOverview } from "../src/observability_data";
+
+describe("Hands observability RPC", () => {
+  it("returns only aggregate rows and measures all R2 pages", async () => {
+    const firstRows = [
+      { users: 4, organizations: 2, apps: 3, active_apps: 2, builds: 9, releases: 5 },
+      [{ type: "human", count: 3 }, { type: "agent", count: 1 }],
+      [{ type: "electron", count: 2 }, { type: "android", count: 1 }],
+      [{ type: "electron-installer", count: 7 }],
+      [{ status: "active", count: 4 }],
+      [{ week: "2026-32", count: 2 }],
+      { object_count: 2, size_bytes: 700 },
+    ];
+    let query = 0;
+    const DB = {
+      prepare: () => ({
+        first: async () => firstRows[query++],
+        all: async () => ({ results: firstRows[query++] }),
+      }),
+    };
+    const APK_BUCKET = {
+      list: async (options: { cursor?: string }) => options.cursor
+        ? { objects: [{ key: "private/key-2", size: 9 }], truncated: false }
+        : { objects: [{ key: "private/key-1", size: 5 }], truncated: true, cursor: "next" },
+    };
+
+    const result = await getHandsObservabilityOverview({ DB, APK_BUCKET } as never);
+    expect(result.summary.users).toBe(4);
+    expect(result.storage.r2).toEqual({ object_count: 2, size_bytes: 14 });
+    expect(JSON.stringify(result)).not.toContain("private/key");
+    expect(Object.keys(result)).toEqual([
+      "measured_at", "summary", "users_by_type", "apps_by_platform",
+      "builds_by_product_type", "releases_by_status", "releases_by_week", "storage",
+    ]);
+  });
+});

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "cloudflare:workers": fileURLToPath(new URL("./test/cloudflare_workers_stub.ts", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a separately deployed `admin-worker/` with server-side Login with Raft authorization and per-request role revalidation
- expose only a named aggregate RPC entrypoint from the main Hands Worker; the admin Worker has no Hands D1/R2 binding
- show global user/project/build/release and measured R2 aggregate metrics, with a separate audit D1 for every view
- add a protected manual deployment carrier and production-config renderer

## Security boundary
- no general query/exec RPC; closed aggregate schema only
- no row-level PII, project descriptions, R2 keys, signed URLs, or production config in responses
- unauthenticated API calls return 401 before RPC/audit access
- admin Worker stores no Hands data credential and cannot directly write Hands product storage

## Verification
- Worker: 38 files / 420 tests passed
- Admin worker: 1/1 test passed
- both TypeScript builds passed
- production config renderer smoke passed

No deployment or production configuration mutation performed.
