### PR TITLE
Generate Worker types in Hands Admin deploy

### DIFF
--- a/.github/workflows/deploy-hands-admin.yml
+++ b/.github/workflows/deploy-hands-admin.yml
@@ -32,6 +32,9 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version: "22", cache: "pnpm" }
       - run: pnpm install --frozen-lockfile
+      - name: Generate Hands Worker types
+        working-directory: worker
+        run: pnpm exec wrangler types --config wrangler.hands.jsonc
       - name: Validate
         run: |
           pnpm --filter @botiverse/hands-worker build


### PR DESCRIPTION
Fixes first production deploy run 31684442572, which failed before any mutation because a clean runner lacked the gitignored worker/worker-configuration.d.ts. Generate types from the checked-in Hands Worker config before validation, matching the main server deploy discipline. No auth/application/config behavior changes.\n\nValidation: admin-worker TypeScript build, 3/3 tests, diff-check.