### PR TITLE
chore(cli): bump to 0.5.15 for hands api release

### DIFF
--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -13,7 +13,7 @@ npm install -g @botiverse/hands-cli
 Or run it without a permanent install:
 
 ```bash
-npm exec --package @botiverse/hands-cli@0.5.14 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.15 -- hands --help
 ```
 
 In CI, pin a version so release scripts stay reproducible.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ npm install -g @botiverse/hands-cli
 hands --help
 
 # Or run without installing globally:
-npm exec --package @botiverse/hands-cli@0.5.14 -- hands --help
+npm exec --package @botiverse/hands-cli@0.5.15 -- hands --help
 
 # Local repo development:
 pnpm --filter @botiverse/hands-cli build

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ const program = new Command();
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.14")
+  .version("0.5.15")
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",


### PR DESCRIPTION
Release-metadata bump so `hands api` (#448) can be published to npm.

Bumps the **4 shipping version refs** 0.5.14 → 0.5.15:
- `packages/cli/package.json` version
- `packages/cli/src/index.ts` `.version()`
- `packages/cli/README.md` npm-exec example
- `docs/public/cli-reference.md` npm-exec example

The 3 `new Command().version("0.5.14")` lines in `cli.test.ts` are incidental test-fixture placeholders (throwaway programs, not the shipped version, not asserted) — intentionally left to keep this a release-metadata-only diff.

Build + 41 tests green. Next: after merge, dispatch `Publish CLI` (dry-run → real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)