### PR TITLE
Stream OHOS feedback uploads with bounded ArkTS parts

### DIFF
--- a/.github/workflows/publish-ohos-sdk.yml
+++ b/.github/workflows/publish-ohos-sdk.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "SDK version to publish. Must match clients/ohos/hands/oh-package.json5."
         required: true
-        default: "0.3.3"
+        default: "0.3.4"
       dry_run:
         description: "Build and prepublish only; skip ohpm publish."
         required: true

--- a/clients/ohos/README.md
+++ b/clients/ohos/README.md
@@ -45,7 +45,7 @@ const ticketId = await HandsFeedbackClient.submit(
   context,                    // common.UIAbilityContext
   'Feed does not refresh',    // message
   'bug',                      // 'feedback' | 'bug' | 'crash'
-  [logFilePath],              // up to 9 files; 50 MB OHOS cap
+  [logFilePath],              // up to 9 files; 200 MB per file
   [],                         // extras: Array<{ key, value }>
 );
 ```

--- a/clients/ohos/hands/changelog.md
+++ b/clients/ohos/hands/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.4
+
+- Upload large feedback attachments through bounded 5 MiB ArkTS reads and an
+  R2 multipart session instead of allocating the whole file in ArkTS.
+- Restore the shared Android/iOS/OHOS 200 MB per-file ceiling, with bounded
+  progress, one retry per part, timeout cancellation, and multipart cleanup.
+
 ## 0.3.3
 
 - Add unified `addBreadcrumb` and handled-error `captureException` APIs.

--- a/clients/ohos/hands/oh-package.json5
+++ b/clients/ohos/hands/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Hands feedback + crash reporting SDK for HarmonyOS (feedback tickets, store-then-send crash upload, device id).",
   "main": "Index.ets",
   "author": "jiacheng <jiacheng@botiverse.dev>",

--- a/clients/ohos/hands/src/main/ets/HandsCrashStoragePolicy.ts
+++ b/clients/ohos/hands/src/main/ets/HandsCrashStoragePolicy.ts
@@ -1,5 +1,5 @@
 /** Runtime/package version reported with OHOS feedback and crash tickets. */
-export const HANDS_OHOS_SDK_VERSION: string = '0.3.3';
+export const HANDS_OHOS_SDK_VERSION: string = '0.3.4';
 
 /**
  * Creates a directory exactly once without treating an already-created

--- a/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
+++ b/clients/ohos/hands/src/main/ets/HandsFeedbackClient.ets
@@ -10,6 +10,13 @@ import batteryInfo from '@ohos.batteryInfo';
 import { Hands } from './Hands';
 import { HANDS_OHOS_SDK_VERSION } from './HandsCrashStoragePolicy';
 import { HandsDeviceId } from './HandsDeviceId';
+import {
+  HANDS_OHOS_PRESIGN_MAX_BYTES,
+  HANDS_OHOS_MULTIPART_MAX_ATTEMPTS,
+  HANDS_OHOS_MULTIPART_PART_BYTES,
+  handsOhosMultipartPartCount,
+  handsOhosMultipartPartLength,
+} from './HandsOhosStreamingUploadPolicy';
 
 const TAG: string = 'HandsFeedbackClient';
 
@@ -24,20 +31,14 @@ function ohBatteryStateName(status: number): string {
 }
 const REQUEST_TIMEOUT_MS: number = 30000;
 const UPLOAD_TIMEOUT_MS: number = 120000;
+const STREAM_UPLOAD_TIMEOUT_MS: number = 10 * 60 * 1000;
 
 /** Server-enforced: at most 9 attachments per ticket. */
 const MAX_ATTACHMENTS: number = 9;
 /** Files up to this size stream inline in the multipart body. */
 const MULTIPART_MAX_BYTES: number = 10 * 1024 * 1024;
-/**
- * Files up to this size upload via presigned direct-to-R2 PUT. Capped at
- * 50 MB on OHOS (vs 200 MB on Android/iOS): ArkTS has no file-path raw-PUT
- * API, so the file is read fully into an ArrayBuffer, and a 200 MB upload can
- * spike memory into an OOM process-kill rather than a handleable error. This
- * returns a clean cap error instead. A follow-up will switch to a NAPI/native
- * streaming PUT and raise this to 200 MB.
- */
-const PRESIGN_MAX_BYTES: number = 50 * 1024 * 1024;
+/** Files up to this size upload through a bounded R2 multipart session. */
+const PRESIGN_MAX_BYTES: number = HANDS_OHOS_PRESIGN_MAX_BYTES;
 
 export interface HandsFeedbackExtras {
   key: string;
@@ -47,8 +48,8 @@ export interface HandsFeedbackExtras {
 interface HandsPresignUpload {
   attachment_id?: string;
   r2_key?: string;
-  upload_url?: string;
-  expires_at?: number;
+  upload_id?: string;
+  part_size?: number;
 }
 
 interface HandsPresignResponse {
@@ -66,6 +67,17 @@ interface HandsPresignedRef {
   filename: string;
   content_type: string;
   size: number;
+}
+
+interface HandsUploadedPart {
+  part_number: number;
+  etag: string;
+}
+
+interface HandsUploadedPartResponse {
+  part_number?: number;
+  etag?: string;
+  size?: number;
 }
 
 function guessContentType(name: string): string {
@@ -87,29 +99,15 @@ function fileSize(path: string): number {
   }
 }
 
-function readFileBytes(path: string): ArrayBuffer {
-  const stat = fs.statSync(path);
-  const buffer = new ArrayBuffer(stat.size);
-  const file = fs.openSync(path, fs.OpenMode.READ_ONLY);
-  try {
-    fs.readSync(file.fd, buffer);
-  } finally {
-    fs.closeSync(file);
-  }
-  return buffer;
-}
-
 /**
  * Submits feedback / crash tickets to the Hands feedback endpoint
  * (multipart/form-data) — the OHOS counterpart of the Android SDK's
  * QuiverFeedback. Device and app metadata are attached automatically.
  *
  * Attachments: up to 9 files. Small files (<= 10 MB) stream inline in the
- * multipart body. Larger files (up to 50 MB on OHOS) upload directly to R2 via
- * a server-issued presigned URL and are referenced in the ticket, so bigger
- * logs / recordings never pass through the Worker body limit. (Android/iOS
- * stream the presigned PUT and allow up to 200 MB; OHOS reads the file into
- * memory — see PRESIGN_MAX_BYTES.)
+ * multipart body. Larger files (up to 200 MB) are read and uploaded as 5 MiB
+ * raw parts through an R2 multipart session. Only one part enters the ArkTS
+ * heap at a time; the complete attachment is never materialized in memory.
  */
 export class HandsFeedbackClient {
   /**
@@ -180,8 +178,8 @@ export class HandsFeedbackClient {
 
     const client = http.createHttp();
     try {
-      // Large attachments go straight to R2 via presigned PUT before the
-      // ticket is submitted; the ticket then references them by r2_key.
+      // Large attachments complete an R2 multipart upload before the ticket
+      // is submitted; the ticket then references them by r2_key.
       const presignedRefs: HandsPresignedRef[] =
         large.length > 0 ? await HandsFeedbackClient.uploadLargeAttachments(client, large) : [];
 
@@ -240,9 +238,8 @@ export class HandsFeedbackClient {
   }
 
   /**
-   * Presign + PUT each large file directly to R2, returning the `presigned`
-   * refs the submit call references. One presign request covers the batch;
-   * the server returns upload URLs in the same order as the request.
+   * Starts one R2 multipart session per large file and uploads bounded raw
+   * parts through the Worker. One start request covers the batch.
    */
   private static async uploadLargeAttachments(
     client: http.HttpRequest,
@@ -266,7 +263,7 @@ export class HandsFeedbackClient {
           'Accept': 'application/json',
           'X-Hands-Client-Key': Hands.config.clientKey,
         },
-        extraData: JSON.stringify({ files: requestFiles }),
+        extraData: JSON.stringify({ files: requestFiles, upload_mode: 'r2_multipart_proxy' }),
         connectTimeout: REQUEST_TIMEOUT_MS,
         readTimeout: REQUEST_TIMEOUT_MS,
       },
@@ -279,35 +276,204 @@ export class HandsFeedbackClient {
     const uploads = (JSON.parse(presignBody) as HandsPresignResponse).uploads ?? [];
 
     const refs: HandsPresignedRef[] = [];
-    for (let index = 0; index < paths.length; index++) {
-      const path = paths[index];
-      const fileName = path.split('/').pop() ?? 'attachment';
-      const upload = uploads[index];
-      const uploadUrl = upload?.upload_url ?? '';
-      const r2Key = upload?.r2_key ?? '';
-      if (uploadUrl.length === 0 || r2Key.length === 0) {
-        throw new Error(`Hands presign entry ${index} missing upload_url/r2_key`);
+    let activeIndex = 0;
+    try {
+      for (; activeIndex < paths.length; activeIndex++) {
+        const path = paths[activeIndex];
+        const fileName = path.split('/').pop() ?? 'attachment';
+        const upload = uploads[activeIndex];
+        const r2Key = upload?.r2_key ?? '';
+        const uploadId = upload?.upload_id ?? '';
+        const partSize = upload?.part_size ?? 0;
+        if (uploadId.length === 0 || r2Key.length === 0 || partSize !== HANDS_OHOS_MULTIPART_PART_BYTES) {
+          throw new Error(`Hands multipart entry ${activeIndex} is incomplete`);
+        }
+        const contentType = guessContentType(fileName);
+        await HandsFeedbackClient.uploadMultipartFile(client, path, fileName, r2Key, uploadId, partSize);
+        refs.push({
+          r2_key: r2Key,
+          filename: fileName,
+          content_type: contentType,
+          size: fileSize(path),
+        });
       }
-      const contentType = guessContentType(fileName);
-      // The presigned PUT signs the content-type, so it must match exactly.
-      const putResponse = await client.request(uploadUrl, {
-        method: http.RequestMethod.PUT,
-        header: { 'Content-Type': contentType },
-        extraData: readFileBytes(path),
-        connectTimeout: REQUEST_TIMEOUT_MS,
-        readTimeout: UPLOAD_TIMEOUT_MS,
-      });
-      const putCode = Number(putResponse.responseCode ?? 0);
-      if (putCode < 200 || putCode >= 300) {
-        throw new Error(`Hands R2 upload failed for ${fileName}: HTTP ${putCode}`);
+    } catch (error) {
+      const pendingAborts: Promise<void>[] = [];
+      for (let pendingIndex = activeIndex; pendingIndex < uploads.length; pendingIndex++) {
+        const pending = uploads[pendingIndex];
+        const pendingKey = pending?.r2_key ?? '';
+        const pendingId = pending?.upload_id ?? '';
+        if (pendingKey.length > 0 && pendingId.length > 0) {
+          pendingAborts.push(HandsFeedbackClient.abortMultipartUpload(client, pendingKey, pendingId));
+        }
       }
-      refs.push({
-        r2_key: r2Key,
-        filename: fileName,
-        content_type: contentType,
-        size: fileSize(path),
-      });
+      await Promise.all(pendingAborts);
+      throw error instanceof Error ? error : new Error(String(error));
     }
     return refs;
+  }
+
+  private static async uploadMultipartFile(
+    client: http.HttpRequest,
+    path: string,
+    fileName: string,
+    r2Key: string,
+    uploadId: string,
+    partSize: number,
+  ): Promise<void> {
+    const declaredBytes = fileSize(path);
+    const partCount = handsOhosMultipartPartCount(declaredBytes);
+    if (partCount === 0 || partSize !== HANDS_OHOS_MULTIPART_PART_BYTES) {
+      throw new Error(`Hands multipart upload has invalid size for ${fileName}`);
+    }
+    const uploadedParts: HandsUploadedPart[] = [];
+    const startedAt = Date.now();
+    try {
+      for (let partIndex = 0; partIndex < partCount; partIndex++) {
+        if (Date.now() - startedAt > STREAM_UPLOAD_TIMEOUT_MS) {
+          throw new Error(`Hands multipart upload timed out for ${fileName}`);
+        }
+        const partLength = handsOhosMultipartPartLength(declaredBytes, partIndex);
+        const part = await HandsFeedbackClient.uploadMultipartPart(
+          client,
+          path,
+          fileName,
+          r2Key,
+          uploadId,
+          partIndex,
+          partLength,
+          declaredBytes,
+        );
+        uploadedParts.push(part);
+        hilog.debug(
+          0x0000,
+          TAG,
+          'R2 multipart progress file=%{public}s sent=%{public}d total=%{public}d',
+          fileName,
+          Math.min(declaredBytes, (partIndex + 1) * partSize),
+          declaredBytes,
+        );
+      }
+      await HandsFeedbackClient.completeMultipartUpload(client, r2Key, uploadId, declaredBytes, uploadedParts);
+    } catch (error) {
+      await HandsFeedbackClient.abortMultipartUpload(client, r2Key, uploadId);
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  private static async uploadMultipartPart(
+    client: http.HttpRequest,
+    path: string,
+    fileName: string,
+    r2Key: string,
+    uploadId: string,
+    partIndex: number,
+    partLength: number,
+    declaredBytes: number,
+  ): Promise<HandsUploadedPart> {
+    let lastError: Error = new Error(`Hands multipart part failed for ${fileName}`);
+    for (let attempt = 1; attempt <= HANDS_OHOS_MULTIPART_MAX_ATTEMPTS; attempt++) {
+      try {
+        if (fileSize(path) !== declaredBytes) throw new Error(`Hands attachment changed during upload: ${fileName}`);
+        const offset = partIndex * HANDS_OHOS_MULTIPART_PART_BYTES;
+        const bytes = await HandsFeedbackClient.readFilePart(path, offset, partLength);
+        const url = `${Hands.config.baseUrl}/public/v2/apps/${Hands.config.appSlug}/feedback/multipart/part` +
+          `?r2_key=${encodeURIComponent(r2Key)}&upload_id=${encodeURIComponent(uploadId)}` +
+          `&part_number=${partIndex + 1}`;
+        const response = await client.request(url, {
+          method: http.RequestMethod.PUT,
+          header: {
+            'Content-Type': 'application/octet-stream',
+            'Accept': 'application/json',
+            'X-Hands-Client-Key': Hands.config.clientKey,
+            'X-Hands-Part-Bytes': String(partLength),
+          },
+          extraData: bytes,
+          connectTimeout: REQUEST_TIMEOUT_MS,
+          readTimeout: UPLOAD_TIMEOUT_MS,
+        });
+        const code = Number(response.responseCode ?? 0);
+        const body = typeof response.result === 'string' ? response.result : '';
+        if (code < 200 || code >= 300) throw new Error(`HTTP ${code}`);
+        const parsed = JSON.parse(body) as HandsUploadedPartResponse;
+        const etag = parsed.etag ?? '';
+        if (parsed.part_number !== partIndex + 1 || parsed.size !== partLength || etag.length === 0) {
+          throw new Error('invalid part receipt');
+        }
+        return { part_number: partIndex + 1, etag: etag };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt < HANDS_OHOS_MULTIPART_MAX_ATTEMPTS) {
+          hilog.warn(0x0000, TAG, 'R2 part retry file=%{public}s part=%{public}d', fileName, partIndex + 1);
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  private static async readFilePart(path: string, offset: number, length: number): Promise<ArrayBuffer> {
+    const file = fs.openSync(path);
+    try {
+      fs.lseek(file.fd, offset);
+      const buffer = new ArrayBuffer(length);
+      const readBytes = await fs.read(file.fd, buffer, { length: length });
+      if (readBytes !== length) {
+        throw new Error(`Hands attachment changed during upload: expected ${length}, read ${readBytes}`);
+      }
+      return buffer;
+    } finally {
+      fs.closeSync(file);
+    }
+  }
+
+  private static async completeMultipartUpload(
+    client: http.HttpRequest,
+    r2Key: string,
+    uploadId: string,
+    size: number,
+    parts: HandsUploadedPart[],
+  ): Promise<void> {
+    const response = await client.request(
+      `${Hands.config.baseUrl}/public/v2/apps/${Hands.config.appSlug}/feedback/multipart/complete`,
+      {
+        method: http.RequestMethod.POST,
+        header: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-Hands-Client-Key': Hands.config.clientKey,
+        },
+        extraData: JSON.stringify({ r2_key: r2Key, upload_id: uploadId, size: size, parts: parts }),
+        connectTimeout: REQUEST_TIMEOUT_MS,
+        readTimeout: UPLOAD_TIMEOUT_MS,
+      },
+    );
+    const code = Number(response.responseCode ?? 0);
+    if (code < 200 || code >= 300) throw new Error(`Hands multipart completion failed: HTTP ${code}`);
+  }
+
+  private static async abortMultipartUpload(
+    client: http.HttpRequest,
+    r2Key: string,
+    uploadId: string,
+  ): Promise<void> {
+    try {
+      await client.request(
+        `${Hands.config.baseUrl}/public/v2/apps/${Hands.config.appSlug}/feedback/multipart/abort`,
+        {
+          method: http.RequestMethod.POST,
+          header: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Hands-Client-Key': Hands.config.clientKey,
+          },
+          extraData: JSON.stringify({ r2_key: r2Key, upload_id: uploadId }),
+          connectTimeout: REQUEST_TIMEOUT_MS,
+          readTimeout: REQUEST_TIMEOUT_MS,
+        },
+      );
+    } catch {
+      // The upload has already failed. Abort is best-effort cleanup and must
+      // not replace the causal transport error returned to the caller.
+    }
   }
 }

--- a/clients/ohos/hands/src/main/ets/HandsOhosStreamingUploadPolicy.ts
+++ b/clients/ohos/hands/src/main/ets/HandsOhosStreamingUploadPolicy.ts
@@ -1,0 +1,24 @@
+/** Files up to this size upload through the bounded R2 multipart path. */
+export const HANDS_OHOS_PRESIGN_MAX_BYTES: number = 200 * 1024 * 1024;
+
+/** R2 requires every multipart part except the last to be at least 5 MiB. */
+export const HANDS_OHOS_MULTIPART_PART_BYTES: number = 5 * 1024 * 1024;
+
+/** A transient transport failure receives one fresh bounded-part attempt. */
+export const HANDS_OHOS_MULTIPART_MAX_ATTEMPTS: number = 2;
+
+export function handsOhosMultipartPartCount(totalBytes: number): number {
+  if (!Number.isSafeInteger(totalBytes) || totalBytes <= 0 || totalBytes > HANDS_OHOS_PRESIGN_MAX_BYTES) {
+    return 0;
+  }
+  return Math.ceil(totalBytes / HANDS_OHOS_MULTIPART_PART_BYTES);
+}
+
+export function handsOhosMultipartPartLength(totalBytes: number, zeroBasedPartIndex: number): number {
+  const partCount = handsOhosMultipartPartCount(totalBytes);
+  if (!Number.isSafeInteger(zeroBasedPartIndex) || zeroBasedPartIndex < 0 || zeroBasedPartIndex >= partCount) {
+    return 0;
+  }
+  const start = zeroBasedPartIndex * HANDS_OHOS_MULTIPART_PART_BYTES;
+  return Math.min(HANDS_OHOS_MULTIPART_PART_BYTES, totalBytes - start);
+}

--- a/clients/ohos/scripts/release-metadata.test.mjs
+++ b/clients/ohos/scripts/release-metadata.test.mjs
@@ -19,7 +19,7 @@ test('published HAR manifest carries the authorized OHPM author identity', () =>
     refType: 'branch',
     refName: 'codex/task215-ohpm-author-retry',
   });
-  assert.equal(metadata.version, '0.3.3');
+  assert.equal(metadata.version, '0.3.4');
   assert.deepEqual(metadata.author, EXPECTED_OHPM_AUTHOR);
 });
 
@@ -35,7 +35,7 @@ test('missing and malformed author fixtures fail before HAR publication', () => 
 
   for (const author of invalidAuthors) {
     assert.throws(
-      () => validatePackageManifest({ version: '0.3.3', author }),
+      () => validatePackageManifest({ version: '0.3.4', author }),
       /OHPM author/,
       `fixture should be rejected: ${String(author)}`,
     );
@@ -44,30 +44,30 @@ test('missing and malformed author fixtures fail before HAR publication', () => 
 
 test('canonical and numbered recovery tags resolve to the same package version', () => {
   const context = {
-    packageVersion: '0.3.3',
+    packageVersion: '0.3.4',
     eventName: 'push',
     refType: 'tag',
   };
   assert.equal(
-    resolveReleaseVersion({ ...context, refName: 'ohos-sdk-v0.3.3' }),
-    '0.3.3',
+    resolveReleaseVersion({ ...context, refName: 'ohos-sdk-v0.3.4' }),
+    '0.3.4',
   );
   assert.equal(
-    resolveReleaseVersion({ ...context, refName: 'ohos-sdk-v0.3.3-retry.1' }),
-    '0.3.3',
+    resolveReleaseVersion({ ...context, refName: 'ohos-sdk-v0.3.4-retry.1' }),
+    '0.3.4',
   );
 });
 
 test('stale or malformed recovery tags fail closed', () => {
   const context = {
-    packageVersion: '0.3.3',
+    packageVersion: '0.3.4',
     eventName: 'push',
     refType: 'tag',
   };
   for (const refName of [
     'ohos-sdk-v0.3.2',
-    'ohos-sdk-v0.3.3-retry.0',
-    'ohos-sdk-v0.3.3-retry.latest',
+    'ohos-sdk-v0.3.4-retry.0',
+    'ohos-sdk-v0.3.4-retry.latest',
   ]) {
     assert.throws(
       () => resolveReleaseVersion({ ...context, refName }),
@@ -79,7 +79,7 @@ test('stale or malformed recovery tags fail closed', () => {
 test('manual release input must still match the package version', () => {
   assert.throws(
     () => resolveReleaseVersion({
-      packageVersion: '0.3.3',
+      packageVersion: '0.3.4',
       eventName: 'workflow_dispatch',
       refType: 'branch',
       refName: 'main',

--- a/clients/ohos/scripts/streaming-upload-source-contract.mjs
+++ b/clients/ohos/scripts/streaming-upload-source-contract.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+
+export function verifyStreamingUploadSource(source) {
+  const failures = [];
+  if (/new\s+ArrayBuffer\s*\(\s*stat\.size\s*\)/.test(source)) {
+    failures.push('whole-file ArrayBuffer allocation is present');
+  }
+  if (/function\s+readFileBytes\s*\(/.test(source)) {
+    failures.push('whole-file readFileBytes helper is present');
+  }
+  if (/request\.uploadFile\s*\(/.test(source)) {
+    failures.push('multipart-only request.uploadFile must not be used for raw attachment bytes');
+  }
+  if (!/upload_mode:\s*['"]r2_multipart_proxy['"]/.test(source)) {
+    failures.push('pure-ArkTS R2 multipart mode is missing');
+  }
+  if (!/fs\.read\s*\(\s*file\.fd\s*,\s*buffer/.test(source)) {
+    failures.push('bounded file-part read is missing');
+  }
+  if (!/HANDS_OHOS_MULTIPART_PART_BYTES/.test(source)) {
+    failures.push('bounded multipart part size is missing');
+  }
+  if (!/feedback\/multipart\/complete/.test(source)) {
+    failures.push('multipart completion is missing');
+  }
+  if (!/feedback\/multipart\/abort/.test(source)) {
+    failures.push('multipart abort cleanup is missing');
+  }
+  return failures;
+}
+
+export function verifyStreamingUploadSourceFile(path) {
+  return verifyStreamingUploadSource(readFileSync(path, 'utf8'));
+}

--- a/clients/ohos/scripts/streaming-upload-source-contract.test.mjs
+++ b/clients/ohos/scripts/streaming-upload-source-contract.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import { verifyStreamingUploadSource } from './streaming-upload-source-contract.mjs';
+
+const clientPath = fileURLToPath(new URL('../hands/src/main/ets/HandsFeedbackClient.ets', import.meta.url));
+const source = readFileSync(clientPath, 'utf8');
+
+test('production OHOS large upload uses bounded pure-ArkTS multipart parts', () => {
+  assert.deepEqual(verifyStreamingUploadSource(source), []);
+});
+
+test('source contract fails causally for each bounded-streaming invariant', () => {
+  const mutations = [
+    source.replace("upload_mode: 'r2_multipart_proxy'", "upload_mode: 'missing'"),
+    source.replace('fs.read(file.fd, buffer', 'fs.missingRead(file.fd, buffer'),
+    source.replaceAll('HANDS_OHOS_MULTIPART_PART_BYTES', 'MISSING_PART_BOUND'),
+    source.replace('feedback/multipart/complete', 'feedback/multipart/missing-complete'),
+    source.replace('feedback/multipart/abort', 'feedback/multipart/missing-abort'),
+    `${source}\nrequest.uploadFile(context, {});\n`,
+    `${source}\nfunction readFileBytes(path: string): ArrayBuffer { return new ArrayBuffer(stat.size); }\n`,
+  ];
+  for (const mutated of mutations) {
+    assert.notDeepEqual(verifyStreamingUploadSource(mutated), []);
+  }
+});

--- a/clients/ohos/tests/src/HandsOhosStreamingUploadPolicy.test.ts
+++ b/clients/ohos/tests/src/HandsOhosStreamingUploadPolicy.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  HANDS_OHOS_PRESIGN_MAX_BYTES,
+  HANDS_OHOS_MULTIPART_MAX_ATTEMPTS,
+  HANDS_OHOS_MULTIPART_PART_BYTES,
+  handsOhosMultipartPartCount,
+  handsOhosMultipartPartLength,
+} from '../../hands/src/main/ets/HandsOhosStreamingUploadPolicy.ts';
+
+test('OHOS bounded multipart ceiling matches Android and iOS at 200 MB', () => {
+  assert.equal(HANDS_OHOS_PRESIGN_MAX_BYTES, 200 * 1024 * 1024);
+  assert.equal(HANDS_OHOS_MULTIPART_PART_BYTES, 5 * 1024 * 1024);
+  assert.equal(HANDS_OHOS_MULTIPART_MAX_ATTEMPTS, 2);
+});
+
+test('part count covers the exact byte range without a whole-file buffer', () => {
+  assert.equal(handsOhosMultipartPartCount(1), 1);
+  assert.equal(handsOhosMultipartPartCount(5 * 1024 * 1024), 1);
+  assert.equal(handsOhosMultipartPartCount(5 * 1024 * 1024 + 1), 2);
+  assert.equal(handsOhosMultipartPartCount(200 * 1024 * 1024), 40);
+  assert.equal(handsOhosMultipartPartCount(0), 0);
+  assert.equal(handsOhosMultipartPartCount(200 * 1024 * 1024 + 1), 0);
+});
+
+test('only the final part may be shorter than 5 MiB', () => {
+  const fiveMiB = 5 * 1024 * 1024;
+  assert.equal(handsOhosMultipartPartLength(fiveMiB + 1, 0), fiveMiB);
+  assert.equal(handsOhosMultipartPartLength(fiveMiB + 1, 1), 1);
+  assert.equal(handsOhosMultipartPartLength(fiveMiB + 1, 2), 0);
+  assert.equal(handsOhosMultipartPartLength(1, 0), 1);
+  assert.equal(handsOhosMultipartPartLength(0, 0), 0);
+});

--- a/docs/public/ohos-sdk.md
+++ b/docs/public/ohos-sdk.md
@@ -54,7 +54,9 @@ const ticketId = await HandsFeedbackClient.submit(
 
 Device metadata (version, model, OS, ABI, locale, per-install device id) is
 attached automatically. Files up to 10 MB use the multipart request; larger
-files use a presigned upload, with a 50 MB OHOS cap.
+files are read as bounded 5 MiB parts and uploaded through an R2 multipart
+session, with the same 200 MB per-file cap as Android and iOS. The complete
+file is never allocated as one ArkTS `ArrayBuffer`.
 
 ## Crash reporting
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -483,6 +483,15 @@ Body: `{ "files": [{ "filename": "...", "content_type": "...", "size": <bytes> }
 Returns `501` if direct upload isn't configured on the server. Total
 attachments (inline + presigned) may not exceed 9.
 
+Pure ArkTS clients that cannot send a file as a raw request body may add
+`"upload_mode": "r2_multipart_proxy"`. The response then contains
+`upload_id` and `part_size` instead of `upload_url`. Upload each sequential raw
+part to `PUT .../feedback/multipart/part`, complete with the returned part
+ETags at `POST .../feedback/multipart/complete`, and call
+`POST .../feedback/multipart/abort` on failure. The server fixes the part size
+at 5 MiB and streams each bounded part into R2 without buffering the complete
+attachment.
+
 ## Share Pages
 
 - `GET /share/:token` — public download page for one release (view/download

--- a/docs/sdk-parity/README.md
+++ b/docs/sdk-parity/README.md
@@ -41,7 +41,7 @@ Sentry does not have at all (see "Moats").
 | Handled errors (`captureException`) | ❌ | ❌ | ❌ | ❌ | ✅ core API |
 | Sessions / release health | ❌ 24h device ping only → **crash-free rate uncomputable** | same | same | same | ✅ signature feature |
 | Performance (transactions/spans/startup/frames) | ❌ | ❌ | ❌ | ❌ | ✅ |
-| User feedback + attachments | ✅ ≤200 MB presigned | ✅ | ✅ (50 MB) | ❌ in SDK (tickets exist server-side) | ⚠️ weaker than ours |
+| User feedback + attachments | ✅ ≤200 MB presigned | ✅ | ✅ ≤200 MB, bounded ArkTS/R2 multipart | ❌ in SDK (tickets exist server-side) | ⚠️ weaker than ours |
 | Log capture | crash-time logcat tail | host-provided via diagnostics provider | ❌ | ❌ | ✅ Logs GA |
 | Session replay / profiling / crons / uptime | ❌ | ❌ | ❌ | ❌ | ✅ |
 | **In-app update distribution + staged rollout** | ✅ full (hash bucketing, force-update, installer) | ❌ | ❌ | ⚠️ CLI publishes electron-updater artifacts | ❌ **Sentry has none** |

--- a/docs/sdk-parity/ohos.md
+++ b/docs/sdk-parity/ohos.md
@@ -2,7 +2,7 @@
 
 Source: `clients/ohos/hands` (ArkTS and release contract read 2026-07-30).
 
-The package and runtime `hands_sdk` metadata share one `0.3.3` release
+The package and runtime `hands_sdk` metadata share one `0.3.4` release
 constant, covered by a host-side parity test.
 
 Positioning note: this SDK is a feedback + crash-ticket client mirroring the
@@ -22,9 +22,10 @@ Android classes; crashes are delivered as feedback tickets (`kind=crash`).
 - **Crash/feedback context** — device (manufacturer/model/brand/marketName/
   deviceType), OS/API, bundle version, arch, locale, timezone, screen, disk,
   battery, per-install device id.
-- **Feedback** — multipart tickets, ≤9 attachments; ≤10 MB inline; presigned
-  R2 PUT above that, **hard cap 50 MB** (whole file read into ArrayBuffer —
-  OOM risk, lower than the 200 MB Android/iOS support).
+- **Feedback** — multipart tickets, ≤9 attachments; ≤10 MB inline; bounded
+  5 MiB ArkTS reads into an R2 multipart session above that, **hard cap 200
+  MB**, matching the Android/iOS per-file contract without a whole-file ArkTS
+  allocation or native dependency.
 - **Device analytics** — 24h-throttled `/metrics` ping.
 
 ## Absent (→ roadmap)
@@ -34,7 +35,7 @@ Android classes; crashes are delivered as feedback tickets (`kind=crash`).
 - **Update checking — none** (prefs store is even named `quiver_update`,
   but no check API exists)
 - Log capture; retry/backoff (failed feedback submit just throws); sampling
-- Streaming attachment upload (fix the 50 MB / OOM limitation)
+- On-device exact-byte and memory-bound coverage for 200 MB attachment uploads
 
 ## Config surface
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -84,6 +84,9 @@ import {
   handleListCrashGroups,
   handleFeedbackStats,
   handlePresignFeedbackAttachments,
+  handleFeedbackMultipartPart,
+  handleCompleteFeedbackMultipart,
+  handleAbortFeedbackMultipart,
 } from "./routes/feedback";
 import { handleDeviceRegister, handleDeviceAnalytics, handleDeviceDetail, handleVersionAnalytics } from "./routes/analytics";
 import { handleSessionEvent, handleReleaseHealth } from "./routes/sessions";
@@ -571,6 +574,9 @@ app.post("/public/v2/apps/:slug/devices", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/metrics", handleDeviceRegister);
 app.post("/public/v2/apps/:slug/sessions", handleSessionEvent);
 app.post("/public/v2/apps/:slug/feedback/presign", handlePresignFeedbackAttachments);
+app.put("/public/v2/apps/:slug/feedback/multipart/part", handleFeedbackMultipartPart);
+app.post("/public/v2/apps/:slug/feedback/multipart/complete", handleCompleteFeedbackMultipart);
+app.post("/public/v2/apps/:slug/feedback/multipart/abort", handleAbortFeedbackMultipart);
 app.get("/api/apps/:appId/reporter-feedback", handleListReporterFeedback);
 app.post("/api/apps/:appId/reporter-feedback/session", handleMintReporterSession);
 app.put("/api/apps/:appId/reporter-feedback/route-subject", handleBindReporterRouteSubject);

--- a/worker/src/routes/feedback.ts
+++ b/worker/src/routes/feedback.ts
@@ -24,6 +24,8 @@ const MAX_ATTACHMENTS = 9;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // inline multipart cap (through the Worker)
 const MAX_PRESIGNED_BYTES = 200 * 1024 * 1024; // direct-to-R2 cap
 const PRESIGN_TTL_SECONDS = 900;
+const MULTIPART_PART_BYTES = 5 * 1024 * 1024;
+const MAX_MULTIPART_PARTS = MAX_PRESIGNED_BYTES / MULTIPART_PART_BYTES;
 const MAX_MESSAGE_CHARS = 10_000;
 const DIRECT_RATE_LIMIT_PER_HOUR = 10;
 const TRUSTED_REPORTER_RATE_LIMIT_PER_HOUR = 100;
@@ -86,6 +88,27 @@ type FeedbackApp = {
   platform: string | null;
 };
 
+async function authorizeFeedbackUpload(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug");
+  if (!slug) return { response: c.json({ error: "slug required" }, 400) };
+  const app = await c.env.DB.prepare(
+    "SELECT id, client_key FROM apps WHERE slug = ?1 AND archived = 0",
+  )
+    .bind(slug)
+    .first<{ id: string; client_key: string | null }>();
+  if (!app) return { response: c.json({ error: `app '${slug}' not found` }, 404) };
+  const presented =
+    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
+  if (!app.client_key || presented !== app.client_key) {
+    return { response: c.json({ error: "invalid or missing client key" }, 401) };
+  }
+  return { app };
+}
+
+function validFeedbackMultipartKey(appId: string, r2Key: string): boolean {
+  return r2Key.startsWith(`feedback/${appId}/presigned/`) && r2Key.length <= 512;
+}
+
 /**
  * Presigned direct-to-R2 upload for large feedback attachments. Client-key
  * gated (same as submit). Body: { files: [{ filename, content_type, size }] }.
@@ -94,21 +117,14 @@ type FeedbackApp = {
  * r2_keys via the `presigned` form field.
  */
 export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: Env }>) {
-  const slug = c.req.param("slug");
-  if (!slug) return c.json({ error: "slug required" }, 400);
-  const app = await c.env.DB.prepare(
-    "SELECT id, client_key FROM apps WHERE slug = ?1 AND archived = 0",
-  )
-    .bind(slug)
-    .first<{ id: string; client_key: string | null }>();
-  if (!app) return c.json({ error: `app '${slug}' not found` }, 404);
-  const presented =
-    c.req.header("X-Hands-Client-Key") ?? c.req.header("X-Quiver-Client-Key") ?? c.req.query("client_key") ?? "";
-  if (!app.client_key || presented !== app.client_key) {
-    return c.json({ error: "invalid or missing client key" }, 401);
-  }
+  const auth = await authorizeFeedbackUpload(c);
+  if ("response" in auth) return auth.response;
+  const { app } = auth;
 
-  let body: { files?: Array<{ filename?: string; content_type?: string; size?: number }> };
+  let body: {
+    files?: Array<{ filename?: string; content_type?: string; size?: number }>;
+    upload_mode?: string;
+  };
   try {
     body = await c.req.json();
   } catch {
@@ -118,14 +134,8 @@ export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: En
   if (files.length === 0 || files.length > MAX_ATTACHMENTS) {
     return c.json({ error: `files must contain 1-${MAX_ATTACHMENTS} entries` }, 400);
   }
-
-  const now = Date.now();
-  const out: Array<{
-    attachment_id: string;
-    r2_key: string;
-    upload_url: string;
-    expires_at: number;
-  }> = [];
+  // Validate the complete batch before creating any multipart session. A bad
+  // later entry must not strand an earlier R2 multipart upload.
   for (const [index, file] of files.entries()) {
     const size = typeof file.size === "number" ? file.size : 0;
     if (size <= 0 || size > MAX_PRESIGNED_BYTES) {
@@ -134,12 +144,45 @@ export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: En
         400,
       );
     }
+  }
+
+  const now = Date.now();
+  const multipart = body.upload_mode === "r2_multipart_proxy";
+  const out: Array<{
+    attachment_id: string;
+    r2_key: string;
+    upload_url?: string;
+    expires_at?: number;
+    upload_id?: string;
+    part_size?: number;
+  }> = [];
+  const startedMultipartUploads: R2MultipartUpload[] = [];
+  for (const [index, file] of files.entries()) {
     const safeName =
       String(file.filename ?? "").replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) ||
       `attachment-${index}`;
     const contentType = String(file.content_type ?? "application/octet-stream").slice(0, 100);
     const attachmentId = crypto.randomUUID();
     const r2Key = `feedback/${app.id}/presigned/${attachmentId}-${safeName}`;
+    if (multipart) {
+      let upload: R2MultipartUpload;
+      try {
+        upload = await c.env.APK_BUCKET.createMultipartUpload(r2Key, {
+          httpMetadata: { contentType },
+        });
+      } catch {
+        await Promise.allSettled(startedMultipartUploads.map((started) => started.abort()));
+        return c.json({ error: "multipart upload is not available" }, 503);
+      }
+      startedMultipartUploads.push(upload);
+      out.push({
+        attachment_id: attachmentId,
+        r2_key: r2Key,
+        upload_id: upload.uploadId,
+        part_size: MULTIPART_PART_BYTES,
+      });
+      continue;
+    }
     const uploadUrl = await presignR2UploadUrl(c.env, r2Key, contentType, PRESIGN_TTL_SECONDS);
     if (!uploadUrl) {
       return c.json({ error: "direct upload is not configured on this server" }, 501);
@@ -152,6 +195,145 @@ export async function handlePresignFeedbackAttachments(c: Context<{ Bindings: En
     });
   }
   return c.json({ uploads: out });
+}
+
+/**
+ * Proxies one bounded raw part from pure ArkTS into an R2 multipart upload.
+ * The body is streamed through to R2; the Worker never buffers the attachment
+ * or even a complete 5 MiB part.
+ */
+export async function handleFeedbackMultipartPart(c: Context<{ Bindings: Env }>) {
+  const auth = await authorizeFeedbackUpload(c);
+  if ("response" in auth) return auth.response;
+  const r2Key = c.req.query("r2_key") ?? "";
+  const uploadId = c.req.query("upload_id") ?? "";
+  const partNumber = Number(c.req.query("part_number") ?? "0");
+  const declaredBytes = Number(c.req.header("X-Hands-Part-Bytes") ?? "0");
+  if (!validFeedbackMultipartKey(auth.app.id, r2Key)) {
+    return c.json({ error: "invalid multipart r2_key" }, 400);
+  }
+  if (uploadId.length === 0 || uploadId.length > 2048) {
+    return c.json({ error: "invalid multipart upload_id" }, 400);
+  }
+  if (!Number.isSafeInteger(partNumber) || partNumber < 1 || partNumber > MAX_MULTIPART_PARTS) {
+    return c.json({ error: `part_number must be 1-${MAX_MULTIPART_PARTS}` }, 400);
+  }
+  if (!Number.isSafeInteger(declaredBytes) || declaredBytes < 1 || declaredBytes > MULTIPART_PART_BYTES) {
+    return c.json({ error: `X-Hands-Part-Bytes must be 1-${MULTIPART_PART_BYTES}` }, 400);
+  }
+  if (!c.req.raw.body) return c.json({ error: "raw part body required" }, 400);
+
+  let receivedBytes = 0;
+  const boundedBody = c.req.raw.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      receivedBytes += chunk.byteLength;
+      if (receivedBytes > declaredBytes || receivedBytes > MULTIPART_PART_BYTES) {
+        throw new Error("multipart part exceeds declared size");
+      }
+      controller.enqueue(chunk);
+    },
+  }));
+  const upload = c.env.APK_BUCKET.resumeMultipartUpload(r2Key, uploadId);
+  try {
+    const part = await upload.uploadPart(partNumber, boundedBody);
+    if (receivedBytes !== declaredBytes) {
+      await upload.abort();
+      return c.json({ error: "multipart part size mismatch" }, 400);
+    }
+    return c.json({ part_number: part.partNumber, etag: part.etag, size: receivedBytes });
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "feedback_multipart_part_failed",
+      app_id: auth.app.id,
+      part_number: partNumber,
+      error: error instanceof Error ? error.message : String(error),
+    }));
+    return c.json({ error: "multipart part upload failed" }, 502);
+  }
+}
+
+export async function handleCompleteFeedbackMultipart(c: Context<{ Bindings: Env }>) {
+  const auth = await authorizeFeedbackUpload(c);
+  if ("response" in auth) return auth.response;
+  let body: {
+    r2_key?: string;
+    upload_id?: string;
+    size?: number;
+    parts?: Array<{ part_number?: number; etag?: string }>;
+  };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "JSON body required" }, 400);
+  }
+  const r2Key = String(body.r2_key ?? "");
+  const uploadId = String(body.upload_id ?? "");
+  const size = typeof body.size === "number" ? body.size : 0;
+  const parts = Array.isArray(body.parts) ? body.parts : [];
+  if (!validFeedbackMultipartKey(auth.app.id, r2Key)) {
+    return c.json({ error: "invalid multipart r2_key" }, 400);
+  }
+  if (uploadId.length === 0 || uploadId.length > 2048) {
+    return c.json({ error: "invalid multipart upload_id" }, 400);
+  }
+  if (!Number.isSafeInteger(size) || size < 1 || size > MAX_PRESIGNED_BYTES) {
+    return c.json({ error: `size must be 1-${MAX_PRESIGNED_BYTES}` }, 400);
+  }
+  const expectedParts = Math.ceil(size / MULTIPART_PART_BYTES);
+  if (parts.length !== expectedParts || expectedParts > MAX_MULTIPART_PARTS) {
+    return c.json({ error: `parts must contain exactly ${expectedParts} entries` }, 400);
+  }
+  const uploadedParts: R2UploadedPart[] = [];
+  for (let index = 0; index < parts.length; index++) {
+    const entry = parts[index];
+    if (!entry) return c.json({ error: "missing multipart part" }, 400);
+    const partNumber = entry.part_number;
+    const etag = String(entry.etag ?? "");
+    if (partNumber !== index + 1 || etag.length === 0 || etag.length > 256) {
+      return c.json({ error: "parts must be sequential and contain valid etags" }, 400);
+    }
+    uploadedParts.push({ partNumber, etag });
+  }
+  const upload = c.env.APK_BUCKET.resumeMultipartUpload(r2Key, uploadId);
+  try {
+    const object = await upload.complete(uploadedParts);
+    if (object.size !== size) {
+      await c.env.APK_BUCKET.delete(r2Key);
+      return c.json({ error: "completed multipart upload size mismatch" }, 400);
+    }
+    return c.json({ r2_key: r2Key, size: object.size });
+  } catch (error) {
+    console.warn(JSON.stringify({
+      event: "feedback_multipart_complete_failed",
+      app_id: auth.app.id,
+      error: error instanceof Error ? error.message : String(error),
+    }));
+    return c.json({ error: "multipart completion failed" }, 502);
+  }
+}
+
+export async function handleAbortFeedbackMultipart(c: Context<{ Bindings: Env }>) {
+  const auth = await authorizeFeedbackUpload(c);
+  if ("response" in auth) return auth.response;
+  let body: { r2_key?: string; upload_id?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "JSON body required" }, 400);
+  }
+  const r2Key = String(body.r2_key ?? "");
+  const uploadId = String(body.upload_id ?? "");
+  if (!validFeedbackMultipartKey(auth.app.id, r2Key) || uploadId.length === 0 || uploadId.length > 2048) {
+    return c.json({ error: "invalid multipart upload target" }, 400);
+  }
+  try {
+    await c.env.APK_BUCKET.resumeMultipartUpload(r2Key, uploadId).abort();
+    return c.json({ aborted: true });
+  } catch {
+    // Abort is idempotent from the SDK's perspective: an already-expired or
+    // already-aborted upload has no durable attachment to clean up.
+    return c.json({ aborted: true });
+  }
 }
 
 export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) {
@@ -373,6 +555,10 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
       if (!head) {
         return c.json({ error: `presigned upload not found: ${r2Key}` }, 400);
       }
+      const declaredSize = typeof item.size === "number" ? item.size : 0;
+      if (declaredSize <= 0 || head.size !== declaredSize) {
+        return c.json({ error: `presigned upload size mismatch: ${r2Key}` }, 400);
+      }
       const filename =
         String(item.filename ?? "").replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 120) ||
         r2Key.split("/").pop() ||
