### PR TITLE
feat(cli): hands api same-origin authenticated passthrough

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -526,17 +526,26 @@ hatch — every write still hits the same server route.
 # GET with repeatable query params
 hands api GET /api/apps --param platform=android
 
-# POST/PATCH with an inline JSON body, or read the body from a file with @path
-hands api POST /api/apps/raft-android/releases --data '{"buildId":"build-1"}'
-hands api PATCH /api/apps/raft-android/releases/<id>/shares/<sid> --data @body.json
+# PATCH with an inline JSON body. NOTE: path params are raw — <appId> is the app
+# UUID, not a slug: `hands api` passes the path through and does not resolve slugs.
+hands api PATCH /api/apps/<appId>/releases/<releaseId>/shares/<shareId> \
+  --data '{"expires_at":null}'
 
-# Binary responses: write the raw bytes to a file
-hands api GET /api/apps/raft-android/builds/<id>/download --output app.apk
+# ...or read the same body from a file with @path
+hands api PATCH /api/apps/<appId>/releases/<releaseId>/shares/<shareId> \
+  --data @body.json
+
+# Binary / same-origin streaming response: write the raw bytes to a file
+hands api GET /api/apps/<appId>/feedback/<ticketId>/attachments/<attachmentId> \
+  --output attachment.bin
 
 # Machine-readable: print only the response body (no status line)
 hands --json api GET /api/apps
 ```
 
+- **Raw path params.** `<appId>` and the other ids are the resource UUIDs, not
+  slugs — `hands api` passes the path through verbatim and does not resolve
+  slugs the way the dedicated subcommands do.
 - **Same-origin `/api/*` only.** `<path>` is resolved against the active Hands
   API base (honoring the root `--api` flag). A relative path or a **same-origin
   absolute URL** is accepted; cross-origin absolute URLs, `//protocol-relative`

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -515,6 +515,41 @@ hands feedback update raft-android <ticket-id> --status resolved
 
 `--assignee none` unassigns. All subcommands accept `--json` for scripting.
 
+## Direct API Access (`hands api`)
+
+A power-user / scripting affordance for calling a Hands API endpoint directly,
+over the **same** server-side RBAC, audit, and per-endpoint guards a dedicated
+subcommand uses. It is not a permission bypass and not a generic-SQL escape
+hatch — every write still hits the same server route.
+
+```bash
+# GET with repeatable query params
+hands api GET /api/apps --param platform=android
+
+# POST/PATCH with an inline JSON body, or read the body from a file with @path
+hands api POST /api/apps/raft-android/releases --data '{"buildId":"build-1"}'
+hands api PATCH /api/apps/raft-android/releases/<id>/shares/<sid> --data @body.json
+
+# Binary responses: write the raw bytes to a file
+hands api GET /api/apps/raft-android/builds/<id>/download --output app.apk
+
+# Machine-readable: print only the response body (no status line)
+hands --json api GET /api/apps
+```
+
+- **Same-origin `/api/*` only.** `<path>` is resolved against the active Hands
+  API base (honoring the root `--api` flag). A relative path or a **same-origin
+  absolute URL** is accepted; cross-origin absolute URLs, `//protocol-relative`
+  hosts, and `../` traversal that escapes the origin are rejected — so the
+  Authorization bearer never leaves the Hands origin.
+- **Redirects are never followed.** A `3xx` is reported, not chased; following a
+  redirect off-origin would leak the bearer.
+- **Auth + RBAC unchanged.** Reuses your existing CLI login/token; the server
+  enforces the same role checks as any other call.
+- Flags: `--param key=value` (repeatable), `--data <json|@file>`,
+  `--output <file>` (required for binary). Both the global `--api` and `--json`
+  flags are honored.
+
 ## CI Environment Variables
 
 Every variable is read as `HANDS_<name>` first, then the legacy `QUIVER_<name>`,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,6 +68,25 @@ This records external byte evidence; it does not upload the artifact or
 activate a release. Repeating the same declaration is idempotent. Changing an
 immutable version or target field returns a conflict.
 
+## Direct API access (`hands api`)
+
+Call any Hands endpoint directly, over the same server-side RBAC and audit a
+dedicated subcommand uses — a scripting affordance, not a permission bypass:
+
+```bash
+hands api GET /api/apps --param platform=android
+hands api POST /api/apps/raft-android/releases --data '{"buildId":"build-1"}'
+hands api PATCH /api/apps/raft-android/releases/<id>/shares/<sid> --data @body.json
+hands api GET /api/apps/raft-android/builds/<id>/download --output app.apk   # binary
+hands --json api GET /api/apps                                               # body only
+```
+
+Same-origin `/api/*` only (a relative path or a same-origin absolute URL;
+cross-origin, `//protocol-relative`, and `../`-escape are rejected). Redirects
+are never followed, so the bearer never leaves the Hands origin. Honors the
+global `--api` and `--json` flags. Full flag reference:
+`docs/public/cli-reference.md`.
+
 ## CI mode
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -75,17 +75,18 @@ dedicated subcommand uses — a scripting affordance, not a permission bypass:
 
 ```bash
 hands api GET /api/apps --param platform=android
-hands api POST /api/apps/raft-android/releases --data '{"buildId":"build-1"}'
-hands api PATCH /api/apps/raft-android/releases/<id>/shares/<sid> --data @body.json
-hands api GET /api/apps/raft-android/builds/<id>/download --output app.apk   # binary
+hands api PATCH /api/apps/<appId>/releases/<releaseId>/shares/<shareId> --data '{"expires_at":null}'
+hands api PATCH /api/apps/<appId>/releases/<releaseId>/shares/<shareId> --data @body.json
+hands api GET /api/apps/<appId>/feedback/<ticketId>/attachments/<attachmentId> --output attachment.bin
 hands --json api GET /api/apps                                               # body only
 ```
 
-Same-origin `/api/*` only (a relative path or a same-origin absolute URL;
-cross-origin, `//protocol-relative`, and `../`-escape are rejected). Redirects
-are never followed, so the bearer never leaves the Hands origin. Honors the
-global `--api` and `--json` flags. Full flag reference:
-`docs/public/cli-reference.md`.
+Path params are raw — `<appId>` and the other ids are resource UUIDs, not slugs
+(`hands api` does not resolve slugs). Same-origin `/api/*` only (a relative path
+or a same-origin absolute URL; cross-origin, `//protocol-relative`, and
+`../`-escape are rejected). Redirects are never followed, so the bearer never
+leaves the Hands origin. Honors the global `--api` and `--json` flags. Full flag
+reference: <https://hands.build/docs/cli-reference/>.
 
 ## CI mode
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1698,4 +1698,84 @@ describe("hands api same-origin guard (resolveSameOriginApiUrl)", () => {
     // "/api/../admin" normalizes to "/admin" -> no longer under /api/
     expect(() => resolveSameOriginApiUrl("/api/../admin", BASE)).toThrow();
   });
+
+  it("accepts a same-origin absolute URL under /api/", async () => {
+    const { resolveSameOriginApiUrl } = await import("./commands/api.js");
+    // Same-origin absolute is allowed (documented contract): the bearer never
+    // leaves the configured origin, so there is no exfil risk.
+    const u = resolveSameOriginApiUrl("https://hands.build/api/apps", BASE);
+    expect(u.origin).toBe("https://hands.build");
+    expect(u.pathname).toBe("/api/apps");
+  });
+});
+
+describe("hands api command path (--api / --json wiring)", () => {
+  let server: ReturnType<typeof createServer>;
+  let base: string;
+  let received: Array<{ method?: string; url?: string }>;
+  let logs: string[];
+  let errs: string[];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let origHandsApi: string | undefined;
+
+  beforeEach(async () => {
+    received = [];
+    logs = [];
+    errs = [];
+    origHandsApi = process.env.HANDS_API;
+    // If the command wrongly used resolveApiBase() instead of the --api-resolved
+    // base, it would fall back to this unreachable URL and never hit our server.
+    process.env.HANDS_API = "http://127.0.0.1:1";
+    server = createServer((req, res) => {
+      received.push({ method: req.method, url: req.url });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const addr = server.address();
+    base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+    logSpy = vi.spyOn(console, "log").mockImplementation((m?: unknown) => {
+      logs.push(String(m));
+    });
+    errSpy = vi.spyOn(console, "error").mockImplementation((m?: unknown) => {
+      errs.push(String(m));
+    });
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    await new Promise<void>((r) => server.close(() => r()));
+    if (origHandsApi === undefined) delete process.env.HANDS_API;
+    else process.env.HANDS_API = origHandsApi;
+  });
+
+  async function buildProgram(): Promise<Command> {
+    const { setApiBase } = await import("./lib/api.js");
+    const { registerApiCommand } = await import("./commands/api.js");
+    const program = new Command();
+    program.name("hands").option("--api <url>").option("--json", "", false);
+    // Mirror index.ts: resolve --api into the shared client base before actions.
+    program.hook("preAction", () => {
+      const opts = program.opts<{ api?: string }>();
+      const apiBase = opts.api ?? process.env.HANDS_API;
+      if (apiBase) setApiBase(apiBase);
+    });
+    registerApiCommand(program);
+    return program;
+  }
+
+  it("routes to the root --api base, not the config/env fallback", async () => {
+    const program = await buildProgram();
+    await program.parseAsync(["node", "hands", "--api", base, "api", "GET", "/api/ping"]);
+    expect(received).toEqual([{ method: "GET", url: "/api/ping" }]);
+  });
+
+  it("honors the global --json flag (body only, no status line on stderr)", async () => {
+    const program = await buildProgram();
+    await program.parseAsync(["node", "hands", "--api", base, "--json", "api", "GET", "/api/ping"]);
+    expect(logs.join("\n")).toContain('{"ok":true}');
+    expect(errs.join("\n")).not.toMatch(/\b200\b/);
+  });
 });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1666,3 +1666,36 @@ describe("Hands logging integration", () => {
     }
   });
 });
+
+describe("hands api same-origin guard (resolveSameOriginApiUrl)", () => {
+  const BASE = "https://hands.build";
+
+  it("accepts a same-origin /api/ path and preserves query", async () => {
+    const { resolveSameOriginApiUrl } = await import("./commands/api.js");
+    const u = resolveSameOriginApiUrl("/api/apps?x=1", BASE);
+    expect(u.origin).toBe("https://hands.build");
+    expect(u.pathname).toBe("/api/apps");
+    expect(u.searchParams.get("x")).toBe("1");
+  });
+
+  it("rejects an absolute URL to another host (bearer exfil)", async () => {
+    const { resolveSameOriginApiUrl } = await import("./commands/api.js");
+    expect(() => resolveSameOriginApiUrl("https://evil.example/api/x", BASE)).toThrow();
+  });
+
+  it("rejects a //protocol-relative host", async () => {
+    const { resolveSameOriginApiUrl } = await import("./commands/api.js");
+    expect(() => resolveSameOriginApiUrl("//evil.example/api/x", BASE)).toThrow();
+  });
+
+  it("rejects a path outside /api/", async () => {
+    const { resolveSameOriginApiUrl } = await import("./commands/api.js");
+    expect(() => resolveSameOriginApiUrl("/admin/secrets", BASE)).toThrow();
+  });
+
+  it("rejects ../ traversal that escapes /api/", async () => {
+    const { resolveSameOriginApiUrl } = await import("./commands/api.js");
+    // "/api/../admin" normalizes to "/admin" -> no longer under /api/
+    expect(() => resolveSameOriginApiUrl("/api/../admin", BASE)).toThrow();
+  });
+});

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -6,11 +6,13 @@
  * dedicated subcommand would.
  *
  * Security (reviewed with Sentinel — credential/origin boundary):
- *  - Same-origin `/api/*` only. The path is resolved against the configured
- *    Hands API base; the result must keep that exact origin AND its path must
- *    start with `/api/`. This rejects absolute URLs, `//protocol-relative`
- *    hosts, and `../` traversal that escapes the origin — any of which would
- *    otherwise carry the Authorization bearer to another host.
+ *  - Same-origin `/api/*` only. The path is resolved against the CLI's active
+ *    Hands API base (honoring the root `--api` flag). A relative path or a
+ *    same-origin absolute URL is accepted; the result must keep that exact
+ *    origin AND its path must start with `/api/`. This rejects cross-origin
+ *    absolute URLs, `//protocol-relative` hosts, and `../` traversal that
+ *    escapes the origin — any of which would otherwise carry the Authorization
+ *    bearer to another host.
  *  - `redirect: "manual"` — a 3xx is reported, never auto-followed. Following a
  *    redirect off-origin would leak the bearer to the redirect target.
  *  - Reuses the existing CLI identity/token; no scope escalation.
@@ -18,7 +20,8 @@
 
 import type { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
-import { resolveApiBase, resolveAuthToken } from "../lib/config.js";
+import { getApiBase } from "../lib/api.js";
+import { resolveAuthToken } from "../lib/config.js";
 
 const METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
 
@@ -37,8 +40,8 @@ export function resolveSameOriginApiUrl(pathArg: string, apiBase: string): URL {
   }
   if (target.origin !== base.origin) {
     throw new Error(
-      `Refusing '${pathArg}': must be a relative Hands path on ${base.origin} ` +
-        "(no absolute or //protocol-relative URLs).",
+      `Refusing '${pathArg}': must stay on ${base.origin} under /api/ ` +
+        "(no cross-origin or //protocol-relative URLs).",
     );
   }
   if (!target.pathname.startsWith("/api/")) {
@@ -68,7 +71,11 @@ export function registerApiCommand(program: Command): void {
         methodArg: string,
         pathArg: string,
         opts: { param?: string[]; data?: string; output?: string; json?: boolean },
+        command: Command,
       ) => {
+        // Honor the root `--json` global as well as the subcommand flag, matching
+        // the top-level "Every command supports --json" contract.
+        const jsonOnly = opts.json || command.optsWithGlobals<{ json?: boolean }>().json;
         const method = methodArg.toUpperCase();
         if (!METHODS.has(method)) {
           fail(`Unsupported method '${methodArg}'. Use one of: ${[...METHODS].join(", ")}.`);
@@ -76,7 +83,9 @@ export function registerApiCommand(program: Command): void {
 
         let target: URL;
         try {
-          target = resolveSameOriginApiUrl(pathArg, resolveApiBase());
+          // getApiBase() reflects the root `--api` flag (set in preAction); using
+          // resolveApiBase() directly would ignore --api and could target prod.
+          target = resolveSameOriginApiUrl(pathArg, getApiBase());
         } catch (e) {
           fail(e instanceof Error ? e.message : String(e));
         }
@@ -130,7 +139,7 @@ export function registerApiCommand(program: Command): void {
         }
 
         const text = await res.text();
-        if (opts.json) {
+        if (jsonOnly) {
           if (text.length > 0) console.log(text);
         } else {
           console.error(statusLine);

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -1,0 +1,142 @@
+/**
+ * `hands api <method> <path>` — direct authenticated call to a Hands API
+ * endpoint. A power-user / scripting affordance over the SAME server-enforced
+ * RBAC + audit + per-endpoint guards. It is NOT a permission bypass and NOT a
+ * generic-SQL escape hatch: every write still hits the same server route that a
+ * dedicated subcommand would.
+ *
+ * Security (reviewed with Sentinel — credential/origin boundary):
+ *  - Same-origin `/api/*` only. The path is resolved against the configured
+ *    Hands API base; the result must keep that exact origin AND its path must
+ *    start with `/api/`. This rejects absolute URLs, `//protocol-relative`
+ *    hosts, and `../` traversal that escapes the origin — any of which would
+ *    otherwise carry the Authorization bearer to another host.
+ *  - `redirect: "manual"` — a 3xx is reported, never auto-followed. Following a
+ *    redirect off-origin would leak the bearer to the redirect target.
+ *  - Reuses the existing CLI identity/token; no scope escalation.
+ */
+
+import type { Command } from "commander";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolveApiBase, resolveAuthToken } from "../lib/config.js";
+
+const METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+/**
+ * Resolve `pathArg` against the Hands API base and enforce that it is a
+ * same-origin `/api/*` request. Throws if the resolved URL would leave the
+ * Hands origin or is not under `/api/`. Exported for unit tests.
+ */
+export function resolveSameOriginApiUrl(pathArg: string, apiBase: string): URL {
+  const base = new URL(apiBase);
+  let target: URL;
+  try {
+    target = new URL(pathArg, base);
+  } catch {
+    throw new Error(`Invalid path '${pathArg}'.`);
+  }
+  if (target.origin !== base.origin) {
+    throw new Error(
+      `Refusing '${pathArg}': must be a relative Hands path on ${base.origin} ` +
+        "(no absolute or //protocol-relative URLs).",
+    );
+  }
+  if (!target.pathname.startsWith("/api/")) {
+    throw new Error(`Refusing '${target.pathname}': path must start with /api/.`);
+  }
+  return target;
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+export function registerApiCommand(program: Command): void {
+  program
+    .command("api <method> <path>")
+    .description(
+      "Call a Hands API endpoint directly (same-origin /api/* only). " +
+        "Reuses your CLI login; every call still goes through server-side RBAC.",
+    )
+    .option("--param <kv...>", "Query parameter key=value (repeatable).")
+    .option("--data <json|@file>", "JSON request body inline, or @path to read it from a file.")
+    .option("--output <file>", "Write the raw response body to a file (required for binary).")
+    .option("--json", "Print only the response body (omit the status line).", false)
+    .action(
+      async (
+        methodArg: string,
+        pathArg: string,
+        opts: { param?: string[]; data?: string; output?: string; json?: boolean },
+      ) => {
+        const method = methodArg.toUpperCase();
+        if (!METHODS.has(method)) {
+          fail(`Unsupported method '${methodArg}'. Use one of: ${[...METHODS].join(", ")}.`);
+        }
+
+        let target: URL;
+        try {
+          target = resolveSameOriginApiUrl(pathArg, resolveApiBase());
+        } catch (e) {
+          fail(e instanceof Error ? e.message : String(e));
+        }
+
+        for (const kv of opts.param ?? []) {
+          const eq = kv.indexOf("=");
+          if (eq <= 0) fail(`Invalid --param '${kv}', expected key=value.`);
+          target.searchParams.append(kv.slice(0, eq), kv.slice(eq + 1));
+        }
+
+        let body: string | undefined;
+        if (opts.data !== undefined) {
+          body = opts.data.startsWith("@")
+            ? await readFile(opts.data.slice(1), "utf8")
+            : opts.data;
+        }
+
+        const headers: Record<string, string> = { accept: "application/json" };
+        const token = resolveAuthToken();
+        if (token) headers.authorization = `Bearer ${token}`;
+        if (body !== undefined) headers["content-type"] = "application/json";
+
+        const res = await fetch(target.toString(), {
+          method,
+          headers,
+          ...(body !== undefined ? { body } : {}),
+          // Never auto-follow a 3xx: a redirect off the API origin would carry
+          // the bearer token to the redirect target.
+          redirect: "manual",
+        });
+
+        const requestId = res.headers.get("x-request-id") ?? res.headers.get("cf-ray");
+        const statusLine = `${res.status} ${res.statusText}${
+          requestId ? `  request-id=${requestId}` : ""
+        }`;
+
+        if (res.status >= 300 && res.status < 400) {
+          console.error(
+            `${statusLine}\nRedirect to ${res.headers.get("location") ?? "(none)"} not followed ` +
+              "(hands api never follows redirects off the API origin).",
+          );
+          process.exit(1);
+        }
+
+        if (opts.output) {
+          const bytes = Buffer.from(await res.arrayBuffer());
+          await writeFile(opts.output, bytes);
+          console.error(`${statusLine}  → ${opts.output} (${bytes.length} bytes)`);
+          if (res.status >= 400) process.exit(1);
+          return;
+        }
+
+        const text = await res.text();
+        if (opts.json) {
+          if (text.length > 0) console.log(text);
+        } else {
+          console.error(statusLine);
+          if (text.length > 0) console.log(text);
+        }
+        if (res.status >= 400) process.exit(1);
+      },
+    );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import { registerDeployTokenCommands } from "./commands/deploy_tokens.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
 import { registerLogsCommands } from "./commands/logs.js";
 import { registerDeviceGroupCommands } from "./commands/device_groups.js";
+import { registerApiCommand } from "./commands/api.js";
 import { getConfig } from "./lib/config.js";
 import { readEnv } from "./lib/env.js";
 import { setApiBase } from "./lib/api.js";
@@ -92,6 +93,7 @@ registerDeviceGroupCommands(program);
 registerFeedbackCommands(program);
 registerDeployTokenCommands(program);
 registerLogsCommands(program);
+registerApiCommand(program);
 
 program
   .command("version")


### PR DESCRIPTION
`hands api <method> <path>` — direct authenticated call to a Hands API endpoint. A power-user/scripting affordance over the **same** server-enforced RBAC + audit + per-endpoint guards. **Not** a permission bypass and **not** a generic-SQL escape hatch (every write hits the same route a dedicated subcommand would).

## Security (credential/origin boundary — per @Sentinel's criteria)
- **Same-origin `/api/*` only.** `resolveSameOriginApiUrl` resolves the path against the configured Hands API base and rejects anything whose resolved origin ≠ the Hands origin (absolute URLs, `//protocol-relative` hosts, `../` traversal that escapes) or whose path isn't under `/api/`. This prevents the Authorization bearer from being carried to another host.
- **`redirect: "manual"`** — a 3xx is reported, never auto-followed (following off-origin would leak the bearer to the redirect target).
- **Reuses the existing CLI identity/token; no scope escalation.** All RBAC stays server-side.

## Shape
`hands api GET /api/apps`
`hands api POST /api/apps/:appId/shares/:shareId/rebind --data '{...}'`
Flags: `--param key=value` (repeatable), `--data <json|@file>`, `--output <file>` (binary), `--json`. Echoes status/body/request-id.

## Tests
Same-origin guard: accepts `/api/…` + query; rejects absolute URL, `//protocol-relative`, non-`/api/`, and `../` traversal. CLI build clean, 38/38 CLI tests pass.

Requesting @Sentinel security review (origin-bypass/redirect/echo-leak/token-scope) and @Volta owner review. Bound to this exact head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)