### PR TITLE
feat(worker): add Hands Installer consumer service

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -54,6 +54,14 @@ ENV PATH=$PATH:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/build-
 RUN yes | sdkmanager --licenses >/dev/null 2>&1 || true && \
     sdkmanager "build-tools;${ANDROID_SDK_VERSION}" >/dev/null 2>&1
 
+# Compile a narrow wrapper around Google's apksig library. Unlike parsing
+# `apksigner --print-certs`, this preserves verified v3/v3.1 proof-of-rotation
+# order and supports multiple independent signers without guessing from text.
+COPY apkinspect/ApkInspect.java /opt/apkinspect/ApkInspect.java
+RUN javac -encoding UTF-8 \
+    -cp "/opt/android-sdk/build-tools/${ANDROID_SDK_VERSION}/lib/apksigner.jar" \
+    -d /opt/apkinspect /opt/apkinspect/ApkInspect.java
+
 # archive-patcher (delta/differential update generation) — com.eidu fork of
 # Google's Play-Store engine: a single self-contained jar (no transitive deps).
 # Compile the thin PatchGen wrapper against it so the container can generate

--- a/container/apkinspect/ApkInspect.java
+++ b/container/apkinspect/ApkInspect.java
@@ -1,0 +1,59 @@
+import com.android.apksig.ApkVerifier;
+import com.android.apksig.SigningCertificateLineage;
+import java.io.File;
+import java.security.MessageDigest;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** Emits verified APK signer lineages as stable, machine-readable lines. */
+public final class ApkInspect {
+  private static String sha256(X509Certificate certificate) throws Exception {
+    byte[] digest = MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded());
+    StringBuilder output = new StringBuilder(digest.length * 2);
+    for (byte value : digest) output.append(String.format("%02x", value & 0xff));
+    return output.toString();
+  }
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 1) throw new IllegalArgumentException("expected one APK path");
+    ApkVerifier.Result result = new ApkVerifier.Builder(new File(args[0])).build().verify();
+    if (!result.isVerified()) {
+      System.err.println("APK signature verification failed");
+      System.exit(2);
+    }
+
+    List<List<X509Certificate>> lineages = new ArrayList<>();
+    SigningCertificateLineage lineage = result.getSigningCertificateLineage();
+    if (lineage != null) {
+      lineages.add(lineage.getCertificatesInLineage());
+    } else {
+      for (X509Certificate certificate : result.getSignerCertificates()) {
+        lineages.add(List.of(certificate));
+      }
+    }
+    if (lineages.isEmpty()) throw new IllegalStateException("verified APK has no signer");
+
+    List<List<String>> fingerprints = new ArrayList<>();
+    for (List<X509Certificate> certificates : lineages) {
+      if (certificates.isEmpty()) throw new IllegalStateException("empty signer lineage");
+      List<String> fingerprintLineage = new ArrayList<>();
+      for (X509Certificate certificate : certificates) {
+        fingerprintLineage.add(sha256(certificate));
+      }
+      fingerprints.add(fingerprintLineage);
+    }
+    // Independent signer order is canonical by root fingerprint; certificate
+    // order inside each lineage remains the apksig oldest -> current order.
+    fingerprints.sort(Comparator.comparing(lineageFingerprints -> lineageFingerprints.get(0)));
+    for (List<String> fingerprintLineage : fingerprints) {
+      StringBuilder output = new StringBuilder("lineage=");
+      for (int index = 0; index < fingerprintLineage.size(); index++) {
+        if (index > 0) output.append(',');
+        output.append(fingerprintLineage.get(index));
+      }
+      System.out.println(output);
+    }
+  }
+}

--- a/container/src/parsers/apk.ts
+++ b/container/src/parsers/apk.ts
@@ -17,6 +17,8 @@ const execFileAsync = promisify(execFile);
 
 const AAPT_BIN = "/opt/android-sdk/build-tools/34.0.0/aapt";
 const APKSIGNER_BIN = "/opt/android-sdk/build-tools/34.0.0/apksigner";
+const APKSIGNER_JAR = "/opt/android-sdk/build-tools/34.0.0/lib/apksigner.jar";
+const APK_INSPECT_CLASSES = "/opt/apkinspect";
 
 export async function parseApk(
   bytes: Uint8Array,
@@ -89,14 +91,40 @@ export async function parseApk(
       }
     }
 
