### PR TITLE
fix(auth): bind browser login state to local proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Worker configuration:
 - `RAFT_CLIENT_SECRET` as a Worker secret (`wrangler secret put RAFT_CLIENT_SECRET`)
 - `app.hands.build` is the canonical dashboard/login origin. `hands.build` remains the business/API origin for SDKs, CLI/agents, share/download pages, release notes, and docs.
 - Product links and docs use `app.hands.build` for the dashboard and `hands.build` for business surfaces. Both hostnames continue serving compatible Worker routes during the transition; there is no forced cross-domain redirect.
-- Login starts from `app.hands.build`, carries a short-lived signed per-attempt `state` through Raft, uses the registered `https://hands.build/login/raft/callback`, then returns a signed Hands JWT to the dashboard in the URL fragment. The callback validates `state` before exchanging the one-time Raft code. The SPA stores the JWT locally and sends `Authorization: Bearer`; no browser session cookie is required for the browser login handoff.
+- Login starts from `app.hands.build`, carries a short-lived signed per-attempt `state` through Raft, and binds that state to an HttpOnly per-attempt browser proof cookie scoped to `hands.build` and its dashboard subdomain. The registered `https://hands.build/login/raft/callback` validates both before exchanging the one-time Raft code, then returns a signed Hands JWT to the dashboard in the URL fragment. The SPA stores the JWT locally and sends `Authorization: Bearer`; the proof cookie is not a Hands session and is deleted after the login handoff.
 - Optional `RAFT_ALLOWED_SERVER_IDS` / `RAFT_ALLOWED_SERVER_SLUGS` can restrict admin login to specific Raft servers
 
 Do not put Raft client secrets in browser JavaScript, repository files, logs, or public channels.

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -27,12 +27,14 @@ import { encryptAdminRaftToken } from "../lib/admin_raft_token";
 
 const LOGIN_PENDING_COOKIE = "quiver_raft_login_pending";
 const LOGIN_RETURN_COOKIE = "quiver_raft_return";