@@ -382,14 +568,14 @@ export async function handlePublicFeedbackSubmit(c: Context<{ Bindings: Env }>) 
         r2Key,
         filename,
         contentType: (item.content_type ? String(item.content_type).slice(0, 100) : null),
-        sizeBytes: head.size ?? (typeof item.size === "number" ? item.size : 0),
+        sizeBytes: head.size,
         fingerprint: {
           source: "presigned",
           index: attachmentRows.length,
           r2_key: r2Key,
           filename,
           content_type: item.content_type ? String(item.content_type).slice(0, 100) : null,
-          size_bytes: head.size ?? (typeof item.size === "number" ? item.size : 0),
+          size_bytes: head.size,
           etag: head.etag,
         },
       });

--- a/worker/test/feedback_multipart.test.ts
+++ b/worker/test/feedback_multipart.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleAbortFeedbackMultipart,
+  handleCompleteFeedbackMultipart,
+  handleFeedbackMultipartPart,
+  handlePresignFeedbackAttachments,
+} from "../src/routes/feedback";
+
+const APP_ID = "app-ohos";
+const CLIENT_KEY = "qk_ohos";
+const R2_KEY = `feedback/${APP_ID}/presigned/attachment-log.zip`;
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeContext(
+  bucket: Record<string, unknown>,
+  options: {
+    query?: Record<string, string>;
+    headers?: Record<string, string>;
+    json?: unknown;
+    body?: ReadableStream<Uint8Array> | null;
+  } = {},
+) {
+  const headers = options.headers ?? {};
+  return {
+    env: {
+      DB: {
+        prepare: () => ({
+          bind() { return this; },
+          first: async () => ({ id: APP_ID, client_key: CLIENT_KEY }),
+        }),
+      },
+      APK_BUCKET: bucket,
+    },
+    req: {
+      param: (name: string) => name === "slug" ? "raft-ohos" : "",
+      query: (name: string) => options.query?.[name],
+      header: (name: string) => headers[name],
+      json: async () => options.json,
+      raw: { body: options.body ?? null },
+    },
+    json: jsonResponse,
+  } as any;
+}
+
+async function responseJson(response: Response): Promise<Record<string, unknown>> {
+  return await response.json() as Record<string, unknown>;
+}
+
+function byteStream(bytes: number[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(bytes));
+      controller.close();
+    },
+  });
+}
+
+describe("pure-ArkTS feedback R2 multipart proxy", () => {
+  it("starts an R2 multipart session instead of returning a raw presigned PUT", async () => {
+    let startedKey = "";
+    let startedContentType = "";
+    const bucket = {
+      createMultipartUpload: async (key: string, options: { httpMetadata?: { contentType?: string } }) => {
+        startedKey = key;
+        startedContentType = options.httpMetadata?.contentType ?? "";
+        return { key, uploadId: "upload-1" };
+      },
+    };
+    const response = await handlePresignFeedbackAttachments(makeContext(bucket, {
+      headers: { "X-Hands-Client-Key": CLIENT_KEY },
+      json: {
+        upload_mode: "r2_multipart_proxy",
+        files: [{ filename: "log.zip", content_type: "application/zip", size: 50 * 1024 * 1024 + 1 }],
+      },
+    }));
+    expect(response.status).toBe(200);
+    const body = await responseJson(response);
+    const uploads = body.uploads as Array<Record<string, unknown>>;
+    expect(uploads[0]).toMatchObject({ upload_id: "upload-1", part_size: 5 * 1024 * 1024 });
+    expect(uploads[0]?.upload_url).toBeUndefined();
+    expect(startedKey).toMatch(/^feedback\/app-ohos\/presigned\//);
+    expect(startedContentType).toBe("application/zip");
+  });
+
+  it("streams one exact bounded part and returns the R2 receipt", async () => {
+    let received = new Uint8Array();
+    const bucket = {
+      resumeMultipartUpload: () => ({
+        uploadPart: async (partNumber: number, stream: ReadableStream<Uint8Array>) => {
+          const chunks: Uint8Array[] = [];
+          const reader = stream.getReader();
+          while (true) {
+            const next = await reader.read();
+            if (next.done) break;
+            chunks.push(next.value);
+          }
+          received = new Uint8Array(chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0));
+          let offset = 0;
+          for (const chunk of chunks) {
+            received.set(chunk, offset);
+            offset += chunk.byteLength;
+          }
+          return { partNumber, etag: "etag-1" };
+        },
+        abort: async () => {},
+      }),
+    };
+    const response = await handleFeedbackMultipartPart(makeContext(bucket, {
+      query: { r2_key: R2_KEY, upload_id: "upload-1", part_number: "1" },
+      headers: { "X-Hands-Client-Key": CLIENT_KEY, "X-Hands-Part-Bytes": "4" },
+      body: byteStream([1, 2, 3, 4]),
+    }));
+    expect(response.status).toBe(200);
+    expect(await responseJson(response)).toEqual({ part_number: 1, etag: "etag-1", size: 4 });
+    expect([...received]).toEqual([1, 2, 3, 4]);
+  });
+
+  it("aborts a part whose actual bytes differ from the declared bound", async () => {
+    let aborted = false;
+    const upload = {
+      uploadPart: async (partNumber: number, stream: ReadableStream<Uint8Array>) => {
+        const reader = stream.getReader();
+        while (!(await reader.read()).done) { /* consume */ }
+        return { partNumber, etag: "etag-short" };
+      },
+      abort: async () => { aborted = true; },
+    };
+    const response = await handleFeedbackMultipartPart(makeContext({
+      resumeMultipartUpload: () => upload,
+    }, {
+      query: { r2_key: R2_KEY, upload_id: "upload-1", part_number: "1" },
+      headers: { "X-Hands-Client-Key": CLIENT_KEY, "X-Hands-Part-Bytes": "4" },
+      body: byteStream([1, 2, 3]),
+    }));
+    expect(response.status).toBe(400);
+    expect(aborted).toBe(true);
+  });
+
+  it("completes only a sequential exact-size part list", async () => {
+    let completedParts: unknown[] = [];
+    const bucket = {
+      resumeMultipartUpload: () => ({
+        complete: async (parts: unknown[]) => {
+          completedParts = parts;
+          return { size: 5 * 1024 * 1024 + 1 };
+        },
+      }),
+      delete: async () => {},
+    };
+    const response = await handleCompleteFeedbackMultipart(makeContext(bucket, {
+      headers: { "X-Hands-Client-Key": CLIENT_KEY },
+      json: {
+        r2_key: R2_KEY,
+        upload_id: "upload-1",
+        size: 5 * 1024 * 1024 + 1,
+        parts: [
+          { part_number: 1, etag: "etag-1" },
+          { part_number: 2, etag: "etag-2" },
+        ],
+      },
+    }));
+    expect(response.status).toBe(200);
+    expect(completedParts).toEqual([
+      { partNumber: 1, etag: "etag-1" },
+      { partNumber: 2, etag: "etag-2" },
+    ]);
+
+    const invalid = await handleCompleteFeedbackMultipart(makeContext(bucket, {
+      headers: { "X-Hands-Client-Key": CLIENT_KEY },
+      json: {
+        r2_key: R2_KEY,
+        upload_id: "upload-1",
+        size: 5 * 1024 * 1024 + 1,
+        parts: [
+          { part_number: 2, etag: "etag-2" },
+          { part_number: 1, etag: "etag-1" },
+        ],
+      },
+    }));
+    expect(invalid.status).toBe(400);
+  });
+
+  it("treats abort as idempotent cleanup", async () => {
+    let abortCalls = 0;
+    const response = await handleAbortFeedbackMultipart(makeContext({
+      resumeMultipartUpload: () => ({
+        abort: async () => { abortCalls += 1; },
+      }),
+    }, {
+      headers: { "X-Hands-Client-Key": CLIENT_KEY },
+      json: { r2_key: R2_KEY, upload_id: "upload-1" },
+    }));
+    expect(response.status).toBe(200);
+    expect(abortCalls).toBe(1);
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -9253,9 +9253,13 @@ describe("quiver public API v2 — scope resolution", () => {
     expect((await submit([{ r2_key: "feedback/other-app/presigned/x.bin" }])).status).toBe(400);
     // missing object -> 400
     expect((await submit([{ r2_key: "feedback/app-scope/presigned/missing.bin" }])).status).toBe(400);
-    // valid presigned object -> 201, recorded with the real size from head
-    const ok = await submit([
+    // declared and stored size mismatch -> 400 (detects truncated/framed uploads)
+    expect((await submit([
       { r2_key: "feedback/app-scope/presigned/good-file.bin", filename: "good-file.bin", content_type: "application/octet-stream", size: 999 },
+    ])).status).toBe(400);
+    // valid presigned object -> 201, recorded with the exact size from head
+    const ok = await submit([
+      { r2_key: "feedback/app-scope/presigned/good-file.bin", filename: "good-file.bin", content_type: "application/octet-stream", size: 1024 },
     ]);
     expect(ok.status).toBe(201);
     const body = await responseJson<any>(ok);


### PR DESCRIPTION
## Outcome

Removes the OHOS 50 MB whole-`ArrayBuffer` ceiling without adding a native dependency. Pure ArkTS reads one 5 MiB part at a time and sends it as a raw HTTP body to a bounded Worker endpoint; the Worker streams that body into an R2 multipart upload. Each part gets one retry, failures abort the session, completion requires sequential R2 receipts, and the final R2 object size must equal the client-declared file size.

Android and iOS keep their existing direct presigned PUT path. The prospective OHPM coordinate is `@botiverse/hands@0.3.4`; this PR does not publish it.

## Validation on exact `007bb9508140ade4bd61e92ea1b6313fb567fea6`

- OHOS contract/release/source tests: 18 PASS
- Worker suite: 424 PASS, including 5 focused multipart start/part/size/complete/abort tests
- Worker TypeScript build: PASS
- `assembleHar`: PASS
- OHPM `prepublish`: PASS for 0.3.4
- causal source-contract mutations: whole-file allocation, `request.uploadFile`, missing bounded read/part size/complete/abort each RED
- `git diff --check`: PASS

## Explicit boundary

The prior `request.uploadFile` approach was removed because the DevEco SDK contract forces multipart/form-data and cannot satisfy a raw presigned PUT. The replacement stays pure ArkTS and uses Cloudflare R2's multipart API; no NetworkKMM KLIB, NAPI bridge, or native `.so` is packaged.

No OHOS device is currently connected (`hdc list targets` is `[Empty]`). Physical 50 MB+1/200 MB source→stored→download SHA-256 and peak-memory validation are NOT RUN and remain required before publication or Mobile consumption. The source/build evidence proves bounded allocation and protocol shape, not physical-device memory or end-to-end byte equality.

No package publication, server deployment, Mobile update, or app release is included or authorized.

Task #418.
