### PR TITLE
fix(shares): #442 share download/page fall back to latest active version when bound object is missing

### DIFF
--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -100,6 +100,7 @@ type SharePageRow = {
   package_id: string | null;
   share_id: string;
   expires_at: number | null;
+  app_id: string;
   app_slug: string;
   app_name: string;
   channel_slug: string;
@@ -591,15 +592,53 @@ export async function handlePublicReleaseShareDownload(c: Context<{ Bindings: En
     return c.redirect(`/share/${token}`, 302);
   }
 
+  // The bound asset may have been deleted from R2 (e.g. its release was pruned/superseded).
+  // Rather than 302 → a signed URL that 404s, fall back to the app's latest active
+  // installable when one still exists; only if nothing downloadable remains show an error.
+  let r2Key: string | null = row.r2_key;
+  if (!(await c.env.APK_BUCKET.head(row.r2_key))) {
+    r2Key = await findLatestActiveInstallableKey(c.env, row.app_id);
+  }
+  if (!r2Key) {
+    const latestSlug = await findLatestLandingSlugForInactiveShare(c.env.DB, token);
+    return htmlResponse(renderErrorPage(t, t.errUnavailable, latestSlug), 404);
+  }
+
   await recordShareEvent(c, row.share_id, "download");
   const ttl = Number(c.env.SIGNED_URL_TTL_SECONDS ?? "3600");
   const signedUrl = await generateSignedR2Url(
     c.env,
-    row.r2_key,
+    r2Key,
     ttl,
     publicRequestOrigin(c),
   );
   return c.redirect(signedUrl, 302);
+}
+
+/**
+ * The r2_key of the app's most recent active, non-hidden installable that still exists in
+ * R2, or null. Fetches a few candidates newest-first and head-checks each, so a single
+ * pruned object does not defeat the fallback. Used when a share's own bound asset is gone.
+ */
+async function findLatestActiveInstallableKey(env: Env, appId: string): Promise<string | null> {
+  const rows = await env.DB.prepare(
+    `SELECT ba.r2_key AS r2_key
+     FROM releases r
+     JOIN builds b ON b.id = r.build_id
+     JOIN build_assets ba ON ba.build_id = b.id
+     WHERE r.app_id = ?1
+       AND r.status = 'active'
+       AND r.hidden = 0
+       AND ba.artifact_kind = 'installable'
+     ORDER BY r.created_at DESC, ba.filetype = 'apk' DESC, ba.created_at ASC
+     LIMIT 5`,
+  )
+    .bind(appId)
+    .all<{ r2_key: string }>();
+  for (const row of rows.results ?? []) {
+    if (row.r2_key && (await env.APK_BUCKET.head(row.r2_key))) return row.r2_key;
+  }
+  return null;
 }
 
 export async function handlePublicReleaseShareIcon(c: Context<{ Bindings: Env }>) {
@@ -706,6 +745,7 @@ async function findActiveShare(db: D1Database, token: string): Promise<SharePage
        rs.id AS share_id,
        rs.expires_at AS expires_at,
        rs.password_hash AS password_hash,
+       a.id AS app_id,
        a.slug AS app_slug,
        a.name AS app_name,
        COALESCE(

--- a/worker/src/routes/shares.ts
+++ b/worker/src/routes/shares.ts
@@ -569,6 +569,16 @@ export async function handlePublicReleaseShare(c: Context<{ Bindings: Env }>) {
   }
 
   await recordShareEvent(c, row.share_id, "view");
+  // If the bound asset has been deleted from R2 but the app still has a newer active
+  // version, send the visitor to the app's latest-version landing instead of a share
+  // page whose only download 404s. Only when nothing downloadable remains show an error.
+  if (!(await c.env.APK_BUCKET.head(row.r2_key))) {
+    const fallbackKey = await findLatestActiveInstallableKey(c.env, row.app_id);
+    if (fallbackKey) {
+      return c.redirect(`/apps/${encodeURIComponent(row.app_slug)}/latest`, 302);
+    }
+    return htmlResponse(renderErrorPage(t, t.errUnavailable), 404);
+  }
   const origin = publicRequestOrigin(c);
   const downloadUrl = new URL(`/share/${token}/download`, origin).toString();
   const shareUrl = new URL(`/share/${token}`, origin).toString();

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -872,7 +872,9 @@ function makeMockDb() {
 function makeMockEnv(): MockEnv {
   return {
     DB: makeMockDb() as any,
-    APK_BUCKET: null,
+    // Default: R2 objects exist (head resolves). Tests exercising a missing/pruned object
+    // override APK_BUCKET explicitly (e.g. the #442 share-download fallback tests).
+    APK_BUCKET: { head: async (key: string) => ({ key }) },
     ENVIRONMENT: "development",
     ADMIN_API_TOKEN: "test-token-123",
     RAFT_CLIENT_ID: "quiver-test",
@@ -1240,7 +1242,7 @@ describe("quiver route handlers — SQL smoke", () => {
   });
 
   it("dispatchSymbolication selects lanes by app platform, never by content alone", async () => {
-    env.APK_BUCKET = { put: async () => undefined, get: async () => null };
+    env.APK_BUCKET = { put: async () => undefined, get: async () => null, head: async (key: string) => ({ key }) };
     const now = Date.now();
     const mkTicket = async (id: string) => {
       await env.DB.prepare(
@@ -6143,6 +6145,7 @@ describe("quiver public API v2 — scope resolution", () => {
     env.APK_BUCKET = {
       put: async () => undefined,
       get: async () => null,
+      head: async (key: string) => ({ key }),
     };
 
     const {
@@ -8856,6 +8859,25 @@ describe("quiver public API v2 — scope resolution", () => {
     env.APK_BUCKET = { head: async () => null } as any; // everything is gone from R2
     const res = await handlePublicReleaseShareDownload(makeSharePublicContext(env, token));
     expect(res.status).toBe(404);
+  });
+
+  it("share PAGE redirects to the app's latest version when the bound object is gone (#442)", async () => {
+    const env = makeEnv();
+    const { handleCreateReleaseShare, handlePublicReleaseShare } = await import("../src/routes/shares");
+    await seedRelease(env, "rel-pold", "build-pold", [["full", "all"]], { versionCode: 5, versionName: "1.0.5", createdAt: 1000 });
+    await seedAsset(env, "build-pold", "asset-pold", { arch: "arm64-v8a" });
+    const created = await responseJson<any>(
+      await handleCreateReleaseShare(makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-pold" }, { ttl_seconds: 600 })),
+    );
+    const token = new URL(created.share_url).pathname.replace("/share/", "");
+    await seedRelease(env, "rel-pnew", "build-pnew", [["full", "all"]], { versionCode: 9, versionName: "1.0.9", createdAt: 2000 });
+    await seedAsset(env, "build-pnew", "asset-pnew", { arch: "arm64-v8a" });
+    // Bound (old) object gone; latest active (new) object exists.
+    env.APK_BUCKET = { head: async (key: string) => (key === "apps/app-scope/asset-pnew.apk" ? { key } : null) } as any;
+
+    const res = await handlePublicReleaseShare(makeSharePublicContext(env, token));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/apps/scope-app/latest"); // jumps to latest version
   });
 
   it("password-protected share gates page and download until unlocked", async () => {

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -8820,8 +8820,47 @@ describe("quiver public API v2 — scope resolution", () => {
     expect(events.results).toEqual([{ event_type: "view", count: 1 }]);
   });
 
+  it("share download falls back to the app's latest active version when the bound object is gone (#442)", async () => {
+    const env = makeEnv();
+    const { handleCreateReleaseShare, handlePublicReleaseShareDownload } = await import("../src/routes/shares");
+    // The shared (older) release + its asset — this object will be "deleted" from R2.
+    await seedRelease(env, "rel-old", "build-old", [["full", "all"]], { versionCode: 5, versionName: "1.0.5", createdAt: 1000 });
+    await seedAsset(env, "build-old", "asset-old", { arch: "arm64-v8a" }); // r2_key apps/app-scope/asset-old.apk
+    const created = await responseJson<any>(
+      await handleCreateReleaseShare(makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-old" }, { ttl_seconds: 600 })),
+    );
+    const token = new URL(created.share_url).pathname.replace("/share/", "");
+    // A newer active release exists for the same app, with a present object.
+    await seedRelease(env, "rel-new", "build-new", [["full", "all"]], { versionCode: 9, versionName: "1.0.9", createdAt: 2000 });
+    await seedAsset(env, "build-new", "asset-new", { arch: "arm64-v8a" }); // r2_key apps/app-scope/asset-new.apk
+
+    // R2: the shared (old) object is gone; only the latest active (new) object exists.
+    env.APK_BUCKET = { head: async (key: string) => (key === "apps/app-scope/asset-new.apk" ? { key } : null) } as any;
+
+    const res = await handlePublicReleaseShareDownload(makeSharePublicContext(env, token));
+    expect(res.status).toBe(302); // fell back rather than 302→404
+    const loc = res.headers.get("location") ?? "";
+    expect(loc).toContain("asset-new.apk"); // serves the latest active version
+    expect(loc).not.toContain("asset-old.apk"); // not the deleted bound one
+  });
+
+  it("share download 404s only when neither the bound object nor any active version remains (#442)", async () => {
+    const env = makeEnv();
+    const { handleCreateReleaseShare, handlePublicReleaseShareDownload } = await import("../src/routes/shares");
+    await seedRelease(env, "rel-only", "build-only", [["full", "all"]], { versionCode: 3, versionName: "1.0.3" });
+    await seedAsset(env, "build-only", "asset-only", { arch: "arm64-v8a" });
+    const created = await responseJson<any>(
+      await handleCreateReleaseShare(makeShareAdminContext(env, { appId: "app-scope", releaseId: "rel-only" }, { ttl_seconds: 600 })),
+    );
+    const token = new URL(created.share_url).pathname.replace("/share/", "");
+    env.APK_BUCKET = { head: async () => null } as any; // everything is gone from R2
+    const res = await handlePublicReleaseShareDownload(makeSharePublicContext(env, token));
+    expect(res.status).toBe(404);
+  });
+
   it("password-protected share gates page and download until unlocked", async () => {
     const env = makeEnv();
+    env.APK_BUCKET = { head: async (key: string) => ({ key }) } as any; // bound object exists
     const {
       handleCreateReleaseShare,
       handlePublicReleaseShare,
@@ -10520,6 +10559,7 @@ describe("quiver public API v2 — scope resolution", () => {
 
   it("share download redirects to signed R2 and records download stats", async () => {
     const env = makeEnv();
+    env.APK_BUCKET = { head: async (key: string) => ({ key }) } as any; // bound object exists
     const {
       handleCreateReleaseShare,
       handleListReleaseShares,


### PR DESCRIPTION
Fixes #442 — share "Download APK" 404.

## Problem
`/share/<token>/download` resolved the bound release regardless of status then 302-redirected the signed `r2_key` with **no existence check**, so a deleted/pruned object produced a broken 404. The share page had the same gap.

## Fix (code-only, no migration)
- **Download**: `head()` the bound key; on a miss, fall back to the app's latest active installable that still exists in R2 (head-checked, up to 5 candidates) → 302; only when nothing downloadable remains → unavailable page.
- **Share page**: when the bound object is gone but a newer active version exists, 302 → `/apps/<slug>/latest` (per artin) instead of a page whose download 404s.
- Added `app_id` to the share row/query to resolve the app's latest active release.

## Tests
+3 (download→fallback-302-to-latest, download all-gone→404, page→302-to-latest) + existing share tests updated for the new `head()` calls. Worker `routes.test.ts` 198/198, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)