### PR TITLE
Allow configured Raft server members into Hands Admin

### DIFF
--- a/admin-worker/README.md
+++ b/admin-worker/README.md
@@ -3,7 +3,7 @@
 Separately deployed, staff-only observability UI for Hands.
 
 - No Hands D1 or R2 binding. Product data is available only through the main Worker's named `HandsObservability.getOverview()` RPC method.
-- Login with Raft is enforced server-side. An encrypted HttpOnly session carries the Raft token, and every sensitive request re-reads userinfo and rechecks the explicit server allowlist plus owner/admin role.
+- Login with Raft is enforced server-side. An encrypted HttpOnly session carries the Raft token, and every sensitive request re-reads userinfo and rechecks the explicit server allowlist. Every authenticated human or Agent from an allowlisted server may view the dashboard.
 - The RPC response is a closed aggregate schema: counts, bytes, enums, and timestamps only.
 - Every view is written to this Worker's separate audit D1 database.
 - Secrets and production identifiers are injected at deploy time, never committed.

--- a/admin-worker/src/auth.ts
+++ b/admin-worker/src/auth.ts
@@ -38,7 +38,7 @@ export const requireAdmin: MiddlewareHandler<{ Bindings: AdminWorkerEnv; Variabl
     const user = await response.json<Userinfo>();
     const allowed = c.env.RAFT_ALLOWED_SERVER_IDS.split(",").map((value) => value.trim()).filter(Boolean);
     const role = (user.server_role ?? "").toLowerCase();
-    if (user.sub !== session.sub || !allowed.includes(user.server_id) || !["owner", "admin"].includes(role)) {
+    if (user.sub !== session.sub || !allowed.includes(user.server_id)) {
       return c.text("Hands staff access required", 403);
     }
     c.set("session", { ...session, server_id: user.server_id, role, name: user.name ?? user.preferred_username ?? user.sub });
@@ -72,7 +72,7 @@ export async function callback(c: Context<{ Bindings: AdminWorkerEnv }>) {
   const user = await userResponse.json<Userinfo>();
   const allowed = c.env.RAFT_ALLOWED_SERVER_IDS.split(",").map((v) => v.trim()).filter(Boolean);
   const role = (user.server_role ?? "").toLowerCase();
-  if (!allowed.includes(user.server_id) || !["owner", "admin"].includes(role)) return c.text("Hands staff access required", 403);
+  if (!allowed.includes(user.server_id)) return c.text("Hands staff access required", 403);
   const token = await new EncryptJWT({ sub: user.sub, server_id: user.server_id, role, name: user.name ?? user.preferred_username ?? user.sub, access_token })
     .setProtectedHeader({ alg: "dir", enc: "A256GCM" }).setIssuedAt().setExpirationTime("8h").encrypt(key(c.env.SESSION_SECRET));
   setCookie(c, SESSION, token, { httpOnly: true, secure: true, sameSite: "Lax", maxAge: 28_800, path: "/" });

--- a/admin-worker/test/access.test.ts
+++ b/admin-worker/test/access.test.ts
@@ -42,8 +42,8 @@ describe("Hands admin access gate", () => {
   });
 
   it.each([
-    ["a non-admin role", { sub: "user-1", server_id: "server-1", server_role: "member" }],
     ["a server outside the allowlist", { sub: "user-1", server_id: "server-2", server_role: "owner" }],
+    ["a different live principal", { sub: "user-2", server_id: "server-1", server_role: "owner" }],
   ])("rejects %s before calling product RPC or audit storage", async (_name, userinfo) => {
     const getOverview = vi.fn();
     const prepare = vi.fn();
@@ -62,4 +62,47 @@ describe("Hands admin access gate", () => {
     expect(prepare).not.toHaveBeenCalled();
     vi.restoreAllMocks();
   });
+
+  it.each(["member", "viewer", "admin", "owner"])(
+    "allows an authenticated %s from an allowlisted server",
+    async (serverRole) => {
+      const overview = {
+        measured_at: 1,
+        summary: { users: 0, organizations: 0, apps: 0, active_apps: 0, builds: 0, releases: 0 },
+        users_by_type: [],
+        apps_by_platform: [],
+        builds_by_product_type: [],
+        releases_by_status: [],
+        releases_by_week: [],
+        storage: {
+          r2: { object_count: 0, size_bytes: 0 },
+          registered: { object_count: 0, size_bytes: 0 },
+          note: "test",
+        },
+      };
+      const getOverview = vi.fn().mockResolvedValue(overview);
+      const run = vi.fn().mockResolvedValue({ success: true });
+      const bind = vi.fn().mockReturnValue({ run });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify({
+        sub: "user-1",
+        server_id: "server-1",
+        server_role: serverRole,
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+
+      const response = await app.request("https://admin.example/api/overview", {
+        headers: { cookie: await sessionCookie() },
+      }, env(getOverview, prepare));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(overview);
+      expect(getOverview).toHaveBeenCalledOnce();
+      expect(prepare).toHaveBeenCalledOnce();
+      expect(run).toHaveBeenCalledOnce();
+      vi.restoreAllMocks();
+    },
+  );
 });


### PR DESCRIPTION
Changes the Hands Admin access gate from allowlisted server + owner/admin role to authenticated membership in an explicitly allowlisted server, per product decision. Every request still refreshes Raft userinfo and checks live principal identity + server id before RPC/audit. Adds positive coverage for member/viewer/admin/owner and keeps negative coverage for wrong server and mismatched principal.\n\nValidation: admin-worker TypeScript build, 7/7 tests, diff-check.