### PR TITLE
feat(access): additional owner servers

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -400,6 +400,7 @@ export interface AppServerGrant {
   server_id: string | null;
   server_slug: string | null;
   app_role: "admin" | "publisher" | "viewer";
+  access_model: "legacy_role" | "owner_server";
   granted_by: string | null;
   created_at: number;
   updated_at: number;
@@ -739,7 +740,6 @@ export const addAppServerGrant = (
   input: {
     server_id?: string | null;
     server_slug?: string | null;
-    app_role: AppServerGrant["app_role"];
   },
 ) =>
   request<{ ok: boolean }>(`/api/apps/${appId}/server-grants`, {
@@ -747,24 +747,6 @@ export const addAppServerGrant = (
     admin: true,
     body: JSON.stringify(input),
   });
-
-export const updateAppServerGrant = (
-  appId: string,
-  grantKey: string,
-  input: {
-    server_id?: string | null;
-    server_slug?: string | null;
-    app_role: AppServerGrant["app_role"];
-  },
-) =>
-  request<{ ok: boolean }>(
-    `/api/apps/${appId}/server-grants/${encodeURIComponent(grantKey)}`,
-    {
-      method: "PATCH",
-      admin: true,
-      body: JSON.stringify(input),
-    },
-  );
 
 export const removeAppServerGrant = (appId: string, serverId: string) =>
   request<{ ok: boolean }>(

--- a/admin/src/pages/AppAccess.tsx
+++ b/admin/src/pages/AppAccess.tsx
@@ -29,7 +29,6 @@ import {
   removeAppServerGrant,
   revokeAppDeployToken,
   updateAppMember,
-  updateAppServerGrant,
   type AppMember,
   type AppDeployToken,
   type AppPermission,
@@ -206,25 +205,6 @@ function AppServerGrantList({
       }),
   });
 
-  const updateRole = useMutation({
-    mutationFn: ({ grant, appRole }: { grant: (typeof rows)[number]; appRole: AppMember["app_role"] }) =>
-      updateAppServerGrant(appId, grant.id, {
-        server_id: grant.server_id,
-        server_slug: grant.server_slug,
-        app_role: appRole,
-      }),
-    onSuccess: () => {
-      toast.show({ kind: "success", title: "Server access updated" });
-      qc.invalidateQueries({ queryKey: ["app-server-grants", appId] });
-    },
-    onError: (e) =>
-      toast.show({
-        kind: "error",
-        title: "Update failed",
-        description: (e as Error).message,
-      }),
-  });
-
   const visibleRowCount = rows.length + (isOwningOrg ? 1 : 0);
 
   return (
@@ -261,7 +241,6 @@ function AppServerGrantList({
           <thead>
             <tr className="text-slate-500 text-left border-b border-slate-100">
               <th className="font-normal py-1 pr-2">Server</th>
-              <th className="font-normal py-1 pr-2">Server ID</th>
               <th className="font-normal py-1 pr-2">Access</th>
               <th className="font-normal py-1 pr-2">Source</th>
               {canManage && <th className="font-normal py-1">Actions</th>}
@@ -277,12 +256,7 @@ function AppServerGrantList({
                   </div>
                 </td>
                 <td className="py-2 pr-2">
-                  <span className="font-mono text-xs text-slate-600">
-                    {currentServerId || "—"}
-                  </span>
-                </td>
-                <td className="py-2 pr-2">
-                  <span className="text-xs font-medium">Inherited</span>
+                  <span className="text-xs font-medium">Owner server</span>
                 </td>
                 <td className="py-2 pr-2 text-xs text-slate-500">
                   Owning org
@@ -307,47 +281,16 @@ function AppServerGrantList({
                   </div>
                 </td>
                 <td className="py-2 pr-2">
-                  <span className="font-mono text-xs text-slate-600">
-                    {grant.server_id || "—"}
+                  <span className="text-xs font-medium">
+                    {grant.access_model === "owner_server"
+                      ? "Owner server"
+                      : `Legacy ${grant.app_role}`}
                   </span>
                 </td>
-                <td className="py-2 pr-2">
-                  {canManage ? (
-                    <Select
-                      value={grant.app_role}
-                      onValueChange={(value) => {
-                        const appRole = value as AppMember["app_role"];
-                        if (
-                          appRole !== "viewer" &&
-                          !confirm(
-                            `Grant ${appRole} access to every Hands account from ${grant.server_slug || grant.server_id}?`,
-                          )
-                        ) {
-                          return;
-                        }
-                        updateRole.mutate({
-                          grant,
-                          appRole,
-                        });
-                      }}
-                      disabled={updateRole.isPending}
-                    >
-                      <SelectTrigger className="h-8 w-32 text-xs">
-                        <SelectValue />
-                        <SelectIcon />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="viewer">Viewer</SelectItem>
-                        <SelectItem value="publisher">Publisher</SelectItem>
-                        <SelectItem value="admin">Admin</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  ) : (
-                    <span className="text-xs font-medium capitalize">{grant.app_role}</span>
-                  )}
-                </td>
                 <td className="py-2 pr-2 text-xs text-slate-500">
-                  Server visibility
+                  {grant.access_model === "owner_server"
+                    ? "Additional owner"
+                    : "Existing role preserved; remove and re-add to adopt owner-server access"}
                 </td>
                 {canManage && (
                   <td className="py-2 text-xs">
@@ -377,7 +320,7 @@ function AppServerGrantList({
       )}
       {grants.data && isOwningOrg && rows.length === 0 && (
         <p className="text-xs text-slate-500 mt-2">
-          No external server visibility grants yet. The current server has access because it owns this app.
+          No additional owner servers yet. The current server owns this app.
         </p>
       )}
     </div>
@@ -397,21 +340,18 @@ function AddAppServerGrantDialog({
   const toast = useToast();
   const [serverId, setServerId] = useState("");
   const [serverSlug, setServerSlug] = useState("");
-  const [appRole, setAppRole] = useState<AppMember["app_role"]>("viewer");
 
   const add = useMutation({
     mutationFn: () =>
       addAppServerGrant(appId, {
         server_id: serverId.trim() || null,
         server_slug: serverSlug.trim() || null,
-        app_role: appRole,
       }),
     onSuccess: () => {
       toast.show({ kind: "success", title: "Server grant added" });
       qc.invalidateQueries({ queryKey: ["app-server-grants", appId] });
       setServerId("");
       setServerSlug("");
-      setAppRole("viewer");
       onAdded();
     },
     onError: (e) =>
@@ -451,12 +391,9 @@ function AddAppServerGrantDialog({
             className="space-y-3"
             onSubmit={(e) => {
               e.preventDefault();
-              if (
-                appRole !== "viewer" &&
-                !confirm(
-                  `Grant ${appRole} access to every Hands account from ${serverSlug.trim() || serverId.trim()}?`,
-                )
-              ) {
+              if (!confirm(
+                `Make ${serverSlug.trim() || serverId.trim()} an owner server for this app? Its members receive the same role-based access as the creating server.`,
+              )) {
                 return;
               }
               add.mutate();
@@ -479,27 +416,11 @@ function AddAppServerGrantDialog({
                 placeholder="optional"
               />
             </div>
-            <div>
-              <label className="label">Access level</label>
-              <Select
-                value={appRole}
-                onValueChange={(value) => setAppRole(value as AppMember["app_role"])}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                  <SelectIcon />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="viewer">Viewer — can view the app</SelectItem>
-                  <SelectItem value="publisher">Publisher — can manage releases</SelectItem>
-                  <SelectItem value="admin">Admin — can manage app access</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="mt-1 text-xs text-slate-500">
-                Applies to every human and Agent Hands account from this Raft server.
-                Prefer a direct app member grant when only one identity needs access.
-              </p>
-            </div>
+            <p className="text-xs text-slate-500">
+              An additional owner server uses the same role mapping as the server that created the app:
+              server owners/admins can publish releases and manage access; members keep the same
+              bounded member actions as on the creating server; viewers have read-only access.
+            </p>
           </form>
         </DialogBody>
         <DialogFooter>

--- a/migrations/sql/0064_additional_owner_servers.sql
+++ b/migrations/sql/0064_additional_owner_servers.sql
@@ -1,0 +1,6 @@
+-- Existing rows keep their exact configured role and therefore cannot gain
+-- privileges silently. New rows are explicit owner-server rows and derive an
+-- account's app role from that account's role in the Raft server.
+ALTER TABLE app_server_grants
+ADD COLUMN access_model TEXT NOT NULL DEFAULT 'legacy_role'
+  CHECK (access_model IN ('legacy_role', 'owner_server'));

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -109,6 +109,38 @@ export async function getAppServerGrantRole(
   return row?.app_role ?? null;
 }
 
+async function getOwnerServerRole(
+  db: D1Database,
+  appId: string,
+  accountId: string,
+  serverId: string,
+  serverSlug: string | null,
+): Promise<{ org_role: OrgRole | null; legacy_app_role: AppRole | null } | null> {
+  const row = await db.prepare(
+    `SELECT om.org_role, asg.app_role, asg.access_model
+       FROM organizations o
+       JOIN org_members om ON om.org_id = o.id AND om.account_id = ?2
+       JOIN app_server_grants asg
+         ON asg.app_id = ?1
+        AND (
+          (asg.server_id IS NOT NULL AND asg.server_id = ?3)
+          OR (asg.server_slug IS NOT NULL AND asg.server_slug = ?4)
+        )
+      WHERE o.external_provider = 'raft'
+        AND o.external_id = ?3
+      LIMIT 1`,
+  ).bind(appId, accountId, serverId, serverSlug).first<{
+    org_role: OrgRole;
+    app_role: AppRole;
+    access_model: "legacy_role" | "owner_server";
+  }>();
+  if (!row) return null;
+  return {
+    org_role: row.access_model === "owner_server" ? row.org_role : null,
+    legacy_app_role: row.access_model === "legacy_role" ? row.app_role : null,
+  };
+}
+
 export async function getAppOrgId(db: D1Database, appId: string): Promise<string | null> {
   const row = await db
     .prepare("SELECT org_id FROM apps WHERE id = ?1 LIMIT 1")
@@ -121,23 +153,43 @@ export async function getEffectiveRole(
   db: D1Database,
   accountId: string,
   input: { orgId?: string | null; appId?: string | null },
-): Promise<{ org_role: OrgRole | null; app_role: AppRole | null; server_app_role: AppRole | null; org_id: string | null }> {
+): Promise<{
+  org_role: OrgRole | null;
+  app_role: AppRole | null;
+  server_app_role: AppRole | null;
+  server_org_role: OrgRole | null;
+  org_id: string | null;
+}> {
   const orgId = input.orgId ?? (input.appId ? await getAppOrgId(db, input.appId) : null);
   const account = input.appId
     ? (await db.prepare("SELECT server_id, server_slug FROM raft_accounts WHERE id = ?1 LIMIT 1")
       .bind(accountId)
       .first<{ server_id: string; server_slug: string | null }>()) ?? null
     : null;
-  const [orgRole, appRole, serverAppRole] = await Promise.all([
+  const [orgRole, appRole, ownerServerRole] = await Promise.all([
     orgId ? getOrgMemberRole(db, orgId, accountId) : Promise.resolve(null),
     input.appId ? getAppMemberRole(db, input.appId, accountId) : Promise.resolve(null),
     input.appId && account
-      ? getAppServerGrantRole(db, input.appId, account.server_id, account.server_slug)
+      ? getOwnerServerRole(
+          db,
+          input.appId,
+          accountId,
+          account.server_id,
+          account.server_slug,
+        )
       : Promise.resolve(null),
   ]);
+  const serverAppRole = ownerServerRole?.legacy_app_role ?? null;
+  const effectiveOrgRole = orgRole ?? ownerServerRole?.org_role ?? null;
   const roles = [appRole, serverAppRole].filter(Boolean) as AppRole[];
   const effectiveAppRole = strongestAppRole(roles);
-  return { org_role: orgRole, app_role: effectiveAppRole, server_app_role: serverAppRole, org_id: orgId };
+  return {
+    org_role: effectiveOrgRole,
+    app_role: effectiveAppRole,
+    server_app_role: serverAppRole,
+    server_org_role: ownerServerRole?.org_role ?? null,
+    org_id: orgId,
+  };
 }
 
 // Machine-readable 403 for insufficient role: agents/CLI can act on it

--- a/worker/src/openapi/releases.ts
+++ b/worker/src/openapi/releases.ts
@@ -133,8 +133,9 @@ const AppServerGrant = z
     server_slug: z.string().nullable(),
     app_role: AppRole.openapi({
       description:
-        "Backend compatibility role. The admin UI currently presents server grants as visibility grants.",
+        "Deprecated compatibility field. Additional owner-server enforcement derives the caller's app role from their role in that Raft server.",
     }),
+    access_model: z.enum(["legacy_role", "owner_server"]),
     granted_by: z.string().nullable(),
     created_at: z.number().int(),
     updated_at: z.number().int(),
@@ -145,7 +146,6 @@ const UpsertAppServerGrantRequest = z
   .object({
     server_id: z.string().optional(),
     server_slug: z.string().optional(),
-    app_role: AppRole.default("viewer"),
   })
   .openapi("UpsertAppServerGrantRequest");
 
@@ -388,10 +388,10 @@ export function registerReleaseRoutes(registry: OpenApiRegistry) {
 
 function registerAccessRoutes(registry: OpenApiRegistry) {
   for (const [method, path, summary] of [
-    ["get", "/api/apps/{appId}/server-grants", "List Raft server grants for an app"],
-    ["post", "/api/apps/{appId}/server-grants", "Add or update a Raft server visibility grant"],
-    ["patch", "/api/apps/{appId}/server-grants/{serverId}", "Update a Raft server visibility grant"],
-    ["delete", "/api/apps/{appId}/server-grants/{serverId}", "Remove a Raft server visibility grant"],
+    ["get", "/api/apps/{appId}/server-grants", "List additional owner servers for an app"],
+    ["post", "/api/apps/{appId}/server-grants", "Add an owner server to an app"],
+    ["patch", "/api/apps/{appId}/server-grants/{serverId}", "Reject legacy role changes for an owner server"],
+    ["delete", "/api/apps/{appId}/server-grants/{serverId}", "Remove an additional owner server"],
   ] as const) {
     const hasServerId = path.includes("{serverId}");
     const needsBody = method === "post" || method === "patch";

--- a/worker/src/routes/orgs.ts
+++ b/worker/src/routes/orgs.ts
@@ -432,7 +432,7 @@ export async function handleListAppServerGrants(c: AdminContext) {
   const allowed = await ensureAppRole(c, appId, "viewer");
   if (!allowed.ok) return allowed.response;
   const { results } = await c.env.DB.prepare(
-    `SELECT id, app_id, server_id, server_slug, app_role, granted_by, created_at, updated_at
+    `SELECT id, app_id, server_id, server_slug, app_role, access_model, granted_by, created_at, updated_at
      FROM app_server_grants
      WHERE app_id = ?1
      ORDER BY lower(COALESCE(server_slug, server_id)) ASC`,
@@ -448,14 +448,12 @@ export async function handleAddAppServerGrant(c: AdminContext) {
   const body = (await c.req.json().catch(() => ({}))) as {
     server_id?: unknown;
     server_slug?: unknown;
-    app_role?: unknown;
   };
   const serverId = String(body.server_id ?? "").trim() || null;
   const serverSlug = body.server_slug === undefined || body.server_slug === null
     ? null
     : String(body.server_slug).trim() || null;
   if (!serverId && !serverSlug) return c.json({ error: "server_id or server_slug required" }, 400);
-  if (!isAppRole(body.app_role)) return c.json({ error: "app_role must be admin/publisher/viewer" }, 400);
   const timestamp = now();
   const existing = await c.env.DB.prepare(
     `SELECT id
@@ -470,20 +468,20 @@ export async function handleAddAppServerGrant(c: AdminContext) {
   if (existing) {
     await c.env.DB.prepare(
       `UPDATE app_server_grants
-       SET server_id = ?1, server_slug = ?2, app_role = ?3, granted_by = ?4, updated_at = ?5
-       WHERE id = ?6`,
-    ).bind(serverId, serverSlug, body.app_role, actor.id, timestamp, existing.id).run();
+       SET server_id = ?1, server_slug = ?2, app_role = 'admin', access_model = 'owner_server', granted_by = ?3, updated_at = ?4
+       WHERE id = ?5`,
+    ).bind(serverId, serverSlug, actor.id, timestamp, existing.id).run();
   } else {
     await c.env.DB.prepare(
       `INSERT INTO app_server_grants
-       (id, app_id, server_id, server_slug, app_role, granted_by, created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)`,
+       (id, app_id, server_id, server_slug, app_role, access_model, granted_by, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, 'owner_server', ?6, ?7, ?7)`,
     ).bind(
       crypto.randomUUID(),
       appId,
       serverId,
       serverSlug,
-      body.app_role,
+      "admin",
       actor.id,
       timestamp,
     ).run();
@@ -491,10 +489,10 @@ export async function handleAddAppServerGrant(c: AdminContext) {
   await insertAuditLog(c.env.DB, c, {
     app_id: appId,
     action: "app_server_grant.upsert",
-    payload: { server_id: serverId, server_slug: serverSlug, app_role: body.app_role },
+    payload: { server_id: serverId, server_slug: serverSlug, access_model: "owner_server" },
     created_at: timestamp,
   });
-  return c.json({ ok: true, app_id: appId, server_id: serverId, server_slug: serverSlug, app_role: body.app_role }, 201);
+  return c.json({ ok: true, app_id: appId, server_id: serverId, server_slug: serverSlug, access_model: "owner_server" }, 201);
 }
 
 export async function handleUpdateAppServerGrant(c: AdminContext) {
@@ -502,31 +500,12 @@ export async function handleUpdateAppServerGrant(c: AdminContext) {
   const serverKey = c.req.param("serverId") ?? "";
   const allowed = await ensureAppRole(c, appId, "admin");
   if (!allowed.ok) return allowed.response;
-  const body = (await c.req.json().catch(() => ({}))) as {
-    server_id?: unknown;
-    server_slug?: unknown;
-    app_role?: unknown;
-  };
-  if (!isAppRole(body.app_role)) return c.json({ error: "app_role must be admin/publisher/viewer" }, 400);
-  const serverId = body.server_id === undefined || body.server_id === null
-    ? null
-    : String(body.server_id).trim() || null;
-  const serverSlug = body.server_slug === undefined || body.server_slug === null
-    ? null
-    : String(body.server_slug).trim() || null;
-  if (!serverId && !serverSlug) return c.json({ error: "server_id or server_slug required" }, 400);
-  await c.env.DB.prepare(
-    `UPDATE app_server_grants
-     SET server_id = ?1, server_slug = ?2, app_role = ?3, updated_at = ?4
-     WHERE app_id = ?5
-       AND (id = ?6 OR server_id = ?7 OR server_slug = ?8)`,
-  ).bind(serverId, serverSlug, body.app_role, now(), appId, serverKey, serverKey, serverKey).run();
-  await insertAuditLog(c.env.DB, c, {
+  return c.json({
+    error: "owner server access has no configurable role",
+    code: "OWNER_SERVER_ROLE_NOT_CONFIGURABLE",
     app_id: appId,
-    action: "app_server_grant.role_changed",
-    payload: { server_id: serverId, server_slug: serverSlug, app_role: body.app_role },
-  });
-  return c.json({ ok: true, app_id: appId, server_id: serverId, server_slug: serverSlug, app_role: body.app_role });
+    server_key: serverKey,
+  }, 409);
 }
 
 export async function handleRemoveAppServerGrant(c: AdminContext) {

--- a/worker/test/additional_owner_servers_migration.test.ts
+++ b/worker/test/additional_owner_servers_migration.test.ts
@@ -1,0 +1,33 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const dir = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+
+describe("migration 0064 — additional owner servers", () => {
+  it("marks existing configurable grants as legacy without changing their role", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    for (const name of readdirSync(dir).sort()) {
+      if (!name.endsWith(".sql")) continue;
+      if (name === "0064_additional_owner_servers.sql") {
+        db.exec(`
+          INSERT INTO organizations
+            (id, slug, name, external_provider, external_id, created_at, archived)
+          VALUES ('raft_extra', 'extra', 'Extra', 'raft', 'extra-server', 1, 0);
+          INSERT INTO apps (id, org_id, slug, name, platform, created_at)
+          VALUES ('app-1', NULL, 'app-1', 'App 1', 'android', 1);
+          INSERT INTO app_server_grants
+            (id, app_id, server_id, server_slug, app_role, created_at, updated_at)
+          VALUES ('grant-1', 'app-1', 'extra-server', 'extra', 'viewer', 1, 1);
+        `);
+      }
+      db.exec(readFileSync(`${dir}${name}`, "utf8"));
+    }
+
+    expect(db.prepare(
+      "SELECT app_role, access_model FROM app_server_grants WHERE id = 'grant-1'",
+    ).get()).toEqual({ app_role: "viewer", access_model: "legacy_role" });
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -604,6 +604,7 @@ function makeMockDb() {
       server_id TEXT,
       server_slug TEXT,
       app_role TEXT NOT NULL CHECK (app_role IN ('admin', 'publisher', 'viewer')),
+      access_model TEXT NOT NULL DEFAULT 'legacy_role' CHECK (access_model IN ('legacy_role', 'owner_server')),
       granted_by TEXT REFERENCES raft_accounts(id) ON DELETE SET NULL,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
@@ -1805,7 +1806,7 @@ describe("quiver route handlers — SQL smoke", () => {
       .run();
     await env.DB
       .prepare("INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)")
-      .bind("orgmem-external", "raft_external", "external-user", "viewer", now)
+      .bind("orgmem-external", "raft_external", "external-user", "member", now)
       .run();
     await env.DB
       .prepare("INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)")
@@ -1992,7 +1993,7 @@ describe("quiver route handlers — SQL smoke", () => {
       .run();
     await env.DB
       .prepare("INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)")
-      .bind("orgmem-external2", "raft_external2", "external2-user", "viewer", now)
+      .bind("orgmem-external2", "raft_external2", "external2-user", "member", now)
       .run();
     await env.DB
       .prepare("INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?, ?)")
@@ -2016,6 +2017,132 @@ describe("quiver route handlers — SQL smoke", () => {
         org_role: null,
         app_role: "publisher",
         server_app_role: "publisher",
+        server_org_role: null,
+      });
+  });
+
+  it.each([
+    ["owner"],
+    ["admin"],
+    ["member"],
+    ["viewer"],
+  ] as const)("additional owner server preserves the creating-server %s org role", async (orgRole) => {
+    const now = Date.now();
+    const suffix = orgRole;
+    await env.DB.prepare(
+      `INSERT INTO organizations
+       (id, slug, name, external_provider, external_id, created_at, archived)
+       VALUES (?, ?, ?, 'raft', ?, ?, 0)`,
+    ).bind(`raft_shared_${suffix}`, `shared-${suffix}`, `Shared ${suffix}`, `shared-${suffix}`, now).run();
+    await env.DB.prepare(
+      `INSERT INTO raft_accounts
+       (id, provider, provider_subject, server_id, server_slug, principal_type,
+        server_role, username, display_name, avatar_url, raw_profile,
+        created_at, updated_at, last_login_at)
+       VALUES (?, 'raft', ?, ?, ?, 'human', ?, ?, ?, NULL, '{}', ?, ?, ?)`,
+    ).bind(
+      `shared-${suffix}-account`,
+      `shared-${suffix}-subject`,
+      `shared-${suffix}`,
+      `shared-${suffix}`,
+      orgRole,
+      `shared-${suffix}`,
+      `Shared ${suffix}`,
+      now,
+      now,
+      now,
+    ).run();
+    await env.DB.prepare(
+      "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES (?, ?, ?, ?, ?)",
+    ).bind(
+      `orgmem-shared-${suffix}`,
+      `raft_shared_${suffix}`,
+      `shared-${suffix}-account`,
+      orgRole,
+      now,
+    ).run();
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES (?, 'default', ?, ?, 'android', ?)",
+    ).bind(`shared-app-${suffix}`, `shared-app-${suffix}`, `Shared App ${suffix}`, now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_server_grants
+       (id, app_id, server_id, server_slug, app_role, access_model, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'admin', 'owner_server', ?, ?)`,
+    ).bind(
+      `shared-grant-${suffix}`,
+      `shared-app-${suffix}`,
+      `shared-${suffix}`,
+      `shared-${suffix}`,
+      now,
+      now,
+    ).run();
+
+    const { getEffectiveRole } = await import("../src/lib/permissions");
+    await expect(getEffectiveRole(env.DB as any, `shared-${suffix}-account`, {
+      appId: `shared-app-${suffix}`,
+    })).resolves.toMatchObject({
+      org_role: orgRole,
+      app_role: null,
+      server_app_role: null,
+      server_org_role: orgRole,
+    });
+
+    const { ensureAppRole } = await import("../src/lib/permissions");
+    const ctx = {
+      env,
+      get: (key: string) => key === "admin_account"
+        ? { id: `shared-${suffix}-account` }
+        : undefined,
+      json: (body: unknown, status = 200) => new Response(JSON.stringify(body), { status }),
+      req: { url: `https://hands.test/api/apps/shared-app-${suffix}`, method: "GET" },
+    };
+    const read = await ensureAppRole(ctx as any, `shared-app-${suffix}`, "viewer");
+    expect(read.ok).toBe(true);
+    const publish = await ensureAppRole(ctx as any, `shared-app-${suffix}`, "publisher");
+    expect(publish.ok).toBe(orgRole === "owner" || orgRole === "admin");
+    const boundedMember = await ensureAppRole(
+      ctx as any,
+      `shared-app-${suffix}`,
+      "publisher",
+      { orgMinimum: "member" },
+    );
+    expect(boundedMember.ok).toBe(orgRole !== "viewer");
+  });
+
+  it("preserves a legacy viewer grant instead of silently mapping a server member to publisher", async () => {
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO organizations
+       (id, slug, name, external_provider, external_id, created_at, archived)
+       VALUES ('raft_legacy', 'legacy', 'Legacy', 'raft', 'legacy-server', ?, 0)`,
+    ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO raft_accounts
+       (id, provider, provider_subject, server_id, server_slug, principal_type,
+        server_role, username, display_name, avatar_url, raw_profile,
+        created_at, updated_at, last_login_at)
+       VALUES ('legacy-member', 'raft', 'legacy-sub', 'legacy-server', 'legacy',
+               'human', 'member', 'legacy-member', 'Legacy Member', NULL, '{}', ?, ?, ?)`,
+    ).bind(now, now, now).run();
+    await env.DB.prepare(
+      "INSERT INTO org_members (id, org_id, account_id, org_role, joined_at) VALUES ('legacy-orgmem', 'raft_legacy', 'legacy-member', 'member', ?)",
+    ).bind(now).run();
+    await env.DB.prepare(
+      "INSERT INTO apps (id, org_id, slug, name, platform, created_at) VALUES ('legacy-app', 'default', 'legacy-app', 'Legacy App', 'android', ?)",
+    ).bind(now).run();
+    await env.DB.prepare(
+      `INSERT INTO app_server_grants
+       (id, app_id, server_id, server_slug, app_role, access_model, created_at, updated_at)
+       VALUES ('legacy-grant', 'legacy-app', 'legacy-server', 'legacy', 'viewer', 'legacy_role', ?, ?)`,
+    ).bind(now, now).run();
+
+    const { getEffectiveRole } = await import("../src/lib/permissions");
+    await expect(getEffectiveRole(env.DB as any, "legacy-member", { appId: "legacy-app" }))
+      .resolves.toMatchObject({
+        org_role: null,
+        app_role: "viewer",
+        server_app_role: "viewer",
+        server_org_role: null,
       });
   });
 


### PR DESCRIPTION
## Summary

- redefine new Server access rows as additional owner servers instead of configurable app-role grants
- run additional owner-server accounts through the same org-role authorization path used by the creating server
- preserve every pre-existing configurable grant as `legacy_role` so migration cannot silently increase access
- remove the role selector from the console and disclose the owner-server blast radius
- keep exact-account direct grants unchanged

## Compatibility and security

Migration 0064 only adds `access_model` with default `legacy_role`; it does not rewrite existing `app_role` values. Existing viewer/publisher/admin rows therefore retain their exact effective role. New rows are written as `owner_server` and use the account's role in that Raft server through the ordinary `ensureAppRole(..., orgMinimum)` path.

The legacy PATCH role endpoint now fails closed with `OWNER_SERVER_ROLE_NOT_CONFIGURABLE`; admins can remove a legacy row and explicitly re-add that server under the new model.

## Validation

- Worker TypeScript build
- Admin TypeScript check
- Worker full suite: 40 files / 436 tests
- Admin suite: 9 files / 33 tests
- Admin production build
- targeted route + migration tests: 188 tests
- diff-check

No merge or deploy in this PR submission.
