### PR TITLE
feat(agent): expose release share expiry updates

### DIFF
--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -133,12 +133,14 @@ raft integration invoke --service <hands-service> --action publish-release \
 ```
 
 Also available: `list-releases`, `get-release`, `list-release-shares`
-(viewer), `create-release-share` / `revoke-release-share` (publisher —
+(viewer), `create-release-share` / `update-release-share` /
+`revoke-release-share` (publisher —
 share pages are how a draft gets to a human for device review; links have no
-expiry unless you set one and die only on revoke). When reporting a
-release, always cite the build's APK SHA-256 — the binary hash is the
-authority, not a branch head or run id. A 403 means your identity lacks the
-app role: ask an app admin to grant it; never borrow credentials.
+expiry unless you set one, and `update-release-share` with `expires_at: null`
+restores that never-expiring state; such links die only on revoke). When
+reporting a release, always cite the build's APK SHA-256 — the binary hash is
+the authority, not a branch head or run id. A 403 means your identity lacks
+the app role: ask an app admin to grant it; never borrow credentials.
 
 **Humans / CI — hands CLI** (browser login or deploy token):
 

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1139,6 +1139,19 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "update-release-share",
+        description:
+          "Update one unrevoked release share's expiry. Pass expires_at=null to make an existing link live until revoked, or ttl_seconds for a future expiry. Requires app publisher.",
+        endpoint: { method: "PATCH", path: "/api/apps/{app_id}/releases/{release_id}/shares/{share_id}" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "App UUID." },
+          release_id: { type: "string", in: "path", required: true, description: "Current release UUID from a fresh share list." },
+          share_id: { type: "string", in: "path", required: true, description: "Share UUID." },
+          expires_at: { type: "number", in: "body", required: false, nullable: true, description: "Unix millisecond expiry; pass null to make the share live until revoked." },
+          ttl_seconds: { type: "number", in: "body", required: false, description: "Optional future expiry relative to now." },
+        },
+      },
+      {
         name: "revoke-release-share",
         description: "Revoke a share link (the only way a no-expiry link dies). Requires app publisher.",
         endpoint: { method: "DELETE", path: "/api/apps/{app_id}/releases/{release_id}/shares/{share_id}" },

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -11043,6 +11043,10 @@ describe("Hands iOS simulator QA artifacts", () => {
         method: "GET",
         path: "/api/apps/{app_id}/client-key",
       },
+      "update-release-share": {
+        method: "PATCH",
+        path: "/api/apps/{app_id}/releases/{release_id}/shares/{share_id}",
+      },
       "list-app-members": {
         method: "GET",
         path: "/api/apps/{app_id}/members",
@@ -11146,6 +11150,13 @@ describe("Hands iOS simulator QA artifacts", () => {
     expect(byName["purge-app"].parameters).toMatchObject({
       app_id: { type: "string", in: "path", required: true },
       confirm_slug: { type: "string", in: "body", required: true },
+    });
+    expect(byName["update-release-share"].parameters).toMatchObject({
+      app_id: { type: "string", in: "path", required: true },
+      release_id: { type: "string", in: "path", required: true },
+      share_id: { type: "string", in: "path", required: true },
+      expires_at: { type: "number", in: "body", required: false, nullable: true },
+      ttl_seconds: { type: "number", in: "body", required: false },
     });
     expect(byName["bind-reporter-webhook"]).toMatchObject({
       endpoint: {


### PR DESCRIPTION
## Summary
- expose the existing publisher-gated release-share PATCH route as the `update-release-share` Raft Agent Login action
- support explicit `expires_at: null` so agents can make an existing share live until revoked
- document and test the exact manifest contract

## Validation
- `worker/test/routes.test.ts`: 187/187 passed
- `git diff --check`: clean
- production-shaped Worker type generation is covered by Hosted checks (local render requires production environment variables)

No migration. No production write in this PR.