### PR TITLE
feat(testflight): add beta app description API

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -805,6 +805,36 @@ export const verifyAscCredentials = (appId: string, bundleId: string) =>
     body: JSON.stringify({ bundle_id: bundleId }),
   });
 
+export interface BetaAppDescriptionLocalization {
+  id: string;
+  locale: string | null;
+  description: string | null;
+}
+
+export const getTestflightBetaAppDescription = (appId: string) =>
+  request<{
+    bundle_id: string;
+    asc_app_id: string;
+    localizations: BetaAppDescriptionLocalization[];
+  }>(`/api/apps/${appId}/testflight-beta-app-description`, { admin: true });
+
+export const updateTestflightBetaAppDescription = (
+  appId: string,
+  descriptions: Record<string, string>,
+) =>
+  request<{
+    ok: boolean;
+    bundle_id: string;
+    asc_app_id: string;
+    updated_locales: string[];
+    readback_exact: boolean;
+    localizations: BetaAppDescriptionLocalization[];
+  }>(`/api/apps/${appId}/testflight-beta-app-description`, {
+    method: "PUT",
+    admin: true,
+    body: JSON.stringify({ descriptions }),
+  });
+
 // ---------- AppGallery Connect credentials (HarmonyOS) ----------
 
 export interface AgcCredentialsMeta {

--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -187,7 +187,14 @@ presence.
 ### TestFlight upload and distribution
 
 TestFlight is a separate state machine from the Hands draft and from App Store
-production publishing. The integration exposes six actions:
+production publishing. App-level invitation copy is also separate from each
+build's What to Test text. The integration exposes eight actions:
+
+- `get-testflight-beta-app-description` (viewer): read live app-level
+  `betaAppLocalizations.description` values.
+- `update-testflight-beta-app-description` (publisher): upsert only supplied
+  app-level locales and require exact Apple readback. Run this live metadata
+  mutation only with explicit authorization.
 
 - `upload-testflight-build` (app admin): stream the existing signed Hands IPA
   to Apple's Build Upload API.
@@ -208,6 +215,14 @@ production publishing. The integration exposes six actions:
 
 The `.p8` stays encrypted in Hands. No action returns it, activates a Hands
 release, or creates/submits/releases an App Store production version.
+
+```bash
+# App-level Beta App Description. This does not change What to Test or a build.
+raft integration invoke --service <hands-service> \
+  --action update-testflight-beta-app-description \
+  --param app_id=<app-uuid> \
+  --data-json '{"descriptions":{"en-US":"Private collaboration for teams.","zh-Hans":"面向团队的私密协作应用。"}}' --json
+```
 
 ```bash
 # Upload only. Optional bundle_id is an assertion when metadata exists and a

--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -162,6 +162,8 @@ hands builds testflight-status <app> <hands-build-id> --distribution internal
 
 Raft integration actions:
 
+- `get-testflight-beta-app-description`
+- `update-testflight-beta-app-description`
 - `upload-testflight-build`
 - `get-testflight-upload-status`
 - `list-testflight-groups`
@@ -171,6 +173,11 @@ Raft integration actions:
 
 Agents pass Hands app/build ids and stable beta group ids. The integration
 never returns the `.p8` credential.
+
+Beta App Description is app-level invitation copy and uses
+`betaAppLocalizations.description`. It is not the build-level What to Test
+field (`betaBuildLocalizations.whatsNew`). The dedicated update action preserves
+unsupplied locales and succeeds only after exact Apple readback.
 
 ## Apple references
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -138,6 +138,10 @@ import {
   handleTestflightUploadStatus,
 } from "./routes/testflight";
 import { handleAppStoreReview } from "./routes/appstore_review";
+import {
+  handleGetBetaAppDescription,
+  handleUpdateBetaAppDescription,
+} from "./routes/testflight_beta_app_description";
 import { handleGenerateDeltaPatches, handleDeltaSources } from "./routes/delta";
 import { handleUploadApk } from "./routes/upload";
 import {
@@ -1029,6 +1033,16 @@ admin.post("/api/apps/:appId/builds/:buildId/testflight-expire", requireAppRole(
 admin.post("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("publisher"), handleTestflightPublish);
 admin.get("/api/apps/:appId/builds/:buildId/testflight-publish", requireAppRole("viewer"), handleTestflightPublishStatus);
 admin.get("/api/apps/:appId/appstore-review", requireAppRole("viewer"), handleAppStoreReview);
+admin.get(
+  "/api/apps/:appId/testflight-beta-app-description",
+  requireAppRole("viewer"),
+  handleGetBetaAppDescription,
+);
+admin.put(
+  "/api/apps/:appId/testflight-beta-app-description",
+  requireAppRole("publisher"),
+  handleUpdateBetaAppDescription,
+);
 admin.get("/api/apps/:appId/appgallery-review", requireAppRole("viewer"), handleAppGalleryReview);
 admin.put("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleSetAscCredentials);
 admin.delete("/api/apps/:appId/asc-credentials", requireAppRole("admin"), handleDeleteAscCredentials);

--- a/worker/src/lib/asc_api.ts
+++ b/worker/src/lib/asc_api.ts
@@ -332,6 +332,14 @@ export interface BetaBuildLocalizationResource {
   };
 }
 
+export interface BetaAppLocalizationResource {
+  id: string;
+  attributes: {
+    locale: string | null;
+    description: string | null;
+  };
+}
+
 export interface BetaAppReviewSubmissionResource {
   id: string;
   attributes: {
@@ -556,6 +564,116 @@ export async function upsertBetaBuildLocalizations(
         await updateBetaBuildLocalization(creds, {
           localizationId: current.id,
           whatsNew,
+        }),
+      );
+    } else {
+      results.push(current);
+    }
+  }
+  return results;
+}
+
+export async function getBetaAppLocalizations(
+  creds: AscApiCredentials,
+  ascAppId: string,
+): Promise<BetaAppLocalizationResource[]> {
+  const res = await ascRequest<{ data: BetaAppLocalizationResource[] }>(
+    creds,
+    "GET",
+    `/v1/apps/${encodeURIComponent(ascAppId)}/betaAppLocalizations?limit=200`,
+  );
+  return res.data ?? [];
+}
+
+export async function createBetaAppLocalization(
+  creds: AscApiCredentials,
+  args: { ascAppId: string; locale: string; description: string },
+): Promise<BetaAppLocalizationResource> {
+  const res = await ascRequest<{ data: BetaAppLocalizationResource }>(
+    creds,
+    "POST",
+    "/v1/betaAppLocalizations",
+    {
+      data: {
+        type: "betaAppLocalizations",
+        attributes: {
+          locale: args.locale,
+          description: args.description,
+        },
+        relationships: {
+          app: { data: { type: "apps", id: args.ascAppId } },
+        },
+      },
+    },
+  );
+  return res.data;
+}
+
+export async function updateBetaAppLocalization(
+  creds: AscApiCredentials,
+  args: { localizationId: string; description: string },
+): Promise<BetaAppLocalizationResource> {
+  const res = await ascRequest<{ data: BetaAppLocalizationResource }>(
+    creds,
+    "PATCH",
+    `/v1/betaAppLocalizations/${encodeURIComponent(args.localizationId)}`,
+    {
+      data: {
+        type: "betaAppLocalizations",
+        id: args.localizationId,
+        attributes: { description: args.description },
+      },
+    },
+  );
+  return res.data;
+}
+
+/** Create or update supplied app-level descriptions without touching other locales. */
+export async function upsertBetaAppLocalizations(
+  creds: AscApiCredentials,
+  ascAppId: string,
+  descriptions: Record<string, string>,
+): Promise<BetaAppLocalizationResource[]> {
+  const requested = Object.entries(descriptions);
+  if (requested.length === 0) return [];
+  const existing = await getBetaAppLocalizations(creds, ascAppId);
+  const byLocale = new Map(
+    existing
+      .filter((item) => item.attributes.locale)
+      .map((item) => [item.attributes.locale!, item]),
+  );
+  const results: BetaAppLocalizationResource[] = [];
+  for (const [locale, description] of requested) {
+    const current = byLocale.get(locale);
+    if (!current) {
+      try {
+        results.push(
+          await createBetaAppLocalization(creds, {
+            ascAppId,
+            locale,
+            description,
+          }),
+        );
+      } catch (error) {
+        if (!(error instanceof AscApiError) || error.status !== 409) throw error;
+        const raced = (await getBetaAppLocalizations(creds, ascAppId)).find(
+          (item) => item.attributes.locale === locale,
+        );
+        if (!raced) throw error;
+        results.push(
+          raced.attributes.description === description
+            ? raced
+            : await updateBetaAppLocalization(creds, {
+                localizationId: raced.id,
+                description,
+              }),
+        );
+      }
+    } else if (current.attributes.description !== description) {
+      results.push(
+        await updateBetaAppLocalization(creds, {
+          localizationId: current.id,
+          description,
         }),
       );
     } else {

--- a/worker/src/openapi/builds.ts
+++ b/worker/src/openapi/builds.ts
@@ -127,7 +127,55 @@ const TestflightExpireInput = TestflightBundleAssertion.extend({
   confirm_build_number: z.string().regex(/^\d+$/),
 }).strict().openapi("TestflightExpireInput");
 
+const BetaAppDescriptionInput = z.object({
+  descriptions: z
+    .record(z.string().min(1).max(64), z.string().min(1).max(4_000))
+    .refine((value) => Object.keys(value).length > 0, {
+      message: "At least one locale is required.",
+    }),
+}).strict().openapi("BetaAppDescriptionInput");
+
 export function registerBuildRoutes(registry: OpenApiRegistry) {
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/testflight-beta-app-description",
+    tags: ["TestFlight"],
+    summary: "Read app-level TestFlight Beta App Description localizations",
+    description:
+      "Reads betaAppLocalizations.description for the App Store Connect app resolved from the Hands app's main-channel bundle id. This is app-level metadata and is separate from each build's What to Test text.",
+    security: auth,
+    request: { params: AppIdParam },
+    responses: {
+      200: success("Live Beta App Description localizations from Apple.", GenericObject),
+      400: error("The app, bundle id, or ASC credentials are not configured for iOS."),
+      403: error("App viewer role is required."),
+      404: error("Hands or App Store Connect app was not found."),
+      502: error("Apple rejected the metadata request."),
+    },
+  });
+
+  register(registry, {
+    method: "put",
+    path: "/api/apps/{appId}/testflight-beta-app-description",
+    tags: ["TestFlight"],
+    summary: "Upsert app-level TestFlight Beta App Description localizations",
+    description:
+      "Creates or updates only the supplied betaAppLocalizations.description values, preserves other locales, then fetches Apple again and fails unless every requested locale is byte-for-byte equal. It never changes build-level What to Test text, uploads a build, distributes testers, or publishes an App Store version.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      body: { content: json(BetaAppDescriptionInput), required: true },
+    },
+    responses: {
+      200: success("Descriptions updated with exact Apple readback.", GenericObject),
+      400: error("The input, app, bundle id, or ASC credentials are invalid."),
+      403: error("App publisher role is required."),
+      404: error("Hands or App Store Connect app was not found."),
+      409: error("Apple readback did not exactly match the request."),
+      502: error("Apple rejected the metadata update or readback."),
+    },
+  });
+
   register(registry, {
     method: "get",
     path: "/api/apps/{appId}/builds",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -726,7 +726,7 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
       "3. Triage as you work: update-feedback (change status/assignee, e.g. close a fixed ticket) and comment-feedback (attribution note, internal=true for staff-only). Requires org member (or app publisher).",
       "4. Release management (app publisher): create-release from an existing build (DRAFT by default) → update-release with bilingual release_notes → after explicit human authorization, publish-release. See docs.release_guide.",
       "5. iOS simulator QA fixtures: create-ios-simulator-artifact → PUT the .app.zip to upload.url with the returned headers → complete-ios-simulator-artifact → get/presign the durable exact-byte artifact. QA artifacts can never become releases or update offers.",
-      "6. TestFlight: an app admin runs upload-testflight-build and polls get-testflight-upload-status to COMPLETE; an app viewer lists stable beta-group ids, then an app publisher runs publish-testflight-build and polls distribution status. If an exact beta build must be removed from testing, an app admin uses expire-testflight-build with the ASC build id plus version/build confirmations. These actions never activate a Hands release or submit an App Store production release.",
+      "6. TestFlight: get/update-testflight-beta-app-description manage app-level invitation copy separately from build-level What to Test. An app admin runs upload-testflight-build and polls get-testflight-upload-status to COMPLETE; an app viewer lists beta groups, then an app publisher runs publish-testflight-build and polls distribution status. These actions never activate a Hands release or submit an App Store production release.",
     ],
     auth: {
       raft_agents:
@@ -1261,6 +1261,31 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
           submission_id: { type: "string", in: "path", required: true, description: "Hands market submission UUID." },
+        },
+      },
+      {
+        name: "get-testflight-beta-app-description",
+        description:
+          "Read live app-level Beta App Description localizations (betaAppLocalizations.description) from App Store Connect. This is separate from every build's What to Test text. Read-only; requires app viewer.",
+        endpoint: {
+          method: "GET",
+          path: "/api/apps/{app_id}/testflight-beta-app-description",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands iOS app UUID; its main-channel bundle id selects the ASC app." },
+        },
+      },
+      {
+        name: "update-testflight-beta-app-description",
+        description:
+          "Create or update supplied app-level Beta App Description localizations, preserve other locales, and require exact Apple readback. Does not touch build-level What to Test, upload or distribute a build, notify testers, or publish an App Store version. Requires app publisher and explicit authorization for the live metadata change.",
+        endpoint: {
+          method: "PUT",
+          path: "/api/apps/{app_id}/testflight-beta-app-description",
+        },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "Hands iOS app UUID; its main-channel bundle id selects the ASC app." },
+          descriptions: { type: "object", in: "body", required: true, description: "Non-empty locale-to-description map, for example {\"en-US\":\"A private collaboration app\"}." },
         },
       },
       {

--- a/worker/src/routes/testflight_beta_app_description.ts
+++ b/worker/src/routes/testflight_beta_app_description.ts
@@ -1,0 +1,279 @@
+/** App-level TestFlight Beta App Description, separate from build-level What to Test. */
+import type { Context } from "hono";
+import type { AdminEnv } from "../middleware/auth";
+import { getAscCredentials } from "../lib/asc_credentials";
+import {
+  AscApiError,
+  getBetaAppLocalizations,
+  resolveAscAppId,
+  upsertBetaAppLocalizations,
+  type AscApiCredentials,
+  type BetaAppLocalizationResource,
+} from "../lib/asc_api";
+import { insertAuditLog } from "../lib/permissions";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+const MAX_DESCRIPTION_LENGTH = 4_000;
+const MAX_LOCALES_PER_REQUEST = 100;
+const LOCALE_PATTERN = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+
+class BetaAppDescriptionError extends Error {
+  constructor(
+    readonly status: 400 | 404 | 409 | 500 | 502,
+    readonly code: string,
+    message: string,
+    readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+  }
+}
+
+export function parseBetaAppDescriptions(body: unknown): Record<string, string> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new BetaAppDescriptionError(400, "INVALID_BODY", "request body must be an object");
+  }
+  const bodyKeys = Object.keys(body);
+  if (bodyKeys.length !== 1 || bodyKeys[0] !== "descriptions") {
+    throw new BetaAppDescriptionError(
+      400,
+      "INVALID_BODY",
+      "request body may contain only descriptions",
+    );
+  }
+  const descriptions = (body as { descriptions?: unknown }).descriptions;
+  if (!descriptions || typeof descriptions !== "object" || Array.isArray(descriptions)) {
+    throw new BetaAppDescriptionError(
+      400,
+      "INVALID_DESCRIPTIONS",
+      "descriptions must be a non-empty locale-to-text object",
+    );
+  }
+  const entries = Object.entries(descriptions);
+  if (entries.length === 0 || entries.length > MAX_LOCALES_PER_REQUEST) {
+    throw new BetaAppDescriptionError(
+      400,
+      "INVALID_DESCRIPTIONS",
+      `descriptions must contain between 1 and ${MAX_LOCALES_PER_REQUEST} locales`,
+    );
+  }
+  const normalized: Record<string, string> = Object.create(null);
+  for (const [rawLocale, rawDescription] of entries) {
+    const locale = rawLocale.trim();
+    if (
+      !locale ||
+      locale !== rawLocale ||
+      locale.length > 64 ||
+      !LOCALE_PATTERN.test(locale)
+    ) {
+      throw new BetaAppDescriptionError(400, "INVALID_LOCALE", `invalid locale: ${rawLocale}`);
+    }
+    if (typeof rawDescription !== "string") {
+      throw new BetaAppDescriptionError(
+        400,
+        "INVALID_DESCRIPTION",
+        `description for ${locale} must be a string`,
+      );
+    }
+    if (!rawDescription.trim() || rawDescription.length > MAX_DESCRIPTION_LENGTH) {
+      throw new BetaAppDescriptionError(
+        400,
+        "INVALID_DESCRIPTION",
+        `description for ${locale} must contain 1-${MAX_DESCRIPTION_LENGTH} characters`,
+      );
+    }
+    normalized[locale] = rawDescription;
+  }
+  return normalized;
+}
+
+function publicLocalizations(items: BetaAppLocalizationResource[]) {
+  return items
+    .map((item) => ({
+      id: item.id,
+      locale: item.attributes.locale,
+      description: item.attributes.description,
+    }))
+    .sort((a, b) => (a.locale ?? "").localeCompare(b.locale ?? ""));
+}
+
+async function resolveAppContext(c: AdminContext): Promise<{
+  bundleId: string;
+  ascAppId: string;
+  creds: AscApiCredentials;
+}> {
+  const appId = c.req.param("appId") ?? "";
+  const app = await c.env.DB.prepare("SELECT platform FROM apps WHERE id = ?1")
+    .bind(appId)
+    .first<{ platform: string }>();
+  if (!app) throw new BetaAppDescriptionError(404, "APP_NOT_FOUND", "app not found");
+  if (app.platform !== "ios") {
+    throw new BetaAppDescriptionError(
+      400,
+      "APP_NOT_IOS",
+      "Beta App Description is available only for iOS apps",
+    );
+  }
+  const bundleRow = await c.env.DB.prepare(
+    "SELECT bundle_id FROM channels WHERE app_id = ?1 AND slug = 'main' LIMIT 1",
+  )
+    .bind(appId)
+    .first<{ bundle_id: string | null }>();
+  const bundleId = (bundleRow?.bundle_id ?? "").trim();
+  if (!bundleId) {
+    throw new BetaAppDescriptionError(
+      400,
+      "BUNDLE_ID_NOT_CONFIGURED",
+      "the main channel has no App Store bundle id",
+    );
+  }
+  const encKey = c.env.ASC_CRED_ENC_KEY;
+  if (!encKey) {
+    throw new BetaAppDescriptionError(
+      500,
+      "ASC_ENCRYPTION_NOT_CONFIGURED",
+      "server is missing ASC_CRED_ENC_KEY",
+    );
+  }
+  const creds = await getAscCredentials(c.env.DB, encKey, appId);
+  if (!creds) {
+    throw new BetaAppDescriptionError(
+      400,
+      "ASC_CREDENTIALS_NOT_CONFIGURED",
+      "no ASC credentials configured for this app",
+    );
+  }
+  const ascAppId = await resolveAscAppId(creds, bundleId);
+  if (!ascAppId) {
+    throw new BetaAppDescriptionError(
+      404,
+      "ASC_APP_NOT_FOUND",
+      `no App Store Connect app record for bundle id ${bundleId}`,
+    );
+  }
+  return { bundleId, ascAppId, creds };
+}
+
+function errorResponse(c: AdminContext, error: unknown) {
+  if (error instanceof BetaAppDescriptionError) {
+    return c.json(
+      { error: error.message, code: error.code, ...error.details },
+      error.status,
+    );
+  }
+  if (error instanceof AscApiError) {
+    return c.json(
+      { error: error.message, code: "ASC_API_ERROR", status: error.status, detail: error.detail },
+      502,
+    );
+  }
+  throw error;
+}
+
+export async function handleGetBetaAppDescription(c: AdminContext) {
+  try {
+    const { bundleId, ascAppId, creds } = await resolveAppContext(c);
+    const localizations = await getBetaAppLocalizations(creds, ascAppId);
+    return c.json({
+      bundle_id: bundleId,
+      asc_app_id: ascAppId,
+      localizations: publicLocalizations(localizations),
+    });
+  } catch (error) {
+    return errorResponse(c, error);
+  }
+}
+
+export async function handleUpdateBetaAppDescription(c: AdminContext) {
+  try {
+    const descriptions = parseBetaAppDescriptions(await c.req.json().catch(() => null));
+    const { bundleId, ascAppId, creds } = await resolveAppContext(c);
+    const requestId = crypto.randomUUID();
+    const digests: Record<string, string> = {};
+    for (const [locale, description] of Object.entries(descriptions)) {
+      const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(description),
+      );
+      digests[locale] = Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, "0"),
+      ).join("");
+    }
+    await insertAuditLog(c.env.DB, c, {
+      app_id: c.req.param("appId") ?? "",
+      action: "testflight.beta_app_description.update_requested",
+      payload: {
+        request_id: requestId,
+        bundle_id: bundleId,
+        asc_app_id: ascAppId,
+        locales: Object.keys(descriptions).sort(),
+        description_sha256: digests,
+      },
+    });
+
+    let readback: BetaAppLocalizationResource[];
+    try {
+      await upsertBetaAppLocalizations(creds, ascAppId, descriptions);
+      readback = await getBetaAppLocalizations(creds, ascAppId);
+    } catch (error) {
+      await insertAuditLog(c.env.DB, c, {
+        app_id: c.req.param("appId") ?? "",
+        action: "testflight.beta_app_description.update_failed",
+        payload: {
+          request_id: requestId,
+          bundle_id: bundleId,
+          asc_app_id: ascAppId,
+          error: error instanceof AscApiError ? error.message : "unexpected error",
+          asc_status: error instanceof AscApiError ? error.status : null,
+        },
+      });
+      throw error;
+    }
+    const byLocale = new Map(
+      readback.map((item) => [item.attributes.locale, item.attributes.description]),
+    );
+    const mismatched = Object.entries(descriptions)
+      .filter(([locale, description]) => byLocale.get(locale) !== description)
+      .map(([locale]) => locale);
+    if (mismatched.length > 0) {
+      await insertAuditLog(c.env.DB, c, {
+        app_id: c.req.param("appId") ?? "",
+        action: "testflight.beta_app_description.update_mismatch",
+        payload: {
+          request_id: requestId,
+          bundle_id: bundleId,
+          asc_app_id: ascAppId,
+          mismatched_locales: mismatched,
+        },
+      });
+      throw new BetaAppDescriptionError(
+        409,
+        "READBACK_MISMATCH",
+        "App Store Connect readback did not match the requested descriptions",
+        { mismatched_locales: mismatched },
+      );
+    }
+
+    await insertAuditLog(c.env.DB, c, {
+      app_id: c.req.param("appId") ?? "",
+      action: "testflight.beta_app_description.update_verified",
+      payload: {
+        request_id: requestId,
+        bundle_id: bundleId,
+        asc_app_id: ascAppId,
+        locales: Object.keys(descriptions).sort(),
+        readback_exact: true,
+      },
+    });
+    return c.json({
+      ok: true,
+      bundle_id: bundleId,
+      asc_app_id: ascAppId,
+      updated_locales: Object.keys(descriptions).sort(),
+      readback_exact: true,
+      localizations: publicLocalizations(readback),
+    });
+  } catch (error) {
+    return errorResponse(c, error);
+  }
+}

--- a/worker/test/beta_app_description.test.ts
+++ b/worker/test/beta_app_description.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import {
+  getBetaAppLocalizations,
+  upsertBetaAppLocalizations,
+  type AscApiCredentials,
+} from "../src/lib/asc_api";
+import {
+  handleGetBetaAppDescription,
+  handleUpdateBetaAppDescription,
+  parseBetaAppDescriptions,
+} from "../src/routes/testflight_beta_app_description";
+import { encryptP8 } from "../src/lib/asc_credentials";
+
+async function generateTestCreds(): Promise<AscApiCredentials> {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(
+    (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer,
+  );
+  let binary = "";
+  for (const byte of pkcs8) binary += String.fromCharCode(byte);
+  return {
+    key_id: "TESTKEY123",
+    issuer_id: "issuer-uuid-1234",
+    p8: `-----BEGIN PRIVATE KEY-----\n${btoa(binary)}\n-----END PRIVATE KEY-----`,
+  };
+}
+
+function fakeAsc(initial: Record<string, string> = {}) {
+  const localizations = new Map(
+    Object.entries(initial).map(([locale, description], index) => [
+      locale,
+      { id: `loc-${index + 1}`, description },
+    ]),
+  );
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)).data : null;
+    if (method === "GET" && url.pathname === "/v1/apps/asc-app-1/betaAppLocalizations") {
+      return Response.json({
+        data: [...localizations.entries()].map(([locale, value]) => ({
+          type: "betaAppLocalizations",
+          id: value.id,
+          attributes: { locale, description: value.description },
+        })),
+      });
+    }
+    if (method === "POST" && url.pathname === "/v1/betaAppLocalizations") {
+      const id = `loc-${localizations.size + 1}`;
+      localizations.set(body.attributes.locale, {
+        id,
+        description: body.attributes.description,
+      });
+      return Response.json({ data: { id, attributes: body.attributes } }, { status: 201 });
+    }
+    if (method === "PATCH" && url.pathname.startsWith("/v1/betaAppLocalizations/")) {
+      const entry = [...localizations.entries()].find(([, value]) => value.id === body.id);
+      if (entry) entry[1].description = body.attributes.description;
+      return Response.json({
+        data: {
+          id: body.id,
+          attributes: {
+            locale: entry?.[0] ?? null,
+            description: body.attributes.description,
+          },
+        },
+      });
+    }
+    return Response.json(
+      { errors: [{ title: "UNEXPECTED_REQUEST", detail: `${method} ${url.pathname}` }] },
+      { status: 500 },
+    );
+  });
+  return { localizations, fetchMock };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("betaAppLocalizations ASC client", () => {
+  it("uses app-level resources and preserves untouched locales", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc({ "en-US": "Old", "fr-FR": "Conserver" });
+    vi.stubGlobal("fetch", fake.fetchMock);
+
+    await upsertBetaAppLocalizations(creds, "asc-app-1", {
+      "en-US": "New",
+      "zh-Hans": "新描述",
+    });
+    const readback = await getBetaAppLocalizations(creds, "asc-app-1");
+
+    expect(fake.localizations.get("en-US")?.description).toBe("New");
+    expect(fake.localizations.get("zh-Hans")?.description).toBe("新描述");
+    expect(fake.localizations.get("fr-FR")?.description).toBe("Conserver");
+    expect(readback).toHaveLength(3);
+    const calls = fake.fetchMock.mock.calls.map(([url, init]) => [
+      init?.method ?? "GET",
+      new URL(String(url)).pathname,
+    ]);
+    expect(calls).toContainEqual(["PATCH", "/v1/betaAppLocalizations/loc-1"]);
+    expect(calls).toContainEqual(["POST", "/v1/betaAppLocalizations"]);
+    expect(calls.some(([, path]) => String(path).includes("betaBuildLocalizations"))).toBe(false);
+  });
+
+  it("recovers a create race through a fresh app-level read", async () => {
+    const creds = await generateTestCreds();
+    const fake = fakeAsc();
+    let createCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if ((init?.method ?? "GET") === "POST" && url.pathname === "/v1/betaAppLocalizations") {
+        createCalls += 1;
+        fake.localizations.set("ja", { id: "raced", description: "古い" });
+        return Response.json(
+          { errors: [{ title: "ENTITY_ERROR", detail: "locale exists" }] },
+          { status: 409 },
+        );
+      }
+      return fake.fetchMock(input, init);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertBetaAppLocalizations(creds, "asc-app-1", { ja: "新しい" });
+    expect(createCalls).toBe(1);
+    expect(fake.localizations.get("ja")?.description).toBe("新しい");
+  });
+});
+
+describe("Beta App Description route", () => {
+  it("validates a non-empty locale map without accepting blank descriptions", () => {
+    expect({ ...parseBetaAppDescriptions({ descriptions: { "en-US": "  Hello  " } }) })
+      .toEqual({ "en-US": "  Hello  " });
+    expect(() => parseBetaAppDescriptions({ descriptions: {} })).toThrow(/between 1 and 100/);
+    expect(() => parseBetaAppDescriptions({ descriptions: { "en-US": "   " } })).toThrow(
+      /must contain/,
+    );
+    expect(() => parseBetaAppDescriptions({
+      descriptions: { "en-US": "Hello" },
+      what_to_test: { "en-US": "Wrong field" },
+    })).toThrow(/only descriptions/);
+    expect(() => parseBetaAppDescriptions({ descriptions: { __proto__: "unsafe" } }))
+      .toThrow(/between 1 and 100/);
+  });
+
+  it("updates app descriptions, performs exact readback, and writes a redacted audit", async () => {
+    const creds = await generateTestCreds();
+    const encrypted = await encryptP8(creds.p8, "test-key");
+    const fake = fakeAsc({ "en-US": "Old" });
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/v1/apps" && url.searchParams.get("filter[bundleId]") === "build.raft.app") {
+        return Response.json({ data: [{ id: "asc-app-1" }] });
+      }
+      return fake.fetchMock(input, init);
+    }));
+
+    const audits: Array<{ action: string; payload: string }> = [];
+    const db = {
+      prepare(sql: string) {
+        const values: unknown[] = [];
+        return {
+          bind(...args: unknown[]) {
+            values.push(...args);
+            return this;
+          },
+          async first() {
+            if (sql.includes("SELECT platform FROM apps")) return { platform: "ios" };
+            if (sql.includes("SELECT bundle_id FROM channels")) return { bundle_id: "build.raft.app" };
+            if (sql.includes("FROM app_asc_credentials")) {
+              return {
+                id: "cred-1",
+                app_id: "app-1",
+                key_id: creds.key_id,
+                issuer_id: creds.issuer_id,
+                created_by_actor: "tester",
+                created_at: 1,
+                updated_at: 1,
+                p8_ciphertext_b64: encrypted.ciphertext_b64,
+                p8_iv_b64: encrypted.iv_b64,
+              };
+            }
+            return null;
+          },
+          async run() {
+            if (sql.includes("INSERT INTO audit_logs")) {
+              audits.push({ action: String(values[2]), payload: String(values.at(-2)) });
+            }
+            return { success: true };
+          },
+        };
+      },
+    };
+
+    const app = new Hono();
+    app.get("/api/apps/:appId/testflight-beta-app-description", handleGetBetaAppDescription as any);
+    app.put("/api/apps/:appId/testflight-beta-app-description", handleUpdateBetaAppDescription as any);
+    const env = { DB: db, ASC_CRED_ENC_KEY: "test-key" } as any;
+
+    const response = await app.request(
+      "/api/apps/app-1/testflight-beta-app-description",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ descriptions: { "en-US": "New", ja: "新しい" } }),
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      bundle_id: "build.raft.app",
+      asc_app_id: "asc-app-1",
+      updated_locales: ["en-US", "ja"],
+      readback_exact: true,
+    });
+    expect(audits).toHaveLength(2);
+    expect(audits.map((audit) => audit.action)).toEqual([
+      "testflight.beta_app_description.update_requested",
+      "testflight.beta_app_description.update_verified",
+    ]);
+    for (const audit of audits) {
+      expect(audit.payload).not.toContain("New");
+      expect(audit.payload).not.toContain("新しい");
+    }
+
+    const getResponse = await app.request(
+      "/api/apps/app-1/testflight-beta-app-description",
+      undefined,
+      env,
+    );
+    expect(getResponse.status).toBe(200);
+    await expect(getResponse.json()).resolves.toMatchObject({
+      localizations: [
+        { locale: "en-US", description: "New" },
+        { locale: "ja", description: "新しい" },
+      ],
+    });
+  });
+});

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -100,6 +100,7 @@ describe("quiver OpenAPI document", () => {
       "/api/apps/{appId}/builds/{buildId}/external-targets",
       "/api/apps/{appId}/builds/{buildId}/testflight-upload",
       "/api/apps/{appId}/testflight-uploads/{buildUploadId}",
+      "/api/apps/{appId}/testflight-beta-app-description",
       "/api/apps/{appId}/builds/{buildId}/testflight-groups",
       "/api/apps/{appId}/builds/{buildId}/testflight-expire",
       "/api/apps/{appId}/builds/{buildId}/testflight-publish",
@@ -11110,6 +11111,14 @@ describe("Hands iOS simulator QA artifacts", () => {
       "upload-testflight-build": {
         method: "POST",
         path: "/api/apps/{app_id}/builds/{build_id}/testflight-upload",
+      },
+      "get-testflight-beta-app-description": {
+        method: "GET",
+        path: "/api/apps/{app_id}/testflight-beta-app-description",
+      },
+      "update-testflight-beta-app-description": {
+        method: "PUT",
+        path: "/api/apps/{app_id}/testflight-beta-app-description",
       },
       "get-testflight-upload-status": {
         method: "GET",


### PR DESCRIPTION
## Problem

Hands can manage build-level TestFlight What to Test localizations, but has no separate API for the app-level Beta App Description shown in the TestFlight invitation experience. Treating those fields as one surface risks updating the wrong App Store Connect resource.

## Changes

- add app-level `betaAppLocalizations.description` list/create/update/upsert support to the ASC client
- expose dedicated authenticated GET/PUT routes and Agent Login actions, separate from build publication
- preserve unsupplied locales and require an exact Apple readback after updates
- record redacted request and terminal audit receipts without storing description text in the audit payload
- document the boundary and add OpenAPI/admin client contracts

## Follow-up

Live App Store Connect metadata remains unchanged. Use the write action only after explicit authorization for the exact locale text.

## Testing

- `pnpm --filter @botiverse/hands-worker test` (440 passed)
- `pnpm --filter @botiverse/hands-worker test -- beta_app_description.test.ts routes.test.ts` (191 passed)
- `pnpm --filter @botiverse/hands-worker build`
- `pnpm --filter @botiverse/hands-admin build`
- `git diff --check`

The existing Worker lint script cannot start because the repository has ESLint 9 but no `eslint.config.js`/`mjs`/`cjs`.