+const BROWSER_LOGIN_PROOF_COOKIE_PREFIX = "quiver_raft_login_proof_";
 const BROWSER_LOGIN_STATE_TTL_MS = 10 * 60 * 1000;
 
 type BrowserLoginState = {
-  v: 1;
+  v: 2;
   purpose: "hands-browser-login";
   nonce: string;
+  browser_proof_sha256: string;
   return_path: string;
   iat: number;
   exp: number;
@@ -198,7 +200,7 @@ function base64UrlToBytes(input: string): Uint8Array | null {
 async function browserLoginStateKey(clientSecret: string) {
   return crypto.subtle.importKey(
     "raw",
-    new TextEncoder().encode(`hands-browser-login-state-v1:${clientSecret}`),
+    new TextEncoder().encode(`hands-browser-login-state-v2:${clientSecret}`),
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign", "verify"],
@@ -208,12 +210,15 @@ async function browserLoginStateKey(clientSecret: string) {
 async function createBrowserLoginState(
   clientSecret: string,
   returnPath: string,
+  nonce: string,
+  browserProofSha256: string,
 ): Promise<string> {
   const issuedAt = now();
   const payload: BrowserLoginState = {
-    v: 1,
+    v: 2,
     purpose: "hands-browser-login",
-    nonce: randomToken(16),
+    nonce,
+    browser_proof_sha256: browserProofSha256,
     return_path: returnPath,
     iat: Math.floor(issuedAt / 1000),
     exp: Math.floor((issuedAt + BROWSER_LOGIN_STATE_TTL_MS) / 1000),
@@ -248,10 +253,12 @@ async function verifyBrowserLoginState(
     const payload = JSON.parse(new TextDecoder().decode(payloadBytes)) as Partial<BrowserLoginState>;
     const currentTime = Math.floor(now() / 1000);
     if (
-      payload.v !== 1 ||
+      payload.v !== 2 ||
       payload.purpose !== "hands-browser-login" ||
       typeof payload.nonce !== "string" ||
       !/^[a-f0-9]{32}$/.test(payload.nonce) ||
+      typeof payload.browser_proof_sha256 !== "string" ||
+      !/^[a-f0-9]{64}$/.test(payload.browser_proof_sha256) ||
       typeof payload.return_path !== "string" ||
       normalizeReturnPath(payload.return_path) !== payload.return_path ||
       typeof payload.iat !== "number" ||
@@ -266,6 +273,24 @@ async function verifyBrowserLoginState(
   } catch {
     return null;
   }
+}
+
+function browserLoginProofCookieName(nonce: string): string {
+  return `${BROWSER_LOGIN_PROOF_COOKIE_PREFIX}${nonce}`;
+}
+
+function timingSafeEqualText(left: string, right: string): boolean {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  if (leftBytes.byteLength !== rightBytes.byteLength) return false;
+  if (typeof crypto.subtle.timingSafeEqual === "function") {
+    return crypto.subtle.timingSafeEqual(leftBytes, rightBytes);
+  }
+  let difference = 0;
+  for (let index = 0; index < leftBytes.byteLength; index += 1) {
+    difference |= leftBytes[index]! ^ rightBytes[index]!;
+  }
+  return difference === 0;
 }
 
 export async function createSignedJwt(
@@ -687,10 +712,17 @@ export async function handleAuthLogin(c: Context<{ Bindings: Env }>) {
   if (!config.ok) return config.response;
 
   const returnPath = normalizeReturnPath(c.req.query("return") ?? c.req.query("return_to"));
-  const state = await createBrowserLoginState(config.clientSecret, returnPath);
+  const nonce = randomToken(16);
+  const browserProof = randomToken(32);
+  const state = await createBrowserLoginState(
+    config.clientSecret,
+    returnPath,
+    nonce,
+    await sha256Hex(browserProof),
+  );
   // Clear pre-state-flow cookies so a stripped state cannot be mistaken for a
-  // legacy browser callback. Old callbacks already in flight still work until
-  // a new login attempt explicitly supersedes them.
+  // browser callback. Legacy callbacks intentionally restart: accepting a
+  // pending-cookie-only callback would restore the login-CSRF gap.
   deleteCookie(c, LOGIN_PENDING_COOKIE, {
     ...sharedCookieDomainOption(c),
     path: "/",
@@ -698,6 +730,14 @@ export async function handleAuthLogin(c: Context<{ Bindings: Env }>) {
   deleteCookie(c, LOGIN_RETURN_COOKIE, {
     ...sharedCookieDomainOption(c),
     path: "/",
+  });
+  setCookie(c, browserLoginProofCookieName(nonce), browserProof, {
+    httpOnly: true,
+    secure: secureCookie(c),
+    sameSite: "Lax",
+    ...sharedCookieDomainOption(c),
+    path: "/login/raft/callback",
+    maxAge: BROWSER_LOGIN_STATE_TTL_MS / 1000,
   });
 
   const setup = new URL("/login-with-raft/setup", config.raftOrigin);
@@ -738,15 +778,23 @@ export async function handleRaftCallback(c: Context<{ Bindings: Env }>) {
   try {
     const state = c.req.query("state");
     let browserReturnPath: string | null = null;
+    let browserProofCookie: string | null = null;
     if (state) {
       const verifiedState = await verifyBrowserLoginState(config.clientSecret, state);
       if (!verifiedState) {
         return c.text("Invalid or expired local login state. Start again from /api/auth/login.", 400);
       }
+      browserProofCookie = browserLoginProofCookieName(verifiedState.nonce);
+      const browserProof = getCookie(c, browserProofCookie);
+      const browserProofSha256 = browserProof ? await sha256Hex(browserProof) : "";
+      if (
+        !browserProof ||
+        !/^[a-f0-9]{64}$/.test(browserProof) ||
+        !timingSafeEqualText(browserProofSha256, verifiedState.browser_proof_sha256)
+      ) {
+        return c.text("Missing or invalid browser login proof. Start again from /api/auth/login.", 400);
+      }
       browserReturnPath = verifiedState.return_path;
-    } else if (getCookie(c, LOGIN_PENDING_COOKIE)) {
-      // Compatibility for browser logins started before signed state shipped.
-      browserReturnPath = normalizeReturnPath(getCookie(c, LOGIN_RETURN_COOKIE));
     }
 
     const result = await finalizeRaftLogin(c, config, code);
@@ -779,6 +827,12 @@ export async function handleRaftCallback(c: Context<{ Bindings: Env }>) {
       ...sharedCookieDomainOption(c),
       path: "/",
     });
+    if (browserProofCookie) {
+      deleteCookie(c, browserProofCookie, {
+        ...sharedCookieDomainOption(c),
+        path: "/login/raft/callback",
+      });
+    }
     const destination = new URL(browserReturnUrl(c, browserReturnPath), requestOrigin(c));
     destination.hash = new URLSearchParams({
       access_token: result.authToken.token,

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -2276,6 +2276,14 @@ describe("quiver route handlers — SQL smoke", () => {
 });
 
 describe("auth origin handling", () => {
+  function browserProofCookie(response: Response): string {
+    const match = (response.headers.get("set-cookie") ?? "").match(
+      /(quiver_raft_login_proof_[a-f0-9]{32})=([a-f0-9]{64})/,
+    );
+    expect(match).not.toBeNull();
+    return `${match![1]}=${match![2]}`;
+  }
+
   function mockRaftLoginFetch(principalType: "human" | "agent" = "human") {
     return vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
@@ -2391,7 +2399,14 @@ describe("auth origin handling", () => {
       "https://business.example/login/raft/callback",
     );
     expect(location.searchParams.get("state")).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
-    expect(res.headers.get("set-cookie")?.toLowerCase()).not.toContain("max-age=600");
+    const setCookie = res.headers.get("set-cookie")?.toLowerCase() ?? "";
+    expect(browserProofCookie(res)).toMatch(
+      /^quiver_raft_login_proof_[a-f0-9]{32}=[a-f0-9]{64}$/,
+    );
+    expect(setCookie).toContain("httponly");
+    expect(setCookie).toContain("max-age=600");
+    expect(setCookie).toContain("path=/login/raft/callback");
+    expect(setCookie).toContain("domain=business.example");
   });
 
   it("keeps localhost auth callbacks and cookies host-local", async () => {
@@ -2411,10 +2426,13 @@ describe("auth origin handling", () => {
       "http://localhost:8787/login/raft/callback",
     );
     expect(location.searchParams.get("state")).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(browserProofCookie(res)).toMatch(
+      /^quiver_raft_login_proof_[a-f0-9]{32}=[a-f0-9]{64}$/,
+    );
     expect(res.headers.get("set-cookie")?.toLowerCase()).not.toContain("domain=");
   });
 
-  it("completes a delayed install-and-continue browser callback without local cookies", async () => {
+  it("completes a delayed install-and-continue browser callback with its matching proof", async () => {
     const env = makeMockEnv();
     env.RAFT_CLIENT_ID = "test-client";
     const app = new Hono<{ Bindings: MockEnv }>();
@@ -2433,13 +2451,14 @@ describe("auth origin handling", () => {
       const setup = new URL(login.headers.get("location") ?? "");
       const state = setup.searchParams.get("state");
       expect(state).toBeTruthy();
+      const proofCookie = browserProofCookie(login);
 
       nowSpy.mockReturnValue(start + 6 * 60 * 1000);
       globalThis.fetch = mockRaftLoginFetch() as typeof fetch;
 
       const callback = await app.request(
         `https://business.example/login/raft/callback?code=install-code&state=${encodeURIComponent(state!)}`,
-        {},
+        { headers: { cookie: proofCookie } },
         env as any,
       );
 
@@ -2450,6 +2469,9 @@ describe("auth origin handling", () => {
       );
       expect(destination.hash).toContain("access_token=");
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      expect(callback.headers.get("set-cookie")).toContain(
+        `${proofCookie.split("=")[0]}=`,
+      );
     } finally {
       globalThis.fetch = originalFetch;
       nowSpy.mockRestore();
@@ -2473,6 +2495,8 @@ describe("auth origin handling", () => {
     );
     const firstState = new URL(firstLogin.headers.get("location") ?? "").searchParams.get("state")!;
     const secondState = new URL(secondLogin.headers.get("location") ?? "").searchParams.get("state")!;
+    const firstProofCookie = browserProofCookie(firstLogin);
+    const secondProofCookie = browserProofCookie(secondLogin);
     expect(firstState).not.toBe(secondState);
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mockRaftLoginFetch() as typeof fetch;
@@ -2480,12 +2504,12 @@ describe("auth origin handling", () => {
     try {
       const secondCallback = await app.request(
         `https://business.example/login/raft/callback?code=second-code&state=${encodeURIComponent(secondState)}`,
-        {},
+        { headers: { cookie: secondProofCookie } },
         env as any,
       );
       const firstCallback = await app.request(
         `https://business.example/login/raft/callback?code=first-code&state=${encodeURIComponent(firstState)}`,
-        {},
+        { headers: { cookie: firstProofCookie } },
         env as any,
       );
       expect(new URL(secondCallback.headers.get("location") ?? "").pathname).toBe("/apps/second");
@@ -2520,6 +2544,95 @@ describe("auth origin handling", () => {
     }
   });
 
+  it("rejects an attacker-owned browser state and code without the victim proof", async () => {
+    const env = makeMockEnv();
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/login", handleAuthLogin);
+    app.get("/login/raft/callback", handleRaftCallback);
+    const attackerLogin = await app.request(
+      "https://business.example/api/auth/login?return=%2Fapps",
+      {},
+      env as any,
+    );
+    const attackerState = new URL(attackerLogin.headers.get("location") ?? "").searchParams.get(
+      "state",
+    )!;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockRaftLoginFetch() as typeof fetch;
+
+    try {
+      const victimCallback = await app.request(
+        `https://business.example/login/raft/callback?code=attacker-code&state=${encodeURIComponent(attackerState)}`,
+        {},
+        env as any,
+      );
+      expect(victimCallback.status).toBe(400);
+      expect(await victimCallback.text()).toContain("Missing or invalid browser login proof");
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rejects a signed browser state paired with another attempt's proof", async () => {
+    const env = makeMockEnv();
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/api/auth/login", handleAuthLogin);
+    app.get("/login/raft/callback", handleRaftCallback);
+    const attackerLogin = await app.request(
+      "https://business.example/api/auth/login?return=%2Fapps%2Fattacker",
+      {},
+      env as any,
+    );
+    const victimLogin = await app.request(
+      "https://business.example/api/auth/login?return=%2Fapps%2Fvictim",
+      {},
+      env as any,
+    );
+    const attackerState = new URL(attackerLogin.headers.get("location") ?? "").searchParams.get(
+      "state",
+    )!;
+    const [attackerProofName] = browserProofCookie(attackerLogin).split("=");
+    const [, victimProof] = browserProofCookie(victimLogin).split("=");
+    const mismatchedProofCookie = `${attackerProofName}=${victimProof}`;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockRaftLoginFetch() as typeof fetch;
+
+    try {
+      const victimCallback = await app.request(
+        `https://business.example/login/raft/callback?code=attacker-code&state=${encodeURIComponent(attackerState)}`,
+        { headers: { cookie: mismatchedProofCookie } },
+        env as any,
+      );
+      expect(victimCallback.status).toBe(400);
+      expect(await victimCallback.text()).toContain("Missing or invalid browser login proof");
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not revive browser login from the legacy pending cookie", async () => {
+    const env = makeMockEnv();
+    const app = new Hono<{ Bindings: MockEnv }>();
+    app.get("/login/raft/callback", handleRaftCallback);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockRaftLoginFetch() as typeof fetch;
+
+    try {
+      const callback = await app.request(
+        "https://business.example/login/raft/callback?code=human-code",
+        { headers: { cookie: "quiver_raft_login_pending=legacy" } },
+        env as any,
+      );
+      expect(callback.status).toBe(400);
+      expect(await callback.text()).toContain("Missing local login state");
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("rejects tampered browser state before exchanging the one-time code", async () => {
     const env = makeMockEnv();
     const app = new Hono<{ Bindings: MockEnv }>();
@@ -2532,7 +2645,7 @@ describe("auth origin handling", () => {
     );
     const setup = new URL(login.headers.get("location") ?? "");
     const state = setup.searchParams.get("state")!;
-    const tampered = `${state.slice(0, -1)}${state.endsWith("A") ? "B" : "A"}`;
+    const tampered = `${state.startsWith("A") ? "B" : "A"}${state.slice(1)}`;
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn() as typeof fetch;
 


### PR DESCRIPTION
Raft author: @XX. GitHub actor `stdrc` is a shared carrier for PR creation only.

## Summary

- bind every browser OAuth state to a cryptographically random HttpOnly, callback-scoped proof cookie
- verify the proof before exchanging the one-time Raft code, and delete it after a successful handoff
- remove the legacy pending-cookie-only browser fallback while preserving stateless agent callbacks
- preserve delayed and concurrent browser login return paths with per-attempt cookie names

## Security teeth

- attacker-owned valid signed state + code with no victim proof returns 400 before fetch
- another login attempt's proof under the expected cookie name returns 400 before fetch
- removing the proof gate mutates the first attack test from expected 400 to observed 302
- legacy pending cookie alone cannot revive a browser callback

## Verification

- `pnpm -w build` — pass
- `pnpm -w test` — pass (all workspace suites; Worker 454/454)
- focused auth tests — 17/17 pass
- `git diff --check` — pass
- `pnpm -w lint` — repository baseline cannot start ESLint 9 because `origin/main` has no `eslint.config.*`; this PR does not alter lint configuration

No deploy or production mutation.
