### PR TITLE
Add release-share rebinding to the admin

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -225,6 +225,10 @@ export interface Release {
   created_by: string;
   created_at: number;
   updated_at: number;
+  // Flattened build/channel fields returned by the release list endpoint.
+  version_name?: string;
+  version_code?: number;
+  channel?: string;
   // release_metrics (nullable when never checked)
   offered_count?: number | null;
   current_count?: number | null;
@@ -1567,6 +1571,7 @@ export const listWebhookDeliveries = (orgId: string, webhookId: string) =>
 export interface AppShare {
   id: string;
   release_id: string;
+  channel_id: string;
   // Copyable URL; null for legacy shares created before tokens were stored.
   share_url: string | null;
   created_by: string;
@@ -1613,6 +1618,22 @@ export const revokeReleaseShare = (appId: string, releaseId: string, shareId: st
     `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,
     { method: "DELETE", admin: true },
   );
+
+export const rebindReleaseShare = (
+  appId: string,
+  shareId: string,
+  body: { expected_release_id: string; target_release_id: string },
+) =>
+  request<{
+    id: string;
+    previous_release_id: string;
+    release_id: string;
+    target: { status: string; version_name: string; version_code: number; file_hash: string | null; size_bytes: number | null };
+  }>(`/api/apps/${appId}/shares/${shareId}/rebind`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    admin: true,
+  });
 
 // ---- Feedback tickets (task #66) ----
 

--- a/admin/src/pages/Shares.tsx
+++ b/admin/src/pages/Shares.tsx
@@ -15,6 +15,8 @@ import {
   createReleaseShare,
   listAppShares,
   listReleases,
+  getRelease,
+  rebindReleaseShare,
   renewReleaseShare,
   revokeReleaseShare,
 } from "../lib/api";
@@ -24,6 +26,7 @@ export function AppShares({ appId }: { appId: string }) {
   const toast = useToast();
   const queryClient = useQueryClient();
   const [showCreate, setShowCreate] = useState(false);
+  const [rebindShare, setRebindShare] = useState<AppShare | null>(null);
   const [createdUrl, setCreatedUrl] = useState<string | null>(null);
 
   const shares = useQuery({
@@ -193,6 +196,7 @@ export function AppShares({ appId }: { appId: string }) {
                     setExpiry.mutate({ share, ttlDays: days });
                   }}
                   onRevoke={() => revoke.mutate(share)}
+                  onRebind={() => setRebindShare(share)}
                   onSetPassword={() => {
                     const next = window.prompt(
                       share.has_password
@@ -224,6 +228,17 @@ export function AppShares({ appId }: { appId: string }) {
           }}
         />
       )}
+      {rebindShare && (
+        <RebindShareModal
+          appId={appId}
+          share={rebindShare}
+          onClose={() => setRebindShare(null)}
+          onRebound={() => {
+            setRebindShare(null);
+            invalidate();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -242,6 +257,7 @@ function ShareRow({
   onCopyUrl,
   onSetExpiry,
   onRevoke,
+  onRebind,
   onSetPassword,
   busy,
 }: {
@@ -249,6 +265,7 @@ function ShareRow({
   onCopyUrl: () => void;
   onSetExpiry: () => void;
   onRevoke: () => void;
+  onRebind: () => void;
   onSetPassword: () => void;
   busy: boolean;
 }) {
@@ -309,6 +326,9 @@ function ShareRow({
             <Button variant="link" size="sm" className="mr-2" onClick={onSetPassword} disabled={busy}>
               {share.has_password ? "Password…" : "Set password"}
             </Button>
+            <Button variant="link" size="sm" className="mr-2" onClick={onRebind} disabled={busy}>
+              Rebind release…
+            </Button>
             <Button variant="link" size="sm" className="text-red-600" onClick={onRevoke} disabled={busy}>
               Revoke
             </Button>
@@ -316,6 +336,116 @@ function ShareRow({
         )}
       </td>
     </tr>
+  );
+}
+
+function RebindShareModal({
+  appId,
+  share,
+  onClose,
+  onRebound,
+}: {
+  appId: string;
+  share: AppShare;
+  onClose: () => void;
+  onRebound: () => void;
+}) {
+  const toast = useToast();
+  const [targetReleaseId, setTargetReleaseId] = useState("");
+  const releases = useQuery({
+    queryKey: ["releases", appId],
+    queryFn: () => listReleases(appId),
+  });
+  const options = useMemo(
+    () => (releases.data?.releases ?? [])
+      .filter((release) => release.status === "active"
+        && release.id !== share.release_id
+        && release.channel_id === share.channel_id),
+    [releases.data, share.channel_id, share.release_id],
+  );
+  const target = useQuery({
+    queryKey: ["release", appId, targetReleaseId],
+    queryFn: () => getRelease(appId, targetReleaseId),
+    enabled: Boolean(targetReleaseId),
+  });
+  const installable = target.data?.assets.find((asset) => asset.artifact_kind === "installable");
+  const rebind = useMutation({
+    mutationFn: () => rebindReleaseShare(appId, share.id, {
+      expected_release_id: share.release_id,
+      target_release_id: targetReleaseId,
+    }),
+    onSuccess: (data) => {
+      toast.show({
+        kind: "success",
+        title: `Share now points to ${data.target.version_name} (${data.target.version_code})`,
+      });
+      onRebound();
+    },
+    onError: (error) => toast.show({
+      kind: "error",
+      title: "Release rebind failed",
+      description: (error as Error).message,
+    }),
+  });
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader><DialogTitle>Rebind share to another release</DialogTitle></DialogHeader>
+        <DialogBody className="space-y-3">
+          <p className="text-sm text-slate-600">
+            The public URL stays the same. Its version, build, download, and checksum will all point to the selected release.
+          </p>
+          <div className="rounded-md border border-slate-200 p-3 text-sm">
+            <div className="text-xs text-slate-500">Current release</div>
+            <strong>{share.version_name} ({share.version_code})</strong>
+            <span className="ml-2 text-xs text-slate-500">{share.channel_slug}</span>
+          </div>
+          <label className="block text-xs text-slate-600">
+            Target active release
+            <Select
+              items={{
+                "": "Select an active release…",
+                ...Object.fromEntries(options.map((release) => [
+                  release.id,
+                  `${release.version_name ?? release.id.slice(0, 8)} (${release.version_code ?? "—"})`,
+                ])),
+              }}
+              value={targetReleaseId}
+              onValueChange={(value) => setTargetReleaseId(value as string)}
+            >
+              <SelectTrigger className="mt-1 py-1.5!"><SelectValue /><SelectIcon /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">Select an active release…</SelectItem>
+                {options.map((release) => (
+                  <SelectItem key={release.id} value={release.id}>
+                    {release.version_name ?? release.id.slice(0, 8)} ({release.version_code ?? "—"})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+          {target.isLoading && <Skeleton className="h-20 w-full" />}
+          {target.data && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm">
+              <div><strong>{target.data.build.version_name}</strong> ({target.data.build.version_code})</div>
+              <div className="mt-1 text-xs text-slate-600">Build: <code>{target.data.build.id}</code></div>
+              <div className="mt-1 break-all text-xs text-slate-600">Checksum: <code>{installable?.file_hash ?? "No installable asset"}</code></div>
+            </div>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button
+            variant="primary"
+            disabled={!targetReleaseId || !installable || rebind.isPending}
+            onClick={() => rebind.mutate()}
+          >
+            {rebind.isPending ? "Rebinding…" : "Rebind release"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -126,6 +126,62 @@ describe("apiRequest", () => {
   });
 });
 
+describe("release share commands", () => {
+  it("rebinds through the closed API with an explicit expected current release", async () => {
+    const requests: Array<{ method: string; url: string; body?: unknown }> = [];
+    const server = createServer(async (req, res) => {
+      let body: unknown;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      if (req.url === "/api/apps/app-1/shares/share-1/rebind" && req.method === "POST") {
+        return res.end(JSON.stringify({
+          id: "share-1",
+          previous_release_id: "release-old",
+          release_id: "release-new",
+          target: { version_name: "1.9.1", version_code: 1090101, file_hash: "target-hash" },
+        }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+    try {
+      const program = new Command();
+      const { registerReleaseCommands } = await import("../src/commands/releases.js");
+      registerReleaseCommands(program);
+      await program.parseAsync([
+        "node", "hands", "releases", "rebind-share", "raft-android", "share-1",
+        "--from", "release-old", "--to", "release-new",
+      ]);
+      expect(requests.at(-1)).toEqual({
+        method: "POST",
+        url: "/api/apps/app-1/shares/share-1/rebind",
+        body: { expected_release_id: "release-old", target_release_id: "release-new" },
+      });
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
 describe("app provisioning commands", () => {
   it("creates a web app and explicitly reads its client key without verbose-log leakage", async () => {
     const requests: Array<{ method: string; url: string; body?: unknown }> = [];

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -431,6 +431,37 @@ export function registerReleaseCommands(program: Command): void {
         console.log(`  revoked_at: ${new Date(res.revoked_at).toISOString()}`);
       },
     );
+
+  releases
+    .command("rebind-share <appIdOrSlug> <shareId>")
+    .description("Rebind an unrevoked public share to another active release in the same app and channel.")
+    .requiredOption("--from <releaseId>", "Expected current release UUID from a fresh share list.")
+    .requiredOption("--to <releaseId>", "Target active release UUID.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      shareId: string,
+      opts: { from: string; to: string; json?: boolean },
+    ) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const result = await apiRequest<{
+        id: string;
+        previous_release_id: string;
+        release_id: string;
+        target: { version_name: string; version_code: number; file_hash: string | null };
+      }>(`/api/apps/${appId}/shares/${shareId}/rebind`, {
+        method: "POST",
+        body: { expected_release_id: opts.from, target_release_id: opts.to },
+      });
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(`Rebound release share ${result.id}`);
+      console.log(`  release: ${result.previous_release_id} -> ${result.release_id}`);
+      console.log(`  target:  ${result.target.version_name} (${result.target.version_code})`);
+      console.log(`  sha256:  ${result.target.file_hash ?? "unavailable"}`);
+    });
 }
 
 async function resolveAppId(slugOrId: string): Promise<string> {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -68,6 +68,7 @@ import {
   handlePublicReleaseShare,
   handleRevokeReleaseShare,
   handleUpdateReleaseShare,
+  handleRebindReleaseShare,
   handleListAppShares,
   handlePublicReleaseShareUnlock,
   handlePublicReleaseShareIcon,
@@ -809,6 +810,7 @@ admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("
 admin.get("/api/apps/:appId/releases/:releaseId/checks", requireAppRole("viewer"), handleListReleaseChecks);
 admin.post("/api/apps/:appId/releases/:releaseId/checks", requireAppRole("publisher"), handleUpsertReleaseCheck);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
+admin.post("/api/apps/:appId/shares/:shareId/rebind", requireAppRole("publisher"), handleRebindReleaseShare);
 admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);
 admin.get("/api/apps/:appId/client-key", requireAppRole("admin"), handleGetClientKey);
 admin.post("/api/apps/:appId/rotate-client-key", requireAppRole("admin"), handleRotateClientKey);

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1143,6 +1143,18 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "rebind-release-share",
+        description:
+          "Rebind one unrevoked public share URL to another active release in the same app and channel. The expected current release is a required concurrency precondition; update and audit commit atomically. Requires app publisher.",
+        endpoint: { method: "POST", path: "/api/apps/{app_id}/shares/{share_id}/rebind" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          share_id: { type: "string", in: "path", required: true, description: "Share UUID." },
+          expected_release_id: { type: "string", in: "body", required: true, description: "Current release UUID from a fresh share list." },
+          target_release_id: { type: "string", in: "body", required: true, description: "Active target release UUID in the same app and channel." },
+        },
+      },
+      {
         name: "create-deploy-token",
         description:
           "Create an app-scoped deploy token. Requires app admin. The raw token is returned exactly once; store it immediately in a secret manager and never post it to a public channel.",

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -239,6 +239,7 @@ export async function handleListAppShares(c: AdminContext) {
     `SELECT
        rs.id,
        rs.release_id,
+       r.channel_id,
        rs.token,
        rs.created_by,
        rs.created_at,
@@ -393,6 +394,159 @@ export async function handleUpdateReleaseShare(c: AdminContext) {
     release_id: releaseId,
     expires_at: expiresAt,
     revoked_at: null,
+  });
+}
+
+export async function handleRebindReleaseShare(c: AdminContext) {
+  const appId = c.req.param("appId");
+  const shareId = c.req.param("shareId");
+  const body = await c.req.json().catch(() => ({})) as {
+    expected_release_id?: string;
+    target_release_id?: string;
+  };
+  const expectedReleaseId = typeof body.expected_release_id === "string"
+    ? body.expected_release_id.trim()
+    : "";
+  const targetReleaseId = typeof body.target_release_id === "string"
+    ? body.target_release_id.trim()
+    : "";
+  if (!expectedReleaseId || !targetReleaseId) {
+    return c.json({ error: "expected_release_id and target_release_id are required" }, 400);
+  }
+  if (expectedReleaseId === targetReleaseId) {
+    return c.json({ error: "target release must differ from the current release" }, 400);
+  }
+
+  const existing = await c.env.DB.prepare(
+    `SELECT rs.release_id, rs.revoked_at, r.channel_id
+     FROM release_shares rs
+     JOIN releases r ON r.id = rs.release_id
+     WHERE rs.id = ?1 AND r.app_id = ?2`,
+  ).bind(shareId, appId).first<{
+    release_id: string;
+    revoked_at: number | null;
+    channel_id: string;
+  }>();
+  if (!existing) return c.json({ error: "share not found" }, 404);
+  if (existing.revoked_at != null) return c.json({ error: "cannot rebind revoked share" }, 409);
+  if (existing.release_id !== expectedReleaseId) {
+    return c.json({ error: "share release changed", code: "share_rebind_conflict" }, 409);
+  }
+
+  const target = await c.env.DB.prepare(
+    `SELECT r.id, r.status, r.channel_id, b.version_name, b.version_code,
+            ba.file_hash, ba.size_bytes, ba.r2_key
+     FROM releases r
+     JOIN builds b ON b.id = r.build_id
+     LEFT JOIN build_assets ba ON ba.id = (
+       SELECT candidate.id FROM build_assets candidate
+       WHERE candidate.build_id = r.build_id
+         AND candidate.artifact_kind = 'installable'
+       ORDER BY candidate.created_at ASC, candidate.id ASC LIMIT 1
+     )
+     WHERE r.app_id = ?1 AND r.id = ?2`,
+  ).bind(appId, targetReleaseId).first<{
+    id: string;
+    status: string;
+    channel_id: string;
+    version_name: string;
+    version_code: number;
+    file_hash: string | null;
+    size_bytes: number | null;
+    r2_key: string | null;
+  }>();
+  if (!target) return c.json({ error: "target release not found" }, 404);
+  if (target.status !== "active") {
+    return c.json({ error: "target release must be active" }, 409);
+  }
+  if (target.channel_id !== existing.channel_id) {
+    return c.json({ error: "target release must use the share's current channel" }, 409);
+  }
+  if (!target.r2_key || !(await c.env.APK_BUCKET.head(target.r2_key))) {
+    return c.json({ error: "target release installable is unavailable" }, 409);
+  }
+
+  const now = Date.now();
+  const auditId = crypto.randomUUID();
+  const actor = currentActor(c);
+  let results;
+  try {
+    results = await c.env.DB.batch([
+      c.env.DB.prepare(
+        `UPDATE release_shares
+         SET release_id = ?1
+         WHERE id = ?2
+           AND release_id = ?3
+           AND revoked_at IS NULL
+           AND EXISTS (
+             SELECT 1 FROM releases current_release
+             WHERE current_release.id = release_shares.release_id
+               AND current_release.app_id = ?4
+           )
+           AND EXISTS (
+             SELECT 1 FROM releases target_release
+             WHERE target_release.id = ?1
+               AND target_release.app_id = ?4
+               AND target_release.status = 'active'
+               AND target_release.channel_id = (
+                 SELECT current_release.channel_id FROM releases current_release
+                 WHERE current_release.id = release_shares.release_id
+               )
+           )`,
+      ).bind(targetReleaseId, shareId, expectedReleaseId, appId),
+      c.env.DB.prepare(
+        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+         SELECT ?1, ?2, 'release_share.rebind', ?3,
+                json_object(
+                  'share_id', rs.id,
+                  'token_hash', rs.token_hash,
+                  'old_release_id', ?4,
+                  'new_release_id', ?5
+                ),
+                ?6
+         FROM release_shares rs
+         WHERE rs.id = ?7
+           AND rs.release_id = ?5
+           AND changes() = 1`,
+      ).bind(
+        auditId,
+        appId,
+        actor,
+        expectedReleaseId,
+        targetReleaseId,
+        now,
+        shareId,
+      ),
+      // D1 batch rolls back on a statement error, not on a zero-row result.
+      // Force a NOT NULL violation when the preceding audit insert did not
+      // affect exactly one row, so a stale/revoked race cannot commit the
+      // rebind without its audit record.
+      c.env.DB.prepare(
+        `INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at)
+         SELECT ?1, NULL, 'release_share.rebind.assert', ?2, '{}', ?3
+         WHERE changes() <> 1`,
+      ).bind(crypto.randomUUID(), actor, now),
+    ]);
+  } catch {
+    return c.json({ error: "share changed, was revoked, or was not found", code: "share_rebind_conflict" }, 409);
+  }
+  const updateChanges = Number(results[0]?.meta?.changes ?? 0);
+  const auditChanges = Number(results[1]?.meta?.changes ?? 0);
+  if (auditChanges !== 1 || updateChanges !== 1) {
+    return c.json({ error: "share changed, was revoked, or was not found", code: "share_rebind_conflict" }, 409);
+  }
+
+  return c.json({
+    id: shareId,
+    previous_release_id: expectedReleaseId,
+    release_id: targetReleaseId,
+    target: {
+      status: target.status,
+      version_name: target.version_name,
+      version_code: target.version_code,
+      file_hash: target.file_hash,
+      size_bytes: target.size_bytes,
+    },
   });
 }
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6444,7 +6444,8 @@ describe("quiver public API v2 — scope resolution", () => {
 
   it("shares: rejects revoked, non-active, missing, and cross-app rebind targets", async () => {
     const env = makeEnv();
-    env.APK_BUCKET = { head: async (key: string) => ({ key }) };
+    let targetObjectExists = true;
+    env.APK_BUCKET = { head: async (key: string) => targetObjectExists ? ({ key }) : null };
     await seedRelease(env, "rel-rebind-old", "build-rebind-old", [["full", "all"]]);
     await seedAsset(env, "build-rebind-old", "asset-rebind-old");
     await seedRelease(env, "rel-rebind-target", "build-rebind-target", [["full", "all"]], { versionCode: 2 });
@@ -6473,6 +6474,18 @@ describe("quiver public API v2 — scope resolution", () => {
     expect((await call("rel-rebind-target")).status).toBe(404);
     await env.DB.prepare("UPDATE releases SET app_id = ? WHERE id = ?")
       .bind("app-scope", "rel-rebind-target").run();
+    await env.DB.prepare(
+      `INSERT INTO channels (id, app_id, slug, name, enabled_product_types_json, metadata_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).bind("ch-scope-preview", "app-scope", "preview", "Preview", "[]", "{}", 1).run();
+    await env.DB.prepare("UPDATE releases SET channel_id = ? WHERE id = ?")
+      .bind("ch-scope-preview", "rel-rebind-target").run();
+    expect((await call("rel-rebind-target")).status).toBe(409);
+    await env.DB.prepare("UPDATE releases SET channel_id = ? WHERE id = ?")
+      .bind("ch-scope-prod", "rel-rebind-target").run();
+    targetObjectExists = false;
+    expect((await call("rel-rebind-target")).status).toBe(409);
+    targetObjectExists = true;
     await handleRevokeReleaseShare(makeShareAdminContext(env, {
       appId: "app-scope", releaseId: "rel-rebind-old", shareId: created.id,
     }));

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -6381,6 +6381,109 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(await unknownPage.text()).not.toContain("/apps/scope-app/latest");
   });
 
+  it("shares: rebinds one live share atomically to an active release in the same app", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = { head: async (key: string) => ({ key }) };
+    await seedRelease(env, "rel-share-old", "build-share-old", [["full", "all"]], {
+      versionCode: 10,
+      versionName: "1.0.0",
+    });
+    await seedAsset(env, "build-share-old", "asset-share-old", { fileHash: "old-hash" });
+    await seedRelease(env, "rel-share-new", "build-share-new", [["full", "all"]], {
+      versionCode: 11,
+      versionName: "1.1.0",
+    });
+    await seedAsset(env, "build-share-new", "asset-share-new", {
+      fileHash: "new-hash",
+      sizeBytes: 456,
+    });
+    const { handleCreateReleaseShare, handleRebindReleaseShare } = await import("../src/routes/shares");
+    const created = await responseJson<any>(await handleCreateReleaseShare(
+      makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-share-old" }),
+    ));
+
+    const response = await handleRebindReleaseShare(makeShareAdminContext(
+      env,
+      { appId: "app-scope", shareId: created.id },
+      { expected_release_id: "rel-share-old", target_release_id: "rel-share-new" },
+    ));
+    expect(response.status).toBe(200);
+    expect(await responseJson<any>(response)).toMatchObject({
+      id: created.id,
+      previous_release_id: "rel-share-old",
+      release_id: "rel-share-new",
+      target: { status: "active", version_name: "1.1.0", version_code: 11, file_hash: "new-hash", size_bytes: 456 },
+    });
+    const rebound = await env.DB.prepare(
+      "SELECT release_id, token_hash FROM release_shares WHERE id = ?",
+    ).bind(created.id).first() as { release_id: string; token_hash: string };
+    expect(rebound.release_id).toBe("rel-share-new");
+    const audit = await env.DB.prepare(
+      "SELECT actor, payload FROM audit_logs WHERE action = 'release_share.rebind'",
+    ).first() as { actor: string; payload: string };
+    expect(audit.actor).toBe("tester");
+    expect(JSON.parse(audit.payload)).toEqual({
+      share_id: created.id,
+      token_hash: rebound.token_hash,
+      old_release_id: "rel-share-old",
+      new_release_id: "rel-share-new",
+    });
+    expect(audit.payload).not.toContain(new URL(created.share_url).pathname.replace("/share/", ""));
+
+    const staleRetry = await handleRebindReleaseShare(makeShareAdminContext(
+      env,
+      { appId: "app-scope", shareId: created.id },
+      { expected_release_id: "rel-share-old", target_release_id: "rel-share-new" },
+    ));
+    expect(staleRetry.status).toBe(409);
+    const auditCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release_share.rebind'",
+    ).first() as { count: number };
+    expect(auditCount.count).toBe(1);
+  });
+
+  it("shares: rejects revoked, non-active, missing, and cross-app rebind targets", async () => {
+    const env = makeEnv();
+    env.APK_BUCKET = { head: async (key: string) => ({ key }) };
+    await seedRelease(env, "rel-rebind-old", "build-rebind-old", [["full", "all"]]);
+    await seedAsset(env, "build-rebind-old", "asset-rebind-old");
+    await seedRelease(env, "rel-rebind-target", "build-rebind-target", [["full", "all"]], { versionCode: 2 });
+    await seedAsset(env, "build-rebind-target", "asset-rebind-target");
+    const { handleCreateReleaseShare, handleRebindReleaseShare, handleRevokeReleaseShare } = await import("../src/routes/shares");
+    const created = await responseJson<any>(await handleCreateReleaseShare(
+      makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-rebind-old" }),
+    ));
+    const call = (targetReleaseId: string) => handleRebindReleaseShare(makeShareAdminContext(
+      env,
+      { appId: "app-scope", shareId: created.id },
+      { expected_release_id: "rel-rebind-old", target_release_id: targetReleaseId },
+    ));
+
+    expect((await call("missing-release")).status).toBe(404);
+    await env.DB.prepare("UPDATE releases SET status = 'draft' WHERE id = ?")
+      .bind("rel-rebind-target").run();
+    expect((await call("rel-rebind-target")).status).toBe(409);
+    await env.DB.prepare("UPDATE releases SET status = 'active' WHERE id = ?")
+      .bind("rel-rebind-target").run();
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, client_key, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).bind("app-other", "default", "other", "Other", "android", "other-key", 1).run();
+    await env.DB.prepare("UPDATE releases SET app_id = ? WHERE id = ?")
+      .bind("app-other", "rel-rebind-target").run();
+    expect((await call("rel-rebind-target")).status).toBe(404);
+    await env.DB.prepare("UPDATE releases SET app_id = ? WHERE id = ?")
+      .bind("app-scope", "rel-rebind-target").run();
+    await handleRevokeReleaseShare(makeShareAdminContext(env, {
+      appId: "app-scope", releaseId: "rel-rebind-old", shareId: created.id,
+    }));
+    expect((await call("rel-rebind-target")).status).toBe(409);
+
+    const auditCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'release_share.rebind'",
+    ).first() as { count: number };
+    expect(auditCount.count).toBe(0);
+  });
+
   it("latest landing: stable app URL renders the highest active published release", async () => {
     const env = makeEnv();
     await env.DB.prepare("UPDATE apps SET public_history = 1 WHERE id = ?")


### PR DESCRIPTION
## Summary
- add a publisher-only, closed API to rebind one unrevoked share to an active release in the same app and channel
- atomically commit the guarded rebind and token-free audit entry; reject stale, revoked, missing, cross-app/channel, inactive, or missing-object targets
- add the action to the app Shares page with current/target version, build, and checksum confirmation
- expose the exact action through the agent manifest

## Validation
- worker TypeScript: clean
- admin TypeScript: clean
- worker route tests: 182/182
- admin tests: 33/33
- admin production build: clean (existing chunk-size warning only)
- `git diff --check`: clean

No production data was changed and nothing was deployed.