-    const { stdout: certsOut } = await execFileAsync(
+    // First retain the canonical apksigner verification gate used by existing
+    // Hands ingestion.
+    await execFileAsync(
       APKSIGNER_BIN,
-      ["verify", "--print-certs", apkPath],
+      ["verify", apkPath],
       { maxBuffer: 1024 * 1024 },
     );
-    const sha256Match = certsOut.match(/SHA-256 digest:\s*([0-9a-fA-F:]+)/);
-    const signatureSha256 =
-      sha256Match?.[1]?.replace(/:/g, "").toLowerCase() ?? "";
+
+    // Then ask the apksig library for its already-verified signer lineage.
+    // One output line represents one independent signer; fingerprints inside
+    // a line are oldest -> current proof-of-rotation order.
+    const { stdout: lineageOut } = await execFileAsync(
+      "java",
+      ["-cp", `${APKSIGNER_JAR}:${APK_INSPECT_CLASSES}`, "ApkInspect", apkPath],
+      { maxBuffer: 1024 * 1024 },
+    );
+    const signerLineages = [...lineageOut.matchAll(/^lineage=([0-9a-f,]+)$/gm)].map(
+      (match) => match[1]!.split(","),
+    );
+    const uniqueFingerprints = new Set(signerLineages.flat());
+    if (
+      signerLineages.length === 0 ||
+      signerLineages.length > 8 ||
+      signerLineages.some(
+        (lineage) =>
+          lineage.length === 0 ||
+          lineage.length > 16 ||
+          lineage.some((fingerprint) => !/^[0-9a-f]{64}$/.test(fingerprint)),
+      ) ||
+      uniqueFingerprints.size !== signerLineages.flat().length
+    ) {
+      throw new Error("apksig returned an invalid signer lineage");
+    }
+    const signatureSha256 = signerLineages[0]![0]!;
 
     return {
       parser_kind: "apk-aapt",
@@ -114,6 +142,7 @@ export async function parseApk(
         min_sdk: minSdk,
         target_sdk: targetSdk,
         signature_sha256: signatureSha256,
+        signer_lineages: signerLineages,
       },
     };
   } finally {

--- a/migrations/sql/0067_installer_consumer.sql
+++ b/migrations/sql/0067_installer_consumer.sql
@@ -141,7 +141,10 @@ CREATE TABLE installer_asset_metadata (
   filetype             TEXT NOT NULL,
   package_id           TEXT NOT NULL,
   version_code         INTEGER NOT NULL CHECK (version_code >= 0),
-  signer_fingerprint   TEXT NOT NULL,
+  -- JSON array of independent signer lineages. Each lineage is an array of
+  -- lowercase SHA-256 certificate fingerprints ordered oldest -> current.
+  -- Bounds are enforced by the guards below (8 signers, 16 certs each).
+  signer_lineages_json TEXT NOT NULL,
   inspected_file_hash  TEXT NOT NULL,
   inspector_version    TEXT NOT NULL,
   inspected_at         INTEGER NOT NULL,
@@ -149,8 +152,10 @@ CREATE TABLE installer_asset_metadata (
     (platform = 'android' AND filetype = 'apk') OR
     (platform = 'ohos' AND filetype = 'hap')
   ),
-  CHECK (length(signer_fingerprint) = 64 AND signer_fingerprint = lower(signer_fingerprint)
-    AND signer_fingerprint NOT GLOB '*[^0-9a-f]*'),
+  CHECK (length(signer_lineages_json) <= 10000),
+  CHECK (json_valid(signer_lineages_json)
+    AND json_type(signer_lineages_json) = 'array'
+    AND json_array_length(signer_lineages_json) BETWEEN 1 AND 8),
   CHECK (length(inspected_file_hash) = 64 AND inspected_file_hash = lower(inspected_file_hash)
     AND inspected_file_hash NOT GLOB '*[^0-9a-f]*'),
   CHECK (trim(package_id) != ''),
@@ -160,27 +165,74 @@ CREATE TABLE installer_asset_metadata (
 CREATE INDEX idx_installer_asset_metadata_identity
   ON installer_asset_metadata(platform, filetype, package_id, version_code);
 
+-- SQLite CHECK constraints cannot conveniently validate every nested JSON
+-- element. Reject non-array lineages, empty/unbounded lineages, non-canonical
+-- fingerprints, and duplicates anywhere in the signer set.
+CREATE TRIGGER installer_asset_metadata_lineages_insert_guard
+BEFORE INSERT ON installer_asset_metadata
+WHEN EXISTS (
+  SELECT 1 FROM json_each(NEW.signer_lineages_json) AS lineage
+  WHERE lineage.type != 'array'
+     OR json_array_length(lineage.value) NOT BETWEEN 1 AND 16
+) OR EXISTS (
+  SELECT 1
+  FROM json_each(NEW.signer_lineages_json) AS lineage,
+       json_each(lineage.value) AS certificate
+  WHERE certificate.type != 'text'
+     OR length(certificate.value) != 64
+     OR certificate.value != lower(certificate.value)
+     OR certificate.value GLOB '*[^0-9a-f]*'
+) OR (
+  SELECT count(*) FROM json_tree(NEW.signer_lineages_json) WHERE type = 'text'
+) != (
+  SELECT count(DISTINCT atom) FROM json_tree(NEW.signer_lineages_json) WHERE type = 'text'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'installer signer lineages must be bounded, ordered canonical fingerprints');
+END;
+
+CREATE TRIGGER installer_asset_metadata_lineages_update_guard
+BEFORE UPDATE OF signer_lineages_json ON installer_asset_metadata
+WHEN EXISTS (
+  SELECT 1 FROM json_each(NEW.signer_lineages_json) AS lineage
+  WHERE lineage.type != 'array'
+     OR json_array_length(lineage.value) NOT BETWEEN 1 AND 16
+) OR EXISTS (
+  SELECT 1
+  FROM json_each(NEW.signer_lineages_json) AS lineage,
+       json_each(lineage.value) AS certificate
+  WHERE certificate.type != 'text'
+     OR length(certificate.value) != 64
+     OR certificate.value != lower(certificate.value)
+     OR certificate.value GLOB '*[^0-9a-f]*'
+) OR (
+  SELECT count(*) FROM json_tree(NEW.signer_lineages_json) WHERE type = 'text'
+) != (
+  SELECT count(DISTINCT atom) FROM json_tree(NEW.signer_lineages_json) WHERE type = 'text'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'installer signer lineages must be bounded, ordered canonical fingerprints');
+END;
+
 -- Cross-table admission cannot be expressed as a CHECK. Seal the inspector row
--- to the exact immutable artifact bytes and to the app/build identity before it
--- can satisfy an installer manifest query.
+-- to the exact immutable artifact bytes and build version before it can satisfy
+-- an installer manifest query. App package opt-in is checked later at admission,
+-- so inspection can safely happen before a publisher opts into the catalog.
 CREATE TRIGGER installer_asset_metadata_insert_guard
 BEFORE INSERT ON installer_asset_metadata
 WHEN NOT EXISTS (
   SELECT 1
   FROM build_assets ba
   JOIN builds b ON b.id = ba.build_id
-  JOIN apps a ON a.id = b.app_id
   WHERE ba.id = NEW.asset_id
     AND ba.artifact_kind = 'installable'
     AND ba.platform = NEW.platform
     AND ba.filetype = NEW.filetype
     AND ba.file_hash = NEW.inspected_file_hash
     AND b.version_code = NEW.version_code
-    AND a.platform = NEW.platform
-    AND a.installer_package_id = NEW.package_id
 )
 BEGIN
-  SELECT RAISE(ABORT, 'installer metadata must match exact installable asset, build, and app identity');
+  SELECT RAISE(ABORT, 'installer metadata must match exact installable asset and build identity');
 END;
 
 CREATE TRIGGER installer_asset_metadata_update_guard
@@ -189,16 +241,13 @@ WHEN NOT EXISTS (
   SELECT 1
   FROM build_assets ba
   JOIN builds b ON b.id = ba.build_id
-  JOIN apps a ON a.id = b.app_id
   WHERE ba.id = NEW.asset_id
     AND ba.artifact_kind = 'installable'
     AND ba.platform = NEW.platform
     AND ba.filetype = NEW.filetype
     AND ba.file_hash = NEW.inspected_file_hash
     AND b.version_code = NEW.version_code
-    AND a.platform = NEW.platform
-    AND a.installer_package_id = NEW.package_id
 )
 BEGIN
-  SELECT RAISE(ABORT, 'installer metadata must match exact installable asset, build, and app identity');
+  SELECT RAISE(ABORT, 'installer metadata must match exact installable asset and build identity');
 END;

--- a/migrations/sql/0067_installer_consumer.sql
+++ b/migrations/sql/0067_installer_consumer.sql
@@ -1,0 +1,204 @@
+-- Hands Installer consumer auth, explicit catalog admission, subscriptions,
+-- and verified package metadata.
+--
+-- 0066 belongs to the already-in-flight generic CLI Agent Login work. This
+-- migration deliberately starts at 0067 and must not land ahead of 0066.
+
+ALTER TABLE apps ADD COLUMN installer_catalog_public INTEGER NOT NULL DEFAULT 0
+  CHECK (installer_catalog_public IN (0, 1));
+ALTER TABLE apps ADD COLUMN installer_package_id TEXT;
+ALTER TABLE apps ADD COLUMN installer_publisher_name TEXT;
+
+CREATE TRIGGER apps_installer_catalog_insert_guard
+BEFORE INSERT ON apps
+WHEN NEW.installer_catalog_public = 1 AND (
+  NEW.public_history != 1 OR
+  NEW.platform NOT IN ('android', 'ohos') OR
+  NEW.installer_package_id IS NULL OR trim(NEW.installer_package_id) = '' OR
+  NEW.installer_publisher_name IS NULL OR trim(NEW.installer_publisher_name) = ''
+)
+BEGIN
+  SELECT RAISE(ABORT, 'installer catalog requires public history, android/ohos platform, package id, and publisher');
+END;
+
+CREATE TRIGGER apps_installer_catalog_update_guard
+BEFORE UPDATE OF installer_catalog_public, public_history, platform,
+  installer_package_id, installer_publisher_name ON apps
+WHEN NEW.installer_catalog_public = 1 AND (
+  NEW.public_history != 1 OR
+  NEW.platform NOT IN ('android', 'ohos') OR
+  NEW.installer_package_id IS NULL OR trim(NEW.installer_package_id) = '' OR
+  NEW.installer_publisher_name IS NULL OR trim(NEW.installer_publisher_name) = ''
+)
+BEGIN
+  SELECT RAISE(ABORT, 'installer catalog requires public history, android/ohos platform, package id, and publisher');
+END;
+
+CREATE INDEX idx_apps_installer_catalog
+  ON apps(installer_catalog_public, archived, slug, id)
+  WHERE installer_catalog_public = 1;
+
+-- Browser authorization state. The browser cookie contains only the random
+-- id; client, redirect and PKCE bindings stay server-side.
+CREATE TABLE installer_login_requests (
+  id                    TEXT PRIMARY KEY,
+  client_id             TEXT NOT NULL,
+  redirect_uri          TEXT NOT NULL,
+  state                 TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL CHECK (code_challenge_method = 'S256'),
+  created_at            INTEGER NOT NULL,
+  expires_at            INTEGER NOT NULL,
+  CHECK (expires_at > created_at),
+  CHECK (length(code_challenge) = 43)
+);
+
+CREATE INDEX idx_installer_login_requests_expiry
+  ON installer_login_requests(expires_at);
+
+-- One-time browser codes. Only token digests are stored. The callback URI is
+-- part of the binding, as are the Raft human account and installer client.
+CREATE TABLE installer_login_codes (
+  id                    TEXT PRIMARY KEY,
+  code_hash             TEXT NOT NULL UNIQUE,
+  account_id            TEXT NOT NULL REFERENCES raft_accounts(id) ON DELETE CASCADE,
+  client_id             TEXT NOT NULL,
+  redirect_uri          TEXT NOT NULL,
+  state                 TEXT NOT NULL,
+  code_challenge        TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL CHECK (code_challenge_method = 'S256'),
+  created_at            INTEGER NOT NULL,
+  expires_at            INTEGER NOT NULL,
+  consumed_at           INTEGER,
+  consumed_by           TEXT UNIQUE,
+  CHECK (expires_at > created_at),
+  CHECK (length(code_challenge) = 43)
+);
+
+CREATE INDEX idx_installer_login_codes_expiry
+  ON installer_login_codes(expires_at)
+  WHERE consumed_at IS NULL;
+
+-- Opaque access tokens have a separate table and audience by construction;
+-- admin auth middleware cannot parse or accept them as Hands dashboard JWTs.
+CREATE TABLE installer_access_tokens (
+  id          TEXT PRIMARY KEY,
+  account_id  TEXT NOT NULL REFERENCES raft_accounts(id) ON DELETE CASCADE,
+  client_id   TEXT NOT NULL,
+  token_hash  TEXT NOT NULL UNIQUE,
+  family_id   TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  expires_at  INTEGER NOT NULL,
+  revoked_at  INTEGER,
+  CHECK (expires_at > created_at)
+);
+
+CREATE INDEX idx_installer_access_token_lookup
+  ON installer_access_tokens(token_hash, expires_at)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE installer_refresh_tokens (
+  id             TEXT PRIMARY KEY,
+  family_id      TEXT NOT NULL,
+  account_id     TEXT NOT NULL REFERENCES raft_accounts(id) ON DELETE CASCADE,
+  client_id      TEXT NOT NULL,
+  token_hash     TEXT NOT NULL UNIQUE,
+  created_at     INTEGER NOT NULL,
+  expires_at     INTEGER NOT NULL,
+  consumed_at    INTEGER,
+  consumed_by    TEXT UNIQUE,
+  replaced_by_id TEXT REFERENCES installer_refresh_tokens(id),
+  revoked_at     INTEGER,
+  CHECK (expires_at > created_at)
+);
+
+CREATE INDEX idx_installer_refresh_token_lookup
+  ON installer_refresh_tokens(token_hash, expires_at);
+CREATE INDEX idx_installer_refresh_family
+  ON installer_refresh_tokens(family_id, created_at DESC);
+
+CREATE TABLE installer_subscriptions (
+  id                  TEXT PRIMARY KEY,
+  account_id          TEXT NOT NULL REFERENCES raft_accounts(id) ON DELETE CASCADE,
+  app_id              TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  channel_id          TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+  auto_download       INTEGER NOT NULL DEFAULT 0 CHECK (auto_download IN (0, 1)),
+  revision            INTEGER NOT NULL DEFAULT 1 CHECK (revision > 0),
+  created_at          INTEGER NOT NULL,
+  updated_at          INTEGER NOT NULL,
+  deleted_at          INTEGER,
+  UNIQUE (account_id, app_id, channel_id)
+);
+
+CREATE INDEX idx_installer_subscriptions_account
+  ON installer_subscriptions(account_id, deleted_at, updated_at DESC, id);
+
+-- Populated only by a package inspector after exact artifact bytes have been
+-- sealed. Publisher-supplied metadata alone can never satisfy manifest admission.
+CREATE TABLE installer_asset_metadata (
+  asset_id             TEXT PRIMARY KEY REFERENCES build_assets(id) ON DELETE CASCADE,
+  platform             TEXT NOT NULL,
+  filetype             TEXT NOT NULL,
+  package_id           TEXT NOT NULL,
+  version_code         INTEGER NOT NULL CHECK (version_code >= 0),
+  signer_fingerprint   TEXT NOT NULL,
+  inspected_file_hash  TEXT NOT NULL,
+  inspector_version    TEXT NOT NULL,
+  inspected_at         INTEGER NOT NULL,
+  CHECK (
+    (platform = 'android' AND filetype = 'apk') OR
+    (platform = 'ohos' AND filetype = 'hap')
+  ),
+  CHECK (length(signer_fingerprint) = 64 AND signer_fingerprint = lower(signer_fingerprint)
+    AND signer_fingerprint NOT GLOB '*[^0-9a-f]*'),
+  CHECK (length(inspected_file_hash) = 64 AND inspected_file_hash = lower(inspected_file_hash)
+    AND inspected_file_hash NOT GLOB '*[^0-9a-f]*'),
+  CHECK (trim(package_id) != ''),
+  CHECK (trim(inspector_version) != '')
+);
+
+CREATE INDEX idx_installer_asset_metadata_identity
+  ON installer_asset_metadata(platform, filetype, package_id, version_code);
+
+-- Cross-table admission cannot be expressed as a CHECK. Seal the inspector row
+-- to the exact immutable artifact bytes and to the app/build identity before it
+-- can satisfy an installer manifest query.
+CREATE TRIGGER installer_asset_metadata_insert_guard
+BEFORE INSERT ON installer_asset_metadata
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM build_assets ba
+  JOIN builds b ON b.id = ba.build_id
+  JOIN apps a ON a.id = b.app_id
+  WHERE ba.id = NEW.asset_id
+    AND ba.artifact_kind = 'installable'
+    AND ba.platform = NEW.platform
+    AND ba.filetype = NEW.filetype
+    AND ba.file_hash = NEW.inspected_file_hash
+    AND b.version_code = NEW.version_code
+    AND a.platform = NEW.platform
+    AND a.installer_package_id = NEW.package_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'installer metadata must match exact installable asset, build, and app identity');
+END;
+
+CREATE TRIGGER installer_asset_metadata_update_guard
+BEFORE UPDATE ON installer_asset_metadata
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM build_assets ba
+  JOIN builds b ON b.id = ba.build_id
+  JOIN apps a ON a.id = b.app_id
+  WHERE ba.id = NEW.asset_id
+    AND ba.artifact_kind = 'installable'
+    AND ba.platform = NEW.platform
+    AND ba.filetype = NEW.filetype
+    AND ba.file_hash = NEW.inspected_file_hash
+    AND b.version_code = NEW.version_code
+    AND a.platform = NEW.platform
+    AND a.installer_package_id = NEW.package_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'installer metadata must match exact installable asset, build, and app identity');
+END;

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -30,6 +30,8 @@ declare global {
     AGC_CRED_ENC_KEY?: string;
     RAFT_ALLOWED_SERVER_IDS?: string;
     RAFT_ALLOWED_SERVER_SLUGS?: string;
+    /** Exact HTTPS app-link callbacks registered for Hands Installer. */
+    INSTALLER_REDIRECT_URIS?: string;
     HANDS_ADMIN_ALLOWED_SERVER_IDS?: string;
     FEEDBACK_AUDIT_HMAC_KEY?: string;
     FEEDBACK_AUDIT_KEY_VERSION?: string;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -28,6 +28,20 @@ import {
   handleAuthMe,
   handleRaftCallback,
 } from "./routes/auth";
+import {
+  handleInstallerLogin,
+  handleInstallerLogout,
+  handleInstallerRaftCallback,
+  handleInstallerToken,
+} from "./routes/installer_auth";
+import { installerAuthMiddleware, type InstallerVariables } from "./lib/installer_auth";
+import {
+  handleDeleteInstallerSubscription,
+  handleInstallerCatalog,
+  handleInstallerManifest,
+  handleInstallerSubscriptions,
+  handlePutInstallerSubscription,
+} from "./routes/installer";
 import { handleHandsAdminOverview } from "./routes/hands_admin";
 import {
   handleDeleteAgcCredentials,
@@ -555,6 +569,19 @@ app.get("/login/raft/callback", handleRaftCallback);
 app.get("/api/auth/me", handleAuthMe);
 app.get("/api/agent/help", handleAgentHelp);
 app.post("/api/auth/logout", handleAuthLogout);
+app.get("/api/installer/v1/auth/login", handleInstallerLogin);
+app.get("/login/raft/installer/callback", handleInstallerRaftCallback);
+app.post("/api/installer/v1/auth/token", handleInstallerToken);
+app.post("/api/installer/v1/auth/logout", handleInstallerLogout);
+
+const installer = new Hono<{ Bindings: Env; Variables: InstallerVariables }>();
+installer.use("/api/installer/v1/*", installerAuthMiddleware);
+installer.get("/api/installer/v1/catalog", handleInstallerCatalog);
+installer.get("/api/installer/v1/subscriptions", handleInstallerSubscriptions);
+installer.put("/api/installer/v1/subscriptions/:appId/:channel", handlePutInstallerSubscription);
+installer.delete("/api/installer/v1/subscriptions/:appId/:channel", handleDeleteInstallerSubscription);
+installer.get("/api/installer/v1/apps/:appId/channels/:channel/manifest", handleInstallerManifest);
+app.route("/", installer);
 
 app.get("/public/apps/:slug/latest", handlePublicV2Latest);
 app.get("/public/apps/:slug/channels", handlePublicListChannels);
@@ -608,6 +635,7 @@ function isWorkerRoute(pathname: string): boolean {
     pathname === "/api-docs" ||
     pathname === "/docs" ||
     pathname === "/login/raft/callback" ||
+    pathname === "/login/raft/installer/callback" ||
     pathname.startsWith("/api/") ||
     pathname.startsWith("/electron/") ||
     pathname.startsWith("/public/") ||

--- a/worker/src/lib/installer_auth.ts
+++ b/worker/src/lib/installer_auth.ts
@@ -1,0 +1,105 @@
+import type { Context, MiddlewareHandler } from "hono";
+
+export const INSTALLER_CLIENT_ID = "hands-installer";
+export const INSTALLER_ACCESS_TTL_MS = 15 * 60 * 1000;
+export const INSTALLER_REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type InstallerAccount = {
+  id: string;
+  provider_subject: string;
+  server_id: string;
+  principal_type: "human" | "agent";
+  display_name: string;
+};
+
+export type InstallerVariables = {
+  installer_account: InstallerAccount;
+  installer_client_id: string;
+  installer_token_id: string;
+};
+
+export function randomOpaqueToken(bytes = 32): string {
+  const data = new Uint8Array(bytes);
+  crypto.getRandomValues(data);
+  let binary = "";
+  for (const byte of data) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  let binary = "";
+  for (const byte of new Uint8Array(digest)) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function isPkceChallenge(value: string): boolean {
+  return /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+export function isPkceVerifier(value: string): boolean {
+  return /^[A-Za-z0-9._~-]{43,128}$/.test(value);
+}
+
+export function isAllowedRedirectUri(value: string, registeredHttps: string[] = []): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.username || url.password || url.hash) return false;
+  if (url.protocol === "hands-installer:") return url.hostname === "auth" && url.pathname === "/callback";
+  if (url.protocol === "https:") return registeredHttps.includes(url.toString());
+  if (url.protocol !== "http:") return false;
+  return (url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "localhost") &&
+    /^\/callback\/?$/.test(url.pathname);
+}
+
+export function configuredInstallerRedirectUris(env: Env): string[] {
+  return (env.INSTALLER_REDIRECT_URIS || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function bearer(c: Context): string | null {
+  const header = c.req.header("authorization") || "";
+  if (!header.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token || null;
+}
+
+export const installerAuthMiddleware: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: InstallerVariables;
+}> = async (c, next) => {
+  c.header("cache-control", "no-store");
+  const token = bearer(c);
+  if (!token) return c.json({ error: "unauthenticated", code: "unauthenticated" }, 401);
+  const hash = await sha256Hex(token);
+  const timestamp = Date.now();
+  const row = await c.env.DB.prepare(
+    `SELECT t.id AS token_id, t.client_id,
+            a.id, a.provider_subject, a.server_id, a.principal_type, a.display_name
+     FROM installer_access_tokens t
+     JOIN raft_accounts a ON a.id = t.account_id
+     WHERE t.token_hash = ?1 AND t.revoked_at IS NULL AND t.expires_at > ?2
+       AND a.principal_type = 'human'
+     LIMIT 1`,
+  ).bind(hash, timestamp).first<InstallerAccount & { token_id: string; client_id: string }>();
+  if (!row || row.client_id !== INSTALLER_CLIENT_ID) {
+    return c.json({ error: "unauthenticated", code: "unauthenticated" }, 401);
+  }
+  c.set("installer_account", row);
+  c.set("installer_client_id", row.client_id);
+  c.set("installer_token_id", row.token_id);
+  await next();
+};

--- a/worker/src/lib/installer_cursor.ts
+++ b/worker/src/lib/installer_cursor.ts
@@ -1,0 +1,68 @@
+type CursorPayload = {
+  v: 1;
+  kind: "catalog" | "subscriptions";
+  account: string;
+  after: string;
+};
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4));
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+async function key(env: Env): Promise<CryptoKey> {
+  const secret = env.SIGNED_URL_SECRET || env.RAFT_CLIENT_SECRET;
+  if (!secret) throw new Error("installer cursor signing secret is not configured");
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(`hands-installer-cursor-v1:${secret}`),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function encodeInstallerCursor(env: Env, payload: CursorPayload): Promise<string> {
+  const encoded = base64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  const signature = new Uint8Array(await crypto.subtle.sign(
+    "HMAC", await key(env), new TextEncoder().encode(encoded),
+  ));
+  return `${encoded}.${base64Url(signature)}`;
+}
+
+export async function decodeInstallerCursor(
+  env: Env,
+  cursor: string | undefined,
+  expected: Pick<CursorPayload, "kind" | "account">,
+): Promise<string | null | undefined> {
+  if (!cursor) return null;
+  if (cursor.length > 512) return undefined;
+  const [encoded, signature, extra] = cursor.split(".");
+  if (!encoded || !signature || extra) return undefined;
+  const signatureBytes = decodeBase64Url(signature);
+  const payloadBytes = decodeBase64Url(encoded);
+  if (!signatureBytes || !payloadBytes) return undefined;
+  const valid = await crypto.subtle.verify(
+    "HMAC", await key(env), signatureBytes, new TextEncoder().encode(encoded),
+  );
+  if (!valid) return undefined;
+  try {
+    const payload = JSON.parse(new TextDecoder().decode(payloadBytes)) as Partial<CursorPayload>;
+    if (payload.v !== 1 || payload.kind !== expected.kind || payload.account !== expected.account ||
+        typeof payload.after !== "string" || payload.after.length > 256) return undefined;
+    return payload.after;
+  } catch {
+    return undefined;
+  }
+}

--- a/worker/src/lib/release_resolver.ts
+++ b/worker/src/lib/release_resolver.ts
@@ -1,0 +1,95 @@
+export type ActiveReleaseCandidate = {
+  id: string;
+  build_id: string;
+  created_at: number;
+  activated_at: number;
+  product_type: string;
+  rollout_cohort_count: number | null;
+  changelog: string | null;
+};
+
+/** One canonical active/non-QA candidate query for every public download surface. */
+export async function loadActiveReleaseCandidates(
+  db: D1Database,
+  args: { appId: string; channelId: string; productType?: string | null | undefined },
+): Promise<ActiveReleaseCandidate[]> {
+  const withProduct = Boolean(args.productType);
+  const statement = db.prepare(
+    `SELECT r.id, r.build_id, r.created_at,
+            COALESCE(r.activated_at, r.created_at) AS activated_at,
+            r.product_type, r.rollout_cohort_count, r.changelog
+     FROM releases r
+     JOIN builds b ON b.id = r.build_id
+     WHERE r.app_id = ?1 AND r.channel_id = ?2
+       ${withProduct ? "AND r.product_type = ?3" : ""}
+       AND r.status = 'active'
+       AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
+     ORDER BY COALESCE(r.activated_at, r.created_at) DESC`,
+  );
+  const result = await (withProduct
+    ? statement.bind(args.appId, args.channelId, args.productType)
+    : statement.bind(args.appId, args.channelId)
+  ).all<ActiveReleaseCandidate>();
+  return result.results;
+}
+
+export function selectBestAsset<T extends {
+  platform: string;
+  arch: string | null;
+  filetype: string;
+}>(
+  assets: T[],
+  requested: { platform: string | null; arch: string | null; filetype: string },
+): T | null {
+  const filetypeMatches = assets.filter((asset) => asset.filetype === requested.filetype);
+  if (filetypeMatches.length === 0) return null;
+  const parsed = splitPlatformArch(requested.platform);
+  const platform = parsed.platform;
+  const arch = requested.arch ?? parsed.arch;
+  const platformMatches = platform
+    ? filetypeMatches.filter((asset) => asset.platform === platform)
+    : filetypeMatches;
+  const candidates = platformMatches.length > 0 ? platformMatches : filetypeMatches;
+  if (arch) {
+    const archMatch = candidates.find((asset) => asset.arch === arch);
+    if (archMatch) return archMatch;
+  }
+  return candidates.find((asset) => asset.arch === null) ?? candidates[0] ?? null;
+}
+
+function splitPlatformArch(value: string | null): { platform: string | null; arch: string | null } {
+  if (!value) return { platform: null, arch: null };
+  const knownPlatforms = ["android", "darwin", "win32", "linux", "ios", "ohos"];
+  for (const platform of knownPlatforms) {
+    if (value === platform) return { platform, arch: null };
+    const prefix = `${platform}-`;
+    if (value.startsWith(prefix)) {
+      return { platform, arch: value.slice(prefix.length) || null };
+    }
+  }
+  return { platform: value, arch: null };
+}
+
+export function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function rolloutBucket(releaseId: string, key: string): number {
+  return fnv1a32(`${releaseId}:${key}`) % 100;
+}
+
+export function rolloutIncludes(
+  releaseId: string,
+  cohortCount: number | null,
+  key: string | null,
+): boolean {
+  if (cohortCount === null || cohortCount === undefined) return true;
+  if (cohortCount >= 100) return true;
+  if (cohortCount <= 0 || !key) return false;
+  return rolloutBucket(releaseId, key) < cohortCount;
+}

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -28,14 +28,14 @@ import { encryptAdminRaftToken } from "../lib/admin_raft_token";
 const LOGIN_PENDING_COOKIE = "quiver_raft_login_pending";
 const LOGIN_RETURN_COOKIE = "quiver_raft_return";
 
-type RaftTokenResponse = {
+export type RaftTokenResponse = {
   access_token: string;
   token_type: "Bearer";
   expires_in: number;
   scope: string;
 };
 
-type RaftUserinfo = {
+export type RaftUserinfo = {
   sub: string;
   type: "human" | "agent";
   scope: string;
@@ -96,7 +96,7 @@ function browserReturnUrl(
     : returnPath;
 }
 
-function requireRaftConfig(c: Context<{ Bindings: Env }>) {
+export function requireRaftConfig(c: Context<{ Bindings: Env }>) {
   const clientId = c.env.RAFT_CLIENT_ID;
   const clientSecret = c.env.RAFT_CLIENT_SECRET;
   const raftOrigin = c.env.RAFT_ORIGIN;
@@ -234,7 +234,7 @@ function slugifyOrgPart(value: string): string {
   );
 }
 
-function isUserAllowed(env: Env, userinfo: RaftUserinfo): boolean {
+export function isUserAllowed(env: Env, userinfo: RaftUserinfo): boolean {
   const serverIds = (env.RAFT_ALLOWED_SERVER_IDS || "")
     .split(",")
     .map((v) => v.trim())
@@ -250,7 +250,7 @@ function isUserAllowed(env: Env, userinfo: RaftUserinfo): boolean {
   );
 }
 
-async function exchangeRaftCode(
+export async function exchangeRaftCode(
   apiOrigin: string,
   clientId: string,
   clientSecret: string,
@@ -275,7 +275,7 @@ async function exchangeRaftCode(
   return response.json() as Promise<RaftTokenResponse>;
 }
 
-async function fetchRaftUserinfo(
+export async function fetchRaftUserinfo(
   apiOrigin: string,
   accessToken: string,
 ): Promise<RaftUserinfo> {
@@ -291,7 +291,7 @@ async function fetchRaftUserinfo(
   return response.json() as Promise<RaftUserinfo>;
 }
 
-async function upsertRaftAccount(
+export async function upsertRaftAccount(
   db: D1Database,
   userinfo: RaftUserinfo,
 ): Promise<AdminAccount> {

--- a/worker/src/routes/builds.ts
+++ b/worker/src/routes/builds.ts
@@ -107,6 +107,57 @@ interface BuildAssetDownloadRow {
   version_code: number;
 }
 
+interface InstallerAssetIngestionRow {
+  id: string;
+  file_hash: string;
+  size_bytes: number;
+  version_code: number;
+}
+
+const APK_INSPECTOR_VERSION = "android-apksig-34.0.0-v1";
+
+function verifiedApkMetadata(metadata: Record<string, unknown>, asset: InstallerAssetIngestionRow) {
+  const raw = metadata.raw;
+  const lineages = raw && typeof raw === "object"
+    ? (raw as Record<string, unknown>).signer_lineages
+    : null;
+  if (
+    metadata.parser_kind !== "apk-aapt" ||
+    metadata.platform !== "android" ||
+    typeof metadata.package_id !== "string" ||
+    metadata.package_id.length < 1 ||
+    metadata.package_id.length > 255 ||
+    !Number.isInteger(metadata.version_code) ||
+    (metadata.version_code as number) < 0 ||
+    metadata.version_code !== asset.version_code ||
+    metadata.file_hash_sha256 !== asset.file_hash ||
+    metadata.size_bytes !== asset.size_bytes ||
+    !Array.isArray(lineages) ||
+    lineages.length < 1 ||
+    lineages.length > 8
+  ) return null;
+
+  const seen = new Set<string>();
+  const signerLineages: string[][] = [];
+  for (const entry of lineages) {
+    if (!Array.isArray(entry) || entry.length < 1 || entry.length > 16) return null;
+    const lineage: string[] = [];
+    for (const fingerprint of entry) {
+      if (typeof fingerprint !== "string" || !/^[0-9a-f]{64}$/.test(fingerprint)) return null;
+      if (seen.has(fingerprint)) return null;
+      seen.add(fingerprint);
+      lineage.push(fingerprint);
+    }
+    signerLineages.push(lineage);
+  }
+  return {
+    packageId: metadata.package_id,
+    versionCode: metadata.version_code as number,
+    fileHash: metadata.file_hash_sha256 as string,
+    signerLineages,
+  };
+}
+
 function jsonString(value: unknown, fallback: JsonRecord = {}): string {
   if (typeof value === "string") return value;
   return JSON.stringify(value ?? fallback);
@@ -913,11 +964,49 @@ export async function autoParseInstallableAsset(
       icon_content_type?: string | null;
     };
     const { icon_base64, icon_content_type, ...parsed } = metadata;
-    await env.DB.prepare(
+    const now = Date.now();
+    const statements = [env.DB.prepare(
       "UPDATE builds SET parsed_metadata_json = ?1, updated_at = ?2 WHERE id = ?3",
-    )
-      .bind(JSON.stringify(parsed), Date.now(), buildId)
-      .run();
+    ).bind(JSON.stringify(parsed), now, buildId)];
+
+    if (parserKind === "apk-aapt") {
+      const asset = await env.DB.prepare(
+        `SELECT ba.id, ba.file_hash, ba.size_bytes, b.version_code
+         FROM build_assets ba
+         JOIN builds b ON b.id=ba.build_id
+         WHERE ba.build_id=?1 AND b.app_id=?2 AND ba.r2_key=?3
+           AND ba.artifact_kind='installable'
+           AND ba.platform='android' AND ba.filetype='apk'
+         LIMIT 1`,
+      ).bind(buildId, appId, r2Key).first<InstallerAssetIngestionRow>();
+      if (!asset) throw new Error("exact APK asset row not found");
+      const verified = verifiedApkMetadata(metadata, asset);
+      if (!verified) throw new Error("APK inspector metadata does not match exact asset bytes");
+      statements.push(env.DB.prepare(
+        `INSERT INTO installer_asset_metadata
+          (asset_id, platform, filetype, package_id, version_code,
+           signer_lineages_json, inspected_file_hash, inspector_version, inspected_at)
+         VALUES (?1, 'android', 'apk', ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(asset_id) DO UPDATE SET
+           platform=excluded.platform,
+           filetype=excluded.filetype,
+           package_id=excluded.package_id,
+           version_code=excluded.version_code,
+           signer_lineages_json=excluded.signer_lineages_json,
+           inspected_file_hash=excluded.inspected_file_hash,
+           inspector_version=excluded.inspector_version,
+           inspected_at=excluded.inspected_at`,
+      ).bind(
+        asset.id,
+        verified.packageId,
+        verified.versionCode,
+        JSON.stringify(verified.signerLineages),
+        verified.fileHash,
+        APK_INSPECTOR_VERSION,
+        now,
+      ));
+    }
+    await env.DB.batch(statements);
 
     if (icon_base64) {
       const iconBytes = Uint8Array.from(atob(icon_base64), (ch) => ch.charCodeAt(0));
@@ -930,7 +1019,6 @@ export async function autoParseInstallableAsset(
       const hash = Array.from(new Uint8Array(digest))
         .map((b) => b.toString(16).padStart(2, "0"))
         .join("");
-      const now = Date.now();
       await env.DB.batch([
         env.DB.prepare(
           "DELETE FROM build_assets WHERE build_id = ?1 AND artifact_kind = 'app-icon'",

--- a/worker/src/routes/installer.ts
+++ b/worker/src/routes/installer.ts
@@ -29,7 +29,11 @@ type InstallerAsset = {
   size_bytes: number;
   package_id: string;
   version_code: number;
-  signer_fingerprint: string;
+  signer_lineages: string[][];
+};
+
+type InstallerAssetRow = Omit<InstallerAsset, "signer_lineages"> & {
+  signer_lineages_json: string;
 };
 
 type InstallOffer = {
@@ -58,6 +62,30 @@ function pageLimit(c: InstallerContext): number | null {
 
 function timestamp(value: number): string {
   return new Date(value).toISOString();
+}
+
+function parseSignerLineages(value: string): string[][] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length < 1 || parsed.length > 8) return null;
+  const seen = new Set<string>();
+  const lineages: string[][] = [];
+  for (const entry of parsed) {
+    if (!Array.isArray(entry) || entry.length < 1 || entry.length > 16) return null;
+    const lineage: string[] = [];
+    for (const fingerprint of entry) {
+      if (typeof fingerprint !== "string" || !/^[0-9a-f]{64}$/.test(fingerprint)) return null;
+      if (seen.has(fingerprint)) return null;
+      seen.add(fingerprint);
+      lineage.push(fingerprint);
+    }
+    lineages.push(lineage);
+  }
+  return lineages;
 }
 
 async function visibleApp(db: D1Database, appId: string): Promise<VisibleApp | null> {
@@ -102,16 +130,23 @@ async function resolveOffer(
     if (!build) continue;
     const assets = await db.prepare(
       `SELECT ba.id, ba.platform, ba.arch, ba.filetype, ba.r2_key, ba.file_hash,
-              ba.size_bytes, m.package_id, m.version_code, m.signer_fingerprint
+              ba.size_bytes, m.package_id, m.version_code, m.signer_lineages_json
        FROM build_assets ba
        JOIN installer_asset_metadata m ON m.asset_id=ba.id
        WHERE ba.build_id=?1 AND ba.artifact_kind='installable'
          AND ba.file_hash=m.inspected_file_hash
          AND m.package_id=?2 AND m.version_code=?3`,
     ).bind(candidate.build_id, app.installer_package_id, build.version_code)
-      .all<InstallerAsset>();
+      .all<InstallerAssetRow>();
+    const verifiedAssets: InstallerAsset[] = [];
+    for (const row of assets.results) {
+      const signerLineages = parseSignerLineages(row.signer_lineages_json);
+      if (!signerLineages) continue;
+      const { signer_lineages_json: _storedLineages, ...asset } = row;
+      verifiedAssets.push({ ...asset, signer_lineages: signerLineages });
+    }
     const filetype = app.platform === "android" ? "apk" : "hap";
-    const asset = selectBestAsset(assets.results, { platform: app.platform, arch: null, filetype });
+    const asset = selectBestAsset(verifiedAssets, { platform: app.platform, arch: null, filetype });
     if (!asset || asset.platform !== app.platform || asset.filetype !== filetype) continue;
     return {
       releaseId: candidate.id,
@@ -341,7 +376,7 @@ export async function handleInstallerManifest(c: InstallerContext) {
       filetype: offer.asset.filetype,
       size_bytes: offer.asset.size_bytes,
       sha256: offer.asset.file_hash,
-      signer_fingerprint: offer.asset.signer_fingerprint,
+      signer_lineages: offer.asset.signer_lineages,
       download_url: downloadUrl,
       expires_at: new Date(expiresAt).toISOString(),
     },

--- a/worker/src/routes/installer.ts
+++ b/worker/src/routes/installer.ts
@@ -1,0 +1,349 @@
+import type { Context } from "hono";
+import { encodeInstallerCursor, decodeInstallerCursor } from "../lib/installer_cursor";
+import type { InstallerVariables } from "../lib/installer_auth";
+import {
+  loadActiveReleaseCandidates,
+  rolloutIncludes,
+  selectBestAsset,
+} from "../lib/release_resolver";
+import { generateSignedR2Url } from "./public_v2";
+
+type InstallerContext = Context<{ Bindings: Env; Variables: InstallerVariables }>;
+
+type VisibleApp = {
+  id: string;
+  slug: string;
+  name: string;
+  platform: "android" | "ohos";
+  installer_package_id: string;
+  installer_publisher_name: string;
+};
+
+type InstallerAsset = {
+  id: string;
+  platform: string;
+  arch: string | null;
+  filetype: string;
+  r2_key: string;
+  file_hash: string;
+  size_bytes: number;
+  package_id: string;
+  version_code: number;
+  signer_fingerprint: string;
+};
+
+type InstallOffer = {
+  releaseId: string;
+  channel: string;
+  version: string;
+  versionCode: number;
+  asset: InstallerAsset;
+};
+
+function noStore(c: InstallerContext) {
+  c.header("cache-control", "no-store");
+}
+
+function appNotFound(c: InstallerContext) {
+  return c.json({ error: "app not found", code: "app_not_found" }, 404);
+}
+
+function pageLimit(c: InstallerContext): number | null {
+  const raw = c.req.query("limit");
+  if (!raw) return 50;
+  if (!/^[1-9][0-9]{0,2}$/.test(raw)) return null;
+  const value = Number(raw);
+  return value <= 100 ? value : null;
+}
+
+function timestamp(value: number): string {
+  return new Date(value).toISOString();
+}
+
+async function visibleApp(db: D1Database, appId: string): Promise<VisibleApp | null> {
+  return db.prepare(
+    `SELECT id, slug, name, platform, installer_package_id, installer_publisher_name
+     FROM apps
+     WHERE id=?1 AND archived=0 AND public_history=1 AND installer_catalog_public=1
+       AND platform IN ('android','ohos')
+       AND installer_package_id IS NOT NULL AND installer_publisher_name IS NOT NULL
+     LIMIT 1`,
+  ).bind(appId).first<VisibleApp>();
+}
+
+async function resolveOffer(
+  db: D1Database,
+  accountId: string,
+  app: VisibleApp,
+  channelSlug: string,
+): Promise<InstallOffer | null> {
+  const channel = await db.prepare(
+    "SELECT id, slug FROM channels WHERE app_id=?1 AND slug=?2 LIMIT 1",
+  ).bind(app.id, channelSlug).first<{ id: string; slug: string }>();
+  if (!channel) return null;
+  const candidates = await loadActiveReleaseCandidates(db, {
+    appId: app.id,
+    channelId: channel.id,
+  });
+  const rolloutKey = `${accountId}:${app.id}:${channel.id}`;
+  for (const candidate of candidates) {
+    if (!rolloutIncludes(candidate.id, candidate.rollout_cohort_count, rolloutKey)) continue;
+    const scope = await db.prepare(
+      `SELECT 1 AS ok FROM release_scopes
+       WHERE release_id=?1 AND (
+         (scope_type='full' AND scope_value='all') OR
+         (scope_type='platform' AND instr(',' || scope_value || ',', ',' || ?2 || ',') > 0)
+       ) LIMIT 1`,
+    ).bind(candidate.id, app.platform).first<{ ok: number }>();
+    if (!scope) continue;
+    const build = await db.prepare(
+      "SELECT version_name, version_code FROM builds WHERE id=?1 AND app_id=?2 LIMIT 1",
+    ).bind(candidate.build_id, app.id).first<{ version_name: string; version_code: number }>();
+    if (!build) continue;
+    const assets = await db.prepare(
+      `SELECT ba.id, ba.platform, ba.arch, ba.filetype, ba.r2_key, ba.file_hash,
+              ba.size_bytes, m.package_id, m.version_code, m.signer_fingerprint
+       FROM build_assets ba
+       JOIN installer_asset_metadata m ON m.asset_id=ba.id
+       WHERE ba.build_id=?1 AND ba.artifact_kind='installable'
+         AND ba.file_hash=m.inspected_file_hash
+         AND m.package_id=?2 AND m.version_code=?3`,
+    ).bind(candidate.build_id, app.installer_package_id, build.version_code)
+      .all<InstallerAsset>();
+    const filetype = app.platform === "android" ? "apk" : "hap";
+    const asset = selectBestAsset(assets.results, { platform: app.platform, arch: null, filetype });
+    if (!asset || asset.platform !== app.platform || asset.filetype !== filetype) continue;
+    return {
+      releaseId: candidate.id,
+      channel: channel.slug,
+      version: build.version_name,
+      versionCode: build.version_code,
+      asset,
+    };
+  }
+  return null;
+}
+
+export async function handleInstallerCatalog(c: InstallerContext) {
+  noStore(c);
+  const limit = pageLimit(c);
+  if (!limit) return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+  const account = c.get("installer_account");
+  const after = await decodeInstallerCursor(c.env, c.req.query("cursor"), {
+    kind: "catalog", account: account.id,
+  });
+  if (after === undefined) return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+
+  const apps: Array<{
+    id: string; slug: string; name: string; publisher: string; platform: string;
+    package_id: string; channels: Array<{ name: string; latest_version: string; latest_version_code: number }>;
+  }> = [];
+  let scanAfter = after || "";
+  let exhausted = false;
+  while (apps.length <= limit && !exhausted) {
+    const rows = await c.env.DB.prepare(
+      `SELECT id, slug, name, platform, installer_package_id, installer_publisher_name
+       FROM apps
+       WHERE archived=0 AND public_history=1 AND installer_catalog_public=1
+         AND platform IN ('android','ohos') AND id>?1
+       ORDER BY id ASC LIMIT 100`,
+    ).bind(scanAfter).all<VisibleApp>();
+    exhausted = rows.results.length < 100;
+    for (const app of rows.results) {
+      scanAfter = app.id;
+      const channels = await c.env.DB.prepare(
+        "SELECT slug FROM channels WHERE app_id=?1 ORDER BY slug ASC LIMIT 33",
+      ).bind(app.id).all<{ slug: string }>();
+      const admitted = [];
+      for (const channel of channels.results.slice(0, 32)) {
+        const offer = await resolveOffer(c.env.DB, account.id, app, channel.slug);
+        if (offer) admitted.push({
+          name: channel.slug,
+          latest_version: offer.version,
+          latest_version_code: offer.versionCode,
+        });
+      }
+      if (admitted.length) apps.push({
+        id: app.id,
+        slug: app.slug,
+        name: app.name,
+        publisher: app.installer_publisher_name,
+        platform: app.platform,
+        package_id: app.installer_package_id,
+        channels: admitted,
+      });
+      if (apps.length > limit) break;
+    }
+    if (rows.results.length === 0) exhausted = true;
+  }
+  const hasMore = apps.length > limit;
+  if (hasMore) apps.pop();
+  const nextCursor = hasMore
+    ? await encodeInstallerCursor(c.env, {
+      v: 1, kind: "catalog", account: account.id, after: apps[apps.length - 1]!.id,
+    })
+    : null;
+  return c.json({ schema: "hands-installer-catalog.v1", apps, next_cursor: nextCursor });
+}
+
+async function subscriptionPage(c: InstallerContext, after: string, limit: number) {
+  const account = c.get("installer_account");
+  const rows = await c.env.DB.prepare(
+    `SELECT s.id, s.app_id, ch.slug AS channel, s.auto_download, s.revision,
+            s.created_at, s.updated_at
+     FROM installer_subscriptions s
+     JOIN apps a ON a.id=s.app_id AND a.archived=0 AND a.public_history=1
+       AND a.installer_catalog_public=1
+     JOIN channels ch ON ch.id=s.channel_id
+     WHERE s.account_id=?1 AND s.deleted_at IS NULL AND s.id>?2
+     ORDER BY s.id ASC LIMIT ?3`,
+  ).bind(account.id, after, limit + 1).all<{
+    id: string; app_id: string; channel: string; auto_download: number; revision: number;
+    created_at: number; updated_at: number;
+  }>();
+  const hasMore = rows.results.length > limit;
+  const records = rows.results.slice(0, limit).map((row) => ({
+    id: row.id,
+    app_id: row.app_id,
+    channel: row.channel,
+    auto_download: row.auto_download === 1,
+    revision: row.revision,
+    created_at: timestamp(row.created_at),
+    updated_at: timestamp(row.updated_at),
+  }));
+  const nextCursor = hasMore
+    ? await encodeInstallerCursor(c.env, {
+      v: 1, kind: "subscriptions", account: account.id, after: records[records.length - 1]!.id,
+    })
+    : null;
+  return { schema: "hands-installer-subscriptions.v1", subscriptions: records, next_cursor: nextCursor };
+}
+
+export async function handleInstallerSubscriptions(c: InstallerContext) {
+  noStore(c);
+  const limit = pageLimit(c);
+  if (!limit) return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+  const account = c.get("installer_account");
+  const after = await decodeInstallerCursor(c.env, c.req.query("cursor"), {
+    kind: "subscriptions", account: account.id,
+  });
+  if (after === undefined) return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+  return c.json(await subscriptionPage(c, after || "", limit));
+}
+
+async function subscriptionTarget(c: InstallerContext) {
+  const app = await visibleApp(c.env.DB, c.req.param("appId") ?? "");
+  if (!app) return null;
+  const offer = await resolveOffer(c.env.DB, c.get("installer_account").id, app, c.req.param("channel") ?? "");
+  if (!offer) return null;
+  const channel = await c.env.DB.prepare(
+    "SELECT id FROM channels WHERE app_id=?1 AND slug=?2 LIMIT 1",
+  ).bind(app.id, offer.channel).first<{ id: string }>();
+  return channel ? { app, offer, channelId: channel.id } : null;
+}
+
+export async function handlePutInstallerSubscription(c: InstallerContext) {
+  noStore(c);
+  const target = await subscriptionTarget(c);
+  if (!target) return appNotFound(c);
+  let body: { auto_download?: unknown; expected_revision?: unknown };
+  try { body = await c.req.json(); } catch { body = {}; }
+  if (typeof body.auto_download !== "boolean" ||
+      !(body.expected_revision === null || Number.isInteger(body.expected_revision))) {
+    return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+  }
+  const account = c.get("installer_account");
+  const now = Date.now();
+  if (body.expected_revision === null) {
+    const result = await c.env.DB.prepare(
+      `INSERT INTO installer_subscriptions
+       (id, account_id, app_id, channel_id, auto_download, revision, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?6)
+       ON CONFLICT(account_id, app_id, channel_id) DO UPDATE SET
+         auto_download=excluded.auto_download,
+         revision=installer_subscriptions.revision+1,
+         updated_at=excluded.updated_at,
+         deleted_at=NULL
+       WHERE installer_subscriptions.deleted_at IS NOT NULL`,
+    ).bind(crypto.randomUUID(), account.id, target.app.id, target.channelId,
+      body.auto_download ? 1 : 0, now).run();
+    if (result.meta.changes !== 1) {
+      return c.json({ error: "subscription conflict", code: "subscription_conflict" }, 409);
+    }
+  } else {
+    const result = await c.env.DB.prepare(
+      `UPDATE installer_subscriptions
+       SET auto_download=?1, revision=revision+1, updated_at=?2, deleted_at=NULL
+       WHERE account_id=?3 AND app_id=?4 AND channel_id=?5
+         AND deleted_at IS NULL AND revision=?6`,
+    ).bind(body.auto_download ? 1 : 0, now, account.id, target.app.id,
+      target.channelId, body.expected_revision).run();
+    if (result.meta.changes !== 1) {
+      return c.json({ error: "subscription conflict", code: "subscription_conflict" }, 409);
+    }
+  }
+  return c.json(await subscriptionPage(c, "", 100));
+}
+
+export async function handleDeleteInstallerSubscription(c: InstallerContext) {
+  noStore(c);
+  const target = await subscriptionTarget(c);
+  if (!target) return appNotFound(c);
+  let body: { expected_revision?: unknown };
+  try { body = await c.req.json(); } catch { body = {}; }
+  if (!Number.isInteger(body.expected_revision)) {
+    return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+  }
+  const result = await c.env.DB.prepare(
+    `UPDATE installer_subscriptions
+     SET revision=revision+1, updated_at=?1, deleted_at=?1
+     WHERE account_id=?2 AND app_id=?3 AND channel_id=?4
+       AND deleted_at IS NULL AND revision=?5`,
+  ).bind(Date.now(), c.get("installer_account").id, target.app.id, target.channelId,
+    body.expected_revision).run();
+  if (result.meta.changes !== 1) {
+    return c.json({ error: "subscription conflict", code: "subscription_conflict" }, 409);
+  }
+  return c.json(await subscriptionPage(c, "", 100));
+}
+
+export async function handleInstallerManifest(c: InstallerContext) {
+  noStore(c);
+  const app = await visibleApp(c.env.DB, c.req.param("appId") ?? "");
+  if (!app) return appNotFound(c);
+  const offer = await resolveOffer(
+    c.env.DB, c.get("installer_account").id, app, c.req.param("channel") ?? "",
+  );
+  if (!offer) return appNotFound(c);
+  const ttlSeconds = Math.min(2 * 60 * 60, Math.max(60,
+    Number(c.env.SIGNED_URL_TTL_SECONDS || "3600")));
+  const expiresAt = Date.now() + ttlSeconds * 1000;
+  const downloadUrl = await generateSignedR2Url(
+    c.env, offer.asset.r2_key, ttlSeconds, new URL(c.req.url).origin,
+  );
+  return c.json({
+    schema: "hands-installer-manifest.v1",
+    app: {
+      slug: app.slug,
+      publisher: app.installer_publisher_name,
+      platform: app.platform,
+      package_id: app.installer_package_id,
+    },
+    release: {
+      id: offer.releaseId,
+      channel: offer.channel,
+      version: offer.version,
+      version_code: offer.versionCode,
+    },
+    asset: {
+      id: offer.asset.id,
+      platform: offer.asset.platform,
+      filetype: offer.asset.filetype,
+      size_bytes: offer.asset.size_bytes,
+      sha256: offer.asset.file_hash,
+      signer_fingerprint: offer.asset.signer_fingerprint,
+      download_url: downloadUrl,
+      expires_at: new Date(expiresAt).toISOString(),
+    },
+  });
+}

--- a/worker/src/routes/installer_auth.ts
+++ b/worker/src/routes/installer_auth.ts
@@ -1,0 +1,318 @@
+import type { Context } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { businessOrigin, isSecureRequest, requestOrigin } from "../lib/origin";
+import {
+  INSTALLER_ACCESS_TTL_MS,
+  INSTALLER_CLIENT_ID,
+  INSTALLER_REFRESH_TTL_MS,
+  configuredInstallerRedirectUris,
+  isAllowedRedirectUri,
+  isPkceChallenge,
+  isPkceVerifier,
+  pkceChallenge,
+  randomOpaqueToken,
+  sha256Hex,
+} from "../lib/installer_auth";
+import {
+  exchangeRaftCode,
+  fetchRaftUserinfo,
+  isUserAllowed,
+  requireRaftConfig,
+  upsertRaftAccount,
+} from "./auth";
+
+const LOGIN_COOKIE = "hands_installer_login";
+const LOGIN_REQUEST_TTL_MS = 10 * 60 * 1000;
+const LOGIN_CODE_TTL_MS = 2 * 60 * 1000;
+
+type JsonObject = Record<string, unknown>;
+
+function noStore(c: Context) {
+  c.header("cache-control", "no-store");
+}
+
+async function jsonBody(c: Context): Promise<JsonObject | null> {
+  try {
+    const value = await c.req.json();
+    return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function handleInstallerLogin(c: Context<{ Bindings: Env }>) {
+  noStore(c);
+  const config = requireRaftConfig(c);
+  if (!config.ok) return config.response;
+  const clientId = c.req.query("client_id") || "";
+  const redirectUri = c.req.query("redirect_uri") || "";
+  const challenge = c.req.query("code_challenge") || "";
+  const method = c.req.query("code_challenge_method") || "";
+  const state = c.req.query("state") || "";
+  if (clientId !== INSTALLER_CLIENT_ID ||
+      !isAllowedRedirectUri(redirectUri, configuredInstallerRedirectUris(c.env)) ||
+      method !== "S256" || !isPkceChallenge(challenge) ||
+      !/^[A-Za-z0-9._~-]{16,200}$/.test(state)) {
+    return c.json({ error: "invalid authorization request", code: "invalid_request" }, 400);
+  }
+
+  const timestamp = Date.now();
+  const requestId = crypto.randomUUID();
+  await c.env.DB.prepare(
+    `INSERT INTO installer_login_requests
+     (id, client_id, redirect_uri, state, code_challenge, code_challenge_method,
+      created_at, expires_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, 'S256', ?6, ?7)`,
+  ).bind(requestId, clientId, redirectUri, state, challenge, timestamp,
+    timestamp + LOGIN_REQUEST_TTL_MS).run();
+  setCookie(c, LOGIN_COOKIE, requestId, {
+    httpOnly: true,
+    secure: isSecureRequest(c),
+    sameSite: "Lax",
+    path: "/login/raft/installer/callback",
+    maxAge: LOGIN_REQUEST_TTL_MS / 1000,
+  });
+
+  const setup = new URL("/login-with-raft/setup", config.raftOrigin);
+  setup.searchParams.set("client_id", config.clientId);
+  setup.searchParams.set("return_to", `${businessOrigin(c.env, () => requestOrigin(c))}/login/raft/installer/callback`);
+  setup.searchParams.set("scope", "openid profile");
+  noStore(c);
+  return c.redirect(setup.toString(), 302);
+}
+
+export async function handleInstallerRaftCallback(c: Context<{ Bindings: Env }>) {
+  noStore(c);
+  const config = requireRaftConfig(c);
+  if (!config.ok) return config.response;
+  const raftCode = c.req.query("code") || "";
+  const requestId = getCookie(c, LOGIN_COOKIE) || "";
+  if (!raftCode || !requestId) return c.text("Installer login state is missing or expired.", 400);
+  const timestamp = Date.now();
+  const pending = await c.env.DB.prepare(
+    `SELECT id, client_id, redirect_uri, state, code_challenge
+     FROM installer_login_requests WHERE id=?1 AND expires_at>?2 LIMIT 1`,
+  ).bind(requestId, timestamp).first<{
+    id: string; client_id: string; redirect_uri: string; state: string; code_challenge: string;
+  }>();
+  if (!pending) return c.text("Installer login state is missing or expired.", 400);
+
+  try {
+    const token = await exchangeRaftCode(
+      config.raftApiOrigin, config.clientId, config.clientSecret, raftCode,
+    );
+    const userinfo = await fetchRaftUserinfo(config.raftApiOrigin, token.access_token);
+    if (userinfo.type !== "human" || !isUserAllowed(c.env, userinfo)) {
+      return c.text("Hands Installer login is available to allowed human accounts only.", 403);
+    }
+    const account = await upsertRaftAccount(c.env.DB, userinfo);
+    const authorizationCode = randomOpaqueToken();
+    const codeHash = await sha256Hex(authorizationCode);
+    const results = await c.env.DB.batch([
+      c.env.DB.prepare(
+        `INSERT INTO installer_login_codes
+         (id, code_hash, account_id, client_id, redirect_uri, state, code_challenge,
+          code_challenge_method, created_at, expires_at)
+         SELECT ?1, ?2, ?3, client_id, redirect_uri, state, code_challenge,
+                'S256', ?4, ?5
+         FROM installer_login_requests WHERE id=?6 AND expires_at>?4`,
+      ).bind(crypto.randomUUID(), codeHash, account.id, timestamp,
+        timestamp + LOGIN_CODE_TTL_MS, pending.id),
+      c.env.DB.prepare("DELETE FROM installer_login_requests WHERE id=?1").bind(pending.id),
+    ]);
+    if (results.some((result) => result.meta.changes !== 1)) {
+      return c.text("Installer login state is missing or expired.", 400);
+    }
+    deleteCookie(c, LOGIN_COOKIE, { path: "/login/raft/installer/callback" });
+    const destination = new URL(pending.redirect_uri);
+    destination.searchParams.set("code", authorizationCode);
+    destination.searchParams.set("state", pending.state);
+    noStore(c);
+    return c.redirect(destination.toString(), 302);
+  } catch (error) {
+    console.error(`[installer-auth] callback failed: ${error instanceof Error ? error.message : String(error)}`);
+    return c.text("Hands Installer login failed.", 502);
+  }
+}
+
+export async function handleInstallerToken(c: Context<{ Bindings: Env }>) {
+  noStore(c);
+  const body = await jsonBody(c);
+  if (!body) return c.json({ error: "invalid request", code: "invalid_request" }, 400);
+  const grantType = body.grant_type;
+  if (grantType === "authorization_code") return exchangeAuthorizationCode(c, body);
+  if (grantType === "refresh_token") return rotateRefreshToken(c, body);
+  return c.json({ error: "unsupported grant type", code: "invalid_request" }, 400);
+}
+
+async function exchangeAuthorizationCode(
+  c: Context<{ Bindings: Env }>, body: JsonObject,
+) {
+  const code = typeof body.code === "string" ? body.code : "";
+  const verifier = typeof body.code_verifier === "string" ? body.code_verifier : "";
+  const clientId = typeof body.client_id === "string" ? body.client_id : "";
+  const redirectUri = typeof body.redirect_uri === "string" ? body.redirect_uri : "";
+  if (!code || !isPkceVerifier(verifier) || clientId !== INSTALLER_CLIENT_ID ||
+      !isAllowedRedirectUri(redirectUri, configuredInstallerRedirectUris(c.env))) {
+    return c.json({ error: "invalid authorization code", code: "invalid_grant" }, 400);
+  }
+  const codeHash = await sha256Hex(code);
+  const challenge = await pkceChallenge(verifier);
+  const timestamp = Date.now();
+  const row = await c.env.DB.prepare(
+    `SELECT id, account_id FROM installer_login_codes
+     WHERE code_hash=?1 AND client_id=?2 AND redirect_uri=?3 AND code_challenge=?4
+       AND consumed_at IS NULL AND expires_at>?5 LIMIT 1`,
+  ).bind(codeHash, clientId, redirectUri, challenge, timestamp)
+    .first<{ id: string; account_id: string }>();
+  if (!row) return c.json({ error: "invalid authorization code", code: "invalid_grant" }, 400);
+
+  const attempt = crypto.randomUUID();
+  const familyId = crypto.randomUUID();
+  const refreshId = crypto.randomUUID();
+  const accessId = crypto.randomUUID();
+  const refreshToken = randomOpaqueToken();
+  const accessToken = randomOpaqueToken();
+  const refreshHash = await sha256Hex(refreshToken);
+  const accessHash = await sha256Hex(accessToken);
+  const results = await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO installer_refresh_tokens
+       (id, family_id, account_id, client_id, token_hash, created_at, expires_at)
+       SELECT ?1, ?2, account_id, client_id, ?3, ?4, ?5
+       FROM installer_login_codes
+       WHERE id=?6 AND consumed_at IS NULL AND expires_at>?4`,
+    ).bind(refreshId, familyId, refreshHash, timestamp,
+      timestamp + INSTALLER_REFRESH_TTL_MS, row.id),
+    c.env.DB.prepare(
+      `INSERT INTO installer_access_tokens
+       (id, account_id, client_id, token_hash, family_id, created_at, expires_at)
+       SELECT ?1, account_id, client_id, ?2, family_id, ?3, ?4
+       FROM installer_refresh_tokens WHERE id=?5`,
+    ).bind(accessId, accessHash, timestamp, timestamp + INSTALLER_ACCESS_TTL_MS, refreshId),
+    c.env.DB.prepare(
+      `UPDATE installer_login_codes SET consumed_at=?1, consumed_by=?2
+       WHERE id=?3 AND consumed_at IS NULL AND EXISTS
+         (SELECT 1 FROM installer_refresh_tokens WHERE id=?4)`,
+    ).bind(timestamp, attempt, row.id, refreshId),
+  ]);
+  if (results.some((result) => result.meta.changes !== 1)) {
+    return c.json({ error: "invalid authorization code", code: "invalid_grant" }, 400);
+  }
+  noStore(c);
+  return c.json({
+    token_type: "Bearer",
+    access_token: accessToken,
+    expires_in: Math.floor(INSTALLER_ACCESS_TTL_MS / 1000),
+    refresh_token: refreshToken,
+    refresh_expires_in: Math.floor(INSTALLER_REFRESH_TTL_MS / 1000),
+  });
+}
+
+async function rotateRefreshToken(c: Context<{ Bindings: Env }>, body: JsonObject) {
+  const token = typeof body.refresh_token === "string" ? body.refresh_token : "";
+  const clientId = typeof body.client_id === "string" ? body.client_id : "";
+  if (!token || clientId !== INSTALLER_CLIENT_ID) {
+    return c.json({ error: "invalid refresh token", code: "invalid_grant" }, 400);
+  }
+  const hash = await sha256Hex(token);
+  const timestamp = Date.now();
+  const current = await c.env.DB.prepare(
+    `SELECT id, family_id, account_id, client_id, expires_at, consumed_at, revoked_at
+     FROM installer_refresh_tokens WHERE token_hash=?1 LIMIT 1`,
+  ).bind(hash).first<{
+    id: string; family_id: string; account_id: string; client_id: string;
+    expires_at: number; consumed_at: number | null; revoked_at: number | null;
+  }>();
+  if (!current || current.client_id !== clientId || current.expires_at <= timestamp || current.revoked_at) {
+    return c.json({ error: "invalid refresh token", code: "invalid_grant" }, 400);
+  }
+  if (current.consumed_at) {
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        "UPDATE installer_refresh_tokens SET revoked_at=?1 WHERE family_id=?2 AND revoked_at IS NULL",
+      ).bind(timestamp, current.family_id),
+      c.env.DB.prepare(
+        "UPDATE installer_access_tokens SET revoked_at=?1 WHERE family_id=?2 AND revoked_at IS NULL",
+      ).bind(timestamp, current.family_id),
+    ]);
+    return c.json({ error: "invalid refresh token", code: "invalid_grant" }, 400);
+  }
+
+  const successorId = crypto.randomUUID();
+  const accessId = crypto.randomUUID();
+  const successor = randomOpaqueToken();
+  const accessToken = randomOpaqueToken();
+  const successorHash = await sha256Hex(successor);
+  const accessHash = await sha256Hex(accessToken);
+  const accessExpiresAt = Math.min(timestamp + INSTALLER_ACCESS_TTL_MS, current.expires_at);
+  const results = await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO installer_refresh_tokens
+       (id, family_id, account_id, client_id, token_hash, created_at, expires_at)
+       SELECT ?1, family_id, account_id, client_id, ?2, ?3, expires_at
+       FROM installer_refresh_tokens
+       WHERE id=?4 AND consumed_at IS NULL AND revoked_at IS NULL AND expires_at>?3`,
+    ).bind(successorId, successorHash, timestamp, current.id),
+    c.env.DB.prepare(
+      `INSERT INTO installer_access_tokens
+       (id, account_id, client_id, token_hash, family_id, created_at, expires_at)
+       SELECT ?1, account_id, client_id, ?2, family_id, ?3, ?4
+       FROM installer_refresh_tokens WHERE id=?5`,
+    ).bind(accessId, accessHash, timestamp, accessExpiresAt, successorId),
+    c.env.DB.prepare(
+      `UPDATE installer_access_tokens SET revoked_at=?1
+       WHERE family_id=?2 AND id<>?3 AND revoked_at IS NULL`,
+    ).bind(timestamp, current.family_id, accessId),
+    c.env.DB.prepare(
+      `UPDATE installer_refresh_tokens
+       SET consumed_at=?1, consumed_by=?2, replaced_by_id=?2
+       WHERE id=?3 AND consumed_at IS NULL AND EXISTS
+         (SELECT 1 FROM installer_refresh_tokens WHERE id=?2)`,
+    ).bind(timestamp, successorId, current.id),
+  ]);
+  if (results[0]?.meta.changes !== 1 || results[1]?.meta.changes !== 1 ||
+      results[3]?.meta.changes !== 1) {
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        "UPDATE installer_refresh_tokens SET revoked_at=?1 WHERE family_id=?2 AND revoked_at IS NULL",
+      ).bind(timestamp, current.family_id),
+      c.env.DB.prepare(
+        "UPDATE installer_access_tokens SET revoked_at=?1 WHERE family_id=?2 AND revoked_at IS NULL",
+      ).bind(timestamp, current.family_id),
+    ]);
+    return c.json({ error: "invalid refresh token", code: "invalid_grant" }, 400);
+  }
+  noStore(c);
+  return c.json({
+    token_type: "Bearer",
+    access_token: accessToken,
+    expires_in: Math.max(1, Math.floor((accessExpiresAt - timestamp) / 1000)),
+    refresh_token: successor,
+    refresh_expires_in: Math.max(0, Math.floor((current.expires_at - timestamp) / 1000)),
+  });
+}
+
+export async function handleInstallerLogout(c: Context<{ Bindings: Env }>) {
+  noStore(c);
+  const body = await jsonBody(c);
+  const token = body && typeof body.refresh_token === "string" ? body.refresh_token : "";
+  if (!token) return c.json({ ok: true });
+  const hash = await sha256Hex(token);
+  const timestamp = Date.now();
+  const row = await c.env.DB.prepare(
+    "SELECT family_id FROM installer_refresh_tokens WHERE token_hash=?1 LIMIT 1",
+  ).bind(hash).first<{ family_id: string }>();
+  if (row) {
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        "UPDATE installer_refresh_tokens SET revoked_at=?1 WHERE family_id=?2 AND revoked_at IS NULL",
+      ).bind(timestamp, row.family_id),
+      c.env.DB.prepare(
+        "UPDATE installer_access_tokens SET revoked_at=?1 WHERE family_id=?2 AND revoked_at IS NULL",
+      ).bind(timestamp, row.family_id),
+    ]);
+  }
+  noStore(c);
+  return c.json({ ok: true });
+}

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -23,6 +23,15 @@ import { requestOrigin } from "../lib/origin";
 import { presignR2DownloadUrl } from "../lib/r2_presign";
 import { parseReleaseNotes, resolveReleaseNote, type ReleaseNotes } from "../lib/release_notes";
 import { isFeatureEnabled } from "../lib/feature_flags";
+import {
+  fnv1a32,
+  loadActiveReleaseCandidates,
+  rolloutBucket,
+  rolloutIncludes,
+  selectBestAsset,
+} from "../lib/release_resolver";
+
+export { fnv1a32, rolloutBucket, rolloutIncludes, selectBestAsset };
 
 interface ScopedResolution {
   release_id: string;
@@ -113,38 +122,11 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
 
   // Candidates: active releases on (channel, [product_type]). No time window:
   // an active release must stay resolvable no matter how old it is.
-  const candidateSql = productType
-    ? `SELECT r.id, r.build_id, r.created_at,
-              COALESCE(r.activated_at, r.created_at) AS activated_at,
-              r.product_type, r.rollout_cohort_count, r.changelog
-       FROM releases r
-       JOIN builds b ON b.id = r.build_id
-       WHERE r.app_id = ?1 AND r.channel_id = ?2 AND r.product_type = ?3
-         AND r.status = 'active'
-         AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
-       ORDER BY COALESCE(r.activated_at, r.created_at) DESC`
-    : `SELECT r.id, r.build_id, r.created_at,
-              COALESCE(r.activated_at, r.created_at) AS activated_at,
-              r.product_type, r.rollout_cohort_count, r.changelog
-       FROM releases r
-       JOIN builds b ON b.id = r.build_id
-       WHERE r.app_id = ?1 AND r.channel_id = ?2
-         AND r.status = 'active'
-         AND b.product_type != 'ios-simulator-qa' AND b.release_type != 'qa'
-       ORDER BY COALESCE(r.activated_at, r.created_at) DESC`;
-  const candidateStmt = c.env.DB.prepare(candidateSql);
-  const allCandidates = await (productType
-    ? candidateStmt.bind(app.id, channelRow.id, productType)
-    : candidateStmt.bind(app.id, channelRow.id)
-  ).all<{
-    id: string;
-    build_id: string;
-    created_at: number;
-    activated_at: number;
-    product_type: string;
-    rollout_cohort_count: number | null;
-    changelog: string | null;
-  }>();
+  const allCandidates = { results: await loadActiveReleaseCandidates(c.env.DB, {
+    appId: app.id,
+    channelId: channelRow.id,
+    productType,
+  }) };
 
   if (allCandidates.results.length === 0) {
     return c.json(
@@ -599,68 +581,6 @@ async function findDeltaPatch(
     size_bytes: row.size_bytes,
     target_sha256: row.target_sha256,
   };
-}
-
-export function selectBestAsset(
-  assets: PublicAssetResponse[],
-  requested: {
-    platform: string | null;
-    arch: string | null;
-    filetype: string;
-  },
-): PublicAssetResponse | null {
-  const filetypeMatches = assets.filter((a) => a.filetype === requested.filetype);
-  if (filetypeMatches.length === 0) return null;
-  const pool = filetypeMatches;
-  const parsed = splitPlatformArch(requested.platform);
-  const platform = parsed.platform;
-  const arch = requested.arch ?? parsed.arch;
-  const platformMatches = platform
-    ? pool.filter((a) => a.platform === platform)
-    : pool;
-  const candidates = platformMatches.length > 0 ? platformMatches : pool;
-  if (arch) {
-    const archMatch = candidates.find((a) => a.arch === arch);
-    if (archMatch) return archMatch;
-  }
-  return candidates.find((a) => a.arch === null) ?? candidates[0] ?? null;
-}
-
-/**
- * Stable 32-bit FNV-1a hash. Deterministic across runtimes so a device keeps
- * the same bucket for a given release while the rollout percentage climbs.
- */
-export function fnv1a32(input: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
-}
-
-/** Bucket in [0, 100). Salted by release id so cohorts reshuffle per release. */
-export function rolloutBucket(releaseId: string, deviceId: string): number {
-  return fnv1a32(`${releaseId}:${deviceId}`) % 100;
-}
-
-/**
- * true when the release should be served to this client.
- * - null / >=100 cohort count: fully rolled out, everyone matches.
- * - gated release + no device id: excluded (legacy clients only get full
- *   releases; they fall through to the previous active release).
- * - gated release + device id: stable bucket must fall under the percentage.
- */
-export function rolloutIncludes(
-  releaseId: string,
-  cohortCount: number | null,
-  deviceId: string | null,
-): boolean {
-  if (cohortCount === null || cohortCount === undefined) return true;
-  if (cohortCount >= 100) return true;
-  if (cohortCount <= 0) return false;
-  if (!deviceId) return false;
-  return rolloutBucket(releaseId, deviceId) < cohortCount;
 }
 
 /**

--- a/worker/test/installer_consumer_migration.test.ts
+++ b/worker/test/installer_consumer_migration.test.ts
@@ -1,0 +1,145 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const migrationDir = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+
+function migratedDatabase() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  for (const name of readdirSync(migrationDir).sort()) {
+    if (!name.endsWith(".sql")) continue;
+    db.exec(readFileSync(`${migrationDir}${name}`, "utf8"));
+  }
+  return db;
+}
+
+function seedIdentity(db: Database.Database) {
+  db.exec(`
+    INSERT INTO raft_accounts
+      (id, provider_subject, server_id, principal_type, display_name, raw_profile,
+       created_at, updated_at, last_login_at)
+    VALUES ('account-1', 'human-1', 'server-1', 'human', 'Human', '{}', 1, 1, 1);
+
+    INSERT INTO apps
+      (id, slug, name, platform, created_at, public_history,
+       installer_catalog_public, installer_package_id, installer_publisher_name)
+    VALUES ('app-1', 'app-1', 'App 1', 'android', 1, 1, 1,
+            'dev.hands.app', 'Hands');
+    INSERT INTO channels (id, app_id, slug, name, created_at)
+    VALUES ('channel-1', 'app-1', 'main', 'Main', 1);
+  `);
+}
+
+describe("migration 0067 — installer consumer", () => {
+  it("only admits explicitly public Android/OHOS apps with package identity", () => {
+    const db = migratedDatabase();
+
+    expect(() => db.exec(`
+      INSERT INTO apps
+        (id, slug, name, platform, created_at, installer_catalog_public)
+      VALUES ('private-app', 'private-app', 'Private', 'android', 1, 1);
+    `)).toThrow(/installer catalog requires public history/);
+
+    db.exec(`
+      INSERT INTO apps (id, slug, name, platform, created_at)
+      VALUES ('app-1', 'app-1', 'App 1', 'android', 1);
+    `);
+    expect(() => db.exec(`
+      UPDATE apps SET installer_catalog_public=1, public_history=1,
+        installer_package_id='dev.hands.app', installer_publisher_name='Hands'
+      WHERE id='app-1';
+    `)).not.toThrow();
+    expect(() => db.exec("UPDATE apps SET public_history=0 WHERE id='app-1'"))
+      .toThrow(/installer catalog requires public history/);
+  });
+
+  it("keeps login and refresh secrets unique and refresh families independently revocable", () => {
+    const db = migratedDatabase();
+    seedIdentity(db);
+
+    db.exec(`
+      INSERT INTO installer_login_codes
+        (id, code_hash, account_id, client_id, redirect_uri, state, code_challenge,
+         code_challenge_method, created_at, expires_at)
+      VALUES ('code-1', 'hash-1', 'account-1', 'client-1', 'hands://callback',
+              'state-1', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'S256', 1, 2);
+      INSERT INTO installer_refresh_tokens
+        (id, family_id, account_id, client_id, token_hash, created_at, expires_at)
+      VALUES ('refresh-1', 'family-1', 'account-1', 'client-1', 'refresh-hash-1', 1, 10);
+    `);
+
+    expect(() => db.exec(`
+      INSERT INTO installer_login_codes
+        (id, code_hash, account_id, client_id, redirect_uri, state, code_challenge,
+         code_challenge_method, created_at, expires_at)
+      VALUES ('code-2', 'hash-1', 'account-1', 'client-1', 'hands://callback',
+              'state-2', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'S256', 1, 2);
+    `)).toThrow(/UNIQUE/);
+    expect(() => db.exec(`
+      INSERT INTO installer_refresh_tokens
+        (id, family_id, account_id, client_id, token_hash, created_at, expires_at)
+      VALUES ('refresh-2', 'family-2', 'account-1', 'client-1', 'refresh-hash-1', 1, 10);
+    `)).toThrow(/UNIQUE/);
+
+    db.exec("UPDATE installer_refresh_tokens SET revoked_at=5 WHERE family_id='family-1'");
+    expect(db.prepare(
+      "SELECT revoked_at FROM installer_refresh_tokens WHERE id='refresh-1'",
+    ).pluck().get()).toBe(5);
+  });
+
+  it("allows one revisioned subscription row per account/app/channel", () => {
+    const db = migratedDatabase();
+    seedIdentity(db);
+    db.exec(`
+      INSERT INTO installer_subscriptions
+        (id, account_id, app_id, channel_id, revision, created_at, updated_at)
+      VALUES ('sub-1', 'account-1', 'app-1', 'channel-1', 1, 1, 1);
+    `);
+    expect(() => db.exec(`
+      INSERT INTO installer_subscriptions
+        (id, account_id, app_id, channel_id, revision, created_at, updated_at)
+      VALUES ('sub-2', 'account-1', 'app-1', 'channel-1', 1, 1, 1);
+    `)).toThrow(/UNIQUE/);
+    expect(() => db.exec("UPDATE installer_subscriptions SET revision=0 WHERE id='sub-1'"))
+      .toThrow(/CHECK/);
+  });
+
+  it("binds inspected metadata to the exact installable asset bytes and build identity", () => {
+    const db = migratedDatabase();
+    seedIdentity(db);
+    db.exec(`
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name,
+         version_code, source, status, created_at, updated_at)
+      VALUES ('build-1', 'app-1', 'channel-1', 'android-apk', 'stable', '1.0.0',
+              100, 'ci', 'succeeded', 1, 1);
+      INSERT INTO build_assets
+        (id, build_id, platform, filetype, r2_key, file_hash, size_bytes,
+         created_at, artifact_kind)
+      VALUES ('asset-1', 'build-1', 'android', 'apk', 'artifact.apk',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              10, 1, 'installable');
+      INSERT INTO installer_asset_metadata
+        (asset_id, platform, filetype, package_id, version_code,
+         signer_fingerprint, inspected_file_hash, inspector_version, inspected_at)
+      VALUES ('asset-1', 'android', 'apk', 'dev.hands.app', 100,
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              'inspector-v1', 2);
+    `);
+
+    expect(() => db.exec(`
+      UPDATE installer_asset_metadata
+      SET inspected_file_hash='cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+      WHERE asset_id='asset-1';
+    `)).toThrow(/must match exact installable asset/);
+    expect(() => db.exec(`
+      UPDATE installer_asset_metadata SET version_code=101 WHERE asset_id='asset-1';
+    `)).toThrow(/must match exact installable asset/);
+    expect(() => db.exec(`
+      UPDATE installer_asset_metadata SET package_id='dev.other' WHERE asset_id='asset-1';
+    `)).toThrow(/must match exact installable asset/);
+  });
+});

--- a/worker/test/installer_consumer_migration.test.ts
+++ b/worker/test/installer_consumer_migration.test.ts
@@ -106,7 +106,7 @@ describe("migration 0067 — installer consumer", () => {
       .toThrow(/CHECK/);
   });
 
-  it("binds inspected metadata to the exact installable asset bytes and build identity", () => {
+  it("binds inspected metadata to exact asset bytes while allowing inspection before opt-in", () => {
     const db = migratedDatabase();
     seedIdentity(db);
     db.exec(`
@@ -123,9 +123,10 @@ describe("migration 0067 — installer consumer", () => {
               10, 1, 'installable');
       INSERT INTO installer_asset_metadata
         (asset_id, platform, filetype, package_id, version_code,
-         signer_fingerprint, inspected_file_hash, inspector_version, inspected_at)
+         signer_lineages_json, inspected_file_hash, inspector_version, inspected_at)
       VALUES ('asset-1', 'android', 'apk', 'dev.hands.app', 100,
-              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+              '[["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]]',
               'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               'inspector-v1', 2);
     `);
@@ -140,6 +141,50 @@ describe("migration 0067 — installer consumer", () => {
     `)).toThrow(/must match exact installable asset/);
     expect(() => db.exec(`
       UPDATE installer_asset_metadata SET package_id='dev.other' WHERE asset_id='asset-1';
-    `)).toThrow(/must match exact installable asset/);
+    `)).not.toThrow();
+  });
+
+  it("enforces bounded canonical unique ordered signer lineages", () => {
+    const db = migratedDatabase();
+    seedIdentity(db);
+    db.exec(`
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name,
+         version_code, source, status, created_at, updated_at)
+      VALUES ('build-1', 'app-1', 'channel-1', 'android-apk', 'stable', '1.0.0',
+              100, 'ci', 'succeeded', 1, 1);
+      INSERT INTO build_assets
+        (id, build_id, platform, filetype, r2_key, file_hash, size_bytes,
+         created_at, artifact_kind)
+      VALUES ('asset-1', 'build-1', 'android', 'apk', 'artifact.apk',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              10, 1, 'installable');
+      INSERT INTO installer_asset_metadata
+        (asset_id, platform, filetype, package_id, version_code,
+         signer_lineages_json, inspected_file_hash, inspector_version, inspected_at)
+      VALUES ('asset-1', 'android', 'apk', 'dev.hands.app', 100,
+              '[["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]]',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              'inspector-v1', 2);
+    `);
+    const update = db.prepare(
+      "UPDATE installer_asset_metadata SET signer_lineages_json=? WHERE asset_id='asset-1'",
+    );
+    expect(() => update.run("[]")).toThrow(/CHECK/);
+    expect(() => update.run(JSON.stringify([
+      ["b".repeat(64), "b".repeat(64)],
+    ]))).toThrow(/bounded, ordered canonical/);
+    expect(() => update.run(JSON.stringify([["B".repeat(64)]])))
+      .toThrow(/bounded, ordered canonical/);
+    expect(() => update.run(JSON.stringify(Array.from(
+      { length: 9 }, (_, index) => [(index + 1).toString(16).padStart(64, "0")],
+    )))).toThrow(/CHECK/);
+    expect(() => update.run(JSON.stringify([Array.from(
+      { length: 17 }, (_, index) => (index + 1).toString(16).padStart(64, "0"),
+    )]))).toThrow(/bounded, ordered canonical/);
+    expect(JSON.parse(db.prepare(
+      "SELECT signer_lineages_json FROM installer_asset_metadata WHERE asset_id='asset-1'",
+    ).pluck().get() as string)).toEqual([["b".repeat(64), "c".repeat(64)]]);
   });
 });

--- a/worker/test/installer_routes.test.ts
+++ b/worker/test/installer_routes.test.ts
@@ -1,0 +1,340 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  installerAuthMiddleware,
+  pkceChallenge,
+  sha256Hex,
+  type InstallerVariables,
+} from "../src/lib/installer_auth";
+import { handleInstallerToken } from "../src/routes/installer_auth";
+import { authMiddleware } from "../src/middleware/auth";
+import {
+  handleInstallerCatalog,
+  handleInstallerManifest,
+  handlePutInstallerSubscription,
+} from "../src/routes/installer";
+
+const migrationDir = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+
+function d1(sqlite: Database.Database): D1Database {
+  const prepare = (sql: string) => {
+    const indexes: number[] = [];
+    const statement = sqlite.prepare(sql.replace(/\?(\d+)/g, (_match, index) => {
+      indexes.push(Number(index));
+      return "?";
+    }));
+    const bind = (...parameters: unknown[]) => {
+      const expanded = indexes.length ? indexes.map((index) => parameters[index - 1]) : parameters;
+      const runSync = () => {
+        const info = statement.run(...expanded);
+        return { success: true, meta: { changes: info.changes } };
+      };
+      const allSync = () => statement.reader
+        ? { success: true, results: statement.all(...expanded) }
+        : runSync();
+      return {
+        _batchSync: allSync,
+        run: async () => runSync(),
+        all: async () => ({ success: true, results: statement.all(...expanded) }),
+        first: async (column?: string) => {
+          const row = statement.get(...expanded) as Record<string, unknown> | undefined;
+          return column ? row?.[column] ?? null : row ?? null;
+        },
+      };
+    };
+    return { bind, run: () => bind().run(), all: () => bind().all(), first: () => bind().first() };
+  };
+  return {
+    prepare,
+    batch: async (statements: Array<{ _batchSync: () => unknown }>) =>
+      sqlite.transaction(() => statements.map((statement) => statement._batchSync()))(),
+  } as unknown as D1Database;
+}
+
+function database() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  for (const name of readdirSync(migrationDir).sort()) {
+    if (name.endsWith(".sql")) sqlite.exec(readFileSync(`${migrationDir}${name}`, "utf8"));
+  }
+  return sqlite;
+}
+
+function envFor(sqlite: Database.Database): Env {
+  return {
+    DB: d1(sqlite),
+    ENVIRONMENT: "development",
+    ADMIN_API_TOKEN: "admin-token",
+    RAFT_CLIENT_ID: "hands-test",
+    RAFT_CLIENT_SECRET: "raft-secret",
+    RAFT_ORIGIN: "https://raft.test",
+    RAFT_API_ORIGIN: "https://raft-api.test",
+    BUSINESS_ORIGIN: "https://hands.test",
+    DASHBOARD_ORIGIN: "https://app.hands.test",
+    SIGNED_URL_SECRET: "signed-secret",
+    SIGNED_URL_TTL_SECONDS: "3600",
+  } as unknown as Env;
+}
+
+const context = {
+  waitUntil() {},
+  passThroughOnException() {},
+  props: {},
+} as unknown as ExecutionContext;
+
+async function fetchWorker(env: Env, path: string, init?: RequestInit) {
+  const app = new Hono<{ Bindings: Env; Variables: InstallerVariables }>();
+  app.post("/api/installer/v1/auth/token", handleInstallerToken);
+  app.use("/api/installer/v1/*", installerAuthMiddleware);
+  app.get("/api/installer/v1/catalog", handleInstallerCatalog);
+  app.put("/api/installer/v1/subscriptions/:appId/:channel", handlePutInstallerSubscription);
+  app.get("/api/installer/v1/apps/:appId/channels/:channel/manifest", handleInstallerManifest);
+  return app.fetch(new Request(`https://hands.test${path}`, init), env, context);
+}
+
+async function issueConsumerSession(sqlite: Database.Database, env: Env) {
+  const verifier = "a".repeat(43);
+  const code = "authorization-code";
+  const challenge = await pkceChallenge(verifier);
+  sqlite.exec(`
+    INSERT INTO raft_accounts
+      (id, provider_subject, server_id, principal_type, display_name, raw_profile,
+       created_at, updated_at, last_login_at)
+    VALUES ('account-1', 'human-1', 'server-1', 'human', 'Human', '{}', 1, 1, 1);
+  `);
+  sqlite.prepare(`
+    INSERT INTO installer_login_codes
+      (id, code_hash, account_id, client_id, redirect_uri, state, code_challenge,
+       code_challenge_method, created_at, expires_at)
+    VALUES ('code-1', ?, 'account-1', 'hands-installer',
+            'hands-installer://auth/callback', 'state-1234567890', ?, 'S256', 1, ?)
+  `).run(await sha256Hex(code), challenge, Date.now() + 60_000);
+  const response = await fetchWorker(env, "/api/installer/v1/auth/token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      client_id: "hands-installer",
+      redirect_uri: "hands-installer://auth/callback",
+    }),
+  });
+  expect(response.status).toBe(200);
+  return response.json() as Promise<{ access_token: string; refresh_token: string }>;
+}
+
+function seedOffer(sqlite: Database.Database, overrides: { optedIn?: boolean; releaseType?: string } = {}) {
+  const optedIn = overrides.optedIn ?? true;
+  const releaseType = overrides.releaseType ?? "stable";
+  sqlite.exec(`
+    INSERT INTO apps
+      (id, slug, name, platform, created_at, public_history, installer_catalog_public,
+       installer_package_id, installer_publisher_name)
+    VALUES ('app-1', 'app-one', 'App One', 'android', 1, 1, ${optedIn ? 1 : 0},
+            'dev.hands.app', 'Hands');
+    INSERT INTO channels (id, app_id, slug, name, created_at)
+    VALUES ('channel-1', 'app-1', 'main', 'Main', 1);
+    INSERT INTO builds
+      (id, app_id, channel_id, product_type, release_type, version_name,
+       version_code, source, status, created_at, updated_at)
+    VALUES ('build-1', 'app-1', 'channel-1', 'android-apk', '${releaseType}',
+            '1.2.3', 10203, 'ci', 'succeeded', 1, 1);
+    INSERT INTO releases
+      (id, app_id, build_id, channel_id, product_type, release_type, status,
+       created_by, created_at, updated_at, activated_at)
+    VALUES ('release-1', 'app-1', 'build-1', 'channel-1', 'android-apk',
+            '${releaseType}', 'active', 'test', 1, 1, 1);
+    INSERT INTO release_scopes (id, release_id, scope_type, scope_value, created_at)
+    VALUES ('scope-1', 'release-1', 'full', 'all', 1);
+    INSERT INTO build_assets
+      (id, build_id, platform, filetype, r2_key, file_hash, size_bytes,
+       created_at, artifact_kind)
+    VALUES ('asset-1', 'build-1', 'android', 'apk', 'artifact.apk',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            10, 1, 'installable');
+  `);
+  if (optedIn) sqlite.exec(`
+    INSERT INTO installer_asset_metadata
+      (asset_id, platform, filetype, package_id, version_code, signer_fingerprint,
+       inspected_file_hash, inspector_version, inspected_at)
+    VALUES ('asset-1', 'android', 'apk', 'dev.hands.app', 10203,
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'inspector-v1', 2);
+  `);
+}
+
+describe("Hands Installer routes", () => {
+  let sqlite: Database.Database;
+  let env: Env;
+
+  beforeEach(() => {
+    sqlite = database();
+    env = envFor(sqlite);
+  });
+
+  it("exchanges a PKCE code once and rejects dashboard/admin tokens", async () => {
+    const verifier = "a".repeat(43);
+    const challenge = await pkceChallenge(verifier);
+    sqlite.exec(`
+      INSERT INTO raft_accounts
+        (id, provider_subject, server_id, principal_type, display_name, raw_profile,
+         created_at, updated_at, last_login_at)
+      VALUES ('account-1', 'human-1', 'server-1', 'human', 'Human', '{}', 1, 1, 1);
+    `);
+    sqlite.prepare(`
+      INSERT INTO installer_login_codes
+        (id, code_hash, account_id, client_id, redirect_uri, state, code_challenge,
+         code_challenge_method, created_at, expires_at)
+      VALUES ('code-1', ?, 'account-1', 'hands-installer',
+              'hands-installer://auth/callback', 'state-1234567890', ?, 'S256', 1, ?)
+    `).run(await sha256Hex("authorization-code"), challenge, Date.now() + 60_000);
+    const wrongVerifier = await fetchWorker(env, "/api/installer/v1/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code", code: "authorization-code",
+        code_verifier: "b".repeat(43), client_id: "hands-installer",
+        redirect_uri: "hands-installer://auth/callback",
+      }),
+    });
+    expect(wrongVerifier.status).toBe(400);
+    const correct = await fetchWorker(env, "/api/installer/v1/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code", code: "authorization-code",
+        code_verifier: verifier, client_id: "hands-installer",
+        redirect_uri: "hands-installer://auth/callback",
+      }),
+    });
+    const session = await correct.json() as { access_token: string };
+    const replay = await fetchWorker(env, "/api/installer/v1/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        code: "authorization-code",
+        code_verifier: "a".repeat(43),
+        client_id: "hands-installer",
+        redirect_uri: "hands-installer://auth/callback",
+      }),
+    });
+    expect(replay.status).toBe(400);
+    expect(await replay.json()).toMatchObject({ code: "invalid_grant" });
+
+    const consumer = await fetchWorker(env, "/api/installer/v1/catalog", {
+      headers: { authorization: `Bearer ${session.access_token}` },
+    });
+    expect(consumer.status).toBe(200);
+    const admin = await fetchWorker(env, "/api/installer/v1/catalog", {
+      headers: { authorization: "Bearer admin-token" },
+    });
+    expect(admin.status).toBe(401);
+
+    const adminApp = new Hono<{ Bindings: Env }>();
+    adminApp.use("/api/apps/*", authMiddleware as never);
+    adminApp.get("/api/apps/private", (c) => c.json({ ok: true }));
+    const cannotEscalate = await adminApp.fetch(new Request("https://hands.test/api/apps/private", {
+      headers: { authorization: `Bearer ${session.access_token}` },
+    }), env, context);
+    expect(cannotEscalate.status).toBe(401);
+  });
+
+  it("uses one active/non-QA rollout resolver for catalog and manifest", async () => {
+    const session = await issueConsumerSession(sqlite, env);
+    seedOffer(sqlite);
+    const headers = { authorization: `Bearer ${session.access_token}` };
+    const catalog = await fetchWorker(env, "/api/installer/v1/catalog", { headers });
+    expect(catalog.status).toBe(200);
+    expect(await catalog.json()).toMatchObject({
+      schema: "hands-installer-catalog.v1",
+      apps: [{ id: "app-1", channels: [{ name: "main", latest_version: "1.2.3" }] }],
+    });
+    const manifest = await fetchWorker(
+      env, "/api/installer/v1/apps/app-1/channels/main/manifest", { headers },
+    );
+    expect(manifest.status).toBe(200);
+    expect(await manifest.json()).toMatchObject({
+      schema: "hands-installer-manifest.v1",
+      release: { id: "release-1", version: "1.2.3", version_code: 10203 },
+      asset: { id: "asset-1", platform: "android", filetype: "apk" },
+    });
+  });
+
+  it("does not enumerate non-opted-in apps or QA releases", async () => {
+    const session = await issueConsumerSession(sqlite, env);
+    seedOffer(sqlite, { optedIn: false });
+    const headers = { authorization: `Bearer ${session.access_token}` };
+    const catalog = await fetchWorker(env, "/api/installer/v1/catalog", { headers });
+    expect(await catalog.json()).toMatchObject({ apps: [] });
+    const manifest = await fetchWorker(
+      env, "/api/installer/v1/apps/app-1/channels/main/manifest", { headers },
+    );
+    expect(manifest.status).toBe(404);
+    expect(await manifest.json()).toEqual({ error: "app not found", code: "app_not_found" });
+  });
+
+  it("excludes an opted-in app when its only active build is QA", async () => {
+    const session = await issueConsumerSession(sqlite, env);
+    seedOffer(sqlite, { releaseType: "qa" });
+    const headers = { authorization: `Bearer ${session.access_token}` };
+    const catalog = await fetchWorker(env, "/api/installer/v1/catalog", { headers });
+    expect(await catalog.json()).toMatchObject({ apps: [] });
+    const manifest = await fetchWorker(
+      env, "/api/installer/v1/apps/app-1/channels/main/manifest", { headers },
+    );
+    expect(manifest.status).toBe(404);
+  });
+
+  it("uses optimistic subscription revisions with exactly one stale loser", async () => {
+    const session = await issueConsumerSession(sqlite, env);
+    seedOffer(sqlite);
+    const headers = {
+      authorization: `Bearer ${session.access_token}`,
+      "content-type": "application/json",
+    };
+    const create = await fetchWorker(env, "/api/installer/v1/subscriptions/app-1/main", {
+      method: "PUT", headers, body: JSON.stringify({ auto_download: false, expected_revision: null }),
+    });
+    expect(create.status).toBe(200);
+    expect(await create.json()).toMatchObject({ subscriptions: [{ revision: 1 }] });
+    const update = await fetchWorker(env, "/api/installer/v1/subscriptions/app-1/main", {
+      method: "PUT", headers, body: JSON.stringify({ auto_download: true, expected_revision: 1 }),
+    });
+    expect(update.status).toBe(200);
+    const stale = await fetchWorker(env, "/api/installer/v1/subscriptions/app-1/main", {
+      method: "PUT", headers, body: JSON.stringify({ auto_download: false, expected_revision: 1 }),
+    });
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toMatchObject({ code: "subscription_conflict" });
+  });
+
+  it("revokes the whole family when an already-rotated refresh token is reused", async () => {
+    const session = await issueConsumerSession(sqlite, env);
+    const refresh = async () => fetchWorker(env, "/api/installer/v1/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: session.refresh_token,
+        client_id: "hands-installer",
+      }),
+    });
+    const attempts = await Promise.all([refresh(), refresh()]);
+    const first = attempts.find((response) => response.status === 200);
+    const reused = attempts.find((response) => response.status === 400);
+    expect(first).toBeDefined();
+    expect(reused).toBeDefined();
+    const firstTokens = await first!.json() as { access_token: string };
+    expect(await reused!.json()).toMatchObject({ code: "invalid_grant" });
+    const afterRevoke = await fetchWorker(env, "/api/installer/v1/catalog", {
+      headers: { authorization: `Bearer ${firstTokens.access_token}` },
+    });
+    expect(afterRevoke.status).toBe(401);
+  });
+});

--- a/worker/test/installer_routes.test.ts
+++ b/worker/test/installer_routes.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 import { Hono } from "hono";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installerAuthMiddleware,
   pkceChallenge,
@@ -16,6 +16,29 @@ import {
   handleInstallerManifest,
   handlePutInstallerSubscription,
 } from "../src/routes/installer";
+import { autoParseInstallableAsset } from "../src/routes/builds";
+
+vi.mock("@cloudflare/containers", () => ({
+  getRandom: async () => ({
+    fetch: async () => Response.json({
+      parser_kind: "apk-aapt",
+      platform: "android",
+      arch: null,
+      version: "1.2.3",
+      version_code: 10203,
+      package_id: "dev.hands.app",
+      app_label: "App One",
+      size_bytes: 0,
+      file_hash_sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      raw: {
+        signer_lineages: [[
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        ]],
+      },
+    }),
+  }),
+}));
 
 const migrationDir = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
 
@@ -159,10 +182,11 @@ function seedOffer(sqlite: Database.Database, overrides: { optedIn?: boolean; re
   `);
   if (optedIn) sqlite.exec(`
     INSERT INTO installer_asset_metadata
-      (asset_id, platform, filetype, package_id, version_code, signer_fingerprint,
+      (asset_id, platform, filetype, package_id, version_code, signer_lineages_json,
        inspected_file_hash, inspector_version, inspected_at)
     VALUES ('asset-1', 'android', 'apk', 'dev.hands.app', 10203,
-            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            '[["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+               "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]]',
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             'inspector-v1', 2);
   `);
@@ -262,8 +286,108 @@ describe("Hands Installer routes", () => {
     expect(await manifest.json()).toMatchObject({
       schema: "hands-installer-manifest.v1",
       release: { id: "release-1", version: "1.2.3", version_code: 10203 },
-      asset: { id: "asset-1", platform: "android", filetype: "apk" },
+      asset: {
+        id: "asset-1",
+        platform: "android",
+        filetype: "apk",
+        signer_lineages: [[
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        ]],
+      },
     });
+  });
+
+  it("persists verified APK inspection against the exact asset before catalog opt-in", async () => {
+    sqlite.exec(`
+      INSERT INTO apps (id, slug, name, platform, created_at)
+      VALUES ('app-1', 'app-one', 'App One', 'android', 1);
+      INSERT INTO channels (id, app_id, slug, name, created_at)
+      VALUES ('channel-1', 'app-1', 'main', 'Main', 1);
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name,
+         version_code, source, status, created_at, updated_at)
+      VALUES ('build-1', 'app-1', 'channel-1', 'android-apk', 'stable',
+              '1.2.3', 10203, 'ci', 'succeeded', 1, 1);
+      INSERT INTO build_assets
+        (id, build_id, platform, filetype, r2_key, file_hash, size_bytes,
+         created_at, artifact_kind)
+      VALUES ('asset-1', 'build-1', 'android', 'apk', 'artifact.apk',
+              'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+              0, 1, 'installable');
+    `);
+    env.APK_BUCKET = {
+      get: async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
+    } as unknown as R2Bucket;
+    env.APK_PARSER = {} as never;
+    await autoParseInstallableAsset(env, "app-1", "build-1", "artifact.apk", "apk-aapt");
+    const row = sqlite.prepare(
+      `SELECT package_id, version_code, signer_lineages_json, inspected_file_hash,
+              inspector_version
+       FROM installer_asset_metadata WHERE asset_id='asset-1'`,
+    ).get() as Record<string, unknown>;
+    expect(row).toMatchObject({
+      package_id: "dev.hands.app",
+      version_code: 10203,
+      inspected_file_hash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      inspector_version: "android-apksig-34.0.0-v1",
+    });
+    expect(JSON.parse(row.signer_lineages_json as string)).toEqual([[
+      "b".repeat(64), "c".repeat(64),
+    ]]);
+    expect(sqlite.prepare(
+      "SELECT installer_catalog_public FROM apps WHERE id='app-1'",
+    ).pluck().get()).toBe(0);
+  });
+
+  it("does not offer or sign an asset whose stored signer lineages fail closed validation", async () => {
+    const session = await issueConsumerSession(sqlite, env);
+    seedOffer(sqlite);
+    sqlite.exec(`
+      DROP TRIGGER installer_asset_metadata_lineages_update_guard;
+      PRAGMA ignore_check_constraints = ON;
+      UPDATE installer_asset_metadata
+      SET signer_lineages_json='[["not-a-fingerprint"]]'
+      WHERE asset_id='asset-1';
+    `);
+    const response = await fetchWorker(
+      env,
+      "/api/installer/v1/apps/app-1/channels/main/manifest",
+      { headers: { authorization: `Bearer ${session.access_token}` } },
+    );
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "app not found", code: "app_not_found" });
+  });
+
+  it("does not ingest parser metadata when the inspected bytes mismatch the asset hash", async () => {
+    sqlite.exec(`
+      INSERT INTO apps (id, slug, name, platform, created_at)
+      VALUES ('app-1', 'app-one', 'App One', 'android', 1);
+      INSERT INTO channels (id, app_id, slug, name, created_at)
+      VALUES ('channel-1', 'app-1', 'main', 'Main', 1);
+      INSERT INTO builds
+        (id, app_id, channel_id, product_type, release_type, version_name,
+         version_code, source, status, created_at, updated_at)
+      VALUES ('build-1', 'app-1', 'channel-1', 'android-apk', 'stable',
+              '1.2.3', 10203, 'ci', 'succeeded', 1, 1);
+      INSERT INTO build_assets
+        (id, build_id, platform, filetype, r2_key, file_hash, size_bytes,
+         created_at, artifact_kind)
+      VALUES ('asset-1', 'build-1', 'android', 'apk', 'artifact.apk',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              0, 1, 'installable');
+    `);
+    env.APK_BUCKET = {
+      get: async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
+    } as unknown as R2Bucket;
+    env.APK_PARSER = {} as never;
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await autoParseInstallableAsset(env, "app-1", "build-1", "artifact.apk", "apk-aapt");
+    error.mockRestore();
+    expect(sqlite.prepare("SELECT count(*) FROM installer_asset_metadata").pluck().get()).toBe(0);
+    expect(sqlite.prepare(
+      "SELECT parsed_metadata_json FROM builds WHERE id='build-1'",
+    ).pluck().get()).toBe("{}");
   });
 
   it("does not enumerate non-opted-in apps or QA releases", async () => {


### PR DESCRIPTION
Implements the Hands Installer v1 Worker source contract:

- human-only PKCE consumer auth with opaque access and rotating refresh tokens
- explicit non-enumerating catalog admission
- revision-guarded subscriptions
- active/non-QA rollout-aware APK/HAP manifests
- shared public_v2 candidate, rollout, and asset resolver
- exact inspected artifact/hash/package/version binding
- bounded ordered signer lineages, derived from full APK verification and bound to immutable asset bytes
- automatic verified APK parser → installer metadata ingestion before catalog opt-in

Validation on current head:
- Worker and container TypeScript builds: green
- Worker tests: 45 files / 460 tests green
- Android build-tools 34.0.0 `apksig` helper compiled and parsed the real public `raft-android` 1.9.1 APK as old→current lineage `b4919381…1a45` → `5f08bbe8…b0b1`, with exact package/version/hash readback

Migration 0067 must not land or deploy before the in-flight 0066 Agent Login migration. Production deployment remains frozen, and no migration, deploy, production data write, package, or release is authorized by this PR.
