### PR TITLE
feat(agent-login): RFC 057 CLI agent-login (CP2 server + CP3 CLI) — migration 0066, PKCE exchange, auto-refresh + single-flight

### DIFF
--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -133,17 +133,22 @@ agent_refresh_tokens(
 Additive/backward-compatible; index on `token_hash`. Revocation = set `revoked_at`
 (and cascade the chain on reuse). Admin revoke path (revoke all for an agent).
 
-## Lifecycle revocation (Argus advisory)
+## Lifecycle revocation (Argus advisory; scope confirmed by @XX census)
 
 Hands binds every grant/refresh record to `(server, agent, integration, service)`, so
-it has the material to **revoke by identity**. As a Hands service policy:
+it has the material to **revoke by identity**. Scope this version:
 
-- Support revoke-all-for-`(agent[/server/service])` (admin + programmatic).
-- **On agent-lifecycle termination**, revoke that agent's refresh tokens. Trigger
-  options (coordination with @XX): (a) a daemon/Raft "agent terminated" signal if one
-  exists; (b) short refresh TTL bounds the window regardless; (c) manual/admin revoke.
-  CP2 implements the revoke-by-identity capability; the automatic trigger source is a
-  CP2 open item pending whether Raft exposes a termination hook.
+- **CP2 implements** revoke-by-identity / revoke-all-for-`(agent[/server/service])`
+  (admin + programmatic).
+- **Automatic lifecycle trigger = NOT_AVAILABLE.** Per @XX's source census there is no
+  agent-terminated/-deleted hook an installed service may subscribe to — the internal
+  `agent:deleted` Socket.IO is browser-only (not an Agent Login action, not an app
+  webhook, not in canonical `AgentLifecycleEventType`); Hands must not connect to it.
+- Until a generic lifecycle outbound contract exists, exposure is bounded by **short
+  access TTL + refresh expiry/revocation**. Refresh must **not** re-query Raft agent
+  liveness (no hidden online dependency).
+- "Raft agent delete/terminate → auto-revoke service refresh" is a **separate platform
+  follow-up**, not a Hands CP2 prerequisite or a completed item.
 
 ## CLI auth store (CP3)
 

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -41,11 +41,11 @@ never mutates state.
 ```
 hands login  (agent env)
   0. CLI generates high-entropy code_verifier; code_challenge = base64url(SHA-256(verifier))
-  1. raft integration invoke <hands-service> --action agent-login
+  1. raft integration invoke --service hands-4cc7a2 --action agent-login
        input:  { schema:request.v1, code_challenge, code_challenge_method:"S256" }
-       result: { schema:grant.v1, service:"hands", grant:<opaque single-use>, expires_at:<=300s }
+       result: { schema:grant.v1, service:<exact RAFT_CLIENT_ID, e.g. hands-4cc7a2>, grant:<opaque single-use>, expires_at:<RFC3339, <=300s> }
   2. POST <hands-api>/api/auth/agent/exchange  { schema:exchange.v1, grant, code_verifier }
-       -> { access_token, refresh_token, access_expires_at }
+       -> raft-cli-agent-session.v1 { schema, token_type:"Bearer", access_token, access_expires_at:<RFC3339>, refresh_token, refresh_expires_at:<RFC3339|null> }
   3. store at $SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/hands/auth.json
   4. subsequent calls use access_token; auto-refresh (below)
 ```
@@ -59,8 +59,15 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
   `hands-auth-jwt-v1` HMAC), but **short TTL** (proposed 15m; final TTL aligned to
   the existing human-JWT TTL — to be read from source at CP2, not guessed).
 - **refresh token** = NEW opaque high-entropy secret; only its hash is stored
-  server-side; revocable + rotated on every use; bound to `(agent_id, server_id,
+  server-side; revocable + rotated on every use; bound to `(server_id, agent_id,
   service)`.
+- **Identity (XX-frozen):** `agent_id = authenticated_account.provider_subject` (the
+  Raft agent identity — the grant/refresh binding + per-agent revoke key);
+  `account_id = authenticated_account.id` (the Hands-local account row — used as
+  `raft_sessions.account_id` and the access-JWT `sub`, so the token resolves via the
+  normal auth middleware). `service = RAFT_CLIENT_ID` (the exact installed client key,
+  e.g. `hands-4cc7a2` — NOT the brand "hands"). All derived server-side; CLI/body can
+  neither supply nor override them; any missing required value → fail closed.
 
 ## Worker endpoints (CP2)
 
@@ -75,7 +82,8 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
   **ignoring `x-hands-org-id`**, so the org header can never rebind the grant's
   server/account. (Requires `principal_type=agent`.)
 - Writes a Hands-side grant record (`identity + code_challenge + nonce + issued/expiry`,
-  storing the grant digest). Returns `{ schema:"…grant.v1", service:"hands", grant, expires_at (<=300s) }`.
+  storing the grant digest). Returns `{ schema:"raft-cli-agent-login-grant.v1", service:<exact RAFT_CLIENT_ID>, grant, expires_at:<RFC3339, strictly future, <=300s> }`.
+- Closed input: the request body accepts ONLY `{ schema, code_challenge, code_challenge_method }`; extension fields are rejected. `code_challenge` must be strict base64url (no padding), decode to exactly 32 bytes, and canonical round-trip.
 - **Handler teeth (Volta):**
   1. `authenticated_account` is set ONLY on the valid Hands-session branch; the
      deploy-token fallback must not synthesize it. Handler **fails closed** if it is absent.
@@ -86,27 +94,42 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
 
 ### `POST /api/auth/agent/exchange`
 - Body: `{ schema:"raft-cli-agent-login-exchange.v1", grant, code_verifier }`.
-- Consume + proof-verify per the Grant interface (atomic single-use; identity from
-  the grant binding; `SHA-256(verifier)==code_challenge`). Any failure → fail closed
-  with a stable error from the closed set (no token). `code_verifier` is never
-  logged/stored.
-- On success: mint short access JWT + issue refresh token; persist refresh hash;
-  both bound to the proven `identity`.
-- Response: `{ access_token, refresh_token, access_expires_at }`.
+- `code_verifier` validated per **RFC 7636** (43–128 chars, unreserved charset
+  `[A-Za-z0-9-._~]`) BEFORE hashing — a malformed verifier can never be exchanged.
+- **Binding check:** the grant's stored `service` must still equal the current
+  `RAFT_CLIENT_ID` and pass the slug regex `^[a-z0-9][a-z0-9._-]{0,79}$`, else
+  `grant_binding_mismatch` (cross-service redemption fail-closed).
+- Consume + proof-verify (atomic single-use; identity from the grant binding;
+  `SHA-256(verifier)==code_challenge`). Any failure → fail closed with a stable error
+  from the closed set (no token). `code_verifier` is never logged/stored.
+- **Atomicity/concurrency:** the consume + session INSERT + refresh INSERT run in ONE
+  D1 `batch()`. The winner is selected by the consume `UPDATE ... WHERE consumed_at IS
+  NULL` and stamps a **unique attempt id** (`consumed_by`); the mint INSERTs guard on
+  that attempt id (NOT the timestamp, which same-millisecond racers share). Success
+  requires all three statements to change exactly one row; otherwise no tokens are
+  minted here (a batch error rolls back the consume too — a grant is never burned
+  without issuing tokens).
+- On success: mint short access JWT (`sub`=account_id) backed by a `raft_sessions` row
+  + issue rotating refresh; both bound to the proven identity.
+- Response: `raft-cli-agent-session.v1` `{ schema, token_type:"Bearer", access_token,
+  access_expires_at:<RFC3339>, refresh_token, refresh_expires_at:<RFC3339|null> }`.
 
 ### `POST /api/auth/agent/refresh`
-- Body: `{ refresh_token }`.
+- Body: `{ schema:"raft-cli-agent-refresh.v1", refresh_token }`.
 - Looks up by hash; if unknown / expired / revoked / **already-rotated (reuse)** →
   fail closed AND revoke the whole rotation chain (reuse = compromise signal).
-- On success: rotate (issue new access + new refresh, mark old rotated), persist.
-- Response: `{ access_token, refresh_token, access_expires_at }`.
+- On success: rotate (fence-revoke old + mint successor in ONE D1 `batch()`, guarded on
+  a unique attempt id `revoked_by` so same-ms concurrent rotations can't double-issue;
+  a concurrent loser gets `temporarily_unavailable` and must re-read the store, never
+  overwriting a newer session with an older rotation result).
+- Response: a complete new `raft-cli-agent-session.v1` (same shape as exchange).
 
 Both endpoints: grant/refresh values never logged; errors carry a stable `code`,
 never the secret.
 
 ## Server-side storage (CP2 migration)
 
-New D1 tables (next migration number at CP2 time — main is currently at `0065`).
+New D1 tables in migration `0066` (added in-place while unreleased; main was at `0065`).
 
 Grant records (Hands owns the grant lifecycle — issue at `agent-login`, consume at
 `exchange`, atomically):
@@ -115,14 +138,18 @@ Grant records (Hands owns the grant lifecycle — issue at `agent-login`, consum
 agent_login_grants(
   grant_digest TEXT PRIMARY KEY,       -- digest only, never the raw grant
   server_id TEXT NOT NULL,             -- all identity fields from the authenticated
-  agent_id TEXT NOT NULL,              -- Agent Login context, NOT the request body
+  agent_id TEXT NOT NULL,              -- Agent Login context, NOT the request body:
+                                       --   agent_id  = authenticated_account.provider_subject
+  account_id TEXT NOT NULL,            --   account_id = authenticated_account.id
   integration TEXT NOT NULL,
-  service TEXT NOT NULL,
+  service TEXT NOT NULL,               -- exact RAFT_CLIENT_ID (e.g. hands-4cc7a2)
   code_challenge TEXT NOT NULL,        -- S256; verified against verifier at exchange
   nonce TEXT NOT NULL,
   issued_at INTEGER NOT NULL,
   expires_at INTEGER NOT NULL,         -- <=300s from issue
-  consumed_at INTEGER                  -- set atomically with mint; single-use
+  consumed_at INTEGER,                 -- set atomically with mint; single-use
+  consumed_by TEXT                     -- unique attempt id of the winning exchange
+                                       -- (ownership token; guards the mint INSERTs)
 )
 ```
 
@@ -132,14 +159,17 @@ Refresh tokens:
 agent_refresh_tokens(
   id TEXT PRIMARY KEY,
   token_hash TEXT NOT NULL UNIQUE,     -- hash only, never the raw token
-  agent_id TEXT NOT NULL,
   server_id TEXT NOT NULL,
-  service TEXT NOT NULL,
+  agent_id TEXT NOT NULL,              -- provider_subject (binding + per-agent revoke key)
+  account_id TEXT NOT NULL,            -- Hands account row (session subject on rotation)
+  integration TEXT NOT NULL,
+  service TEXT NOT NULL,               -- exact RAFT_CLIENT_ID
   app_scope TEXT,                      -- if the access is app-scoped
   created_at INTEGER NOT NULL,
   expires_at INTEGER NOT NULL,
   rotated_from TEXT,                   -- prior token id in the chain
-  revoked_at INTEGER
+  revoked_at INTEGER,
+  revoked_by TEXT                      -- unique attempt id of the rotation that fenced it
 )
 ```
 
@@ -168,7 +198,9 @@ it has the material to **revoke by identity**. Scope this version:
 - Path: **`$SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/hands/auth.json`**.
 - Write: **atomic replace** (write temp in same dir + `rename`); file mode `0600`,
   directory mode `0700`.
-- Contents: `{ access_token, refresh_token, access_expires_at }` (+ api base).
+- Contents: the `raft-cli-agent-session.v1` fields (`access_token`, `access_expires_at`,
+  `refresh_token`, `refresh_expires_at`, `token_type`) + service slug + `updated_at`
+  (+ api base). No Raft bearer or Raft profile credential.
 - Never written to env; never logged; never printed to stdout/stderr.
 
 ## Auto-refresh (CP3)
@@ -194,11 +226,19 @@ Action input:
 ```
 Action result (strict):
 ```json
-{"schema":"raft-cli-agent-login-grant.v1","service":"hands","grant":"<opaque single-use>","expires_at":"<future RFC3339, <=300s>"}
+{"schema":"raft-cli-agent-login-grant.v1","service":"<exact RAFT_CLIENT_ID, e.g. hands-4cc7a2>","grant":"<opaque single-use>","expires_at":"<future RFC3339, <=300s>"}
 ```
 Hands exchange request:
 ```json
-{"schema":"raft-cli-agent-login-exchange.v1","grant":"…","code_verifier":"…"}
+{"schema":"raft-cli-agent-login-exchange.v1","grant":"…","code_verifier":"<RFC 7636, 43–128 unreserved chars>"}
+```
+Exchange / refresh success (raft-cli-agent-session.v1):
+```json
+{"schema":"raft-cli-agent-session.v1","token_type":"Bearer","access_token":"…","access_expires_at":"<RFC3339>","refresh_token":"…","refresh_expires_at":"<RFC3339|null>"}
+```
+Refresh request:
+```json
+{"schema":"raft-cli-agent-refresh.v1","refresh_token":"…"}
 ```
 
 Grant record (Raft-side) binds authenticated `server/agent/integration/service` +
@@ -206,8 +246,10 @@ issued/expiry + `code_challenge` + nonce; stores the grant digest where possible
 consume + used-transition is atomic. Server/agent id are **proven via the grant
 binding, never client-self-reported**.
 
-**Exchange error closed-set:** `invalid` / `expired` / `consumed` /
-`binding_mismatch` / `grant_proof_mismatch` / `temporarily_unavailable`. Only
+**Error closed-set (frozen, verified vs slock `2cb55a4e`):** exchange →
+`grant_invalid` / `grant_expired` / `grant_consumed` / `grant_binding_mismatch` /
+`grant_proof_mismatch`; refresh → `refresh_invalid` / `refresh_expired` /
+`refresh_reused` / `refresh_revoked`; shared → `temporarily_unavailable`. Only
 `temporarily_unavailable` is bounded-retryable; an ambiguous exchange does NOT retry
 the old grant — the CLI acquires a fresh one.
 
@@ -261,8 +303,9 @@ Hands's local proof check; `server/agent` id is never client-self-reported.
 | Any one marker missing / `raft` not executable | human/CI path, unchanged |
 | Human/CI (no markers) | existing login byte-for-byte identical |
 | exchange with valid grant + matching verifier | access + refresh issued; store written 0600, dir 0700 |
-| exchange with wrong/absent code_verifier | `grant_proof_mismatch`, no token |
-| exchange with expired/consumed/cross-bound grant | `expired`/`consumed`/`binding_mismatch`, fail closed, no token |
+| exchange with malformed/absent code_verifier | `grant_invalid` (RFC 7636 format), grant not burned |
+| exchange with well-formed but wrong code_verifier | `grant_proof_mismatch`, grant not burned |
+| exchange with expired/consumed/cross-bound grant | `grant_expired`/`grant_consumed`/`grant_binding_mismatch`, fail closed, no token |
 | verifier in any Raft-bound payload/log/store | never present (proof stays CLI↔Hands) |
 | agent-login: agent session (server A) + `x-hands-org-id` → linked server B | grant binds A (or fail closed), never B |
 | agent-login via deploy-token (no `authenticated_account`) | fail closed, no grant |

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -1,0 +1,173 @@
+# Hands CLI agent login — first reference instance (CP1 contract draft)
+
+Status: **proposed design (CP1)**. No runtime, schema, or production change is
+authorized by this document. It freezes the Hands-side shape so CP2 (Worker) and
+CP3 (CLI) implement to a reviewed contract. Hands is the **first instance** of the
+generic `CLI agent login` capability; there is **no Hands-special-casing** — the
+same recipe applies to any service that adopts the generic contract.
+
+Cross-refs: generic contract owned by @XX (Raft-side, task #1); this is the Hands
+instance (#joint-hands task #2). Security review lands in `#proj-hands` with
+@Sentinel; CLI/client owner review with @Volta.
+
+## Scope
+
+- Let an **agent** run `hands login` with no browser, obtaining a short-lived
+  Hands access token + a revocable refresh token, stored per-agent.
+- **Humans / CI paths are unchanged, byte-for-byte** (browser login, `--token`,
+  `HANDS_AUTH_TOKEN`/`HANDS_BEARER_TOKEN`, `~/.config/quiver/auth.json`).
+
+## Non-goals
+
+- No daemon-held service credential / proxy (XX's census: existing Raft transport
+  suffices; deferred heavier "daemon holds all" is out of scope).
+- No hard isolation between same-OS-user agents (see Threat model).
+- No change to the human/CI login or to `hands api` (#448).
+
+## Environment detection (agent path gate)
+
+The agent path is taken **only when ALL of these hold**:
+
+1. `SLOCK_CLI_TRANSPORT_DIR` is set,
+2. `raft` is on PATH and executable,
+3. `SLOCK_HOME` is set,
+4. `SLOCK_AGENT_ID` is set.
+
+Any one missing → fall through to the existing human/CI login unchanged. Detection
+never mutates state.
+
+## Flow
+
+```
+hands login  (agent env)
+  1. raft integration invoke <hands-service> --action agent-login
+       -> one-time grant   (format/TTL/binding/errors = XX's frozen contract; see "Grant interface")
+  2. POST <hands-api>/api/auth/agent/exchange   { grant }
+       -> { access_token, refresh_token, access_expires_at }
+  3. store at $SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/hands/auth.json
+  4. subsequent calls use access_token; auto-refresh (below)
+```
+
+The final Hands tokens are exchanged by the **Hands CLI ↔ Hands API** directly;
+they are never handed back to Raft/daemon and never appear in the `invoke` output.
+
+## Token model
+
+- **access token** = reuse the existing Hands JWT signer (`worker/src/routes/auth.ts`,
+  `hands-auth-jwt-v1` HMAC), but **short TTL** (proposed 15m; final TTL aligned to
+  the existing human-JWT TTL — to be read from source at CP2, not guessed).
+- **refresh token** = NEW opaque high-entropy secret; only its hash is stored
+  server-side; revocable + rotated on every use; bound to `(agent_id, server_id,
+  service)`.
+
+## Worker endpoints (CP2)
+
+### `POST /api/auth/agent/exchange`
+- Body: `{ grant }`.
+- Validates the grant per the Grant interface (single-use, unexpired, bound to the
+  calling agent/server/service). On any failure → fail closed (401/400, no token).
+- On success: mint short access JWT + issue refresh token; persist refresh hash.
+- Response: `{ access_token, refresh_token, access_expires_at }`.
+
+### `POST /api/auth/agent/refresh`
+- Body: `{ refresh_token }`.
+- Looks up by hash; if unknown / expired / revoked / **already-rotated (reuse)** →
+  fail closed AND revoke the whole rotation chain (reuse = compromise signal).
+- On success: rotate (issue new access + new refresh, mark old rotated), persist.
+- Response: `{ access_token, refresh_token, access_expires_at }`.
+
+Both endpoints: grant/refresh values never logged; errors carry a stable `code`,
+never the secret.
+
+## Refresh-token storage (CP2 migration)
+
+New D1 table (next migration number at CP2 time — currently main is at `0065`):
+
+```
+agent_refresh_tokens(
+  id TEXT PRIMARY KEY,
+  token_hash TEXT NOT NULL UNIQUE,     -- hash only, never the raw token
+  agent_id TEXT NOT NULL,
+  server_id TEXT NOT NULL,
+  service TEXT NOT NULL,
+  app_scope TEXT,                      -- if the access is app-scoped
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  rotated_from TEXT,                   -- prior token id in the chain
+  revoked_at INTEGER
+)
+```
+
+Additive/backward-compatible; index on `token_hash`. Revocation = set `revoked_at`
+(and cascade the chain on reuse). Admin revoke path (revoke all for an agent).
+
+## CLI auth store (CP3)
+
+- Path: **`$SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/hands/auth.json`**.
+- Write: **atomic replace** (write temp in same dir + `rename`); file mode `0600`,
+  directory mode `0700`.
+- Contents: `{ access_token, refresh_token, access_expires_at }` (+ api base).
+- Never written to env; never logged; never printed to stdout/stderr.
+
+## Auto-refresh (CP3)
+
+- Refresh proactively shortly **before** `access_expires_at`, and reactively **once**
+  on a `401`.
+- Concurrency: single-flight refresh (lock/temp file) so parallel `hands` invocations
+  don't double-rotate; crash mid-rotate must not lock the agent out (recover from the
+  last durably-persisted token).
+- `expired / reused / revoked` refresh → clear the store and require a fresh
+  `hands login`.
+
+## Grant interface (depends on XX's frozen `agent-login` action contract — task #1)
+
+Pending from XX: the one-time grant's **fields, TTL, binding (agent/server/service),
+single-use/replay guarantee, and error codes**, plus **how Hands validates/consumes
+it** (call back to Raft to consume, or verify a signed grant + Raft tracks single-use).
+CP2's `exchange` validation is written to exactly this contract; until frozen, the
+validation is an interface stub, not a guessed protocol.
+
+## Threat model (honest)
+
+- `0600`/`0700` + the per-agent path prevent **accidental cross-agent sharing** and
+  reads by **other OS users**.
+- They do **NOT** hard-isolate agents running as the **same OS user** (they can read
+  each other's files at the OS level). Hard isolation would need a daemon proxy /
+  per-agent OS identity — deferred future hardening, explicitly out of scope here.
+- Blast radius: leaked access token dies in minutes; leaked refresh token is
+  revocable server-side and rotation makes replay detectable.
+
+## Security invariants
+
+1. Grant and tokens never printed, never in env, never in error/log output.
+2. Cross-`agent_id` / cross-`server_id` / cross-`service`, replay, and expiry all
+   fail closed with no side effect.
+3. Human/CI login path is byte-for-byte unchanged; agent path is additive.
+4. Refresh reuse (a rotated token used again) revokes the whole chain.
+5. No arbitrary-argv / no self-made Raft protocol — CLI calls only the frozen
+   `agent-login` manifest action.
+
+## Test matrix (CP2/CP3)
+
+| Scenario | Required result |
+| --- | --- |
+| All 4 daemon markers present | agent login path taken |
+| Any one marker missing / `raft` not executable | human/CI path, unchanged |
+| Human/CI (no markers) | existing login byte-for-byte identical |
+| exchange with valid grant | access + refresh issued; store written 0600, dir 0700 |
+| exchange with expired/replayed/cross-bound grant | fail closed, no token, stable code |
+| refresh happy path | rotates; old refresh no longer valid |
+| refresh reuse (rotated token) | fail closed + chain revoked |
+| refresh expired / revoked | store cleared, re-login required |
+| access 401 mid-session | single auto-refresh, then retry |
+| parallel invocations | single-flight refresh, no double-rotate |
+| crash mid-rotate | recover from last persisted token, no lockout |
+| any output (stdout/stderr/json/error) | contains no grant/token |
+
+## Checkpoints
+
+- **CP1** (this doc): freeze Hands-side shape; align with XX; Sentinel security
+  pre-read (in `#proj-hands`).
+- **CP2**: Worker PR — refresh table migration + `exchange`/`refresh` endpoints
+  (grant validation to XX's frozen contract).
+- **CP3**: CLI PR — detection + `hands login` agent branch + store + auto-refresh.

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -64,6 +64,13 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
 
 ## Worker endpoints (CP2)
 
+### `agent-login` action (Hands manifest action; reached via `integration invoke`)
+- Input: `{ schema:"raft-cli-agent-login-request.v1", code_challenge, code_challenge_method:"S256" }`.
+- Hands reads `server/agent/integration/service` **from the authenticated Agent Login
+  context of the invoke** (never from the request body).
+- Writes a Hands-side grant record (`identity + code_challenge + nonce + issued/expiry`,
+  storing the grant digest). Returns `{ schema:"…grant.v1", service:"hands", grant, expires_at (<=300s) }`.
+
 ### `POST /api/auth/agent/exchange`
 - Body: `{ schema:"raft-cli-agent-login-exchange.v1", grant, code_verifier }`.
 - Consume + proof-verify per the Grant interface (atomic single-use; identity from
@@ -84,9 +91,29 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
 Both endpoints: grant/refresh values never logged; errors carry a stable `code`,
 never the secret.
 
-## Refresh-token storage (CP2 migration)
+## Server-side storage (CP2 migration)
 
-New D1 table (next migration number at CP2 time — currently main is at `0065`):
+New D1 tables (next migration number at CP2 time — main is currently at `0065`).
+
+Grant records (Hands owns the grant lifecycle — issue at `agent-login`, consume at
+`exchange`, atomically):
+
+```
+agent_login_grants(
+  grant_digest TEXT PRIMARY KEY,       -- digest only, never the raw grant
+  server_id TEXT NOT NULL,             -- all identity fields from the authenticated
+  agent_id TEXT NOT NULL,              -- Agent Login context, NOT the request body
+  integration TEXT NOT NULL,
+  service TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,        -- S256; verified against verifier at exchange
+  nonce TEXT NOT NULL,
+  issued_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,         -- <=300s from issue
+  consumed_at INTEGER                  -- set atomically with mint; single-use
+)
+```
+
+Refresh tokens:
 
 ```
 agent_refresh_tokens(
@@ -154,13 +181,23 @@ binding, never client-self-reported**.
 `temporarily_unavailable` is bounded-retryable; an ambiguous exchange does NOT retry
 the old grant — the CLI acquires a fresh one.
 
-**Consumption locus — PENDING @XX confirm** (my seat can't read RFC 057 directly):
-my read is Hands exchange receives `{grant, code_verifier}` → calls Raft to atomically
-consume the opaque `grant` (grant only, verifier NOT sent) → Raft returns the bound
-`{identity, code_challenge, nonce}` → Hands verifies `SHA-256(verifier) ==
-code_challenge` locally (mismatch → `grant_proof_mismatch`) → mints access+refresh
-bound to `identity`. If RFC 057 splits consume/verify differently, this section
-updates to match before CP2 code.
+**Consumption locus — CONFIRMED by @XX (RFC 057): fully Hands-local, NO Raft callback
+at exchange.**
+
+1. `agent-login` **action is executed by Hands** (the invoke transports the request
+   to the Hands service). Hands reads `server/agent/integration/service` identity from
+   the authenticated Agent Login context, writes its OWN grant record
+   (`identity + code_challenge + nonce + expiry`, storing the grant digest), and
+   returns only the opaque `grant` to the CLI.
+2. CLI sends `{grant, code_verifier}` to the Hands exchange endpoint.
+3. Hands finds its own record by grant digest → checks unexpired/unconsumed/binding
+   → verifies `SHA-256(code_verifier)==code_challenge` (mismatch → `grant_proof_mismatch`)
+   → in the **same atomic transaction** marks the grant consumed and mints
+   access+refresh; session identity comes from the grant record.
+
+Raft/daemon never sees the verifier and is not called at exchange (no Raft online
+dependency, no second identity hop). `grant_proof_mismatch` originates only from
+Hands's local proof check; `server/agent` id is never client-self-reported.
 
 ## Threat model (honest)
 

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -76,6 +76,13 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
   server/account. (Requires `principal_type=agent`.)
 - Writes a Hands-side grant record (`identity + code_challenge + nonce + issued/expiry`,
   storing the grant digest). Returns `{ schema:"…grant.v1", service:"hands", grant, expires_at (<=300s) }`.
+- **Handler teeth (Volta):**
+  1. `authenticated_account` is set ONLY on the valid Hands-session branch; the
+     deploy-token fallback must not synthesize it. Handler **fails closed** if it is absent.
+  2. Require `principal_type === "agent"` — a human session (even with a raw account)
+     cannot obtain an agent grant.
+  3. The grant's audit actor/identity derive from `authenticated_account`, NOT the
+     org-switched `admin_actor`/current actor (else the grant binds A but audit logs B).
 
 ### `POST /api/auth/agent/exchange`
 - Body: `{ schema:"raft-cli-agent-login-exchange.v1", grant, code_verifier }`.
@@ -258,6 +265,9 @@ Hands's local proof check; `server/agent` id is never client-self-reported.
 | exchange with expired/consumed/cross-bound grant | `expired`/`consumed`/`binding_mismatch`, fail closed, no token |
 | verifier in any Raft-bound payload/log/store | never present (proof stays CLI↔Hands) |
 | agent-login: agent session (server A) + `x-hands-org-id` → linked server B | grant binds A (or fail closed), never B |
+| agent-login via deploy-token (no `authenticated_account`) | fail closed, no grant |
+| agent-login with a human session | rejected (agent principal required), no grant |
+| grant audit record under an active-org header | actor/identity = authenticated account (A), never the org-switched account |
 | `temporarily_unavailable` vs ambiguous exchange | former bounded-retry; latter acquires a fresh grant, never retries the old |
 | refresh happy path | rotates; old refresh no longer valid |
 | refresh reuse (rotated token) | fail closed + chain revoked |

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -133,6 +133,18 @@ agent_refresh_tokens(
 Additive/backward-compatible; index on `token_hash`. Revocation = set `revoked_at`
 (and cascade the chain on reuse). Admin revoke path (revoke all for an agent).
 
+## Lifecycle revocation (Argus advisory)
+
+Hands binds every grant/refresh record to `(server, agent, integration, service)`, so
+it has the material to **revoke by identity**. As a Hands service policy:
+
+- Support revoke-all-for-`(agent[/server/service])` (admin + programmatic).
+- **On agent-lifecycle termination**, revoke that agent's refresh tokens. Trigger
+  options (coordination with @XX): (a) a daemon/Raft "agent terminated" signal if one
+  exists; (b) short refresh TTL bounds the window regardless; (c) manual/admin revoke.
+  CP2 implements the revoke-by-identity capability; the automatic trigger source is a
+  CP2 open item pending whether Raft exposes a termination hook.
+
 ## CLI auth store (CP3)
 
 - Path: **`$SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/hands/auth.json`**.

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -40,9 +40,11 @@ never mutates state.
 
 ```
 hands login  (agent env)
+  0. CLI generates high-entropy code_verifier; code_challenge = base64url(SHA-256(verifier))
   1. raft integration invoke <hands-service> --action agent-login
-       -> one-time grant   (format/TTL/binding/errors = XX's frozen contract; see "Grant interface")
-  2. POST <hands-api>/api/auth/agent/exchange   { grant }
+       input:  { schema:request.v1, code_challenge, code_challenge_method:"S256" }
+       result: { schema:grant.v1, service:"hands", grant:<opaque single-use>, expires_at:<=300s }
+  2. POST <hands-api>/api/auth/agent/exchange  { schema:exchange.v1, grant, code_verifier }
        -> { access_token, refresh_token, access_expires_at }
   3. store at $SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/hands/auth.json
   4. subsequent calls use access_token; auto-refresh (below)
@@ -63,10 +65,13 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
 ## Worker endpoints (CP2)
 
 ### `POST /api/auth/agent/exchange`
-- Body: `{ grant }`.
-- Validates the grant per the Grant interface (single-use, unexpired, bound to the
-  calling agent/server/service). On any failure → fail closed (401/400, no token).
-- On success: mint short access JWT + issue refresh token; persist refresh hash.
+- Body: `{ schema:"raft-cli-agent-login-exchange.v1", grant, code_verifier }`.
+- Consume + proof-verify per the Grant interface (atomic single-use; identity from
+  the grant binding; `SHA-256(verifier)==code_challenge`). Any failure → fail closed
+  with a stable error from the closed set (no token). `code_verifier` is never
+  logged/stored.
+- On success: mint short access JWT + issue refresh token; persist refresh hash;
+  both bound to the proven `identity`.
 - Response: `{ access_token, refresh_token, access_expires_at }`.
 
 ### `POST /api/auth/agent/refresh`
@@ -119,13 +124,43 @@ Additive/backward-compatible; index on `token_hash`. Revocation = set `revoked_a
 - `expired / reused / revoked` refresh → clear the store and require a fresh
   `hands login`.
 
-## Grant interface (depends on XX's frozen `agent-login` action contract — task #1)
+## Grant interface — FROZEN (RFC 057 / slock PR #6496, `7b0c8cdf`)
 
-Pending from XX: the one-time grant's **fields, TTL, binding (agent/server/service),
-single-use/replay guarantee, and error codes**, plus **how Hands validates/consumes
-it** (call back to Raft to consume, or verify a signed grant + Raft tracks single-use).
-CP2's `exchange` validation is written to exactly this contract; until frozen, the
-validation is an interface stub, not a guessed protocol.
+Proof-key (PKCE-style) bound grant — a bare-bearer grant is rejected: stealing the
+stdout grant alone must not allow exchange. The CLI generates a high-entropy
+`code_verifier` locally; only its S256 challenge reaches Raft; the verifier is sent
+only to the Hands exchange endpoint and **never** to Raft, logs, or the store.
+
+Action input:
+```json
+{"schema":"raft-cli-agent-login-request.v1","code_challenge":"<base64url SHA-256, 32 bytes>","code_challenge_method":"S256"}
+```
+Action result (strict):
+```json
+{"schema":"raft-cli-agent-login-grant.v1","service":"hands","grant":"<opaque single-use>","expires_at":"<future RFC3339, <=300s>"}
+```
+Hands exchange request:
+```json
+{"schema":"raft-cli-agent-login-exchange.v1","grant":"…","code_verifier":"…"}
+```
+
+Grant record (Raft-side) binds authenticated `server/agent/integration/service` +
+issued/expiry + `code_challenge` + nonce; stores the grant digest where possible;
+consume + used-transition is atomic. Server/agent id are **proven via the grant
+binding, never client-self-reported**.
+
+**Exchange error closed-set:** `invalid` / `expired` / `consumed` /
+`binding_mismatch` / `grant_proof_mismatch` / `temporarily_unavailable`. Only
+`temporarily_unavailable` is bounded-retryable; an ambiguous exchange does NOT retry
+the old grant — the CLI acquires a fresh one.
+
+**Consumption locus — PENDING @XX confirm** (my seat can't read RFC 057 directly):
+my read is Hands exchange receives `{grant, code_verifier}` → calls Raft to atomically
+consume the opaque `grant` (grant only, verifier NOT sent) → Raft returns the bound
+`{identity, code_challenge, nonce}` → Hands verifies `SHA-256(verifier) ==
+code_challenge` locally (mismatch → `grant_proof_mismatch`) → mints access+refresh
+bound to `identity`. If RFC 057 splits consume/verify differently, this section
+updates to match before CP2 code.
 
 ## Threat model (honest)
 
@@ -154,8 +189,11 @@ validation is an interface stub, not a guessed protocol.
 | All 4 daemon markers present | agent login path taken |
 | Any one marker missing / `raft` not executable | human/CI path, unchanged |
 | Human/CI (no markers) | existing login byte-for-byte identical |
-| exchange with valid grant | access + refresh issued; store written 0600, dir 0700 |
-| exchange with expired/replayed/cross-bound grant | fail closed, no token, stable code |
+| exchange with valid grant + matching verifier | access + refresh issued; store written 0600, dir 0700 |
+| exchange with wrong/absent code_verifier | `grant_proof_mismatch`, no token |
+| exchange with expired/consumed/cross-bound grant | `expired`/`consumed`/`binding_mismatch`, fail closed, no token |
+| verifier in any Raft-bound payload/log/store | never present (proof stays CLI↔Hands) |
+| `temporarily_unavailable` vs ambiguous exchange | former bounded-retry; latter acquires a fresh grant, never retries the old |
 | refresh happy path | rotates; old refresh no longer valid |
 | refresh reuse (rotated token) | fail closed + chain revoked |
 | refresh expired / revoked | store cleared, re-login required |

--- a/docs/agent-cli-login-hands-instance.md
+++ b/docs/agent-cli-login-hands-instance.md
@@ -66,8 +66,14 @@ they are never handed back to Raft/daemon and never appear in the `invoke` outpu
 
 ### `agent-login` action (Hands manifest action; reached via `integration invoke`)
 - Input: `{ schema:"raft-cli-agent-login-request.v1", code_challenge, code_challenge_method:"S256" }`.
-- Hands reads `server/agent/integration/service` **from the authenticated Agent Login
-  context of the invoke** (never from the request body).
+- Hands reads `server/agent/integration/service` from the **session-authenticated
+  account** (never from the request body). **Critical:** it must read the
+  **pre-org-switch** account, NOT `c.get("admin_account")` — `authMiddleware` runs
+  `accountForRequestedOrg()` which, given an `x-hands-org-id` header, swaps to a linked
+  account and stores *that* in `admin_account`. CP2 exposes the original as
+  `authenticated_account` (set before the swap) and this endpoint reads it while
+  **ignoring `x-hands-org-id`**, so the org header can never rebind the grant's
+  server/account. (Requires `principal_type=agent`.)
 - Writes a Hands-side grant record (`identity + code_challenge + nonce + issued/expiry`,
   storing the grant digest). Returns `{ schema:"…grant.v1", service:"hands", grant, expires_at (<=300s) }`.
 
@@ -235,6 +241,10 @@ Hands's local proof check; `server/agent` id is never client-self-reported.
 4. Refresh reuse (a rotated token used again) revokes the whole chain.
 5. No arbitrary-argv / no self-made Raft protocol — CLI calls only the frozen
    `agent-login` manifest action.
+6. **Org header cannot rebind identity.** `agent-login` binds the grant to the
+   pre-org-switch session-authenticated account and ignores `x-hands-org-id`; an
+   `x-hands-org-id` pointing at a linked account/server must never change the grant's
+   `server/agent` binding.
 
 ## Test matrix (CP2/CP3)
 
@@ -247,6 +257,7 @@ Hands's local proof check; `server/agent` id is never client-self-reported.
 | exchange with wrong/absent code_verifier | `grant_proof_mismatch`, no token |
 | exchange with expired/consumed/cross-bound grant | `expired`/`consumed`/`binding_mismatch`, fail closed, no token |
 | verifier in any Raft-bound payload/log/store | never present (proof stays CLI↔Hands) |
+| agent-login: agent session (server A) + `x-hands-org-id` → linked server B | grant binds A (or fail closed), never B |
 | `temporarily_unavailable` vs ambiguous exchange | former bounded-retry; latter acquires a fresh grant, never retries the old |
 | refresh happy path | rotates; old refresh no longer valid |
 | refresh reuse (rotated token) | fail closed + chain revoked |

--- a/migrations/sql/0066_agent_login_tokens.sql
+++ b/migrations/sql/0066_agent_login_tokens.sql
@@ -18,7 +18,10 @@ CREATE TABLE agent_login_grants (
   nonce          TEXT NOT NULL,
   issued_at      INTEGER NOT NULL,
   expires_at     INTEGER NOT NULL,        -- <= issued_at + 300s
-  consumed_at    INTEGER                  -- set atomically with mint; enforces single-use
+  consumed_at    INTEGER,                 -- set atomically with mint; enforces single-use
+  consumed_by    TEXT                     -- unique attempt id of the winning exchange; the
+                                          -- ownership token the mint INSERTs guard on (NOT the
+                                          -- timestamp — same-ms concurrent losers would collide)
 );
 
 CREATE INDEX idx_agent_login_grants_identity
@@ -39,7 +42,10 @@ CREATE TABLE agent_refresh_tokens (
   created_at   INTEGER NOT NULL,
   expires_at   INTEGER NOT NULL,
   rotated_from TEXT REFERENCES agent_refresh_tokens(id) ON DELETE SET NULL,
-  revoked_at   INTEGER
+  revoked_at   INTEGER,
+  revoked_by   TEXT                        -- unique attempt id of the rotation that fenced this
+                                           -- token; the ownership token the successor mint guards
+                                           -- on (NOT the timestamp). NULL for chain/admin revokes.
 );
 
 -- Revoke-by-identity (agent lifecycle / admin) and expiry sweeps.

--- a/migrations/sql/0066_agent_login_tokens.sql
+++ b/migrations/sql/0066_agent_login_tokens.sql
@@ -9,7 +9,9 @@
 CREATE TABLE agent_login_grants (
   grant_digest   TEXT PRIMARY KEY,        -- digest of the opaque grant; raw never stored
   server_id      TEXT NOT NULL,           -- identity fields come from the authenticated
-  agent_id       TEXT NOT NULL,           -- Agent Login invoke context, never the request body
+  agent_id       TEXT NOT NULL,           -- Agent Login invoke context, never the request body:
+                                          --   agent_id  = authenticated_account.provider_subject (Raft agent identity)
+  account_id     TEXT NOT NULL,           --   account_id = authenticated_account.id (Hands-local account row)
   integration    TEXT NOT NULL,
   service        TEXT NOT NULL,
   code_challenge TEXT NOT NULL,           -- S256; verified against the exchange verifier
@@ -29,7 +31,8 @@ CREATE TABLE agent_refresh_tokens (
   id           TEXT PRIMARY KEY,
   token_hash   TEXT NOT NULL UNIQUE,      -- hash of the refresh token; raw never stored
   server_id    TEXT NOT NULL,
-  agent_id     TEXT NOT NULL,
+  agent_id     TEXT NOT NULL,             -- authenticated_account.provider_subject (Raft agent identity)
+  account_id   TEXT NOT NULL,             -- authenticated_account.id (Hands-local account row)
   integration  TEXT NOT NULL,
   service      TEXT NOT NULL,
   app_scope    TEXT,                       -- present when the access is app-scoped

--- a/migrations/sql/0066_agent_login_tokens.sql
+++ b/migrations/sql/0066_agent_login_tokens.sql
@@ -1,0 +1,47 @@
+-- Generic CLI agent login (RFC 057) — Hands first instance, server-side storage.
+-- Two additive tables:
+--   * one-time proof-key grants, issued at the `agent-login` action and consumed
+--     atomically at exchange (verifier proof checked against code_challenge);
+--   * revocable / rotating refresh tokens.
+-- Both bind the authenticated Raft identity (server/agent/integration/service).
+-- Only digests/hashes are stored — never the raw grant, refresh token, or verifier.
+
+CREATE TABLE agent_login_grants (
+  grant_digest   TEXT PRIMARY KEY,        -- digest of the opaque grant; raw never stored
+  server_id      TEXT NOT NULL,           -- identity fields come from the authenticated
+  agent_id       TEXT NOT NULL,           -- Agent Login invoke context, never the request body
+  integration    TEXT NOT NULL,
+  service        TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,           -- S256; verified against the exchange verifier
+  nonce          TEXT NOT NULL,
+  issued_at      INTEGER NOT NULL,
+  expires_at     INTEGER NOT NULL,        -- <= issued_at + 300s
+  consumed_at    INTEGER                  -- set atomically with mint; enforces single-use
+);
+
+CREATE INDEX idx_agent_login_grants_identity
+  ON agent_login_grants (server_id, agent_id, service);
+
+CREATE INDEX idx_agent_login_grants_expiry
+  ON agent_login_grants (expires_at);
+
+CREATE TABLE agent_refresh_tokens (
+  id           TEXT PRIMARY KEY,
+  token_hash   TEXT NOT NULL UNIQUE,      -- hash of the refresh token; raw never stored
+  server_id    TEXT NOT NULL,
+  agent_id     TEXT NOT NULL,
+  integration  TEXT NOT NULL,
+  service      TEXT NOT NULL,
+  app_scope    TEXT,                       -- present when the access is app-scoped
+  created_at   INTEGER NOT NULL,
+  expires_at   INTEGER NOT NULL,
+  rotated_from TEXT REFERENCES agent_refresh_tokens(id) ON DELETE SET NULL,
+  revoked_at   INTEGER
+);
+
+-- Revoke-by-identity (agent lifecycle / admin) and expiry sweeps.
+CREATE INDEX idx_agent_refresh_tokens_identity
+  ON agent_refresh_tokens (server_id, agent_id, service);
+
+CREATE INDEX idx_agent_refresh_tokens_expiry
+  ON agent_refresh_tokens (expires_at);

--- a/packages/cli/src/agent_login.test.ts
+++ b/packages/cli/src/agent_login.test.ts
@@ -1,18 +1,21 @@
 /**
- * CP3 checkpoint-1: agent-login flow (env detection, strict invoke-result validation
- * = Volta's acceptance tooth, session validation, PKCE, atomic store, full flow).
+ * CP3 agent-login: hardened flow + isolation. Covers Volta's 5 findings —
+ * V1 admission tri-state, V3 fixed-service + validation + path containment,
+ * V4 strict non-leaking parse, V5 hardened atomic store — plus the full flow.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, statSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer, type Server } from "node:http";
 import { createHash } from "node:crypto";
 import {
-  detectAgentEnv,
+  admitAgent,
   agentAuthPath,
   readAgentAccessToken,
+  readAgentApiBase,
   HANDS_SERVICE,
+  type AgentEnv,
 } from "./lib/agent_env.js";
 import {
   generatePkce,
@@ -23,7 +26,12 @@ import {
   type AgentSession,
 } from "./lib/agent_auth.js";
 
-const AGENT = { transportDir: "/t", slockHome: "/home/x/.slock", agentId: "agent-7" };
+const T0 = 1_700_000_000_000; // fixed clock (ms)
+const GRANT_EXPIRES = new Date(T0 + 200_000).toISOString(); // <=300s future
+
+function agentEnvAt(slockHome: string, transportDir: string): AgentEnv {
+  return { transportDir, slockHome, agentId: "agent-7", raftBin: join(transportDir, "raft") };
+}
 
 function invokeEnvelope(over: Record<string, unknown> = {}, resultOver: Record<string, unknown> = {}) {
   return JSON.stringify({
@@ -36,7 +44,7 @@ function invokeEnvelope(over: Record<string, unknown> = {}, resultOver: Record<s
         schema: "raft-cli-agent-login-grant.v1",
         service: HANDS_SERVICE,
         grant: "opaque-grant",
-        expires_at: "2026-08-17T09:00:00.000Z",
+        expires_at: GRANT_EXPIRES,
         ...resultOver,
       },
       ...over,
@@ -53,109 +61,141 @@ const SESSION: AgentSession = {
   refresh_expires_at: "2026-09-16T09:00:00.000Z",
 };
 
-describe("agent env detection", () => {
-  it("returns the env only when all three daemon vars are present", () => {
-    const full = { SLOCK_CLI_TRANSPORT_DIR: "/t", SLOCK_HOME: "/h", SLOCK_AGENT_ID: "a" };
-    expect(detectAgentEnv(full as any)).toEqual({ transportDir: "/t", slockHome: "/h", agentId: "a" });
-    expect(detectAgentEnv({ SLOCK_HOME: "/h", SLOCK_AGENT_ID: "a" } as any)).toBeNull();
-    expect(detectAgentEnv({ SLOCK_CLI_TRANSPORT_DIR: "/t", SLOCK_AGENT_ID: "a" } as any)).toBeNull();
-    expect(detectAgentEnv({ SLOCK_CLI_TRANSPORT_DIR: "/t", SLOCK_HOME: "/h" } as any)).toBeNull();
-    expect(detectAgentEnv({} as any)).toBeNull();
+describe("V1 admission tri-state", () => {
+  let dir: string;
+  let transport: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "admit-"));
+    transport = join(dir, "transport");
+    mkdirSync(transport, { recursive: true });
+    writeFileSync(join(transport, "raft"), "#!/bin/sh\n", { mode: 0o755 });
   });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-  it("builds the canonical per-agent store path", () => {
-    expect(agentAuthPath(AGENT)).toBe(
-      `/home/x/.slock/agents/agent-7/integrations/${HANDS_SERVICE}/auth.json`,
-    );
+  it("no markers → human", () => {
+    expect(admitAgent({} as any).kind).toBe("human");
+  });
+  it("complete + executable wrapper → agent pinned to the transport-dir wrapper", () => {
+    const a = admitAgent({ SLOCK_CLI_TRANSPORT_DIR: transport, SLOCK_HOME: dir, SLOCK_AGENT_ID: "agent-7" } as any);
+    expect(a.kind).toBe("agent");
+    if (a.kind === "agent") expect(a.env.raftBin).toBe(join(transport, "raft"));
+  });
+  it("partial markers → fail_closed (never human)", () => {
+    expect(admitAgent({ SLOCK_HOME: dir, SLOCK_AGENT_ID: "a" } as any).kind).toBe("fail_closed");
+  });
+  it("invalid agent id → fail_closed", () => {
+    const a = admitAgent({ SLOCK_CLI_TRANSPORT_DIR: transport, SLOCK_HOME: dir, SLOCK_AGENT_ID: "../evil" } as any);
+    expect(a.kind).toBe("fail_closed");
+  });
+  it("missing wrapper → fail_closed", () => {
+    const a = admitAgent({ SLOCK_CLI_TRANSPORT_DIR: join(dir, "nope"), SLOCK_HOME: dir, SLOCK_AGENT_ID: "agent-7" } as any);
+    expect(a.kind).toBe("fail_closed");
+  });
+  // Root bypasses the X_OK permission bit, so this assertion is only meaningful as a
+  // non-root user.
+  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(asRoot)("non-executable wrapper → fail_closed", () => {
+    chmodSync(join(transport, "raft"), 0o644);
+    const a = admitAgent({ SLOCK_CLI_TRANSPORT_DIR: transport, SLOCK_HOME: dir, SLOCK_AGENT_ID: "agent-7" } as any);
+    expect(a.kind).toBe("fail_closed");
+  });
+});
+
+describe("V3 path containment + fixed service", () => {
+  it("builds the canonical path for the compiled service", () => {
+    const a = agentEnvAt("/home/x/.slock", "/t");
+    expect(agentAuthPath(a)).toBe(`/home/x/.slock/agents/agent-7/integrations/${HANDS_SERVICE}/auth.json`);
+  });
+  it("rejects a service slug with traversal / bad chars", () => {
+    const a = agentEnvAt("/home/x/.slock", "/t");
+    expect(() => agentAuthPath(a, "../escape")).toThrow(/service slug/);
+    expect(() => agentAuthPath(a, "UPPER")).toThrow(/service slug/);
   });
 });
 
 describe("PKCE", () => {
-  it("verifier is RFC 7636 valid and challenge = base64url(sha256(verifier))", () => {
+  it("verifier is RFC 7636 valid; challenge = base64url(sha256(verifier))", () => {
     const { verifier, challenge } = generatePkce();
     expect(verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
-    const expected = createHash("sha256").update(verifier).digest("base64url");
-    expect(challenge).toBe(expected);
-    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(challenge).toBe(createHash("sha256").update(verifier).digest("base64url"));
   });
 });
 
-describe("parseAgentLoginInvoke (strict invoke-result validation — acceptance tooth)", () => {
+describe("V4 strict, non-leaking invoke parse", () => {
   it("accepts a well-formed envelope", () => {
-    expect(parseAgentLoginInvoke(invokeEnvelope(), HANDS_SERVICE)).toEqual({
-      grant: "opaque-grant",
-      expires_at: "2026-08-17T09:00:00.000Z",
-    });
+    expect(parseAgentLoginInvoke(invokeEnvelope(), HANDS_SERVICE, T0)).toEqual({ grant: "opaque-grant", expires_at: GRANT_EXPIRES });
   });
-  it("rejects non-JSON", () => {
-    expect(() => parseAgentLoginInvoke("not json", HANDS_SERVICE)).toThrow(/did not return JSON/);
+  it("requires ok=true / service / action / status=200", () => {
+    expect(() => parseAgentLoginInvoke(JSON.stringify({ ok: false }), HANDS_SERVICE, T0)).toThrow(/did not succeed/);
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ service: "hands-other" }), HANDS_SERVICE, T0)).toThrow(/service/);
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ action: "whoami" }), HANDS_SERVICE, T0)).toThrow(/action/);
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ status: 500 }), HANDS_SERVICE, T0)).toThrow(/HTTP 200/);
   });
-  it("rejects outer ok=false", () => {
-    expect(() => parseAgentLoginInvoke(JSON.stringify({ ok: false, error: "nope" }), HANDS_SERVICE)).toThrow(/did not succeed/);
+  it("closed-key: rejects extension fields in the grant result", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { extra: "x" }), HANDS_SERVICE, T0)).toThrow(/unexpected fields/);
   });
-  it("rejects a service mismatch (outer)", () => {
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({ service: "hands-other" }), HANDS_SERVICE)).toThrow(/service mismatch/);
+  it("validates expires_at: RFC3339, strictly future, <=300s", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: "nope" }), HANDS_SERVICE, T0)).toThrow(/RFC3339/);
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 - 1000).toISOString() }), HANDS_SERVICE, T0)).toThrow(/already expired/);
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 400_000).toISOString() }), HANDS_SERVICE, T0)).toThrow(/300s/);
   });
-  it("rejects an action mismatch", () => {
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({ action: "whoami" }), HANDS_SERVICE)).toThrow(/action mismatch/);
-  });
-  it("rejects a non-200 action status", () => {
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({ status: 403 }), HANDS_SERVICE)).toThrow(/HTTP 403/);
-  });
-  it("rejects a wrong grant result schema", () => {
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { schema: "something.v9" }), HANDS_SERVICE)).toThrow(/grant result schema/);
-  });
-  it("rejects a grant-result service mismatch", () => {
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { service: "hands-other" }), HANDS_SERVICE)).toThrow(/grant service mismatch/);
-  });
-  it("rejects a missing grant", () => {
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { grant: "" }), HANDS_SERVICE)).toThrow(/grant missing/);
+  it("NEVER echoes raw stdout in error messages (no credential leak)", () => {
+    const secret = "SECRET-grant-payload-should-not-appear";
+    try {
+      parseAgentLoginInvoke(JSON.stringify({ ok: false, error: secret, data: { result: { grant: secret } } }), HANDS_SERVICE, T0);
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).not.toContain(secret);
+    }
   });
 });
 
-describe("parseAgentSession (session.v1 validation)", () => {
-  it("accepts a well-formed session and null refresh_expires_at", () => {
+describe("V4 strict session parse", () => {
+  it("accepts a valid session and null refresh expiry", () => {
     expect(parseAgentSession(SESSION)).toEqual(SESSION);
     expect(parseAgentSession({ ...SESSION, refresh_expires_at: null }).refresh_expires_at).toBeNull();
   });
-  it("rejects bad schema / token_type / missing fields / bad refresh expiry", () => {
-    expect(() => parseAgentSession({ ...SESSION, schema: "x" })).toThrow(/session schema/);
+  it("rejects extension fields, bad schema/token_type/expiry", () => {
+    expect(() => parseAgentSession({ ...SESSION, extra: 1 })).toThrow(/unexpected fields/);
     expect(() => parseAgentSession({ ...SESSION, token_type: "Basic" })).toThrow(/token_type/);
-    expect(() => parseAgentSession({ ...SESSION, access_token: "" })).toThrow(/access_token/);
-    expect(() => parseAgentSession({ ...SESSION, refresh_expires_at: 123 })).toThrow(/refresh_expires_at/);
+    expect(() => parseAgentSession({ ...SESSION, access_expires_at: "nope" })).toThrow(/RFC3339/);
   });
 });
 
-describe("atomic store", () => {
+describe("V5 hardened atomic store", () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "agent-auth-")); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "store-")); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-  it("writes 0600 file under 0700 dirs, and reads the access token back", () => {
-    const a = { transportDir: "/t", slockHome: dir, agentId: "agent-9" };
-    const path = writeAgentSession(a, HANDS_SERVICE, SESSION, () => "2026-08-17T00:00:00.000Z");
-    expect(path).toBe(agentAuthPath(a));
+  it("writes 0600 file under verified-0700 dirs, records api_base, reads back", () => {
+    const a = agentEnvAt(dir, "/t");
+    const path = writeAgentSession(a, HANDS_SERVICE, SESSION, "https://api.example", () => "2026-08-17T00:00:00.000Z");
     const rec = JSON.parse(readFileSync(path, "utf8"));
-    expect(rec).toMatchObject({ ...SESSION, service: HANDS_SERVICE, updated_at: "2026-08-17T00:00:00.000Z" });
-    // No group/other permissions on the credential file or its dir.
+    expect(rec).toMatchObject({ ...SESSION, service: HANDS_SERVICE, api_base: "https://api.example", updated_at: "2026-08-17T00:00:00.000Z" });
     expect(statSync(path).mode & 0o077).toBe(0);
-    expect(statSync(join(dir, "agents", "agent-9", "integrations", HANDS_SERVICE)).mode & 0o077).toBe(0);
+    expect(statSync(join(dir, "agents", "agent-7", "integrations", HANDS_SERVICE)).mode & 0o077).toBe(0);
     expect(readAgentAccessToken(a)).toBe("acc-123");
+    expect(readAgentApiBase(a)).toBe("https://api.example");
   });
 
-  it("readAgentAccessToken returns null when absent", () => {
-    expect(readAgentAccessToken({ transportDir: "/t", slockHome: dir, agentId: "missing" })).toBeNull();
+  it("repairs a pre-existing wide integrations dir to 0700", () => {
+    const a = agentEnvAt(dir, "/t");
+    const wide = join(dir, "agents", "agent-7", "integrations");
+    mkdirSync(wide, { recursive: true, mode: 0o777 });
+    chmodSync(wide, 0o777);
+    writeAgentSession(a, HANDS_SERVICE, SESSION, "https://api.example");
+    expect(statSync(wide).mode & 0o077).toBe(0);
   });
 });
 
-describe("runAgentLogin (full flow: invoke → exchange → store)", () => {
+describe("runAgentLogin (full flow via pinned wrapper)", () => {
   let dir: string;
   let server: Server;
   let base: string;
   let exchangeBody: any;
 
   beforeEach(async () => {
-    dir = mkdtempSync(join(tmpdir(), "agent-flow-"));
+    dir = mkdtempSync(join(tmpdir(), "flow-"));
     server = createServer((req, res) => {
       let raw = "";
       req.on("data", (c) => (raw += c));
@@ -164,9 +204,7 @@ describe("runAgentLogin (full flow: invoke → exchange → store)", () => {
         if (req.url === "/api/auth/agent/exchange" && req.method === "POST") {
           res.writeHead(200, { "content-type": "application/json" });
           res.end(JSON.stringify(SESSION));
-        } else {
-          res.writeHead(404); res.end("{}");
-        }
+        } else { res.writeHead(404); res.end("{}"); }
       });
     });
     await new Promise<void>((r) => server.listen(0, r));
@@ -179,29 +217,92 @@ describe("runAgentLogin (full flow: invoke → exchange → store)", () => {
     await new Promise<void>((r) => server.close(() => r()));
   });
 
-  it("invokes agent-login, exchanges the grant, and stores the session", async () => {
-    const a = { transportDir: "/t", slockHome: dir, agentId: "agent-flow" };
-    let invokedArgs: string[] = [];
+  it("invokes → exchanges → stores; sends a verifier not the challenge", async () => {
+    const a = agentEnvAt(dir, "/t");
+    let invoked: string[] = [];
     const session = await runAgentLogin(a, {
-      invoke: (args) => { invokedArgs = args; return { status: 0, stdout: invokeEnvelope(), stderr: "" }; },
+      now: T0,
+      invoke: (args) => { invoked = args; return { status: 0, stdout: invokeEnvelope(), stderr: "" }; },
     });
-    // invoke was called with the right service/action + a request-schema body.
-    expect(invokedArgs).toContain("agent-login");
-    expect(invokedArgs).toContain(HANDS_SERVICE);
-    // exchange sent the exchange schema + grant + a verifier (never the challenge).
+    expect(invoked).toContain("agent-login");
     expect(exchangeBody.schema).toBe("raft-cli-agent-login-exchange.v1");
     expect(exchangeBody.grant).toBe("opaque-grant");
     expect(exchangeBody.code_verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
-    // stored + returned.
     expect(session).toEqual(SESSION);
     expect(readAgentAccessToken(a)).toBe("acc-123");
+    expect(readAgentApiBase(a)).toBe(base);
   });
 
-  it("fails (and stores nothing) when invoke returns a bad envelope", async () => {
-    const a = { transportDir: "/t", slockHome: dir, agentId: "agent-bad" };
-    await expect(
-      runAgentLogin(a, { invoke: () => ({ status: 0, stdout: JSON.stringify({ ok: false, error: "denied" }), stderr: "" }) }),
-    ).rejects.toThrow(/did not succeed/);
-    expect(readAgentAccessToken(a)).toBeNull();
+  it("rejects a non-zero invoke exit and stores nothing", async () => {
+    const a = agentEnvAt(dir, "/t");
+    await expect(runAgentLogin(a, { now: T0, invoke: () => ({ status: 1, stdout: invokeEnvelope(), stderr: "boom" }) }))
+      .rejects.toThrow(/non-zero status/);
+    expect(existsSync(agentAuthPath(a))).toBe(false);
+  });
+});
+
+const ENV_KEYS = ["SLOCK_CLI_TRANSPORT_DIR", "SLOCK_HOME", "SLOCK_AGENT_ID", "HANDS_AUTH_TOKEN", "XDG_CONFIG_HOME"] as const;
+function saveEnv() {
+  const s: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) s[k] = process.env[k];
+  return () => { for (const k of ENV_KEYS) { if (s[k] === undefined) delete process.env[k]; else process.env[k] = s[k]!; } };
+}
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+describe("V2 per-agent credential isolation (config.resolveAuthToken)", () => {
+  let dir: string;
+  let transport: string;
+  let restore: () => void;
+  beforeEach(() => {
+    restore = saveEnv();
+    dir = mkdtempSync(join(tmpdir(), "iso-"));
+    transport = join(dir, "transport");
+    mkdirSync(transport, { recursive: true });
+    writeFileSync(join(transport, "raft"), "#!/bin/sh\n", { mode: 0o755 });
+    process.env.SLOCK_CLI_TRANSPORT_DIR = transport;
+    process.env.SLOCK_HOME = dir;
+    process.env.SLOCK_AGENT_ID = "agent-7";
+    process.env.HANDS_AUTH_TOKEN = "ambient-human-token"; // must be IGNORED in agent mode
+    process.env.XDG_CONFIG_HOME = join(dir, "xdg");
+  });
+  afterEach(() => { restore(); rmSync(dir, { recursive: true, force: true }); });
+
+  it("agent mode with a store → the agent token, never the ambient HANDS_AUTH_TOKEN", async () => {
+    const { resolveAuthToken } = await import("./lib/config.js");
+    writeAgentSession(agentEnvAt(dir, transport), HANDS_SERVICE, SESSION, "https://api.example");
+    expect(resolveAuthToken()).toBe("acc-123");
+  });
+  it("agent mode with no store → undefined (require login; no ambient fallback)", async () => {
+    const { resolveAuthToken } = await import("./lib/config.js");
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+});
+
+describe("B quiver→hands config migration (human path)", () => {
+  let dir: string;
+  let restore: () => void;
+  beforeEach(() => {
+    restore = saveEnv();
+    dir = mkdtempSync(join(tmpdir(), "mig-"));
+    for (const k of ["SLOCK_CLI_TRANSPORT_DIR", "SLOCK_HOME", "SLOCK_AGENT_ID", "HANDS_AUTH_TOKEN"] as const) delete process.env[k];
+    process.env.XDG_CONFIG_HOME = dir;
+  });
+  afterEach(() => { try { chmodSync(dir, 0o700); } catch { /* ignore */ } restore(); rmSync(dir, { recursive: true, force: true }); });
+
+  it("migrates legacy ~/.config/quiver/auth.json to the hands path on first read", async () => {
+    mkdirSync(join(dir, "quiver"), { recursive: true });
+    writeFileSync(join(dir, "quiver", "auth.json"), JSON.stringify({ authToken: "legacy", apiBase: "https://legacy" }));
+    const { getConfig, configPath } = await import("./lib/config.js");
+    expect(getConfig().authToken).toBe("legacy");
+    expect(existsSync(configPath())).toBe(true);
+    expect(JSON.parse(readFileSync(configPath(), "utf8")).authToken).toBe("legacy");
+  });
+
+  it.skipIf(isRoot)("keeps legacy credentials when the migration write fails", async () => {
+    mkdirSync(join(dir, "quiver"), { recursive: true });
+    writeFileSync(join(dir, "quiver", "auth.json"), JSON.stringify({ authToken: "legacy" }));
+    chmodSync(dir, 0o500); // read-only: creating the hands/ dir fails
+    const { getConfig } = await import("./lib/config.js");
+    expect(getConfig().authToken).toBe("legacy"); // old credentials still usable
   });
 });

--- a/packages/cli/src/agent_login.test.ts
+++ b/packages/cli/src/agent_login.test.ts
@@ -134,6 +134,12 @@ describe("V4 strict, non-leaking invoke parse", () => {
   it("closed-key: rejects extension fields in the grant result", () => {
     expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { extra: "x" }), HANDS_SERVICE, T0)).toThrow(/unexpected fields/);
   });
+  it("closed-envelope: rejects extension fields in the outer wrapper and data", () => {
+    const withOuterExtra = JSON.stringify({ ...JSON.parse(invokeEnvelope()), extra: "x" });
+    expect(() => parseAgentLoginInvoke(withOuterExtra, HANDS_SERVICE, T0)).toThrow(/envelope has unexpected fields/);
+    // invokeEnvelope(over) spreads `over` into `data`, so this adds a 5th data key.
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ extra: "x" }), HANDS_SERVICE, T0)).toThrow(/data has unexpected fields/);
+  });
   it("validates expires_at: RFC3339, strictly future, <=300s", () => {
     expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: "nope" }), HANDS_SERVICE, T0)).toThrow(/RFC3339/);
     expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 - 1000).toISOString() }), HANDS_SERVICE, T0)).toThrow(/already expired/);
@@ -151,14 +157,23 @@ describe("V4 strict, non-leaking invoke parse", () => {
 });
 
 describe("V4 strict session parse", () => {
+  const BEFORE = Date.parse(SESSION.access_expires_at) - 1000; // clock before both expiries
   it("accepts a valid session and null refresh expiry", () => {
-    expect(parseAgentSession(SESSION)).toEqual(SESSION);
-    expect(parseAgentSession({ ...SESSION, refresh_expires_at: null }).refresh_expires_at).toBeNull();
+    expect(parseAgentSession(SESSION, BEFORE)).toEqual(SESSION);
+    expect(parseAgentSession({ ...SESSION, refresh_expires_at: null }, BEFORE).refresh_expires_at).toBeNull();
   });
   it("rejects extension fields, bad schema/token_type/expiry", () => {
-    expect(() => parseAgentSession({ ...SESSION, extra: 1 })).toThrow(/unexpected fields/);
-    expect(() => parseAgentSession({ ...SESSION, token_type: "Basic" })).toThrow(/token_type/);
-    expect(() => parseAgentSession({ ...SESSION, access_expires_at: "nope" })).toThrow(/RFC3339/);
+    expect(() => parseAgentSession({ ...SESSION, extra: 1 }, BEFORE)).toThrow(/unexpected fields/);
+    expect(() => parseAgentSession({ ...SESSION, token_type: "Basic" }, BEFORE)).toThrow(/token_type/);
+    expect(() => parseAgentSession({ ...SESSION, access_expires_at: "nope" }, BEFORE)).toThrow(/RFC3339/);
+  });
+  it("strict-future: rejects an access/refresh token already expired at `now`", () => {
+    const afterAccess = Date.parse(SESSION.access_expires_at) + 1;
+    expect(() => parseAgentSession(SESSION, afterAccess)).toThrow(/access token is already expired/);
+    // access still future, but refresh already expired at `now`.
+    const afterRefresh = Date.parse(SESSION.refresh_expires_at!) + 1;
+    const futureAccess = { ...SESSION, access_expires_at: new Date(afterRefresh + 1000).toISOString() };
+    expect(() => parseAgentSession(futureAccess, afterRefresh)).toThrow(/refresh token is already expired/);
   });
 });
 
@@ -193,15 +208,27 @@ describe("runAgentLogin (full flow via pinned wrapper)", () => {
   let server: Server;
   let base: string;
   let exchangeBody: any;
+  let exchangeAuth: string | undefined;
+  let refreshHits: number;
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), "flow-"));
+    exchangeAuth = undefined;
+    refreshHits = 0;
     server = createServer((req, res) => {
       let raw = "";
       req.on("data", (c) => (raw += c));
       req.on("end", () => {
-        exchangeBody = JSON.parse(raw || "{}");
+        // A terminal refresh (reused/revoked) — must never be reached during a fresh login.
+        if (req.url === "/api/auth/agent/refresh") {
+          refreshHits += 1;
+          res.writeHead(409, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "refresh_reused" }));
+          return;
+        }
         if (req.url === "/api/auth/agent/exchange" && req.method === "POST") {
+          exchangeBody = JSON.parse(raw || "{}");
+          exchangeAuth = req.headers["authorization"] as string | undefined;
           res.writeHead(200, { "content-type": "application/json" });
           res.end(JSON.stringify(SESSION));
         } else { res.writeHead(404); res.end("{}"); }
@@ -238,6 +265,22 @@ describe("runAgentLogin (full flow via pinned wrapper)", () => {
     await expect(runAgentLogin(a, { now: T0, invoke: () => ({ status: 1, stdout: invokeEnvelope(), stderr: "boom" }) }))
       .rejects.toThrow(/non-zero status/);
     expect(existsSync(agentAuthPath(a))).toBe(false);
+  });
+
+  it("a terminal old refresh does NOT block a fresh login (independent exchange, no old Bearer)", async () => {
+    const a = agentEnvAt(dir, "/t");
+    // Pre-seed a store whose refresh is terminal (would 409) and whose access is expired.
+    // The recovery path (`hands login`) must spend the fresh grant WITHOUT touching it.
+    writeAgentSession(
+      a, HANDS_SERVICE,
+      { ...SESSION, access_token: "old-acc", refresh_token: "old-ref", access_expires_at: new Date(T0 - 1000).toISOString() },
+      base, () => new Date(T0).toISOString(),
+    );
+    const session = await runAgentLogin(a, { now: T0, invoke: () => ({ status: 0, stdout: invokeEnvelope(), stderr: "" }) });
+    expect(session.access_token).toBe("acc-123");        // exchange succeeded
+    expect(readAgentAccessToken(a)).toBe("acc-123");     // store replaced with the new session
+    expect(refreshHits).toBe(0);                          // the bad refresh was never attempted
+    expect(exchangeAuth).toBeUndefined();                // exchange carried NO stored Bearer
   });
 });
 

--- a/packages/cli/src/agent_login.test.ts
+++ b/packages/cli/src/agent_login.test.ts
@@ -1,0 +1,207 @@
+/**
+ * CP3 checkpoint-1: agent-login flow (env detection, strict invoke-result validation
+ * = Volta's acceptance tooth, session validation, PKCE, atomic store, full flow).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, statSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import {
+  detectAgentEnv,
+  agentAuthPath,
+  readAgentAccessToken,
+  HANDS_SERVICE,
+} from "./lib/agent_env.js";
+import {
+  generatePkce,
+  parseAgentLoginInvoke,
+  parseAgentSession,
+  writeAgentSession,
+  runAgentLogin,
+  type AgentSession,
+} from "./lib/agent_auth.js";
+
+const AGENT = { transportDir: "/t", slockHome: "/home/x/.slock", agentId: "agent-7" };
+
+function invokeEnvelope(over: Record<string, unknown> = {}, resultOver: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    ok: true,
+    data: {
+      service: HANDS_SERVICE,
+      action: "agent-login",
+      status: 200,
+      result: {
+        schema: "raft-cli-agent-login-grant.v1",
+        service: HANDS_SERVICE,
+        grant: "opaque-grant",
+        expires_at: "2026-08-17T09:00:00.000Z",
+        ...resultOver,
+      },
+      ...over,
+    },
+  });
+}
+
+const SESSION: AgentSession = {
+  schema: "raft-cli-agent-session.v1",
+  token_type: "Bearer",
+  access_token: "acc-123",
+  access_expires_at: "2026-08-17T10:00:00.000Z",
+  refresh_token: "ref-456",
+  refresh_expires_at: "2026-09-16T09:00:00.000Z",
+};
+
+describe("agent env detection", () => {
+  it("returns the env only when all three daemon vars are present", () => {
+    const full = { SLOCK_CLI_TRANSPORT_DIR: "/t", SLOCK_HOME: "/h", SLOCK_AGENT_ID: "a" };
+    expect(detectAgentEnv(full as any)).toEqual({ transportDir: "/t", slockHome: "/h", agentId: "a" });
+    expect(detectAgentEnv({ SLOCK_HOME: "/h", SLOCK_AGENT_ID: "a" } as any)).toBeNull();
+    expect(detectAgentEnv({ SLOCK_CLI_TRANSPORT_DIR: "/t", SLOCK_AGENT_ID: "a" } as any)).toBeNull();
+    expect(detectAgentEnv({ SLOCK_CLI_TRANSPORT_DIR: "/t", SLOCK_HOME: "/h" } as any)).toBeNull();
+    expect(detectAgentEnv({} as any)).toBeNull();
+  });
+
+  it("builds the canonical per-agent store path", () => {
+    expect(agentAuthPath(AGENT)).toBe(
+      `/home/x/.slock/agents/agent-7/integrations/${HANDS_SERVICE}/auth.json`,
+    );
+  });
+});
+
+describe("PKCE", () => {
+  it("verifier is RFC 7636 valid and challenge = base64url(sha256(verifier))", () => {
+    const { verifier, challenge } = generatePkce();
+    expect(verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+    const expected = createHash("sha256").update(verifier).digest("base64url");
+    expect(challenge).toBe(expected);
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+});
+
+describe("parseAgentLoginInvoke (strict invoke-result validation — acceptance tooth)", () => {
+  it("accepts a well-formed envelope", () => {
+    expect(parseAgentLoginInvoke(invokeEnvelope(), HANDS_SERVICE)).toEqual({
+      grant: "opaque-grant",
+      expires_at: "2026-08-17T09:00:00.000Z",
+    });
+  });
+  it("rejects non-JSON", () => {
+    expect(() => parseAgentLoginInvoke("not json", HANDS_SERVICE)).toThrow(/did not return JSON/);
+  });
+  it("rejects outer ok=false", () => {
+    expect(() => parseAgentLoginInvoke(JSON.stringify({ ok: false, error: "nope" }), HANDS_SERVICE)).toThrow(/did not succeed/);
+  });
+  it("rejects a service mismatch (outer)", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ service: "hands-other" }), HANDS_SERVICE)).toThrow(/service mismatch/);
+  });
+  it("rejects an action mismatch", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ action: "whoami" }), HANDS_SERVICE)).toThrow(/action mismatch/);
+  });
+  it("rejects a non-200 action status", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({ status: 403 }), HANDS_SERVICE)).toThrow(/HTTP 403/);
+  });
+  it("rejects a wrong grant result schema", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { schema: "something.v9" }), HANDS_SERVICE)).toThrow(/grant result schema/);
+  });
+  it("rejects a grant-result service mismatch", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { service: "hands-other" }), HANDS_SERVICE)).toThrow(/grant service mismatch/);
+  });
+  it("rejects a missing grant", () => {
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { grant: "" }), HANDS_SERVICE)).toThrow(/grant missing/);
+  });
+});
+
+describe("parseAgentSession (session.v1 validation)", () => {
+  it("accepts a well-formed session and null refresh_expires_at", () => {
+    expect(parseAgentSession(SESSION)).toEqual(SESSION);
+    expect(parseAgentSession({ ...SESSION, refresh_expires_at: null }).refresh_expires_at).toBeNull();
+  });
+  it("rejects bad schema / token_type / missing fields / bad refresh expiry", () => {
+    expect(() => parseAgentSession({ ...SESSION, schema: "x" })).toThrow(/session schema/);
+    expect(() => parseAgentSession({ ...SESSION, token_type: "Basic" })).toThrow(/token_type/);
+    expect(() => parseAgentSession({ ...SESSION, access_token: "" })).toThrow(/access_token/);
+    expect(() => parseAgentSession({ ...SESSION, refresh_expires_at: 123 })).toThrow(/refresh_expires_at/);
+  });
+});
+
+describe("atomic store", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "agent-auth-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it("writes 0600 file under 0700 dirs, and reads the access token back", () => {
+    const a = { transportDir: "/t", slockHome: dir, agentId: "agent-9" };
+    const path = writeAgentSession(a, HANDS_SERVICE, SESSION, () => "2026-08-17T00:00:00.000Z");
+    expect(path).toBe(agentAuthPath(a));
+    const rec = JSON.parse(readFileSync(path, "utf8"));
+    expect(rec).toMatchObject({ ...SESSION, service: HANDS_SERVICE, updated_at: "2026-08-17T00:00:00.000Z" });
+    // No group/other permissions on the credential file or its dir.
+    expect(statSync(path).mode & 0o077).toBe(0);
+    expect(statSync(join(dir, "agents", "agent-9", "integrations", HANDS_SERVICE)).mode & 0o077).toBe(0);
+    expect(readAgentAccessToken(a)).toBe("acc-123");
+  });
+
+  it("readAgentAccessToken returns null when absent", () => {
+    expect(readAgentAccessToken({ transportDir: "/t", slockHome: dir, agentId: "missing" })).toBeNull();
+  });
+});
+
+describe("runAgentLogin (full flow: invoke → exchange → store)", () => {
+  let dir: string;
+  let server: Server;
+  let base: string;
+  let exchangeBody: any;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "agent-flow-"));
+    server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        exchangeBody = JSON.parse(raw || "{}");
+        if (req.url === "/api/auth/agent/exchange" && req.method === "POST") {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify(SESSION));
+        } else {
+          res.writeHead(404); res.end("{}");
+        }
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, r));
+    base = `http://127.0.0.1:${(server.address() as any).port}`;
+    process.env.HANDS_API = base;
+  });
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.HANDS_API;
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("invokes agent-login, exchanges the grant, and stores the session", async () => {
+    const a = { transportDir: "/t", slockHome: dir, agentId: "agent-flow" };
+    let invokedArgs: string[] = [];
+    const session = await runAgentLogin(a, {
+      invoke: (args) => { invokedArgs = args; return { status: 0, stdout: invokeEnvelope(), stderr: "" }; },
+    });
+    // invoke was called with the right service/action + a request-schema body.
+    expect(invokedArgs).toContain("agent-login");
+    expect(invokedArgs).toContain(HANDS_SERVICE);
+    // exchange sent the exchange schema + grant + a verifier (never the challenge).
+    expect(exchangeBody.schema).toBe("raft-cli-agent-login-exchange.v1");
+    expect(exchangeBody.grant).toBe("opaque-grant");
+    expect(exchangeBody.code_verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+    // stored + returned.
+    expect(session).toEqual(SESSION);
+    expect(readAgentAccessToken(a)).toBe("acc-123");
+  });
+
+  it("fails (and stores nothing) when invoke returns a bad envelope", async () => {
+    const a = { transportDir: "/t", slockHome: dir, agentId: "agent-bad" };
+    await expect(
+      runAgentLogin(a, { invoke: () => ({ status: 0, stdout: JSON.stringify({ ok: false, error: "denied" }), stderr: "" }) }),
+    ).rejects.toThrow(/did not succeed/);
+    expect(readAgentAccessToken(a)).toBeNull();
+  });
+});

--- a/packages/cli/src/agent_login.test.ts
+++ b/packages/cli/src/agent_login.test.ts
@@ -349,3 +349,55 @@ describe("B quiver→hands config migration (human path)", () => {
     expect(getConfig().authToken).toBe("legacy"); // old credentials still usable
   });
 });
+
+// Round 2: the exchange is secret-bearing (grant + code_verifier) — refuse redirects, bound body.
+describe("exchange endpoint hardening (real server)", () => {
+  let dir: string;
+  let primary: Server;
+  let secondary: Server;
+  let secondHits: number;
+  let mode: "redirect" | "huge";
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "xchg-"));
+    secondHits = 0;
+    mode = "redirect";
+    secondary = createServer((_req, res) => {
+      secondHits += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(SESSION));
+    });
+    await new Promise<void>((r) => secondary.listen(0, r));
+    const secondBase = `http://127.0.0.1:${(secondary.address() as any).port}`;
+    primary = createServer((req, res) => {
+      if (req.url === "/api/auth/agent/exchange") {
+        if (mode === "redirect") { res.writeHead(307, { location: `${secondBase}/api/auth/agent/exchange` }); res.end(); return; }
+        res.writeHead(200, { "content-type": "application/json" }); res.end("x".repeat(70 * 1024)); return;
+      }
+      res.writeHead(404); res.end("{}");
+    });
+    await new Promise<void>((r) => primary.listen(0, r));
+    process.env.HANDS_API = `http://127.0.0.1:${(primary.address() as any).port}`;
+  });
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.HANDS_API;
+    await new Promise<void>((r) => primary.close(() => r()));
+    await new Promise<void>((r) => secondary.close(() => r()));
+  });
+
+  it("refuses to follow a 307 (never forwards grant + code_verifier to the redirect target)", async () => {
+    mode = "redirect";
+    const a = agentEnvAt(dir, "/t");
+    await expect(runAgentLogin(a, { now: T0, invoke: () => ({ status: 0, stdout: invokeEnvelope(), stderr: "" }) }))
+      .rejects.toThrow(/HTTP 307/);
+    expect(secondHits).toBe(0);
+  });
+
+  it("rejects an oversized exchange response body", async () => {
+    mode = "huge";
+    const a = agentEnvAt(dir, "/t");
+    await expect(runAgentLogin(a, { now: T0, invoke: () => ({ status: 0, stdout: invokeEnvelope(), stderr: "" }) }))
+      .rejects.toThrow(/size limit/);
+  });
+});

--- a/packages/cli/src/agent_refresh.test.ts
+++ b/packages/cli/src/agent_refresh.test.ts
@@ -1,0 +1,135 @@
+/**
+ * CP3 checkpoint-2: agent token auto-refresh + cross-process single-flight.
+ * Deterministic via injected fetch/sleep/now (true multi-process races aren't unit-
+ * testable, but winner/loser/stale-break/no-overwrite paths are).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { agentAuthPath, HANDS_SERVICE, readAgentAccessToken, type AgentEnv } from "./lib/agent_env.js";
+import { writeAgentSession, type AgentSession } from "./lib/agent_auth.js";
+import { getFreshAgentAccessToken, forceRefreshAgentToken } from "./lib/agent_refresh.js";
+
+const T0 = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+function session(over: Partial<AgentSession> = {}): AgentSession {
+  return {
+    schema: "raft-cli-agent-session.v1",
+    token_type: "Bearer",
+    access_token: "acc-old",
+    access_expires_at: new Date(T0 + 10 * 60 * 1000).toISOString(),
+    refresh_token: "ref-old",
+    refresh_expires_at: new Date(T0 + 30 * DAY).toISOString(),
+    ...over,
+  };
+}
+const NEW_SESSION: AgentSession = {
+  schema: "raft-cli-agent-session.v1",
+  token_type: "Bearer",
+  access_token: "acc-new",
+  access_expires_at: new Date(T0 + 20 * 60 * 1000).toISOString(),
+  refresh_token: "ref-new",
+  refresh_expires_at: new Date(T0 + 30 * DAY).toISOString(),
+};
+
+function mockFetch(body: unknown, status = 200, calls?: { n: number }) {
+  return (async () => {
+    if (calls) calls.n++;
+    return { ok: status >= 200 && status < 300, status, text: async () => (typeof body === "string" ? body : JSON.stringify(body)) };
+  }) as unknown as typeof fetch;
+}
+const noSleep = async () => {};
+
+function env(dir: string): AgentEnv {
+  return { transportDir: "/t", slockHome: dir, agentId: "agent-1", raftBin: "/t/raft" };
+}
+function store(a: AgentEnv, s: AgentSession) {
+  writeAgentSession(a, HANDS_SERVICE, s, "https://api.example", () => new Date(T0).toISOString());
+}
+
+describe("auto-refresh", () => {
+  let dir: string;
+  let a: AgentEnv;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "refresh-")); a = env(dir); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("no store → null", async () => {
+    expect(await getFreshAgentAccessToken(a, { now: T0, sleepImpl: noSleep })).toBeNull();
+  });
+
+  it("token comfortably unexpired → returns it, no refresh call", async () => {
+    store(a, session());
+    const calls = { n: 0 };
+    const tok = await getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl: noSleep });
+    expect(tok).toBe("acc-old");
+    expect(calls.n).toBe(0);
+  });
+
+  it("near-expiry → rotates, persists, returns the new access token", async () => {
+    store(a, session({ access_expires_at: new Date(T0 + 30 * 1000).toISOString() })); // within 60s skew
+    const calls = { n: 0 };
+    const tok = await getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl: noSleep });
+    expect(tok).toBe("acc-new");
+    expect(calls.n).toBe(1);
+    expect(readAgentAccessToken(a)).toBe("acc-new");
+  });
+
+  it("refresh HTTP failure → throws without echoing the body, keeps the old store", async () => {
+    store(a, session({ access_expires_at: new Date(T0 - 1000).toISOString() }));
+    const secret = "SECRET-refresh-token-in-body";
+    await expect(
+      getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(secret, 401), sleepImpl: noSleep }),
+    ).rejects.toThrow(/HTTP 401/);
+    let err = "";
+    try {
+      await getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(secret, 401), sleepImpl: noSleep });
+    } catch (e) { err = (e as Error).message; }
+    expect(err).not.toContain(secret);
+    expect(readAgentAccessToken(a)).toBe("acc-old"); // unchanged
+  });
+
+  it("forceRefresh rotates even when the token is unexpired", async () => {
+    store(a, session());
+    const calls = { n: 0 };
+    const tok = await forceRefreshAgentToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl: noSleep });
+    expect(tok).toBe("acc-new");
+    expect(calls.n).toBe(1);
+  });
+});
+
+describe("single-flight", () => {
+  let dir: string;
+  let a: AgentEnv;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "sf-")); a = env(dir); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("loser (lock held by a live holder) waits, uses the winner's newer session, never rotates", async () => {
+    store(a, session({ access_expires_at: new Date(T0 - 1000).toISOString() })); // stale
+    const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
+    writeFileSync(lock, "held"); // fresh mtime ⇒ live holder, not stale
+    const calls = { n: 0 };
+    let polls = 0;
+    const sleepImpl = async () => {
+      polls++;
+      if (polls === 2) store(a, NEW_SESSION); // the winner writes the fresh session mid-wait
+    };
+    const tok = await getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl });
+    expect(tok).toBe("acc-new"); // used the winner's session
+    expect(calls.n).toBe(0); // never rotated itself
+  });
+
+  it("breaks a stale lock, then acquires and refreshes", async () => {
+    store(a, session({ access_expires_at: new Date(T0 - 1000).toISOString() }));
+    const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
+    writeFileSync(lock, "dead-holder");
+    const staleSec = (Date.now() - 60_000) / 1000; // 60s old > 30s stale threshold
+    utimesSync(lock, staleSec, staleSec);
+    const calls = { n: 0 };
+    const tok = await getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl: noSleep });
+    expect(tok).toBe("acc-new");
+    expect(calls.n).toBe(1); // broke the stale lock and refreshed
+    expect(existsSync(lock)).toBe(false); // released after
+  });
+});

--- a/packages/cli/src/agent_refresh.test.ts
+++ b/packages/cli/src/agent_refresh.test.ts
@@ -4,13 +4,13 @@
  * testable, but winner/loser/stale-break/no-overwrite paths are).
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { agentAuthPath, HANDS_SERVICE, readAgentAccessToken, type AgentEnv } from "./lib/agent_env.js";
 import { writeAgentSession, type AgentSession } from "./lib/agent_auth.js";
 import { createServer, type Server } from "node:http";
-import { getFreshAgentAccessToken, forceRefreshAgentToken, releaseOwnLock, breakIfDeadOwner } from "./lib/agent_refresh.js";
+import { getFreshAgentAccessToken, forceRefreshAgentToken, releaseOwnLock, acquireIfDeadOwner } from "./lib/agent_refresh.js";
 
 const DEAD_PID = 2_147_483_646; // beyond any real pid_max ⇒ process.kill(pid,0) → ESRCH
 
@@ -159,34 +159,34 @@ describe("single-flight", () => {
     ).rejects.toThrow(/timed out/);
   });
 
-  // Finding #3 (round 2): a live owner (incl. suspended/stalled — pid still exists) is
-  // NEVER broken; only a provably-dead owner is; a replacement owner is not TOCTOU-deleted.
-  it("breakIfDeadOwner: live owner (real pid) is never broken", () => {
+  // Finding #3: a live owner (incl. suspended/stalled — pid still exists) is NEVER stolen;
+  // only a provably-dead owner is reaped (and then the main lock is re-acquired under fence).
+  it("acquireIfDeadOwner: live owner (real pid) is never stolen", () => {
     const lock = join(dir, ".auth.refresh.lock");
     writeFileSync(lock, `${process.pid}:live`);
-    expect(breakIfDeadOwner(lock)).toBe(false);
-    expect(existsSync(lock)).toBe(true);
+    expect(acquireIfDeadOwner(lock, "me:1")).toBe(false); // loser
+    expect(readFileSync(lock, "utf8")).toBe(`${process.pid}:live`); // untouched
+    expect(existsSync(`${lock}.reap`)).toBe(false); // fence released
   });
-  it("breakIfDeadOwner: unparseable owner fails closed (not broken)", () => {
+  it("acquireIfDeadOwner: unparseable owner fails closed (loser)", () => {
     const lock = join(dir, ".auth.refresh.lock");
     writeFileSync(lock, "no-pid-here");
-    expect(breakIfDeadOwner(lock)).toBe(false);
-    expect(existsSync(lock)).toBe(true);
+    expect(acquireIfDeadOwner(lock, "me:1")).toBe(false);
+    expect(readFileSync(lock, "utf8")).toBe("no-pid-here");
   });
-  it("breakIfDeadOwner: dead owner is broken", () => {
+  it("acquireIfDeadOwner: dead owner is reaped and re-acquired under the fence", () => {
     const lock = join(dir, ".auth.refresh.lock");
     writeFileSync(lock, `${DEAD_PID}:abandoned`);
-    expect(breakIfDeadOwner(lock)).toBe(true);
-    expect(existsSync(lock)).toBe(false);
+    expect(acquireIfDeadOwner(lock, "me:winner")).toBe(true);
+    expect(readFileSync(lock, "utf8")).toBe("me:winner"); // we now hold it
+    expect(existsSync(`${lock}.reap`)).toBe(false); // fence released
   });
-  it("breakIfDeadOwner: dead owner replaced between reads is NOT deleted (TOCTOU guard)", () => {
+  it("acquireIfDeadOwner: a live reaper fence blocks a second recoverer (fail closed)", () => {
     const lock = join(dir, ".auth.refresh.lock");
-    writeFileSync(lock, `${process.pid}:replacement`); // the file now holds a LIVE new owner
-    // Injected reader: first read = the dead owner we saw, second read = the replacement.
-    let n = 0;
-    const readOwner = () => { n += 1; return n === 1 ? `${DEAD_PID}:gone` : `${process.pid}:replacement`; };
-    expect(breakIfDeadOwner(lock, readOwner)).toBe(false); // replaced under us ⇒ leave it
-    expect(existsSync(lock)).toBe(true);
+    writeFileSync(lock, `${DEAD_PID}:abandoned`);
+    writeFileSync(`${lock}.reap`, `${process.pid}:live-reaper`); // a live reaper holds the fence
+    expect(acquireIfDeadOwner(lock, "me:1")).toBe(false); // second recoverer → loser
+    expect(readFileSync(lock, "utf8")).toBe(`${DEAD_PID}:abandoned`); // dead lock left for the live reaper
   });
 
   // Finding #3: release must never delete a lock that a foreign holder now owns.
@@ -198,6 +198,24 @@ describe("single-flight", () => {
     releaseOwnLock(lock, "owner-A"); // our id ⇒ delete it
     expect(existsSync(lock)).toBe(false);
   });
+
+  // Finding #3 (round 3): two concurrent recoverers of the SAME dead lock must produce
+  // exactly ONE refresh — the reaper fence + O_EXCL re-acquire serialize the recovery.
+  it("two concurrent recoverers of a dead lock produce exactly one refresh", async () => {
+    store(a, session({ access_expires_at: new Date(T0 - 1000).toISOString() }));
+    const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
+    writeFileSync(lock, `${DEAD_PID}:abandoned`);
+    const calls = { n: 0 };
+    const fetchImpl = mockFetch(NEW_SESSION, 200, calls);
+    const [t1, t2] = await Promise.all([
+      forceRefreshAgentToken(a, { now: T0, fetchImpl, sleepImpl: noSleep }),
+      forceRefreshAgentToken(a, { now: T0, fetchImpl, sleepImpl: noSleep }),
+    ]);
+    expect(calls.n).toBe(1); // exactly one rotate across both recoverers
+    expect([t1, t2].sort()).toEqual(["acc-new", "acc-new"]); // both end up with the winner's session
+    expect(existsSync(lock)).toBe(false); // released after
+    expect(existsSync(`${lock}.reap`)).toBe(false); // fence released
+  });
 });
 
 // Round 2: secret-bearing token endpoints must refuse redirects and bound the body.
@@ -208,7 +226,7 @@ describe("refresh token endpoint hardening (real server)", () => {
   let secondary: Server;
   let base: string;
   let secondHits: number;
-  let mode: "redirect" | "huge";
+  let mode: "redirect" | "huge" | "hang";
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), "sf-net-"));
@@ -225,6 +243,7 @@ describe("refresh token endpoint hardening (real server)", () => {
     primary = createServer((req, res) => {
       if (req.url === "/api/auth/agent/refresh") {
         if (mode === "redirect") { res.writeHead(307, { location: `${secondBase}/api/auth/agent/refresh` }); res.end(); return; }
+        if (mode === "hang") { res.writeHead(200, { "content-type": "application/json" }); res.write("{"); return; } // headers flushed, body never ends
         res.writeHead(200, { "content-type": "application/json" }); res.end("x".repeat(70 * 1024)); return; // "huge"
       }
       res.writeHead(404); res.end("{}");
@@ -234,6 +253,8 @@ describe("refresh token endpoint hardening (real server)", () => {
   });
   afterEach(async () => {
     rmSync(dir, { recursive: true, force: true });
+    primary.closeAllConnections?.(); // drop any hanging (slow-body) connection
+    secondary.closeAllConnections?.();
     await new Promise<void>((r) => primary.close(() => r()));
     await new Promise<void>((r) => secondary.close(() => r()));
   });
@@ -257,5 +278,17 @@ describe("refresh token endpoint hardening (real server)", () => {
     mode = "huge";
     storeAt(base);
     await expect(forceRefreshAgentToken(a, { now: T0, sleepImpl: noSleep })).rejects.toThrow(/size limit/);
+  });
+
+  // Finding #3 (round 3): headers flush fast but the body never completes — the deadline
+  // must cover the body read, aborting it AND releasing the lock (not just headers).
+  it("aborts a fast-headers/never-ending body at the deadline and releases the lock", async () => {
+    mode = "hang";
+    storeAt(base);
+    await expect(
+      forceRefreshAgentToken(a, { now: T0, sleepImpl: noSleep, deadlineMs: 50 }),
+    ).rejects.toThrow();
+    const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
+    expect(existsSync(lock)).toBe(false); // lock released after the aborted refresh
   });
 });

--- a/packages/cli/src/agent_refresh.test.ts
+++ b/packages/cli/src/agent_refresh.test.ts
@@ -4,12 +4,15 @@
  * testable, but winner/loser/stale-break/no-overwrite paths are).
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { agentAuthPath, HANDS_SERVICE, readAgentAccessToken, type AgentEnv } from "./lib/agent_env.js";
 import { writeAgentSession, type AgentSession } from "./lib/agent_auth.js";
-import { getFreshAgentAccessToken, forceRefreshAgentToken, releaseOwnLock } from "./lib/agent_refresh.js";
+import { createServer, type Server } from "node:http";
+import { getFreshAgentAccessToken, forceRefreshAgentToken, releaseOwnLock, breakIfDeadOwner } from "./lib/agent_refresh.js";
+
+const DEAD_PID = 2_147_483_646; // beyond any real pid_max ⇒ process.kill(pid,0) → ESRCH
 
 const T0 = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
@@ -120,26 +123,24 @@ describe("single-flight", () => {
     expect(calls.n).toBe(0); // never rotated itself
   });
 
-  it("breaks a stale lock, then acquires and refreshes", async () => {
+  it("breaks a lock whose owner process is dead, then acquires and refreshes", async () => {
     store(a, session({ access_expires_at: new Date(T0 - 1000).toISOString() }));
     const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
-    writeFileSync(lock, "dead-holder");
-    const staleSec = (Date.now() - 60_000) / 1000; // 60s old > 30s stale threshold
-    utimesSync(lock, staleSec, staleSec);
+    writeFileSync(lock, `${DEAD_PID}:abandoned`); // owner process is dead ⇒ safe to break
     const calls = { n: 0 };
     const tok = await getFreshAgentAccessToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl: noSleep });
     expect(tok).toBe("acc-new");
-    expect(calls.n).toBe(1); // broke the stale lock and refreshed
+    expect(calls.n).toBe(1); // broke the dead-owner lock and refreshed
     expect(existsSync(lock)).toBe(false); // released after
   });
 
   // Finding #2: a fresh (unexpired) token that the server 401'd must NOT be re-handed by
   // a concurrent loser — it would just 401 again. The loser waits for the winner's
   // strictly-newer session (changed refresh token), and never rotates itself.
-  it("forced loser with a fresh-but-401 token waits for the winner's newer session (slow live holder, lock intact)", async () => {
+  it("forced loser with a fresh-but-401 token waits for the winner's newer session (live holder, lock intact)", async () => {
     store(a, session()); // acc-old is comfortably unexpired (T0+10min), ref-old
     const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
-    writeFileSync(lock, "live-owner"); // fresh mtime ⇒ a live (slow) holder
+    writeFileSync(lock, `${process.pid}:live`); // owner pid is alive ⇒ never broken
     const calls = { n: 0 };
     let polls = 0;
     const sleepImpl = async () => { polls++; if (polls === 2) store(a, NEW_SESSION); };
@@ -152,10 +153,40 @@ describe("single-flight", () => {
   it("forced loser fails (never re-hands the old 401'd token) when no newer session arrives", async () => {
     store(a, session()); // fresh token, but forced (post-401)
     const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
-    writeFileSync(lock, "live-owner");
+    writeFileSync(lock, `${process.pid}:live`);
     await expect(
       forceRefreshAgentToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200), sleepImpl: noSleep }),
     ).rejects.toThrow(/timed out/);
+  });
+
+  // Finding #3 (round 2): a live owner (incl. suspended/stalled — pid still exists) is
+  // NEVER broken; only a provably-dead owner is; a replacement owner is not TOCTOU-deleted.
+  it("breakIfDeadOwner: live owner (real pid) is never broken", () => {
+    const lock = join(dir, ".auth.refresh.lock");
+    writeFileSync(lock, `${process.pid}:live`);
+    expect(breakIfDeadOwner(lock)).toBe(false);
+    expect(existsSync(lock)).toBe(true);
+  });
+  it("breakIfDeadOwner: unparseable owner fails closed (not broken)", () => {
+    const lock = join(dir, ".auth.refresh.lock");
+    writeFileSync(lock, "no-pid-here");
+    expect(breakIfDeadOwner(lock)).toBe(false);
+    expect(existsSync(lock)).toBe(true);
+  });
+  it("breakIfDeadOwner: dead owner is broken", () => {
+    const lock = join(dir, ".auth.refresh.lock");
+    writeFileSync(lock, `${DEAD_PID}:abandoned`);
+    expect(breakIfDeadOwner(lock)).toBe(true);
+    expect(existsSync(lock)).toBe(false);
+  });
+  it("breakIfDeadOwner: dead owner replaced between reads is NOT deleted (TOCTOU guard)", () => {
+    const lock = join(dir, ".auth.refresh.lock");
+    writeFileSync(lock, `${process.pid}:replacement`); // the file now holds a LIVE new owner
+    // Injected reader: first read = the dead owner we saw, second read = the replacement.
+    let n = 0;
+    const readOwner = () => { n += 1; return n === 1 ? `${DEAD_PID}:gone` : `${process.pid}:replacement`; };
+    expect(breakIfDeadOwner(lock, readOwner)).toBe(false); // replaced under us ⇒ leave it
+    expect(existsSync(lock)).toBe(true);
   });
 
   // Finding #3: release must never delete a lock that a foreign holder now owns.
@@ -166,5 +197,65 @@ describe("single-flight", () => {
     expect(existsSync(lock)).toBe(true);
     releaseOwnLock(lock, "owner-A"); // our id ⇒ delete it
     expect(existsSync(lock)).toBe(false);
+  });
+});
+
+// Round 2: secret-bearing token endpoints must refuse redirects and bound the body.
+describe("refresh token endpoint hardening (real server)", () => {
+  let dir: string;
+  let a: AgentEnv;
+  let primary: Server;
+  let secondary: Server;
+  let base: string;
+  let secondHits: number;
+  let mode: "redirect" | "huge";
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "sf-net-"));
+    a = env(dir);
+    secondHits = 0;
+    mode = "redirect";
+    secondary = createServer((_req, res) => {
+      secondHits += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(NEW_SESSION));
+    });
+    await new Promise<void>((r) => secondary.listen(0, r));
+    const secondBase = `http://127.0.0.1:${(secondary.address() as any).port}`;
+    primary = createServer((req, res) => {
+      if (req.url === "/api/auth/agent/refresh") {
+        if (mode === "redirect") { res.writeHead(307, { location: `${secondBase}/api/auth/agent/refresh` }); res.end(); return; }
+        res.writeHead(200, { "content-type": "application/json" }); res.end("x".repeat(70 * 1024)); return; // "huge"
+      }
+      res.writeHead(404); res.end("{}");
+    });
+    await new Promise<void>((r) => primary.listen(0, r));
+    base = `http://127.0.0.1:${(primary.address() as any).port}`;
+  });
+  afterEach(async () => {
+    rmSync(dir, { recursive: true, force: true });
+    await new Promise<void>((r) => primary.close(() => r()));
+    await new Promise<void>((r) => secondary.close(() => r()));
+  });
+
+  function storeAt(apiBase: string) {
+    writeAgentSession(
+      a, HANDS_SERVICE,
+      session({ access_expires_at: new Date(T0 - 1000).toISOString() }),
+      apiBase, () => new Date(T0).toISOString(),
+    );
+  }
+
+  it("refuses to follow a 307 (never forwards the refresh_token to the redirect target)", async () => {
+    mode = "redirect";
+    storeAt(base);
+    await expect(forceRefreshAgentToken(a, { now: T0, sleepImpl: noSleep })).rejects.toThrow(/HTTP 307/);
+    expect(secondHits).toBe(0); // the redirect target was never contacted
+  });
+
+  it("rejects an oversized refresh response body", async () => {
+    mode = "huge";
+    storeAt(base);
+    await expect(forceRefreshAgentToken(a, { now: T0, sleepImpl: noSleep })).rejects.toThrow(/size limit/);
   });
 });

--- a/packages/cli/src/agent_refresh.test.ts
+++ b/packages/cli/src/agent_refresh.test.ts
@@ -10,6 +10,8 @@ import { join, dirname } from "node:path";
 import { agentAuthPath, HANDS_SERVICE, readAgentAccessToken, type AgentEnv } from "./lib/agent_env.js";
 import { writeAgentSession, type AgentSession } from "./lib/agent_auth.js";
 import { createServer, type Server } from "node:http";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { getFreshAgentAccessToken, forceRefreshAgentToken, releaseOwnLock, acquireIfDeadOwner } from "./lib/agent_refresh.js";
 
 const DEAD_PID = 2_147_483_646; // beyond any real pid_max ⇒ process.kill(pid,0) → ESRCH
@@ -181,12 +183,19 @@ describe("single-flight", () => {
     expect(readFileSync(lock, "utf8")).toBe("me:winner"); // we now hold it
     expect(existsSync(`${lock}.reap`)).toBe(false); // fence released
   });
-  it("acquireIfDeadOwner: a live reaper fence blocks a second recoverer (fail closed)", () => {
+  it("acquireIfDeadOwner: ANY existing reaper fence blocks a second recoverer (no auto-recovery)", () => {
     const lock = join(dir, ".auth.refresh.lock");
     writeFileSync(lock, `${DEAD_PID}:abandoned`);
-    writeFileSync(`${lock}.reap`, `${process.pid}:live-reaper`); // a live reaper holds the fence
-    expect(acquireIfDeadOwner(lock, "me:1")).toBe(false); // second recoverer → loser
-    expect(readFileSync(lock, "utf8")).toBe(`${DEAD_PID}:abandoned`); // dead lock left for the live reaper
+    // A live reaper's fence blocks, as expected.
+    writeFileSync(`${lock}.reap`, `${process.pid}:live-reaper`);
+    expect(acquireIfDeadOwner(lock, "me:1")).toBe(false);
+    expect(readFileSync(lock, "utf8")).toBe(`${DEAD_PID}:abandoned`);
+    // A LEFTOVER fence whose reaper pid is DEAD also blocks — we never auto-recover it
+    // (that would recurse the reap race). Fail closed; leave it for manual cleanup.
+    writeFileSync(`${lock}.reap`, `${DEAD_PID}:crashed-reaper`);
+    expect(acquireIfDeadOwner(lock, "me:1")).toBe(false);
+    expect(existsSync(`${lock}.reap`)).toBe(true); // NOT auto-removed
+    expect(readFileSync(lock, "utf8")).toBe(`${DEAD_PID}:abandoned`);
   });
 
   // Finding #3: release must never delete a lock that a foreign holder now owns.
@@ -199,23 +208,54 @@ describe("single-flight", () => {
     expect(existsSync(lock)).toBe(false);
   });
 
-  // Finding #3 (round 3): two concurrent recoverers of the SAME dead lock must produce
-  // exactly ONE refresh — the reaper fence + O_EXCL re-acquire serialize the recovery.
-  it("two concurrent recoverers of a dead lock produce exactly one refresh", async () => {
-    store(a, session({ access_expires_at: new Date(T0 - 1000).toISOString() }));
+  // Finding #3 (round 3): TWO REAL PROCESSES recovering the SAME dead lock must produce
+  // exactly ONE refresh. Single-event-loop Promise.all cannot exercise this (acquireIfDeadOwner
+  // is all-synchronous, so the first finishes before the second starts) — so we fork two tsx
+  // workers, park both at a file barrier, release together, and count server-side refreshes.
+  it("two REAL concurrent processes recovering a dead lock produce exactly one refresh", async () => {
+    let hits = 0;
+    const server = createServer((_req, res) => {
+      hits += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(NEW_SESSION));
+    });
+    await new Promise<void>((r) => server.listen(0, r));
+    const base = `http://127.0.0.1:${(server.address() as any).port}`;
+    writeAgentSession(
+      a, HANDS_SERVICE,
+      session({ access_expires_at: new Date(T0 - 1000).toISOString() }),
+      base, () => new Date(T0).toISOString(),
+    );
     const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
     writeFileSync(lock, `${DEAD_PID}:abandoned`);
-    const calls = { n: 0 };
-    const fetchImpl = mockFetch(NEW_SESSION, 200, calls);
-    const [t1, t2] = await Promise.all([
-      forceRefreshAgentToken(a, { now: T0, fetchImpl, sleepImpl: noSleep }),
-      forceRefreshAgentToken(a, { now: T0, fetchImpl, sleepImpl: noSleep }),
-    ]);
-    expect(calls.n).toBe(1); // exactly one rotate across both recoverers
-    expect([t1, t2].sort()).toEqual(["acc-new", "acc-new"]); // both end up with the winner's session
-    expect(existsSync(lock)).toBe(false); // released after
+
+    const tsxBin = fileURLToPath(new URL("../node_modules/.bin/tsx", import.meta.url));
+    const worker = fileURLToPath(new URL("./refresh_race_worker.mts", import.meta.url));
+    const goFile = join(dir, "go");
+    const spawnWorker = (i: number) => {
+      const ready = join(dir, `ready-${i}`);
+      const p = spawn(tsxBin, [worker, dir, "/t", "agent-1", ready, goFile, String(T0)], { stdio: ["ignore", "pipe", "pipe"] });
+      let out = "";
+      p.stdout.on("data", (d) => { out += String(d); });
+      const done = new Promise<string>((res) => p.on("close", () => res(out)));
+      return { ready, done };
+    };
+    const w1 = spawnWorker(1);
+    const w2 = spawnWorker(2);
+
+    const started = Date.now();
+    while (!(existsSync(w1.ready) && existsSync(w2.ready))) {
+      if (Date.now() - started > 20_000) throw new Error("race workers never became ready");
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    writeFileSync(goFile, "go"); // release both together
+    const [o1, o2] = await Promise.all([w1.done, w2.done]);
+    await new Promise<void>((r) => server.close(() => r()));
+
+    expect(hits).toBe(1); // exactly one refresh across the two real processes
+    expect([o1, o2]).toEqual(["acc-new", "acc-new"]); // both end up with the winner's rotated token
     expect(existsSync(`${lock}.reap`)).toBe(false); // fence released
-  });
+  }, 30_000);
 });
 
 // Round 2: secret-bearing token endpoints must refuse redirects and bound the body.

--- a/packages/cli/src/agent_refresh.test.ts
+++ b/packages/cli/src/agent_refresh.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { agentAuthPath, HANDS_SERVICE, readAgentAccessToken, type AgentEnv } from "./lib/agent_env.js";
 import { writeAgentSession, type AgentSession } from "./lib/agent_auth.js";
-import { getFreshAgentAccessToken, forceRefreshAgentToken } from "./lib/agent_refresh.js";
+import { getFreshAgentAccessToken, forceRefreshAgentToken, releaseOwnLock } from "./lib/agent_refresh.js";
 
 const T0 = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
@@ -131,5 +131,40 @@ describe("single-flight", () => {
     expect(tok).toBe("acc-new");
     expect(calls.n).toBe(1); // broke the stale lock and refreshed
     expect(existsSync(lock)).toBe(false); // released after
+  });
+
+  // Finding #2: a fresh (unexpired) token that the server 401'd must NOT be re-handed by
+  // a concurrent loser — it would just 401 again. The loser waits for the winner's
+  // strictly-newer session (changed refresh token), and never rotates itself.
+  it("forced loser with a fresh-but-401 token waits for the winner's newer session (slow live holder, lock intact)", async () => {
+    store(a, session()); // acc-old is comfortably unexpired (T0+10min), ref-old
+    const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
+    writeFileSync(lock, "live-owner"); // fresh mtime ⇒ a live (slow) holder
+    const calls = { n: 0 };
+    let polls = 0;
+    const sleepImpl = async () => { polls++; if (polls === 2) store(a, NEW_SESSION); };
+    const tok = await forceRefreshAgentToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200, calls), sleepImpl });
+    expect(tok).toBe("acc-new"); // the winner's rotated session, not the 401'd token
+    expect(calls.n).toBe(0); // loser never rotated
+    expect(existsSync(lock)).toBe(true); // never broke the live holder's lock
+  });
+
+  it("forced loser fails (never re-hands the old 401'd token) when no newer session arrives", async () => {
+    store(a, session()); // fresh token, but forced (post-401)
+    const lock = join(dirname(agentAuthPath(a)), ".auth.refresh.lock");
+    writeFileSync(lock, "live-owner");
+    await expect(
+      forceRefreshAgentToken(a, { now: T0, fetchImpl: mockFetch(NEW_SESSION, 200), sleepImpl: noSleep }),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  // Finding #3: release must never delete a lock that a foreign holder now owns.
+  it("releaseOwnLock deletes only our own lock, never a foreign holder's", () => {
+    const lock = join(dir, ".auth.refresh.lock");
+    writeFileSync(lock, "owner-A");
+    releaseOwnLock(lock, "owner-B"); // foreign id ⇒ leave it
+    expect(existsSync(lock)).toBe(true);
+    releaseOwnLock(lock, "owner-A"); // our id ⇒ delete it
+    expect(existsSync(lock)).toBe(false);
   });
 });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -30,6 +30,11 @@ describe("config round-trip", () => {
     process.env.XDG_CONFIG_HOME = dir;
     delete process.env.HANDS_API;
     delete process.env.QUIVER_API;
+    // These tests exercise the HUMAN config path; clear any inherited agent markers
+    // (the test runner may itself be a managed agent) so admission is `human`.
+    delete process.env.SLOCK_CLI_TRANSPORT_DIR;
+    delete process.env.SLOCK_HOME;
+    delete process.env.SLOCK_AGENT_ID;
   });
 
   afterEach(() => {
@@ -51,7 +56,7 @@ describe("config round-trip", () => {
   it("saveConfig persists to the XDG path", async () => {
     const { saveConfig, getConfig } = await import("../src/lib/config.js");
     saveConfig({ apiBase: "https://example.test", sessionCookie: "tok123" });
-    const path = join(dir, "quiver", "auth.json");
+    const path = join(dir, "hands", "auth.json");
     expect(existsSync(path)).toBe(true);
     const raw = JSON.parse(readFileSync(path, "utf8"));
     expect(raw.apiBase).toBe("https://example.test");
@@ -67,6 +72,10 @@ describe("apiRequest", () => {
   let lastAuthorization: string | null = null;
 
   beforeEach(async () => {
+    // Human/CI auth path: clear inherited agent markers so admission is `human`.
+    delete process.env.SLOCK_CLI_TRANSPORT_DIR;
+    delete process.env.SLOCK_HOME;
+    delete process.env.SLOCK_AGENT_ID;
     server = createServer((req, res) => {
       lastCookie = req.headers.cookie ?? null;
       lastAuthorization = req.headers.authorization ?? null;

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -20,8 +20,7 @@
 
 import type { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
-import { getApiBase } from "../lib/api.js";
-import { resolveAuthToken } from "../lib/config.js";
+import { getApiBase, agentAwareFetch } from "../lib/api.js";
 
 const METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
 
@@ -103,18 +102,20 @@ export function registerApiCommand(program: Command): void {
             : opts.data;
         }
 
-        const headers: Record<string, string> = { accept: "application/json" };
-        const token = resolveAuthToken();
-        if (token) headers.authorization = `Bearer ${token}`;
-        if (body !== undefined) headers["content-type"] = "application/json";
-
-        const res = await fetch(target.toString(), {
-          method,
-          headers,
-          ...(body !== undefined ? { body } : {}),
-          // Never auto-follow a 3xx: a redirect off the API origin would carry
-          // the bearer token to the redirect target.
-          redirect: "manual",
+        // Agent-aware: proactive refresh + one guarded 401 retry in agent mode, same as
+        // every other CLI HTTP path. The request is rebuilt per attempt with the bearer.
+        const res = await agentAwareFetch((bearer) => {
+          const headers: Record<string, string> = { accept: "application/json" };
+          if (bearer) headers.authorization = `Bearer ${bearer}`;
+          if (body !== undefined) headers["content-type"] = "application/json";
+          return fetch(target.toString(), {
+            method,
+            headers,
+            ...(body !== undefined ? { body } : {}),
+            // Never auto-follow a 3xx: a redirect off the API origin would carry
+            // the bearer token to the redirect target.
+            redirect: "manual",
+          });
         });
 
         const requestId = res.headers.get("x-request-id") ?? res.headers.get("cf-ray");

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -17,8 +17,10 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { Command } from "commander";
-import { apiRequest, getApiBase, QuiverApiError } from "../lib/api.js";
+import { apiRequest, getApiBase, setApiBase, QuiverApiError } from "../lib/api.js";
 import { clearConfig, saveConfig, getConfig } from "../lib/config.js";
+import { detectAgentEnv, HANDS_SERVICE } from "../lib/agent_env.js";
+import { runAgentLogin } from "../lib/agent_auth.js";
 
 async function promptSecret(message: string): Promise<string> {
   // Use a raw-mode readline so we can mask input with '*'.
@@ -73,6 +75,30 @@ export function registerLoginCommands(program: Command): void {
         printUrl?: boolean;
       }) => {
         const apiBase = opts.api ?? getApiBase();
+
+        // Managed-agent path (RFC 057): no browser, no paste. Detected via the
+        // daemon-injected env; runs agent-login → exchange → store under $SLOCK_HOME.
+        // An explicit --token forces the human paste path even inside an agent.
+        const agentEnv = detectAgentEnv();
+        if (agentEnv && !opts.token) {
+          if (opts.printUrl) {
+            console.log("(agent environment) `hands login` runs the non-interactive agent-login flow — no URL to open.");
+            return;
+          }
+          setApiBase(apiBase); // exchange must target this API base
+          try {
+            const session = await runAgentLogin(agentEnv);
+            console.log(`✔ Agent login complete (service ${HANDS_SERVICE}).`);
+            console.log(`  Stored under $SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/${HANDS_SERVICE}/auth.json`);
+            console.log(`  access token expires ${session.access_expires_at}; refresh rotates automatically.`);
+            console.log("  Subsequent `hands` commands use the stored Hands token directly.");
+          } catch (e) {
+            console.error(`✘ Agent login failed: ${e instanceof Error ? e.message : String(e)}`);
+            process.exit(1);
+          }
+          return;
+        }
+
         const loginUrl = `${apiBase}/api/auth/login?return_to=${encodeURIComponent("/cli/callback")}`;
 
         if (opts.printUrl) {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -17,9 +17,10 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { Command } from "commander";
+import { rmSync } from "node:fs";
 import { apiRequest, getApiBase, setApiBase, QuiverApiError } from "../lib/api.js";
-import { clearConfig, saveConfig, getConfig } from "../lib/config.js";
-import { detectAgentEnv, HANDS_SERVICE } from "../lib/agent_env.js";
+import { clearConfig, saveConfig, getConfig, configPath } from "../lib/config.js";
+import { admitAgent, agentAuthPath, HANDS_SERVICE } from "../lib/agent_env.js";
 import { runAgentLogin } from "../lib/agent_auth.js";
 
 async function promptSecret(message: string): Promise<string> {
@@ -75,19 +76,23 @@ export function registerLoginCommands(program: Command): void {
         printUrl?: boolean;
       }) => {
         const apiBase = opts.api ?? getApiBase();
+        const admission = admitAgent();
 
-        // Managed-agent path (RFC 057): no browser, no paste. Detected via the
-        // daemon-injected env; runs agent-login → exchange → store under $SLOCK_HOME.
-        // An explicit --token forces the human paste path even inside an agent.
-        const agentEnv = detectAgentEnv();
-        if (agentEnv && !opts.token) {
+        // Managed-agent path (RFC 057): no browser, no paste. Runs agent-login →
+        // exchange → store under $SLOCK_HOME. Isolated from the human config.
+        if (admission.kind === "agent") {
+          if (opts.token) {
+            // Never let --token write the human config from inside an agent.
+            console.error("✘ In a managed agent environment, run `hands login` without --token (agent-login is used instead).");
+            process.exit(1);
+          }
           if (opts.printUrl) {
             console.log("(agent environment) `hands login` runs the non-interactive agent-login flow — no URL to open.");
             return;
           }
           setApiBase(apiBase); // exchange must target this API base
           try {
-            const session = await runAgentLogin(agentEnv);
+            const session = await runAgentLogin(admission.env);
             console.log(`✔ Agent login complete (service ${HANDS_SERVICE}).`);
             console.log(`  Stored under $SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/${HANDS_SERVICE}/auth.json`);
             console.log(`  access token expires ${session.access_expires_at}; refresh rotates automatically.`);
@@ -97,6 +102,11 @@ export function registerLoginCommands(program: Command): void {
             process.exit(1);
           }
           return;
+        }
+        if (admission.kind === "fail_closed") {
+          // Partial/invalid agent markers must never silently use human credentials.
+          console.error(`✘ Agent environment is incomplete or invalid (${admission.reason}); refusing to fall back to human login. Fix the agent environment and retry.`);
+          process.exit(1);
         }
 
         const loginUrl = `${apiBase}/api/auth/login?return_to=${encodeURIComponent("/cli/callback")}`;
@@ -129,7 +139,7 @@ export function registerLoginCommands(program: Command): void {
         // Persist the token + apiBase to config file.
         clearConfig();
         saveConfig({ apiBase, authToken: token });
-        console.log(`✔ Saved to ${configDisplayPath()}`);
+        console.log(`✔ Saved to ${configPath()}`);
         console.log(`  API base: ${apiBase}`);
 
         // Verify the token works by calling /api/auth/me.
@@ -158,23 +168,33 @@ export function registerLoginCommands(program: Command): void {
 
   program
     .command("logout")
-    .description("Clear the saved Hands JWT.")
+    .description("Clear the saved Hands token (agent store in an agent, else human config).")
     .action(() => {
+      const admission = admitAgent();
+      if (admission.kind === "agent") {
+        // Clear the per-agent store only; never touch the human config.
+        const path = agentAuthPath(admission.env);
+        try {
+          rmSync(path, { force: true });
+          console.log(`✔ Agent Hands token cleared (${path}).`);
+        } catch (e) {
+          console.error(`✘ Failed to clear agent token: ${e instanceof Error ? e.message : String(e)}`);
+          process.exit(1);
+        }
+        return;
+      }
+      if (admission.kind === "fail_closed") {
+        console.error(`✘ Agent environment is incomplete or invalid (${admission.reason}).`);
+        process.exit(1);
+      }
       const cfg = getConfig();
       if (!cfg.authToken && !cfg.sessionCookie) {
-        console.log("Not logged in (no saved Hands JWT).");
+        console.log("Not logged in (no saved Hands token).");
         return;
       }
       clearConfig();
-      console.log(`✔ Logged out (token cleared from ${configDisplayPath()}).`);
+      console.log(`✔ Logged out (token cleared from ${configPath()}).`);
     });
-}
-
-function configDisplayPath(): string {
-  // Mirror getConfig's path resolution for display only.
-  const xdg = process.env.XDG_CONFIG_HOME;
-  const dir = xdg && xdg.length > 0 ? xdg : `${process.env.HOME ?? "~"}/.config`;
-  return `${dir}/quiver/auth.json`;
 }
 
 // Keep the command module side-effect free when imported by tests.

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -12,8 +12,8 @@ const NO_AUTH_HELP =
   "  • Agents / CI: set HANDS_BEARER_TOKEN to a deploy token\n" +
   "      (console → App → Settings → Deploy Tokens; publisher role to release).\n" +
   "  • Humans: run `hands login` and paste the browser callback JWT.\n" +
-  "  • Raft agents: run `raft integration login --service <hands-service>` and use\n" +
-  "      the integration session through `raft integration invoke`.";
+  "  • Raft agents: run `hands login` — it auto-detects the managed agent and completes\n" +
+  "      the agent-login handshake via your Raft integration session (no URL to open).";
 
 interface MeResponse {
   account?: {

--- a/packages/cli/src/lib/agent_auth.ts
+++ b/packages/cli/src/lib/agent_auth.ts
@@ -1,0 +1,185 @@
+/**
+ * Agent CLI login flow (RFC 057, CP3): the non-interactive `hands login` used inside
+ * a managed Raft agent. No browser, no paste.
+ *
+ *   1. Generate a PKCE code_verifier locally; send only its S256 challenge to Raft.
+ *   2. `raft integration invoke --service <key> --action agent-login --json` → a
+ *      one-time grant, STRICTLY validated (the CP3 acceptance tooth: outer success +
+ *      exact service/action + grant result schema — never trust a loose envelope).
+ *   3. Exchange { grant, code_verifier } at the Hands PUBLIC exchange endpoint for a
+ *      raft-cli-agent-session.v1 (short access token + rotating refresh).
+ *   4. Atomically persist the session under $SLOCK_HOME (0600 file / 0700 dirs).
+ *
+ * The verifier never reaches Raft, logs, or the store. Only the Hands token is stored.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, renameSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes, createHash } from "node:crypto";
+import { apiRequest } from "./api.js";
+import { agentAuthPath, HANDS_SERVICE, type AgentEnv } from "./agent_env.js";
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** PKCE S256: a 64-byte verifier → 86 unreserved base64url chars (within RFC 7636's
+ *  43–128), and its SHA-256 challenge as unpadded base64url. */
+export function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = base64url(randomBytes(64));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+/**
+ * Strictly validate a `raft integration invoke --action agent-login --json` result.
+ * Real envelope (verified against the live daemon):
+ *   { ok:true, data:{ service, action, status, result:{ schema, service, grant, expires_at } } }
+ * Anything not matching exactly is rejected — the CLI never relies on the manifest for
+ * output enforcement (Volta's CP3 acceptance tooth).
+ */
+export function parseAgentLoginInvoke(
+  stdout: string,
+  service: string,
+): { grant: string; expires_at: string } {
+  let outer: any;
+  try {
+    outer = JSON.parse(stdout);
+  } catch {
+    throw new Error("agent-login: `raft integration invoke` did not return JSON");
+  }
+  if (!outer || outer.ok !== true) {
+    const err = outer && typeof outer.error === "string" ? outer.error : stdout.slice(0, 200);
+    throw new Error(`agent-login: invoke did not succeed: ${err}`);
+  }
+  const data = outer.data;
+  if (!data || data.service !== service) {
+    throw new Error(`agent-login: service mismatch (got ${data?.service}, want ${service})`);
+  }
+  if (data.action !== "agent-login") {
+    throw new Error(`agent-login: action mismatch (got ${data?.action})`);
+  }
+  if (data.status !== 200) {
+    throw new Error(`agent-login: action returned HTTP ${data?.status}`);
+  }
+  const result = data.result;
+  if (!result || result.schema !== "raft-cli-agent-login-grant.v1") {
+    throw new Error("agent-login: unexpected grant result schema");
+  }
+  if (result.service !== service) {
+    throw new Error(`agent-login: grant service mismatch (got ${result.service}, want ${service})`);
+  }
+  if (typeof result.grant !== "string" || result.grant.length === 0) {
+    throw new Error("agent-login: grant missing from result");
+  }
+  if (typeof result.expires_at !== "string" || result.expires_at.length === 0) {
+    throw new Error("agent-login: grant expires_at missing from result");
+  }
+  return { grant: result.grant, expires_at: result.expires_at };
+}
+
+export interface AgentSession {
+  schema: "raft-cli-agent-session.v1";
+  token_type: "Bearer";
+  access_token: string;
+  access_expires_at: string; // RFC3339
+  refresh_token: string;
+  refresh_expires_at: string | null; // RFC3339 | null
+}
+
+/** Strictly validate the exchange/refresh success body (raft-cli-agent-session.v1). */
+export function parseAgentSession(body: any): AgentSession {
+  if (!body || body.schema !== "raft-cli-agent-session.v1") {
+    throw new Error("agent-login: unexpected session schema from exchange");
+  }
+  if (body.token_type !== "Bearer") {
+    throw new Error("agent-login: unexpected token_type from exchange");
+  }
+  for (const k of ["access_token", "access_expires_at", "refresh_token"] as const) {
+    if (typeof body[k] !== "string" || body[k].length === 0) {
+      throw new Error(`agent-login: session missing ${k}`);
+    }
+  }
+  if (body.refresh_expires_at !== null && typeof body.refresh_expires_at !== "string") {
+    throw new Error("agent-login: session refresh_expires_at must be a string or null");
+  }
+  return body as AgentSession;
+}
+
+/** Stored record = the session.v1 fields + service slug + updated_at (no Raft creds). */
+export interface StoredAgentAuth extends AgentSession {
+  service: string;
+  updated_at: string;
+}
+
+/** Atomic write (temp file + rename); 0600 file, 0700 dirs — per RFC 057 store rules. */
+export function writeAgentSession(
+  a: AgentEnv,
+  service: string,
+  session: AgentSession,
+  now: () => string = () => new Date().toISOString(),
+): string {
+  const path = agentAuthPath(a, service);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const record: StoredAgentAuth = { ...session, service, updated_at: now() };
+  const tmp = `${path}.tmp-${process.pid}`;
+  try {
+    writeFileSync(tmp, JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
+    renameSync(tmp, path);
+  } catch (e) {
+    try { rmSync(tmp, { force: true }); } catch { /* best effort */ }
+    throw e;
+  }
+  return path;
+}
+
+export interface AgentLoginOptions {
+  raftBin?: string; // default "raft" (the daemon-injected wrapper on PATH)
+  service?: string; // default HANDS_SERVICE (exact installed client key)
+  /** Injectable invoke runner for tests (defaults to spawning `raft`). */
+  invoke?: (args: string[]) => { status: number | null; stdout: string; stderr: string };
+}
+
+function defaultInvoke(raftBin: string, args: string[]) {
+  const res = spawnSync(raftBin, args, { encoding: "utf8" });
+  return {
+    status: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
+  };
+}
+
+/**
+ * Full agent-login flow: invoke → strict-validate grant → exchange → strict-validate
+ * session → atomic store. Returns the stored session on success.
+ */
+export async function runAgentLogin(a: AgentEnv, opts: AgentLoginOptions = {}): Promise<AgentSession> {
+  const service = opts.service ?? HANDS_SERVICE;
+  const { verifier, challenge } = generatePkce();
+  const args = [
+    "integration", "invoke",
+    "--service", service,
+    "--action", "agent-login",
+    "--json",
+    "--data-json", JSON.stringify({
+      schema: "raft-cli-agent-login-request.v1",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }),
+  ];
+  const runner = opts.invoke ?? ((a2: string[]) => defaultInvoke(opts.raftBin ?? "raft", a2));
+  const res = runner(args);
+  if (!res.stdout) {
+    throw new Error(`agent-login: raft invoke produced no output (${res.stderr || `exit ${res.status}`})`);
+  }
+  const { grant } = parseAgentLoginInvoke(res.stdout, service);
+
+  // Exchange at the Hands PUBLIC endpoint (no prior Hands session required).
+  const body = await apiRequest("/api/auth/agent/exchange", {
+    method: "POST",
+    body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier },
+  });
+  const session = parseAgentSession(body);
+  writeAgentSession(a, service, session);
+  return session;
+}

--- a/packages/cli/src/lib/agent_auth.ts
+++ b/packages/cli/src/lib/agent_auth.ts
@@ -22,7 +22,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { randomBytes, createHash } from "node:crypto";
-import { apiRequest, getApiBase } from "./api.js";
+import { getApiBase } from "./api.js";
 import { agentAuthPath, HANDS_SERVICE, type AgentEnv } from "./agent_env.js";
 
 function base64url(buf: Buffer): string {
@@ -69,9 +69,17 @@ export function parseAgentLoginInvoke(
     throw new Error("agent-login: `raft integration invoke` did not return JSON");
   }
   if (!outer || typeof outer !== "object") throw new Error("agent-login: invoke output is not an object");
+  // Check success first: a failed invoke may legitimately carry a different shape
+  // (e.g. {ok:false, error}); only the success wrapper is the closed {ok, data}.
   if (outer.ok !== true) throw new Error("agent-login: invoke did not succeed");
+  // Closed envelope: an unexpected extra field means the wire drifted from the
+  // checkpoint contract; fail rather than ignore.
+  if (!hasExactKeys(outer, ["ok", "data"])) throw new Error("agent-login: invoke envelope has unexpected fields");
   const data = outer.data;
   if (!data || typeof data !== "object") throw new Error("agent-login: invoke result is missing data");
+  if (!hasExactKeys(data, ["service", "action", "status", "result"])) {
+    throw new Error("agent-login: invoke data has unexpected fields");
+  }
   if (data.service !== service) throw new Error("agent-login: invoke service does not match the requested service");
   if (data.action !== "agent-login") throw new Error("agent-login: invoke action is not agent-login");
   if (data.status !== 200) throw new Error("agent-login: agent-login action did not return HTTP 200");
@@ -99,8 +107,13 @@ export interface AgentSession {
   refresh_expires_at: string | null; // RFC3339 | null
 }
 
-/** Strictly validate the exchange/refresh success body (closed keys + RFC3339). */
-export function parseAgentSession(body: any): AgentSession {
+/**
+ * Strictly validate the exchange/refresh success body (closed keys + RFC3339).
+ * `now` is injected so validation is deterministic: a freshly issued session MUST
+ * have a strictly-future access expiry (and refresh expiry, when present) — otherwise
+ * we would persist an already-dead session that the very next request must refresh.
+ */
+export function parseAgentSession(body: any, now: number): AgentSession {
   if (!body || typeof body !== "object") throw new Error("agent-login: exchange response is not an object");
   if (!hasExactKeys(body, ["schema", "token_type", "access_token", "access_expires_at", "refresh_token", "refresh_expires_at"])) {
     throw new Error("agent-login: session has unexpected fields");
@@ -110,9 +123,13 @@ export function parseAgentSession(body: any): AgentSession {
   for (const k of ["access_token", "refresh_token"] as const) {
     if (typeof body[k] !== "string" || body[k].length === 0) throw new Error(`agent-login: session missing ${k}`);
   }
-  if (parseRfc3339(body.access_expires_at) === null) throw new Error("agent-login: session access_expires_at is not RFC3339");
-  if (body.refresh_expires_at !== null && parseRfc3339(body.refresh_expires_at) === null) {
-    throw new Error("agent-login: session refresh_expires_at must be RFC3339 or null");
+  const accessExp = parseRfc3339(body.access_expires_at);
+  if (accessExp === null) throw new Error("agent-login: session access_expires_at is not RFC3339");
+  if (accessExp <= now) throw new Error("agent-login: session access token is already expired");
+  if (body.refresh_expires_at !== null) {
+    const refreshExp = parseRfc3339(body.refresh_expires_at);
+    if (refreshExp === null) throw new Error("agent-login: session refresh_expires_at must be RFC3339 or null");
+    if (refreshExp <= now) throw new Error("agent-login: session refresh token is already expired");
   }
   return body as AgentSession;
 }
@@ -178,6 +195,8 @@ export interface AgentLoginOptions {
   now?: number; // injectable clock (ms) for tests
   /** Injectable invoke runner for tests; defaults to spawning the pinned wrapper. */
   invoke?: (args: string[]) => { status: number | null; stdout: string; stderr: string };
+  /** Injectable fetch for the exchange; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
 }
 
 function defaultInvoke(raftBin: string, args: string[]) {
@@ -216,12 +235,29 @@ export async function runAgentLogin(a: AgentEnv, opts: AgentLoginOptions = {}): 
   }
   const { grant } = parseAgentLoginInvoke(res.stdout, service, now);
 
+  // Independent token request: NO stored Bearer, NO auto-refresh. `hands login` is the
+  // recovery path when the stored refresh has reached a terminal state
+  // (expired/reused/revoked); routing this exchange through the api client would first
+  // try to refresh that dead token and throw before the fresh grant is ever spent.
   const apiBase = getApiBase();
-  const body = await apiRequest("/api/auth/agent/exchange", {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const exchangeRes = await fetchImpl(new URL("/api/auth/agent/exchange", apiBase).toString(), {
     method: "POST",
-    body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier },
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({ schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier }),
   });
-  const session = parseAgentSession(body);
+  const exchangeText = await exchangeRes.text();
+  if (!exchangeRes.ok) {
+    // Stable reason only; never echo the response body (may carry token material).
+    throw new Error(`agent-login: grant exchange failed (HTTP ${exchangeRes.status})`);
+  }
+  let exchangeBody: unknown;
+  try {
+    exchangeBody = JSON.parse(exchangeText);
+  } catch {
+    throw new Error("agent-login: exchange response was not JSON");
+  }
+  const session = parseAgentSession(exchangeBody, now);
   writeAgentSession(a, service, session, apiBase);
   return session;
 }

--- a/packages/cli/src/lib/agent_auth.ts
+++ b/packages/cli/src/lib/agent_auth.ts
@@ -190,6 +190,49 @@ export function writeAgentSession(
   return path;
 }
 
+// Token responses are small JSON; cap the read so a hostile/broken endpoint cannot
+// stream an unbounded body. Shared by the exchange and refresh token requests.
+export const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
+
+/**
+ * Read a response body with a hard byte cap. If an AbortController is supplied it is
+ * aborted when the cap is exceeded (so a still-open connection is torn down, and — in
+ * `rotate` — the same controller's deadline keeps covering this read). Falls back to
+ * `.text()` for response doubles that expose no stream (still cap-checked).
+ */
+export async function readBoundedText(res: Response, controller?: AbortController): Promise<string> {
+  const declared = Number(res.headers?.get?.("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_TOKEN_RESPONSE_BYTES) {
+    controller?.abort();
+    throw new Error("agent-login: token response exceeds the size limit");
+  }
+  const reader = (res.body as ReadableStream<Uint8Array> | null | undefined)?.getReader?.();
+  if (!reader) {
+    const t = await res.text();
+    if (t.length > MAX_TOKEN_RESPONSE_BYTES) throw new Error("agent-login: token response exceeds the size limit");
+    return t;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > MAX_TOKEN_RESPONSE_BYTES) {
+        controller?.abort();
+        try { await reader.cancel(); } catch { /* ignore */ }
+        throw new Error("agent-login: token response exceeds the size limit");
+      }
+      chunks.push(value);
+    }
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) { out.set(c, off); off += c.byteLength; }
+  return new TextDecoder().decode(out);
+}
+
 export interface AgentLoginOptions {
   service?: string; // default HANDS_SERVICE (compiled-fixed exact client key)
   now?: number; // injectable clock (ms) for tests
@@ -245,12 +288,15 @@ export async function runAgentLogin(a: AgentEnv, opts: AgentLoginOptions = {}): 
     method: "POST",
     headers: { "content-type": "application/json", accept: "application/json" },
     body: JSON.stringify({ schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier }),
+    // Never follow a redirect: a 307/308 would forward the grant + code_verifier body
+    // to the redirect target. `manual` leaves a 3xx as a non-ok status we reject below.
+    redirect: "manual",
   });
-  const exchangeText = await exchangeRes.text();
   if (!exchangeRes.ok) {
     // Stable reason only; never echo the response body (may carry token material).
     throw new Error(`agent-login: grant exchange failed (HTTP ${exchangeRes.status})`);
   }
+  const exchangeText = await readBoundedText(exchangeRes);
   let exchangeBody: unknown;
   try {
     exchangeBody = JSON.parse(exchangeText);

--- a/packages/cli/src/lib/agent_auth.ts
+++ b/packages/cli/src/lib/agent_auth.ts
@@ -3,44 +3,64 @@
  * a managed Raft agent. No browser, no paste.
  *
  *   1. Generate a PKCE code_verifier locally; send only its S256 challenge to Raft.
- *   2. `raft integration invoke --service <key> --action agent-login --json` → a
- *      one-time grant, STRICTLY validated (the CP3 acceptance tooth: outer success +
- *      exact service/action + grant result schema — never trust a loose envelope).
- *   3. Exchange { grant, code_verifier } at the Hands PUBLIC exchange endpoint for a
- *      raft-cli-agent-session.v1 (short access token + rotating refresh).
- *   4. Atomically persist the session under $SLOCK_HOME (0600 file / 0700 dirs).
+ *   2. Run the EXACT wrapper `$SLOCK_CLI_TRANSPORT_DIR/raft integration invoke
+ *      --action agent-login --json` (never PATH `raft`); require exit 0; STRICTLY
+ *      validate the result (outer success + exact service/action/status + closed grant
+ *      result schema + RFC3339/future/<=300s expiry). Errors carry only stable reasons
+ *      — never the raw stdout/stderr/body (which could contain grant/action payload).
+ *   3. Exchange { grant, code_verifier } at the Hands PUBLIC endpoint for a
+ *      raft-cli-agent-session.v1; strictly validate it (closed keys + RFC3339 expiries).
+ *   4. Atomically persist under $SLOCK_HOME (O_EXCL temp + fsync + rename; 0600 file /
+ *      verified-0700 dirs), recording the api base so the resolver never needs config.
  *
  * The verifier never reaches Raft, logs, or the store. Only the Hands token is stored.
  */
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, renameSync, rmSync } from "node:fs";
-import { dirname } from "node:path";
+import {
+  openSync, writeSync, fsyncSync, closeSync, renameSync, rmSync,
+  mkdirSync, statSync, chmodSync,
+} from "node:fs";
+import { join } from "node:path";
 import { randomBytes, createHash } from "node:crypto";
-import { apiRequest } from "./api.js";
+import { apiRequest, getApiBase } from "./api.js";
 import { agentAuthPath, HANDS_SERVICE, type AgentEnv } from "./agent_env.js";
 
 function base64url(buf: Buffer): string {
   return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
-/** PKCE S256: a 64-byte verifier → 86 unreserved base64url chars (within RFC 7636's
- *  43–128), and its SHA-256 challenge as unpadded base64url. */
+/** PKCE S256: 64-byte verifier → 86 unreserved base64url chars (within RFC 7636's
+ *  43–128), challenge = unpadded base64url SHA-256. */
 export function generatePkce(): { verifier: string; challenge: string } {
   const verifier = base64url(randomBytes(64));
   const challenge = base64url(createHash("sha256").update(verifier).digest());
   return { verifier, challenge };
 }
 
+function hasExactKeys(o: Record<string, unknown>, keys: readonly string[]): boolean {
+  const k = Object.keys(o);
+  return k.length === keys.length && keys.every((key) => Object.prototype.hasOwnProperty.call(o, key));
+}
+
+/** Parse an RFC3339 date-time to epoch ms, or null. Rejects bare dates / bad offsets. */
+function parseRfc3339(s: unknown): number | null {
+  if (typeof s !== "string") return null;
+  if (!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(Z|[+-]\d\d:\d\d)$/.test(s)) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
 /**
  * Strictly validate a `raft integration invoke --action agent-login --json` result.
  * Real envelope (verified against the live daemon):
- *   { ok:true, data:{ service, action, status, result:{ schema, service, grant, expires_at } } }
- * Anything not matching exactly is rejected — the CLI never relies on the manifest for
- * output enforcement (Volta's CP3 acceptance tooth).
+ *   { ok:true, data:{ service, action, status, result:{schema,service,grant,expires_at} } }
+ * The Hands-owned `result` is closed-key validated; the Raft envelope (outer/data) is
+ * validated by exact required values. NO part of stdout is ever echoed in an error.
  */
 export function parseAgentLoginInvoke(
   stdout: string,
   service: string,
+  now: number,
 ): { grant: string; expires_at: string } {
   let outer: any;
   try {
@@ -48,33 +68,25 @@ export function parseAgentLoginInvoke(
   } catch {
     throw new Error("agent-login: `raft integration invoke` did not return JSON");
   }
-  if (!outer || outer.ok !== true) {
-    const err = outer && typeof outer.error === "string" ? outer.error : stdout.slice(0, 200);
-    throw new Error(`agent-login: invoke did not succeed: ${err}`);
-  }
+  if (!outer || typeof outer !== "object") throw new Error("agent-login: invoke output is not an object");
+  if (outer.ok !== true) throw new Error("agent-login: invoke did not succeed");
   const data = outer.data;
-  if (!data || data.service !== service) {
-    throw new Error(`agent-login: service mismatch (got ${data?.service}, want ${service})`);
-  }
-  if (data.action !== "agent-login") {
-    throw new Error(`agent-login: action mismatch (got ${data?.action})`);
-  }
-  if (data.status !== 200) {
-    throw new Error(`agent-login: action returned HTTP ${data?.status}`);
-  }
+  if (!data || typeof data !== "object") throw new Error("agent-login: invoke result is missing data");
+  if (data.service !== service) throw new Error("agent-login: invoke service does not match the requested service");
+  if (data.action !== "agent-login") throw new Error("agent-login: invoke action is not agent-login");
+  if (data.status !== 200) throw new Error("agent-login: agent-login action did not return HTTP 200");
   const result = data.result;
-  if (!result || result.schema !== "raft-cli-agent-login-grant.v1") {
-    throw new Error("agent-login: unexpected grant result schema");
+  if (!result || typeof result !== "object") throw new Error("agent-login: invoke result is missing the grant body");
+  if (!hasExactKeys(result, ["schema", "service", "grant", "expires_at"])) {
+    throw new Error("agent-login: grant result has unexpected fields");
   }
-  if (result.service !== service) {
-    throw new Error(`agent-login: grant service mismatch (got ${result.service}, want ${service})`);
-  }
-  if (typeof result.grant !== "string" || result.grant.length === 0) {
-    throw new Error("agent-login: grant missing from result");
-  }
-  if (typeof result.expires_at !== "string" || result.expires_at.length === 0) {
-    throw new Error("agent-login: grant expires_at missing from result");
-  }
+  if (result.schema !== "raft-cli-agent-login-grant.v1") throw new Error("agent-login: unexpected grant result schema");
+  if (result.service !== service) throw new Error("agent-login: grant result service mismatch");
+  if (typeof result.grant !== "string" || result.grant.length === 0) throw new Error("agent-login: grant is missing");
+  const exp = parseRfc3339(result.expires_at);
+  if (exp === null) throw new Error("agent-login: grant expires_at is not an RFC3339 timestamp");
+  if (exp <= now) throw new Error("agent-login: grant is already expired");
+  if (exp > now + 300_000) throw new Error("agent-login: grant expiry exceeds the 300s ceiling");
   return { grant: result.grant, expires_at: result.expires_at };
 }
 
@@ -87,74 +99,103 @@ export interface AgentSession {
   refresh_expires_at: string | null; // RFC3339 | null
 }
 
-/** Strictly validate the exchange/refresh success body (raft-cli-agent-session.v1). */
+/** Strictly validate the exchange/refresh success body (closed keys + RFC3339). */
 export function parseAgentSession(body: any): AgentSession {
-  if (!body || body.schema !== "raft-cli-agent-session.v1") {
-    throw new Error("agent-login: unexpected session schema from exchange");
+  if (!body || typeof body !== "object") throw new Error("agent-login: exchange response is not an object");
+  if (!hasExactKeys(body, ["schema", "token_type", "access_token", "access_expires_at", "refresh_token", "refresh_expires_at"])) {
+    throw new Error("agent-login: session has unexpected fields");
   }
-  if (body.token_type !== "Bearer") {
-    throw new Error("agent-login: unexpected token_type from exchange");
+  if (body.schema !== "raft-cli-agent-session.v1") throw new Error("agent-login: unexpected session schema");
+  if (body.token_type !== "Bearer") throw new Error("agent-login: unexpected token_type");
+  for (const k of ["access_token", "refresh_token"] as const) {
+    if (typeof body[k] !== "string" || body[k].length === 0) throw new Error(`agent-login: session missing ${k}`);
   }
-  for (const k of ["access_token", "access_expires_at", "refresh_token"] as const) {
-    if (typeof body[k] !== "string" || body[k].length === 0) {
-      throw new Error(`agent-login: session missing ${k}`);
-    }
-  }
-  if (body.refresh_expires_at !== null && typeof body.refresh_expires_at !== "string") {
-    throw new Error("agent-login: session refresh_expires_at must be a string or null");
+  if (parseRfc3339(body.access_expires_at) === null) throw new Error("agent-login: session access_expires_at is not RFC3339");
+  if (body.refresh_expires_at !== null && parseRfc3339(body.refresh_expires_at) === null) {
+    throw new Error("agent-login: session refresh_expires_at must be RFC3339 or null");
   }
   return body as AgentSession;
 }
 
-/** Stored record = the session.v1 fields + service slug + updated_at (no Raft creds). */
 export interface StoredAgentAuth extends AgentSession {
   service: string;
+  api_base: string;
   updated_at: string;
 }
 
-/** Atomic write (temp file + rename); 0600 file, 0700 dirs — per RFC 057 store rules. */
+/** mkdir (if needed) + verify/repair 0700 (no group/other) on one path component. */
+function ensureSecureDir(dir: string): void {
+  try {
+    mkdirSync(dir, { mode: 0o700 });
+  } catch (e: any) {
+    if (e?.code !== "EEXIST") throw e;
+  }
+  const st = statSync(dir);
+  if (!st.isDirectory()) throw new Error("agent-login: store path component is not a directory");
+  if ((st.mode & 0o077) !== 0) chmodSync(dir, 0o700); // repair a pre-existing wide dir
+}
+
+/**
+ * Atomic, hardened store write: O_EXCL unique temp in the same dir, 0600, write +
+ * fsync + close, atomic rename. Each dir component under $SLOCK_HOME is ensured AND
+ * verified 0700 (repairing a pre-existing wide dir). $SLOCK_HOME itself is not chmod'd.
+ * On any failure the temp is removed and the previous file is left intact.
+ */
 export function writeAgentSession(
   a: AgentEnv,
   service: string,
   session: AgentSession,
+  apiBase: string,
   now: () => string = () => new Date().toISOString(),
 ): string {
-  const path = agentAuthPath(a, service);
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  const record: StoredAgentAuth = { ...session, service, updated_at: now() };
-  const tmp = `${path}.tmp-${process.pid}`;
+  const path = agentAuthPath(a, service); // validates slug + agent id + containment
+  let dir = a.slockHome;
+  for (const seg of ["agents", a.agentId, "integrations", service]) {
+    dir = join(dir, seg);
+    ensureSecureDir(dir);
+  }
+  const record: StoredAgentAuth = { ...session, service, api_base: apiBase, updated_at: now() };
+  const payload = JSON.stringify(record, null, 2) + "\n";
+  const tmp = join(dir, `.auth.${randomBytes(8).toString("hex")}.tmp`);
+  let fd: number | null = null;
   try {
-    writeFileSync(tmp, JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
+    fd = openSync(tmp, "wx", 0o600); // 'wx' = O_CREAT|O_EXCL|O_WRONLY
+    writeSync(fd, payload);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
     renameSync(tmp, path);
   } catch (e) {
-    try { rmSync(tmp, { force: true }); } catch { /* best effort */ }
-    throw e;
+    if (fd !== null) { try { closeSync(fd); } catch { /* ignore */ } }
+    try { rmSync(tmp, { force: true }); } catch { /* ignore */ }
+    throw e; // previous auth.json (if any) is left intact
   }
   return path;
 }
 
 export interface AgentLoginOptions {
-  raftBin?: string; // default "raft" (the daemon-injected wrapper on PATH)
-  service?: string; // default HANDS_SERVICE (exact installed client key)
-  /** Injectable invoke runner for tests (defaults to spawning `raft`). */
+  service?: string; // default HANDS_SERVICE (compiled-fixed exact client key)
+  now?: number; // injectable clock (ms) for tests
+  /** Injectable invoke runner for tests; defaults to spawning the pinned wrapper. */
   invoke?: (args: string[]) => { status: number | null; stdout: string; stderr: string };
 }
 
 function defaultInvoke(raftBin: string, args: string[]) {
   const res = spawnSync(raftBin, args, { encoding: "utf8" });
   return {
-    status: res.status,
+    status: res.error ? null : res.status,
     stdout: res.stdout ?? "",
-    stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
+    stderr: res.stderr ?? "",
   };
 }
 
 /**
- * Full agent-login flow: invoke → strict-validate grant → exchange → strict-validate
- * session → atomic store. Returns the stored session on success.
+ * Full agent-login flow: invoke the pinned wrapper → strict-validate grant → exchange
+ * → strict-validate session → atomic store. Returns the stored session on success.
  */
 export async function runAgentLogin(a: AgentEnv, opts: AgentLoginOptions = {}): Promise<AgentSession> {
   const service = opts.service ?? HANDS_SERVICE;
+  const now = opts.now ?? Date.now();
   const { verifier, challenge } = generatePkce();
   const args = [
     "integration", "invoke",
@@ -167,19 +208,20 @@ export async function runAgentLogin(a: AgentEnv, opts: AgentLoginOptions = {}): 
       code_challenge_method: "S256",
     }),
   ];
-  const runner = opts.invoke ?? ((a2: string[]) => defaultInvoke(opts.raftBin ?? "raft", a2));
+  const runner = opts.invoke ?? ((a2: string[]) => defaultInvoke(a.raftBin, a2));
   const res = runner(args);
-  if (!res.stdout) {
-    throw new Error(`agent-login: raft invoke produced no output (${res.stderr || `exit ${res.status}`})`);
+  if (res.status !== 0) {
+    // Require a clean exit; never echo stdout/stderr (may carry grant/action payload).
+    throw new Error(`agent-login: raft invoke exited with a non-zero status (${res.status ?? "spawn error"})`);
   }
-  const { grant } = parseAgentLoginInvoke(res.stdout, service);
+  const { grant } = parseAgentLoginInvoke(res.stdout, service, now);
 
-  // Exchange at the Hands PUBLIC endpoint (no prior Hands session required).
+  const apiBase = getApiBase();
   const body = await apiRequest("/api/auth/agent/exchange", {
     method: "POST",
     body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier },
   });
   const session = parseAgentSession(body);
-  writeAgentSession(a, service, session);
+  writeAgentSession(a, service, session, apiBase);
   return session;
 }

--- a/packages/cli/src/lib/agent_env.ts
+++ b/packages/cli/src/lib/agent_env.ts
@@ -1,56 +1,118 @@
 /**
- * Agent runtime detection + credential-store path (RFC 057 agent login, CP3).
+ * Agent runtime admission + credential-store path (RFC 057 agent login, CP3).
  *
- * A managed Raft agent CLI is identified by the daemon-injected environment:
- * SLOCK_CLI_TRANSPORT_DIR + SLOCK_HOME + SLOCK_AGENT_ID (a `raft` wrapper is on PATH).
- * When present, `hands login` uses the non-interactive agent-login flow (no browser
- * paste) and stores the exchanged Hands token under $SLOCK_HOME — per-agent, isolated
- * from the human config file at ~/.config/quiver/auth.json.
+ * Admission is TRI-STATE (Volta): no markers → normal human/CI; any agent marker but
+ * incomplete/invalid/no-executable-wrapper → FAIL CLOSED (never fall back to human
+ * credentials); complete + valid → agent mode, pinned to the exact `raft` wrapper
+ * inside $SLOCK_CLI_TRANSPORT_DIR (never the PATH `raft`).
  */
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { accessSync, constants, existsSync, readFileSync, statSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
 
-// The exact installed Raft client key this CLI is built for (Argus live probe:
-// `hands-4cc7a2`; the CLI selects the service by this exact key). Overridable via
-// HANDS_AGENT_SERVICE for non-prod builds / tests — never the brand "hands".
-export const HANDS_SERVICE = process.env.HANDS_AGENT_SERVICE ?? "hands-4cc7a2";
+// Compiled-fixed exact installed Raft client key. NOT environment-overridable: it is
+// both the invoke target AND part of the on-disk store path, so an override would be a
+// cross-service / path-injection vector. Tests inject a service via function params.
+export const HANDS_SERVICE = "hands-4cc7a2";
+
+// RFC 057 service slug.
+const SERVICE_SLUG_RE = /^[a-z0-9][a-z0-9._-]{0,79}$/;
+// Daemon-issued agent id: a conservative safe token (no separators/traversal).
+const AGENT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export interface AgentEnv {
   transportDir: string;
   slockHome: string;
   agentId: string;
+  raftBin: string; // the exact wrapper inside transportDir (never PATH `raft`)
+}
+
+export type Admission =
+  | { kind: "human" }
+  | { kind: "agent"; env: AgentEnv }
+  | { kind: "fail_closed"; reason: string };
+
+function isExecutableFile(p: string): boolean {
+  try {
+    if (!statSync(p).isFile()) return false;
+    accessSync(p, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
- * Return the agent env iff ALL required daemon-injected vars are present, else null.
- * All three are required together — a partial set is not a managed-agent environment.
+ * Decide human vs agent vs fail-closed. Once ANY agent marker is present we never
+ * return `human` — a partial/invalid environment fails closed rather than silently
+ * using ambient human credentials.
  */
-export function detectAgentEnv(env: NodeJS.ProcessEnv = process.env): AgentEnv | null {
+export function admitAgent(env: NodeJS.ProcessEnv = process.env): Admission {
   const transportDir = env.SLOCK_CLI_TRANSPORT_DIR;
   const slockHome = env.SLOCK_HOME;
   const agentId = env.SLOCK_AGENT_ID;
-  if (!transportDir || !slockHome || !agentId) return null;
-  return { transportDir, slockHome, agentId };
+  if (!transportDir && !slockHome && !agentId) return { kind: "human" };
+  if (!transportDir || !slockHome || !agentId) {
+    return { kind: "fail_closed", reason: "incomplete agent markers" };
+  }
+  if (!AGENT_ID_RE.test(agentId)) {
+    return { kind: "fail_closed", reason: "invalid SLOCK_AGENT_ID" };
+  }
+  const raftBin = join(transportDir, "raft");
+  if (!isExecutableFile(raftBin)) {
+    return { kind: "fail_closed", reason: "raft wrapper missing or not executable in transport dir" };
+  }
+  return { kind: "agent", env: { transportDir, slockHome, agentId, raftBin } };
 }
 
-/** Canonical per-agent auth store path (RFC 057 local credential store). */
+/** Canonical per-agent store path, with slug validation + root containment. */
 export function agentAuthPath(a: AgentEnv, service: string = HANDS_SERVICE): string {
-  return join(a.slockHome, "agents", a.agentId, "integrations", service, "auth.json");
+  if (!SERVICE_SLUG_RE.test(service)) throw new Error("invalid service slug");
+  if (!AGENT_ID_RE.test(a.agentId)) throw new Error("invalid agent id");
+  const root = resolve(a.slockHome, "agents", a.agentId, "integrations");
+  const path = resolve(root, service, "auth.json");
+  // Belt-and-suspenders containment (agentId/service are already regex-validated).
+  if (path !== join(root, service, "auth.json") || !path.startsWith(root + sep)) {
+    throw new Error("resolved store path escapes the integrations root");
+  }
+  return path;
 }
 
 /**
  * Read the stored Hands access token for this agent, or null if absent/unreadable.
- * Kept dependency-free (fs + path only) so `config.ts` can call it without an import
- * cycle through the api client. Auto-refresh-on-expiry lands in CP3 checkpoint-2.
+ * Dependency-free (fs + path only) so `config.ts` can call it without an import cycle
+ * through the api client. Auto-refresh-on-expiry lands in CP3 checkpoint-2.
  */
 export function readAgentAccessToken(a: AgentEnv, service: string = HANDS_SERVICE): string | null {
-  const path = agentAuthPath(a, service);
+  let path: string;
+  try {
+    path = agentAuthPath(a, service);
+  } catch {
+    return null;
+  }
   if (!existsSync(path)) return null;
   try {
     const parsed = JSON.parse(readFileSync(path, "utf8")) as { access_token?: unknown };
     return typeof parsed?.access_token === "string" && parsed.access_token.length > 0
       ? parsed.access_token
       : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the api base recorded in the agent store (so the resolver never reads the
+ *  human config in agent mode), or null. */
+export function readAgentApiBase(a: AgentEnv, service: string = HANDS_SERVICE): string | null {
+  let path: string;
+  try {
+    path = agentAuthPath(a, service);
+  } catch {
+    return null;
+  }
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { api_base?: unknown };
+    return typeof parsed?.api_base === "string" && parsed.api_base.length > 0 ? parsed.api_base : null;
   } catch {
     return null;
   }

--- a/packages/cli/src/lib/agent_env.ts
+++ b/packages/cli/src/lib/agent_env.ts
@@ -1,0 +1,57 @@
+/**
+ * Agent runtime detection + credential-store path (RFC 057 agent login, CP3).
+ *
+ * A managed Raft agent CLI is identified by the daemon-injected environment:
+ * SLOCK_CLI_TRANSPORT_DIR + SLOCK_HOME + SLOCK_AGENT_ID (a `raft` wrapper is on PATH).
+ * When present, `hands login` uses the non-interactive agent-login flow (no browser
+ * paste) and stores the exchanged Hands token under $SLOCK_HOME — per-agent, isolated
+ * from the human config file at ~/.config/quiver/auth.json.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The exact installed Raft client key this CLI is built for (Argus live probe:
+// `hands-4cc7a2`; the CLI selects the service by this exact key). Overridable via
+// HANDS_AGENT_SERVICE for non-prod builds / tests — never the brand "hands".
+export const HANDS_SERVICE = process.env.HANDS_AGENT_SERVICE ?? "hands-4cc7a2";
+
+export interface AgentEnv {
+  transportDir: string;
+  slockHome: string;
+  agentId: string;
+}
+
+/**
+ * Return the agent env iff ALL required daemon-injected vars are present, else null.
+ * All three are required together — a partial set is not a managed-agent environment.
+ */
+export function detectAgentEnv(env: NodeJS.ProcessEnv = process.env): AgentEnv | null {
+  const transportDir = env.SLOCK_CLI_TRANSPORT_DIR;
+  const slockHome = env.SLOCK_HOME;
+  const agentId = env.SLOCK_AGENT_ID;
+  if (!transportDir || !slockHome || !agentId) return null;
+  return { transportDir, slockHome, agentId };
+}
+
+/** Canonical per-agent auth store path (RFC 057 local credential store). */
+export function agentAuthPath(a: AgentEnv, service: string = HANDS_SERVICE): string {
+  return join(a.slockHome, "agents", a.agentId, "integrations", service, "auth.json");
+}
+
+/**
+ * Read the stored Hands access token for this agent, or null if absent/unreadable.
+ * Kept dependency-free (fs + path only) so `config.ts` can call it without an import
+ * cycle through the api client. Auto-refresh-on-expiry lands in CP3 checkpoint-2.
+ */
+export function readAgentAccessToken(a: AgentEnv, service: string = HANDS_SERVICE): string | null {
+  const path = agentAuthPath(a, service);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { access_token?: unknown };
+    return typeof parsed?.access_token === "string" && parsed.access_token.length > 0
+      ? parsed.access_token
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/lib/agent_refresh.ts
+++ b/packages/cli/src/lib/agent_refresh.ts
@@ -6,18 +6,27 @@
  *   - refreshes PROACTIVELY when the access token is within a skew window of expiry,
  *     and REACTIVELY once after a 401 (driven by api.ts);
  *   - serializes refresh across concurrent `hands` processes sharing one $SLOCK_HOME
- *     via an O_EXCL lock. A concurrent loser re-reads the store and uses the strictly
- *     newer persisted session; it NEVER rotates in parallel or overwrites a newer
- *     session with an older result (a double-rotate would trip the server's
- *     refresh-reuse detection and chain-revoke the family — locking the agent out).
+ *     via an O_EXCL lock. A concurrent loser re-reads the store and returns ONLY the
+ *     strictly-newer session the winner persisted (detected by a changed refresh
+ *     token vs the token it started with); it NEVER rotates in parallel and never
+ *     hands back the same token it came in with (a double-rotate would trip the
+ *     server's refresh-reuse detection and chain-revoke the family — locking the
+ *     agent out; re-handing the just-401'd token would simply 401 again).
+ *
+ * Lock safety without a heartbeat: the refresh fetch is hard-aborted at a deadline
+ * strictly smaller than the stale-lock lease, so a live holder always releases before
+ * its lock can be considered stale. Breaking a lock older than the lease is therefore
+ * provably safe, and release only ever deletes a lock that still carries our own owner
+ * id (never a foreign holder's).
  *
  * It does its own fetch (not the api client) to avoid an import cycle, and never
  * echoes response bodies in errors.
  */
 import {
-  openSync, closeSync, readFileSync, existsSync, statSync, unlinkSync,
+  openSync, closeSync, writeSync, readFileSync, existsSync, statSync, unlinkSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
 import {
   agentAuthPath, HANDS_SERVICE, type AgentEnv,
 } from "./agent_env.js";
@@ -27,8 +36,9 @@ import {
 
 // Refresh when the access token expires within this window (or is already expired).
 export const REFRESH_SKEW_MS = 60_000;
-const LOCK_STALE_MS = 30_000; // break a lock held longer than this (crashed holder)
-const LOCK_WAIT_MS = 5_000; // how long a loser waits for the winner's new session
+const LOCK_STALE_MS = 30_000; // lease: a lock older than this cannot belong to a live holder
+const REFRESH_DEADLINE_MS = 20_000; // refresh fetch hard-aborts STRICTLY before the lease
+const LOCK_WAIT_MS = 25_000; // how long a loser waits for the winner's strictly-newer session
 const LOCK_POLL_MS = 100;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -53,11 +63,20 @@ function accessExpiresWithinSkew(store: StoredAgentAuth, now: number): boolean {
   return !Number.isFinite(exp) || exp - now <= REFRESH_SKEW_MS;
 }
 
+function accessExpired(store: StoredAgentAuth, now: number): boolean {
+  const exp = Date.parse(store.access_expires_at);
+  return !Number.isFinite(exp) || exp <= now;
+}
+
 function lockPath(a: AgentEnv, service: string): string {
   return join(dirname(agentAuthPath(a, service)), ".auth.refresh.lock");
 }
 
-/** POST the refresh token, validate the session, atomically persist it. Own fetch. */
+/**
+ * POST the refresh token, validate the session, atomically persist it. Own fetch,
+ * hard-aborted at REFRESH_DEADLINE_MS so the holder always releases before its lock
+ * can be seen as stale. Never echoes the response body.
+ */
 async function rotate(
   a: AgentEnv,
   service: string,
@@ -65,11 +84,19 @@ async function rotate(
   now: number,
   fetchImpl: typeof fetch,
 ): Promise<AgentSession> {
-  const res = await fetchImpl(new URL("/api/auth/agent/refresh", store.api_base).toString(), {
-    method: "POST",
-    headers: { "content-type": "application/json", accept: "application/json" },
-    body: JSON.stringify({ schema: "raft-cli-agent-refresh.v1", refresh_token: store.refresh_token }),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REFRESH_DEADLINE_MS);
+  let res: Response;
+  try {
+    res = await fetchImpl(new URL("/api/auth/agent/refresh", store.api_base).toString(), {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ schema: "raft-cli-agent-refresh.v1", refresh_token: store.refresh_token }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   if (!res.ok) {
     // Stable reason only; never echo the response body.
@@ -81,7 +108,7 @@ async function rotate(
   } catch {
     throw new Error("agent-login: refresh response was not JSON");
   }
-  const session = parseAgentSession(body);
+  const session = parseAgentSession(body, now);
   writeAgentSession(a, service, session, store.api_base, () => new Date(now).toISOString());
   return session;
 }
@@ -108,7 +135,7 @@ export async function getFreshAgentAccessToken(a: AgentEnv, opts: RefreshOptions
   if (!store) return null;
   if (!accessExpiresWithinSkew(store, now)) return store.access_token; // still fresh
 
-  return singleFlightRefresh(a, service, now, fetchImpl, sleepImpl);
+  return singleFlightRefresh(a, service, store, now, fetchImpl, sleepImpl, /*force*/ false);
 }
 
 /**
@@ -120,27 +147,31 @@ export async function forceRefreshAgentToken(a: AgentEnv, opts: RefreshOptions =
   const now = opts.now ?? Date.now();
   const fetchImpl = opts.fetchImpl ?? fetch;
   const sleepImpl = opts.sleepImpl ?? sleep;
-  if (!readStore(a, service)) return null;
-  return singleFlightRefresh(a, service, now, fetchImpl, sleepImpl, /*force*/ true);
+  const store = readStore(a, service);
+  if (!store) return null;
+  return singleFlightRefresh(a, service, store, now, fetchImpl, sleepImpl, /*force*/ true);
 }
 
 async function singleFlightRefresh(
   a: AgentEnv,
   service: string,
+  baseline: StoredAgentAuth,
   now: number,
   fetchImpl: typeof fetch,
   sleepImpl: (ms: number) => Promise<void>,
-  force = false,
+  force: boolean,
 ): Promise<string | null> {
   const lock = lockPath(a, service);
+  const ownerId = `${process.pid}:${randomBytes(12).toString("hex")}`;
 
-  // Try to acquire the exclusive lock (breaking a stale one from a crashed holder).
   for (;;) {
     let fd: number;
     try {
       fd = openSync(lock, "wx"); // O_CREAT | O_EXCL | O_WRONLY
     } catch (e) {
       if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") throw e;
+      // A live holder finishes or aborts within REFRESH_DEADLINE_MS (strictly < the
+      // lease), so a lock older than the lease cannot belong to a live holder.
       let broke = false;
       try {
         if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
@@ -152,42 +183,63 @@ async function singleFlightRefresh(
       }
       if (broke) continue;
       // Another live process holds it: wait for its strictly-newer session (loser path).
-      return waitForNewerSession(a, service, now, sleepImpl);
+      return waitForNewerSession(a, service, baseline, now, force, sleepImpl);
     }
-    // Winner: re-read (a prior holder may have just refreshed while we blocked), then
-    // refresh only if still needed.
+    // Winner: stamp ownership so release can prove the lock is still ours, then refresh.
+    try {
+      writeSync(fd, ownerId);
+    } finally {
+      try { closeSync(fd); } catch { /* ignore */ }
+    }
     try {
       const fresh = readStore(a, service);
       if (!fresh) return null;
+      // A prior holder may have refreshed while we blocked; only rotate if still needed.
       if (!force && !accessExpiresWithinSkew(fresh, now)) return fresh.access_token;
       const session = await rotate(a, service, fresh, now, fetchImpl);
       return session.access_token;
     } finally {
-      try { closeSync(fd); } catch { /* ignore */ }
-      try { unlinkSync(lock); } catch { /* ignore */ }
+      releaseOwnLock(lock, ownerId);
     }
   }
 }
 
+/** Delete the lock only if it still carries OUR owner id (never a foreign holder's). */
+export function releaseOwnLock(lock: string, ownerId: string): void {
+  try {
+    if (readFileSync(lock, "utf8") === ownerId) unlinkSync(lock);
+  } catch {
+    // already gone, unreadable, or replaced by another owner — leave it be.
+  }
+}
+
 /**
- * Loser path: poll the store for a strictly-newer (fresh) session written by the
- * winner. Never rotates here (that would double-use the refresh token). On timeout,
- * return the current access token as-is (a subsequent 401 is handled by the caller);
- * we never overwrite the store with an older result.
+ * Loser path: poll the store for the winner's strictly-newer session, identified by a
+ * refresh token that differs from the one we started with (`baseline`). Never rotates
+ * here (that would double-use the refresh token). On timeout it FAILS rather than hand
+ * back the token we came in with; a proactive caller may still use a genuinely-unexpired
+ * current token, but a forced (post-401) caller always fails — re-handing a 401'd token
+ * would just 401 again.
  */
 async function waitForNewerSession(
   a: AgentEnv,
   service: string,
+  baseline: StoredAgentAuth,
   now: number,
+  force: boolean,
   sleepImpl: (ms: number) => Promise<void>,
 ): Promise<string | null> {
-  const started = Date.now();
-  for (;;) {
+  // Bound the wait by poll count (not wall-clock) so it is deterministic under an
+  // injected sleep in tests, while keeping the same real-time budget in production.
+  const maxPolls = Math.ceil(LOCK_WAIT_MS / LOCK_POLL_MS);
+  for (let i = 0; i < maxPolls; i += 1) {
     await sleepImpl(LOCK_POLL_MS);
     const cur = readStore(a, service);
-    if (cur && !accessExpiresWithinSkew(cur, now)) return cur.access_token; // winner wrote a fresh one
-    if (Date.now() - started >= LOCK_WAIT_MS) {
-      return cur?.access_token ?? null; // give up waiting; do NOT rotate/overwrite
+    if (cur && cur.refresh_token !== baseline.refresh_token) {
+      return cur.access_token; // the winner rotated: a strictly-newer session is persisted
     }
   }
+  const cur = readStore(a, service);
+  if (!force && cur && !accessExpired(cur, now)) return cur.access_token;
+  throw new Error("agent-login: timed out waiting for a concurrent token refresh");
 }

--- a/packages/cli/src/lib/agent_refresh.ts
+++ b/packages/cli/src/lib/agent_refresh.ts
@@ -54,10 +54,6 @@ function newOwnerId(): string {
   return `${process.pid}:${randomBytes(12).toString("hex")}`;
 }
 
-function safeRead(path: string): string {
-  try { return readFileSync(path, "utf8"); } catch { return ""; }
-}
-
 function readStore(a: AgentEnv, service: string): StoredAgentAuth | null {
   let path: string;
   try {
@@ -263,22 +259,24 @@ export function acquireIfDeadOwner(lock: string, ownerId: string): boolean {
   }
 }
 
-/** Acquire the exclusive reaper fence, recovering only a fence whose reaper PID is dead. */
+/**
+ * Acquire the exclusive reaper fence via a single O_EXCL create. On EEXIST — a reaper is
+ * active, OR one crashed and left the fence — we ALWAYS fail closed (return null → loser).
+ * We deliberately do NOT auto-recover a leftover fence: reading its pid and unlinking it
+ * would recurse the very reap race the fence exists to prevent (two recoverers both unlink
+ * + recreate, then each deletes the other's live fence). A crashed reaper — the fence is
+ * held only across synchronous fs calls, never I/O — leaves a diagnosable fence for manual
+ * cleanup, the agreed "prefer fail-closed on reaper residue" over a second grabbable lock.
+ * Kernel O_EXCL is the sole mutual exclusion; nothing here reads-pid-then-unlinks.
+ */
 function acquireReaperFence(fence: string): number | null {
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      const fd = openSync(fence, "wx");
-      // Stamp with our pid so that, if WE die, another recoverer can prove-dead and reap us.
-      try { writeSync(fd, newOwnerId()); } catch { try { closeSync(fd); } catch { /* */ } return null; }
-      return fd;
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") return null; // cannot create → fail closed
-      const fpid = ownerPid(safeRead(fence));
-      if (fpid === null || ownerAlive(fpid)) return null; // live reaper / uncertain → loser
-      try { unlinkSync(fence); } catch { /* gone / replaced → one retry */ }
-    }
+  try {
+    const fd = openSync(fence, "wx");
+    try { writeSync(fd, newOwnerId()); } catch { /* diagnostic marker only; ignore */ }
+    return fd;
+  } catch {
+    return null; // EEXIST or any error → fail closed (loser); never recover a leftover fence
   }
-  return null;
 }
 
 function ownerPid(owner: string): number | null {

--- a/packages/cli/src/lib/agent_refresh.ts
+++ b/packages/cli/src/lib/agent_refresh.ts
@@ -23,7 +23,7 @@
  * echoes response bodies in errors.
  */
 import {
-  openSync, closeSync, writeSync, readFileSync, existsSync, statSync, unlinkSync,
+  openSync, closeSync, writeSync, readFileSync, existsSync, unlinkSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -31,13 +31,16 @@ import {
   agentAuthPath, HANDS_SERVICE, type AgentEnv,
 } from "./agent_env.js";
 import {
-  parseAgentSession, writeAgentSession, type AgentSession, type StoredAgentAuth,
+  parseAgentSession, writeAgentSession, readBoundedText,
+  type AgentSession, type StoredAgentAuth,
 } from "./agent_auth.js";
 
 // Refresh when the access token expires within this window (or is already expired).
 export const REFRESH_SKEW_MS = 60_000;
-const LOCK_STALE_MS = 30_000; // lease: a lock older than this cannot belong to a live holder
-const REFRESH_DEADLINE_MS = 20_000; // refresh fetch hard-aborts STRICTLY before the lease
+// The whole refresh op (fetch + bounded body read + parse + persist) is aborted at this
+// deadline, so a live holder cannot hold the lock indefinitely. Breaking a lock is NOT
+// time-based, though: a lock is broken only when its owner process is provably dead.
+const REFRESH_DEADLINE_MS = 20_000;
 const LOCK_WAIT_MS = 25_000; // how long a loser waits for the winner's strictly-newer session
 const LOCK_POLL_MS = 100;
 
@@ -86,31 +89,33 @@ async function rotate(
 ): Promise<AgentSession> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REFRESH_DEADLINE_MS);
-  let res: Response;
   try {
-    res = await fetchImpl(new URL("/api/auth/agent/refresh", store.api_base).toString(), {
+    const res = await fetchImpl(new URL("/api/auth/agent/refresh", store.api_base).toString(), {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },
       body: JSON.stringify({ schema: "raft-cli-agent-refresh.v1", refresh_token: store.refresh_token }),
       signal: controller.signal,
+      // Never follow a redirect: a 307/308 would forward the refresh_token body to the target.
+      redirect: "manual",
     });
+    if (!res.ok) {
+      // Stable reason only; never echo the body. `manual` leaves a 3xx as a non-ok status.
+      throw new Error(`agent-login: token refresh failed (HTTP ${res.status})`);
+    }
+    const text = await readBoundedText(res, controller);
+    let body: unknown;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error("agent-login: refresh response was not JSON");
+    }
+    const session = parseAgentSession(body, now);
+    writeAgentSession(a, service, session, store.api_base, () => new Date(now).toISOString());
+    return session;
   } finally {
+    // Deadline stays armed across fetch + bounded read + parse + persist.
     clearTimeout(timer);
   }
-  const text = await res.text();
-  if (!res.ok) {
-    // Stable reason only; never echo the response body.
-    throw new Error(`agent-login: token refresh failed (HTTP ${res.status})`);
-  }
-  let body: unknown;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    throw new Error("agent-login: refresh response was not JSON");
-  }
-  const session = parseAgentSession(body, now);
-  writeAgentSession(a, service, session, store.api_base, () => new Date(now).toISOString());
-  return session;
 }
 
 export interface RefreshOptions {
@@ -170,19 +175,10 @@ async function singleFlightRefresh(
       fd = openSync(lock, "wx"); // O_CREAT | O_EXCL | O_WRONLY
     } catch (e) {
       if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") throw e;
-      // A live holder finishes or aborts within REFRESH_DEADLINE_MS (strictly < the
-      // lease), so a lock older than the lease cannot belong to a live holder.
-      let broke = false;
-      try {
-        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
-          unlinkSync(lock);
-          broke = true;
-        }
-      } catch {
-        broke = true; // lock vanished under us; retry acquire
-      }
-      if (broke) continue;
-      // Another live process holds it: wait for its strictly-newer session (loser path).
+      // Break the lock ONLY if its owner process is provably dead (never on elapsed time
+      // alone: a suspended / stalled live holder keeps its pid). Uncertain → fail closed.
+      if (breakIfDeadOwner(lock)) continue;
+      // A live process holds it: wait for its strictly-newer session (loser path).
       return waitForNewerSession(a, service, baseline, now, force, sleepImpl);
     }
     // Winner: stamp ownership so release can prove the lock is still ours, then refresh.
@@ -210,6 +206,57 @@ export function releaseOwnLock(lock: string, ownerId: string): void {
     if (readFileSync(lock, "utf8") === ownerId) unlinkSync(lock);
   } catch {
     // already gone, unreadable, or replaced by another owner — leave it be.
+  }
+}
+
+/**
+ * Break the lock ONLY if its owner process is provably dead, with a stable-owner compare
+ * to avoid a TOCTOU delete of a replacement owner. A LIVE owner — including one that is
+ * suspended / stalled (its pid still exists) — is NEVER broken. An unparseable owner or
+ * any uncertainty fails closed (do not break; the caller waits as a loser). Returns true
+ * iff the lock was broken (or had vanished) and the caller should retry acquiring it.
+ * `readOwner` is injectable for tests.
+ */
+export function breakIfDeadOwner(
+  lock: string,
+  readOwner: () => string = () => readFileSync(lock, "utf8"),
+): boolean {
+  let owner: string;
+  try {
+    owner = readOwner();
+  } catch {
+    return true; // vanished between EEXIST and read → retry acquire
+  }
+  const pid = ownerPid(owner);
+  if (pid === null || ownerAlive(pid)) return false; // uncertain or live → never steal
+  // Dead owner: confirm it has not been replaced under us before unlinking (TOCTOU guard).
+  let current: string;
+  try {
+    current = readOwner();
+  } catch {
+    return true; // vanished → retry acquire
+  }
+  if (current !== owner) return false; // replaced by a new owner → let it run
+  try {
+    unlinkSync(lock);
+  } catch { /* already gone/replaced — fine */ }
+  return true;
+}
+
+function ownerPid(owner: string): number | null {
+  const m = /^(\d+):/.exec(owner);
+  if (!m) return null;
+  const pid = Number(m[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function ownerAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0); // signal 0: liveness probe, delivers nothing
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code === "ESRCH") return false; // no such process → dead
+    return true; // EPERM (exists) or anything unexpected → fail closed = treat as alive
   }
 }
 

--- a/packages/cli/src/lib/agent_refresh.ts
+++ b/packages/cli/src/lib/agent_refresh.ts
@@ -1,0 +1,193 @@
+/**
+ * Agent token auto-refresh + cross-process single-flight (RFC 057, CP3 checkpoint-2).
+ *
+ * The agent access token is short-lived; a long-lived rotating refresh token in the
+ * store renews it. This module:
+ *   - refreshes PROACTIVELY when the access token is within a skew window of expiry,
+ *     and REACTIVELY once after a 401 (driven by api.ts);
+ *   - serializes refresh across concurrent `hands` processes sharing one $SLOCK_HOME
+ *     via an O_EXCL lock. A concurrent loser re-reads the store and uses the strictly
+ *     newer persisted session; it NEVER rotates in parallel or overwrites a newer
+ *     session with an older result (a double-rotate would trip the server's
+ *     refresh-reuse detection and chain-revoke the family — locking the agent out).
+ *
+ * It does its own fetch (not the api client) to avoid an import cycle, and never
+ * echoes response bodies in errors.
+ */
+import {
+  openSync, closeSync, readFileSync, existsSync, statSync, unlinkSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  agentAuthPath, HANDS_SERVICE, type AgentEnv,
+} from "./agent_env.js";
+import {
+  parseAgentSession, writeAgentSession, type AgentSession, type StoredAgentAuth,
+} from "./agent_auth.js";
+
+// Refresh when the access token expires within this window (or is already expired).
+export const REFRESH_SKEW_MS = 60_000;
+const LOCK_STALE_MS = 30_000; // break a lock held longer than this (crashed holder)
+const LOCK_WAIT_MS = 5_000; // how long a loser waits for the winner's new session
+const LOCK_POLL_MS = 100;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function readStore(a: AgentEnv, service: string): StoredAgentAuth | null {
+  let path: string;
+  try {
+    path = agentAuthPath(a, service);
+  } catch {
+    return null;
+  }
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as StoredAgentAuth;
+  } catch {
+    return null;
+  }
+}
+
+function accessExpiresWithinSkew(store: StoredAgentAuth, now: number): boolean {
+  const exp = Date.parse(store.access_expires_at);
+  return !Number.isFinite(exp) || exp - now <= REFRESH_SKEW_MS;
+}
+
+function lockPath(a: AgentEnv, service: string): string {
+  return join(dirname(agentAuthPath(a, service)), ".auth.refresh.lock");
+}
+
+/** POST the refresh token, validate the session, atomically persist it. Own fetch. */
+async function rotate(
+  a: AgentEnv,
+  service: string,
+  store: StoredAgentAuth,
+  now: number,
+  fetchImpl: typeof fetch,
+): Promise<AgentSession> {
+  const res = await fetchImpl(new URL("/api/auth/agent/refresh", store.api_base).toString(), {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({ schema: "raft-cli-agent-refresh.v1", refresh_token: store.refresh_token }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    // Stable reason only; never echo the response body.
+    throw new Error(`agent-login: token refresh failed (HTTP ${res.status})`);
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error("agent-login: refresh response was not JSON");
+  }
+  const session = parseAgentSession(body);
+  writeAgentSession(a, service, session, store.api_base, () => new Date(now).toISOString());
+  return session;
+}
+
+export interface RefreshOptions {
+  service?: string;
+  now?: number;
+  fetchImpl?: typeof fetch;
+  /** Injectable sleep for tests (defaults to real setTimeout). */
+  sleepImpl?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Return a valid access token, refreshing (single-flight) if it is within the skew
+ * window. Returns null if there is no stored session (caller must `hands login`).
+ */
+export async function getFreshAgentAccessToken(a: AgentEnv, opts: RefreshOptions = {}): Promise<string | null> {
+  const service = opts.service ?? HANDS_SERVICE;
+  const now = opts.now ?? Date.now();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleepImpl = opts.sleepImpl ?? sleep;
+
+  const store = readStore(a, service);
+  if (!store) return null;
+  if (!accessExpiresWithinSkew(store, now)) return store.access_token; // still fresh
+
+  return singleFlightRefresh(a, service, now, fetchImpl, sleepImpl);
+}
+
+/**
+ * Force one refresh (used on a 401 even if the token looked unexpired), single-flight.
+ * Returns null if there is no stored session.
+ */
+export async function forceRefreshAgentToken(a: AgentEnv, opts: RefreshOptions = {}): Promise<string | null> {
+  const service = opts.service ?? HANDS_SERVICE;
+  const now = opts.now ?? Date.now();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleepImpl = opts.sleepImpl ?? sleep;
+  if (!readStore(a, service)) return null;
+  return singleFlightRefresh(a, service, now, fetchImpl, sleepImpl, /*force*/ true);
+}
+
+async function singleFlightRefresh(
+  a: AgentEnv,
+  service: string,
+  now: number,
+  fetchImpl: typeof fetch,
+  sleepImpl: (ms: number) => Promise<void>,
+  force = false,
+): Promise<string | null> {
+  const lock = lockPath(a, service);
+
+  // Try to acquire the exclusive lock (breaking a stale one from a crashed holder).
+  for (;;) {
+    let fd: number;
+    try {
+      fd = openSync(lock, "wx"); // O_CREAT | O_EXCL | O_WRONLY
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") throw e;
+      let broke = false;
+      try {
+        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
+          unlinkSync(lock);
+          broke = true;
+        }
+      } catch {
+        broke = true; // lock vanished under us; retry acquire
+      }
+      if (broke) continue;
+      // Another live process holds it: wait for its strictly-newer session (loser path).
+      return waitForNewerSession(a, service, now, sleepImpl);
+    }
+    // Winner: re-read (a prior holder may have just refreshed while we blocked), then
+    // refresh only if still needed.
+    try {
+      const fresh = readStore(a, service);
+      if (!fresh) return null;
+      if (!force && !accessExpiresWithinSkew(fresh, now)) return fresh.access_token;
+      const session = await rotate(a, service, fresh, now, fetchImpl);
+      return session.access_token;
+    } finally {
+      try { closeSync(fd); } catch { /* ignore */ }
+      try { unlinkSync(lock); } catch { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Loser path: poll the store for a strictly-newer (fresh) session written by the
+ * winner. Never rotates here (that would double-use the refresh token). On timeout,
+ * return the current access token as-is (a subsequent 401 is handled by the caller);
+ * we never overwrite the store with an older result.
+ */
+async function waitForNewerSession(
+  a: AgentEnv,
+  service: string,
+  now: number,
+  sleepImpl: (ms: number) => Promise<void>,
+): Promise<string | null> {
+  const started = Date.now();
+  for (;;) {
+    await sleepImpl(LOCK_POLL_MS);
+    const cur = readStore(a, service);
+    if (cur && !accessExpiresWithinSkew(cur, now)) return cur.access_token; // winner wrote a fresh one
+    if (Date.now() - started >= LOCK_WAIT_MS) {
+      return cur?.access_token ?? null; // give up waiting; do NOT rotate/overwrite
+    }
+  }
+}

--- a/packages/cli/src/lib/agent_refresh.ts
+++ b/packages/cli/src/lib/agent_refresh.ts
@@ -7,20 +7,25 @@
  *     and REACTIVELY once after a 401 (driven by api.ts);
  *   - serializes refresh across concurrent `hands` processes sharing one $SLOCK_HOME
  *     via an O_EXCL lock. A concurrent loser re-reads the store and returns ONLY the
- *     strictly-newer session the winner persisted (detected by a changed refresh
- *     token vs the token it started with); it NEVER rotates in parallel and never
- *     hands back the same token it came in with (a double-rotate would trip the
- *     server's refresh-reuse detection and chain-revoke the family — locking the
- *     agent out; re-handing the just-401'd token would simply 401 again).
+ *     strictly-newer session the winner persisted (a changed refresh token vs the one
+ *     it started with); it NEVER rotates in parallel and never re-hands the token it
+ *     came in with (a double-rotate trips the server's refresh-reuse detection and
+ *     chain-revokes the family; re-handing a just-401'd token would 401 again).
  *
- * Lock safety without a heartbeat: the refresh fetch is hard-aborted at a deadline
- * strictly smaller than the stale-lock lease, so a live holder always releases before
- * its lock can be considered stale. Breaking a lock older than the lease is therefore
- * provably safe, and release only ever deletes a lock that still carries our own owner
- * id (never a foreign holder's).
+ * Lock safety:
+ *   - the refresh op (fetch + bounded body read + parse + persist) is hard-aborted at a
+ *     deadline, so a live holder cannot hold the lock forever;
+ *   - a lock is broken ONLY when its owner process is provably DEAD (`process.kill(pid,0)`
+ *     → ESRCH) — never on elapsed time, so a suspended / stalled but live holder is never
+ *     stolen;
+ *   - dead-lock recovery is serialized by an exclusive reaper fence and the main lock is
+ *     re-acquired WHILE the fence is held, so two concurrent recoverers can never both
+ *     reap-and-rebuild (→ never double-rotate);
+ *   - any uncertainty (unparseable owner, non-ENOENT read error, contended/live fence)
+ *     fails closed: the caller becomes a loser rather than risk an unsafe break.
  *
- * It does its own fetch (not the api client) to avoid an import cycle, and never
- * echoes response bodies in errors.
+ * It does its own fetch (not the api client) to avoid an import cycle, and never echoes
+ * response bodies in errors.
  */
 import {
   openSync, closeSync, writeSync, readFileSync, existsSync, unlinkSync,
@@ -37,14 +42,21 @@ import {
 
 // Refresh when the access token expires within this window (or is already expired).
 export const REFRESH_SKEW_MS = 60_000;
-// The whole refresh op (fetch + bounded body read + parse + persist) is aborted at this
-// deadline, so a live holder cannot hold the lock indefinitely. Breaking a lock is NOT
-// time-based, though: a lock is broken only when its owner process is provably dead.
+// The whole refresh op (fetch + bounded read + parse + persist) is aborted at this
+// deadline. Breaking a lock is NOT time-based, though — only a provably-dead owner is.
 const REFRESH_DEADLINE_MS = 20_000;
 const LOCK_WAIT_MS = 25_000; // how long a loser waits for the winner's strictly-newer session
 const LOCK_POLL_MS = 100;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function newOwnerId(): string {
+  return `${process.pid}:${randomBytes(12).toString("hex")}`;
+}
+
+function safeRead(path: string): string {
+  try { return readFileSync(path, "utf8"); } catch { return ""; }
+}
 
 function readStore(a: AgentEnv, service: string): StoredAgentAuth | null {
   let path: string;
@@ -77,8 +89,9 @@ function lockPath(a: AgentEnv, service: string): string {
 
 /**
  * POST the refresh token, validate the session, atomically persist it. Own fetch,
- * hard-aborted at REFRESH_DEADLINE_MS so the holder always releases before its lock
- * can be seen as stale. Never echoes the response body.
+ * hard-aborted at `deadlineMs` across the WHOLE operation (fetch + bounded body read +
+ * parse + persist), never following a redirect (a 307/308 would forward the refresh
+ * token), and never echoing the body.
  */
 async function rotate(
   a: AgentEnv,
@@ -86,20 +99,20 @@ async function rotate(
   store: StoredAgentAuth,
   now: number,
   fetchImpl: typeof fetch,
+  deadlineMs: number,
 ): Promise<AgentSession> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REFRESH_DEADLINE_MS);
+  const timer = setTimeout(() => controller.abort(), deadlineMs);
   try {
     const res = await fetchImpl(new URL("/api/auth/agent/refresh", store.api_base).toString(), {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },
       body: JSON.stringify({ schema: "raft-cli-agent-refresh.v1", refresh_token: store.refresh_token }),
       signal: controller.signal,
-      // Never follow a redirect: a 307/308 would forward the refresh_token body to the target.
       redirect: "manual",
     });
     if (!res.ok) {
-      // Stable reason only; never echo the body. `manual` leaves a 3xx as a non-ok status.
+      // `manual` leaves a 3xx as a non-ok status. Stable reason only; never echo the body.
       throw new Error(`agent-login: token refresh failed (HTTP ${res.status})`);
     }
     const text = await readBoundedText(res, controller);
@@ -124,6 +137,8 @@ export interface RefreshOptions {
   fetchImpl?: typeof fetch;
   /** Injectable sleep for tests (defaults to real setTimeout). */
   sleepImpl?: (ms: number) => Promise<void>;
+  /** Injectable refresh deadline for tests (defaults to REFRESH_DEADLINE_MS). */
+  deadlineMs?: number;
 }
 
 /**
@@ -135,12 +150,13 @@ export async function getFreshAgentAccessToken(a: AgentEnv, opts: RefreshOptions
   const now = opts.now ?? Date.now();
   const fetchImpl = opts.fetchImpl ?? fetch;
   const sleepImpl = opts.sleepImpl ?? sleep;
+  const deadlineMs = opts.deadlineMs ?? REFRESH_DEADLINE_MS;
 
   const store = readStore(a, service);
   if (!store) return null;
   if (!accessExpiresWithinSkew(store, now)) return store.access_token; // still fresh
 
-  return singleFlightRefresh(a, service, store, now, fetchImpl, sleepImpl, /*force*/ false);
+  return singleFlightRefresh(a, service, store, now, fetchImpl, sleepImpl, /*force*/ false, deadlineMs);
 }
 
 /**
@@ -152,9 +168,10 @@ export async function forceRefreshAgentToken(a: AgentEnv, opts: RefreshOptions =
   const now = opts.now ?? Date.now();
   const fetchImpl = opts.fetchImpl ?? fetch;
   const sleepImpl = opts.sleepImpl ?? sleep;
+  const deadlineMs = opts.deadlineMs ?? REFRESH_DEADLINE_MS;
   const store = readStore(a, service);
   if (!store) return null;
-  return singleFlightRefresh(a, service, store, now, fetchImpl, sleepImpl, /*force*/ true);
+  return singleFlightRefresh(a, service, store, now, fetchImpl, sleepImpl, /*force*/ true, deadlineMs);
 }
 
 async function singleFlightRefresh(
@@ -165,38 +182,34 @@ async function singleFlightRefresh(
   fetchImpl: typeof fetch,
   sleepImpl: (ms: number) => Promise<void>,
   force: boolean,
+  deadlineMs: number,
 ): Promise<string | null> {
   const lock = lockPath(a, service);
-  const ownerId = `${process.pid}:${randomBytes(12).toString("hex")}`;
+  const ownerId = newOwnerId();
 
-  for (;;) {
-    let fd: number;
-    try {
-      fd = openSync(lock, "wx"); // O_CREAT | O_EXCL | O_WRONLY
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") throw e;
-      // Break the lock ONLY if its owner process is provably dead (never on elapsed time
-      // alone: a suspended / stalled live holder keeps its pid). Uncertain → fail closed.
-      if (breakIfDeadOwner(lock)) continue;
-      // A live process holds it: wait for its strictly-newer session (loser path).
-      return waitForNewerSession(a, service, baseline, now, force, sleepImpl);
-    }
-    // Winner: stamp ownership so release can prove the lock is still ours, then refresh.
-    try {
-      writeSync(fd, ownerId);
-    } finally {
-      try { closeSync(fd); } catch { /* ignore */ }
-    }
-    try {
-      const fresh = readStore(a, service);
-      if (!fresh) return null;
-      // A prior holder may have refreshed while we blocked; only rotate if still needed.
-      if (!force && !accessExpiresWithinSkew(fresh, now)) return fresh.access_token;
-      const session = await rotate(a, service, fresh, now, fetchImpl);
-      return session.access_token;
-    } finally {
-      releaseOwnLock(lock, ownerId);
-    }
+  let acquired: boolean;
+  try {
+    const fd = openSync(lock, "wx"); // fast path: no lock present
+    try { writeSync(fd, ownerId); } finally { try { closeSync(fd); } catch { /* ignore */ } }
+    acquired = true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") throw e;
+    // A lock exists: recover it only if its owner is provably dead, under an exclusive
+    // fence, re-acquiring the main lock while the fence is held. Anything else → loser.
+    acquired = acquireIfDeadOwner(lock, ownerId);
+    if (!acquired) return waitForNewerSession(a, service, baseline, now, force, sleepImpl);
+  }
+
+  // Winner: we hold `lock` carrying ownerId.
+  try {
+    const fresh = readStore(a, service);
+    if (!fresh) return null;
+    // A prior holder may have refreshed while we blocked; only rotate if still needed.
+    if (!force && !accessExpiresWithinSkew(fresh, now)) return fresh.access_token;
+    const session = await rotate(a, service, fresh, now, fetchImpl, deadlineMs);
+    return session.access_token;
+  } finally {
+    releaseOwnLock(lock, ownerId);
   }
 }
 
@@ -210,37 +223,62 @@ export function releaseOwnLock(lock: string, ownerId: string): void {
 }
 
 /**
- * Break the lock ONLY if its owner process is provably dead, with a stable-owner compare
- * to avoid a TOCTOU delete of a replacement owner. A LIVE owner — including one that is
- * suspended / stalled (its pid still exists) — is NEVER broken. An unparseable owner or
- * any uncertainty fails closed (do not break; the caller waits as a loser). Returns true
- * iff the lock was broken (or had vanished) and the caller should retry acquiring it.
- * `readOwner` is injectable for tests.
+ * Recover a lock whose owner process is provably dead and acquire it, serialized by an
+ * exclusive reaper fence. Judge-dead → unlink → re-acquire all happen WHILE the fence is
+ * held, so at most one recoverer reaps-and-rebuilds — two concurrent recoverers can never
+ * both re-acquire (→ never double-rotate). A LIVE owner (incl. suspended/stalled — pid
+ * still exists) is never touched. Any uncertainty fails closed. Returns true iff WE now
+ * hold the main lock carrying `ownerId`; false → the caller is a loser.
  */
-export function breakIfDeadOwner(
-  lock: string,
-  readOwner: () => string = () => readFileSync(lock, "utf8"),
-): boolean {
-  let owner: string;
+export function acquireIfDeadOwner(lock: string, ownerId: string): boolean {
+  const ffd = acquireReaperFence(`${lock}.reap`);
+  if (ffd === null) return false; // live/contended/uncertain fence → loser
   try {
-    owner = readOwner();
-  } catch {
-    return true; // vanished between EEXIST and read → retry acquire
+    let owner = "";
+    try {
+      owner = readFileSync(lock, "utf8");
+    } catch (e) {
+      // Only "already gone" is safe to proceed on; any other error is uncertain → loser.
+      if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") return false;
+    }
+    if (owner) {
+      const pid = ownerPid(owner);
+      if (pid === null || ownerAlive(pid)) return false; // live / uncertain owner → loser
+      try { unlinkSync(lock); } catch { /* vanished / already handled */ }
+    }
+    // Re-acquire the main lock while STILL holding the fence, so no other recoverer can
+    // rebuild it underneath us.
+    let fd: number;
+    try {
+      fd = openSync(lock, "wx");
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException)?.code === "EEXIST") return false; // lost the race → loser
+      throw e;
+    }
+    try { writeSync(fd, ownerId); } finally { try { closeSync(fd); } catch { /* ignore */ } }
+    return true;
+  } finally {
+    try { closeSync(ffd); } catch { /* ignore */ }
+    try { unlinkSync(`${lock}.reap`); } catch { /* ignore */ }
   }
-  const pid = ownerPid(owner);
-  if (pid === null || ownerAlive(pid)) return false; // uncertain or live → never steal
-  // Dead owner: confirm it has not been replaced under us before unlinking (TOCTOU guard).
-  let current: string;
-  try {
-    current = readOwner();
-  } catch {
-    return true; // vanished → retry acquire
+}
+
+/** Acquire the exclusive reaper fence, recovering only a fence whose reaper PID is dead. */
+function acquireReaperFence(fence: string): number | null {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const fd = openSync(fence, "wx");
+      // Stamp with our pid so that, if WE die, another recoverer can prove-dead and reap us.
+      try { writeSync(fd, newOwnerId()); } catch { try { closeSync(fd); } catch { /* */ } return null; }
+      return fd;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException)?.code !== "EEXIST") return null; // cannot create → fail closed
+      const fpid = ownerPid(safeRead(fence));
+      if (fpid === null || ownerAlive(fpid)) return null; // live reaper / uncertain → loser
+      try { unlinkSync(fence); } catch { /* gone / replaced → one retry */ }
+    }
   }
-  if (current !== owner) return false; // replaced by a new owner → let it run
-  try {
-    unlinkSync(lock);
-  } catch { /* already gone/replaced — fine */ }
-  return true;
+  return null;
 }
 
 function ownerPid(owner: string): number | null {
@@ -263,10 +301,9 @@ function ownerAlive(pid: number): boolean {
 /**
  * Loser path: poll the store for the winner's strictly-newer session, identified by a
  * refresh token that differs from the one we started with (`baseline`). Never rotates
- * here (that would double-use the refresh token). On timeout it FAILS rather than hand
- * back the token we came in with; a proactive caller may still use a genuinely-unexpired
- * current token, but a forced (post-401) caller always fails — re-handing a 401'd token
- * would just 401 again.
+ * here. On timeout it FAILS rather than hand back the token we came in with; a proactive
+ * caller may still use a genuinely-unexpired current token, but a forced (post-401)
+ * caller always fails — re-handing a 401'd token would just 401 again.
  */
 async function waitForNewerSession(
   a: AgentEnv,
@@ -276,8 +313,8 @@ async function waitForNewerSession(
   force: boolean,
   sleepImpl: (ms: number) => Promise<void>,
 ): Promise<string | null> {
-  // Bound the wait by poll count (not wall-clock) so it is deterministic under an
-  // injected sleep in tests, while keeping the same real-time budget in production.
+  // Bound by poll count (not wall-clock) so it is deterministic under an injected sleep in
+  // tests, while keeping the same real-time budget in production.
   const maxPolls = Math.ceil(LOCK_WAIT_MS / LOCK_POLL_MS);
   for (let i = 0; i < maxPolls; i += 1) {
     await sleepImpl(LOCK_POLL_MS);

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -9,10 +9,26 @@
  */
 
 import { resolveApiBase, resolveAuthToken } from "./config.js";
+import { admitAgent } from "./agent_env.js";
+import { getFreshAgentAccessToken, forceRefreshAgentToken } from "./agent_refresh.js";
 import { readEnv } from "./env.js";
 import { Blob } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
+
+/**
+ * Resolve the bearer for a request. In a managed agent this proactively refreshes the
+ * stored Hands token when it is near expiry (single-flight); a broken agent env yields
+ * no token (fail closed). Human/CI use the ordinary resolver.
+ */
+async function resolveBearer(): Promise<string | undefined> {
+  const admission = admitAgent();
+  if (admission.kind === "agent") {
+    return (await getFreshAgentAccessToken(admission.env)) ?? undefined;
+  }
+  if (admission.kind === "fail_closed") return undefined;
+  return resolveAuthToken();
+}
 
 export class QuiverApiError extends Error {
   readonly status: number;
@@ -54,22 +70,35 @@ export async function apiRequest<T = unknown>(
       url.searchParams.set(k, String(v));
     }
   }
-  const headers: Record<string, string> = {
+  const baseHeaders: Record<string, string> = {
     accept: "application/json",
   };
-  const bearer = resolveAuthToken();
-  if (bearer) headers.authorization = `Bearer ${bearer}`;
   let body: string | undefined;
   if (opts.body !== undefined) {
-    headers["content-type"] = "application/json";
+    baseHeaders["content-type"] = "application/json";
     body = JSON.stringify(opts.body);
   }
-  const res = await fetch(url.toString(), {
-    method: opts.method ?? "GET",
-    headers,
-    ...(body !== undefined ? { body } : {}),
-    ...(opts.signal ? { signal: opts.signal } : {}),
-  });
+  const doFetch = (bearer: string | undefined) => {
+    const headers = { ...baseHeaders };
+    if (bearer) headers.authorization = `Bearer ${bearer}`;
+    return fetch(url.toString(), {
+      method: opts.method ?? "GET",
+      headers,
+      ...(body !== undefined ? { body } : {}),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    });
+  };
+  let res = await doFetch(await resolveBearer());
+  // Agent mode: one guarded refresh + single retry after a 401 (the proactive refresh
+  // in resolveBearer covers near-expiry; this covers a token rejected despite looking
+  // unexpired, e.g. server-side revocation or clock skew).
+  if (res.status === 401) {
+    const admission = admitAgent();
+    if (admission.kind === "agent") {
+      const refreshed = await forceRefreshAgentToken(admission.env);
+      if (refreshed) res = await doFetch(refreshed);
+    }
+  }
   if (readEnv("VERBOSE") === "1") {
     console.error(`> ${opts.method ?? "GET"} ${url}`);
     console.error(`< ${res.status}`);
@@ -107,7 +136,10 @@ export async function apiUploadFile<T = unknown>(
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  const bearer = resolveAuthToken();
+  // Proactively-refreshed bearer in agent mode. No auto-retry here: re-streaming a
+  // large upload on a 401 is expensive; the proactive refresh covers near-expiry, and
+  // a genuine 401 surfaces to the caller to re-invoke.
+  const bearer = await resolveBearer();
   if (bearer) headers.authorization = `Bearer ${bearer}`;
 
   const res = await fetch(url.toString(), {

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -30,6 +30,29 @@ async function resolveBearer(): Promise<string | undefined> {
   return resolveAuthToken();
 }
 
+/**
+ * Run a bearer-parameterized request with agent-aware auth, shared by every CLI HTTP
+ * path (`apiRequest`, `apiUploadFile`, and `hands api`): resolve the bearer (proactive
+ * refresh in agent mode), and on a 401 in agent mode force ONE refresh and retry once.
+ * `doFetch` MUST build a fresh request each call — a request body stream cannot be reused
+ * across attempts, so callers that send a body rebuild it inside the thunk.
+ */
+export async function agentAwareFetch(
+  doFetch: (bearer: string | undefined) => Promise<Response>,
+): Promise<Response> {
+  let res = await doFetch(await resolveBearer());
+  // The proactive refresh in resolveBearer covers near-expiry; this covers a token
+  // rejected despite looking unexpired (server-side revocation, clock skew).
+  if (res.status === 401) {
+    const admission = admitAgent();
+    if (admission.kind === "agent") {
+      const refreshed = await forceRefreshAgentToken(admission.env);
+      if (refreshed) res = await doFetch(refreshed);
+    }
+  }
+  return res;
+}
+
 export class QuiverApiError extends Error {
   readonly status: number;
   readonly body: unknown;
@@ -88,17 +111,7 @@ export async function apiRequest<T = unknown>(
       ...(opts.signal ? { signal: opts.signal } : {}),
     });
   };
-  let res = await doFetch(await resolveBearer());
-  // Agent mode: one guarded refresh + single retry after a 401 (the proactive refresh
-  // in resolveBearer covers near-expiry; this covers a token rejected despite looking
-  // unexpired, e.g. server-side revocation or clock skew).
-  if (res.status === 401) {
-    const admission = admitAgent();
-    if (admission.kind === "agent") {
-      const refreshed = await forceRefreshAgentToken(admission.env);
-      if (refreshed) res = await doFetch(refreshed);
-    }
-  }
+  const res = await agentAwareFetch(doFetch);
   if (readEnv("VERBOSE") === "1") {
     console.error(`> ${opts.method ?? "GET"} ${url}`);
     console.error(`< ${res.status}`);
@@ -129,23 +142,17 @@ export async function apiUploadFile<T = unknown>(
   fieldName = "apk",
 ): Promise<T> {
   const url = new URL(path.startsWith("/") ? path : `/${path}`, getApiBase());
-  const form = new FormData();
   const bytes = await readFile(filePath);
-  form.append(fieldName, new Blob([bytes]), basename(filePath));
-
-  const headers: Record<string, string> = {
-    accept: "application/json",
-  };
-  // Proactively-refreshed bearer in agent mode. No auto-retry here: re-streaming a
-  // large upload on a 401 is expensive; the proactive refresh covers near-expiry, and
-  // a genuine 401 surfaces to the caller to re-invoke.
-  const bearer = await resolveBearer();
-  if (bearer) headers.authorization = `Bearer ${bearer}`;
-
-  const res = await fetch(url.toString(), {
-    method: "POST",
-    headers,
-    body: form,
+  const name = basename(filePath);
+  // Upload is a primary product path, so it uses the SAME agent-aware request + one-401
+  // as every other call. The multipart body is rebuilt per attempt: a body stream can't
+  // be reused, and agent mode may retry once after a 401.
+  const res = await agentAwareFetch((bearer) => {
+    const form = new FormData();
+    form.append(fieldName, new Blob([bytes]), name);
+    const headers: Record<string, string> = { accept: "application/json" };
+    if (bearer) headers.authorization = `Bearer ${bearer}`;
+    return fetch(url.toString(), { method: "POST", headers, body: form });
   });
   if (readEnv("VERBOSE") === "1") {
     console.error(`> POST ${url}`);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -13,6 +13,7 @@
 
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { readEnv } from "./env.js";
+import { detectAgentEnv, readAgentAccessToken } from "./agent_env.js";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
@@ -72,9 +73,16 @@ export function resolveApiBase(): string {
 }
 
 export function resolveAuthToken(): string | undefined {
-  // CI mode wins over file config (env vars are explicit).
+  // CI mode wins over everything (env vars are explicit).
   const env = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN") ?? readEnv("SESSION_COOKIE");
   if (env) return env;
+  // In a managed agent, use the per-agent Hands token stored under $SLOCK_HOME by
+  // `hands login` (never the human config file). CP3 checkpoint-2 adds auto-refresh.
+  const agent = detectAgentEnv();
+  if (agent) {
+    const stored = readAgentAccessToken(agent);
+    if (stored) return stored;
+  }
   const config = getConfig();
   return config.authToken ?? config.sessionCookie;
 }

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,19 +1,28 @@
 /**
- * Config + auth storage for the quiver CLI.
+ * Config + auth storage for the hands CLI.
  *
  * Resolution order for any setting (first wins):
  *   1. CLI flag (--api, --token, ...)
  *   2. Environment variable (HANDS_API, HANDS_AUTH_TOKEN, ...)
- *   3. File at $XDG_CONFIG_HOME/quiver/auth.json (default ~/.config/quiver/auth.json)
+ *   3. Human config file at $XDG_CONFIG_HOME/hands/auth.json (default ~/.config/hands/auth.json)
  *
- * The config file holds:
- *   - apiBase: the Quiver Worker URL the CLI talks to
+ * Agent mode (managed Raft agent) is ISOLATED: it uses ONLY the per-agent Hands token
+ * under $SLOCK_HOME and never reads/writes the human config or ambient env token. A
+ * broken (partial/invalid) agent environment fails closed rather than falling back.
+ *
+ * The human config file holds:
+ *   - apiBase: the Hands Worker URL the CLI talks to
  *   - authToken: the signed Hands JWT returned after `hands login`
+ * A legacy ~/.config/quiver/auth.json is migrated to the hands path on first use.
  */
 
-import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
 import { readEnv } from "./env.js";
-import { detectAgentEnv, readAgentAccessToken } from "./agent_env.js";
+import {
+  admitAgent,
+  readAgentAccessToken,
+  readAgentApiBase,
+} from "./agent_env.js";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
@@ -26,22 +35,46 @@ export interface CliConfig {
 
 const DEFAULT_API_BASE = "https://hands.build";
 
-function configPath(): string {
+function configDir(): string {
   const xdg = process.env.XDG_CONFIG_HOME;
-  const dir = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
-  return join(dir, "quiver", "auth.json");
+  return xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+}
+
+/** Canonical human config path (post-rename). */
+export function configPath(): string {
+  return join(configDir(), "hands", "auth.json");
+}
+
+/** Legacy path from before the quiver→hands rename; read once, then migrated. */
+function legacyConfigPath(): string {
+  return join(configDir(), "quiver", "auth.json");
+}
+
+function readConfigFile(path: string): CliConfig | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as CliConfig;
+    return parsed ?? {};
+  } catch {
+    return null;
+  }
 }
 
 export function getConfig(): CliConfig {
   const path = configPath();
-  if (!existsSync(path)) return {};
+  const current = readConfigFile(path);
+  if (current) return current;
+  // One-time migration from the legacy quiver path. On ANY failure keep the old file
+  // and old credentials (return the legacy config; do not delete or corrupt it).
+  const legacy = readConfigFile(legacyConfigPath());
+  if (!legacy) return {};
   try {
-    const raw = readFileSync(path, "utf8");
-    const parsed = JSON.parse(raw) as CliConfig;
-    return parsed ?? {};
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(legacy, null, 2) + "\n", { mode: 0o600 });
   } catch {
-    return {};
+    return legacy; // migration failed → keep using the legacy credentials
   }
+  return legacy;
 }
 
 export function saveConfig(patch: Partial<CliConfig>): CliConfig {
@@ -67,22 +100,33 @@ export function resolveApiBase(): string {
   if (cliFlag) return cliFlag;
   const env = readEnv("API");
   if (env) return env;
+  const admission = admitAgent();
+  if (admission.kind === "agent") {
+    // Agent mode: the api base comes from the agent store (recorded at login), never
+    // the human config file.
+    return readAgentApiBase(admission.env) ?? DEFAULT_API_BASE;
+  }
+  if (admission.kind === "fail_closed") {
+    return DEFAULT_API_BASE; // broken agent env: no human config fallback
+  }
   const cfg = getConfig();
   if (cfg.apiBase) return cfg.apiBase;
   return DEFAULT_API_BASE;
 }
 
 export function resolveAuthToken(): string | undefined {
-  // CI mode wins over everything (env vars are explicit).
+  const admission = admitAgent();
+  if (admission.kind === "agent") {
+    // Isolated: ONLY the per-agent store. Missing/bad → require `hands login`; never
+    // fall back to HANDS_AUTH_TOKEN or the human config.
+    return readAgentAccessToken(admission.env) ?? undefined;
+  }
+  if (admission.kind === "fail_closed") {
+    return undefined; // broken agent env → no ambient credentials
+  }
+  // Human / CI (no agent markers): env token wins, then the (migrated) human config.
   const env = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN") ?? readEnv("SESSION_COOKIE");
   if (env) return env;
-  // In a managed agent, use the per-agent Hands token stored under $SLOCK_HOME by
-  // `hands login` (never the human config file). CP3 checkpoint-2 adds auto-refresh.
-  const agent = detectAgentEnv();
-  if (agent) {
-    const stored = readAgentAccessToken(agent);
-    if (stored) return stored;
-  }
   const config = getConfig();
   return config.authToken ?? config.sessionCookie;
 }

--- a/packages/cli/src/refresh_race_worker.mts
+++ b/packages/cli/src/refresh_race_worker.mts
@@ -1,0 +1,23 @@
+/**
+ * Test-only worker (run via tsx in a child process) for the two-process dead-lock
+ * recovery race. It reads a pre-seeded agent store from $SLOCK_HOME, waits on a file
+ * barrier so sibling workers are released together, then calls forceRefreshAgentToken
+ * and prints the resulting access token (or "ERR:...") to stdout. NOT a test file.
+ */
+import { existsSync, writeFileSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+import { forceRefreshAgentToken } from "./lib/agent_refresh.js";
+import type { AgentEnv } from "./lib/agent_env.js";
+
+const [slockHome, transportDir, agentId, readyFile, goFile, now] = process.argv.slice(2);
+const a: AgentEnv = { transportDir, slockHome, agentId, raftBin: `${transportDir}/raft` };
+
+writeFileSync(readyFile, "ready");
+while (!existsSync(goFile)) await delay(2); // barrier: released together with the sibling
+
+try {
+  const tok = await forceRefreshAgentToken(a, { now: Number(now) });
+  process.stdout.write(String(tok ?? "null"));
+} catch (e) {
+  process.stdout.write("ERR:" + (e instanceof Error ? e.message : String(e)));
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,7 @@ import {
 import {
   handleAgentManifest,
   handleAgentHelp,
+  handleAgentMigrationHelp,
   handleAuthConfig,
   handleDashboardRedirect,
   handleAuthLogin,
@@ -559,6 +560,7 @@ app.get("/api/auth/login", handleAuthLogin);
 app.get("/login/raft/callback", handleRaftCallback);
 app.get("/api/auth/me", handleAuthMe);
 app.get("/api/agent/help", handleAgentHelp);
+app.get("/api/agent/migration-help", handleAgentMigrationHelp);
 app.post("/api/auth/logout", handleAuthLogout);
 // Agent CLI login token endpoints (RFC 057) — PUBLIC: the grant+verifier / refresh
 // token is itself the credential (OAuth-token-endpoint style), so no prior session.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -19,6 +19,11 @@ import { publicDocAssetPaths } from "./lib/public_docs";
 import { authMiddleware, currentActor } from "./middleware/auth";
 import { requireHandsAdmin } from "./middleware/hands_admin";
 import {
+  handleAgentLoginAction,
+  handleAgentExchange,
+  handleAgentRefresh,
+} from "./routes/agent_login";
+import {
   handleAgentManifest,
   handleAgentHelp,
   handleAuthConfig,
@@ -555,6 +560,10 @@ app.get("/login/raft/callback", handleRaftCallback);
 app.get("/api/auth/me", handleAuthMe);
 app.get("/api/agent/help", handleAgentHelp);
 app.post("/api/auth/logout", handleAuthLogout);
+// Agent CLI login token endpoints (RFC 057) — PUBLIC: the grant+verifier / refresh
+// token is itself the credential (OAuth-token-endpoint style), so no prior session.
+app.post("/api/auth/agent/exchange", handleAgentExchange);
+app.post("/api/auth/agent/refresh", handleAgentRefresh);
 
 app.get("/public/apps/:slug/latest", handlePublicV2Latest);
 app.get("/public/apps/:slug/channels", handlePublicListChannels);
@@ -638,6 +647,10 @@ export const admin = new Hono<{
   };
 }>();
 admin.use("*", authMiddleware);
+
+// Agent CLI login (RFC 057) action — needs the authenticated agent session so it
+// binds the grant to the pre-org-switch identity. Exchange/refresh are public.
+admin.post("/api/auth/agent/login", handleAgentLoginAction);
 
 // Global Hands observability is server-admin scoped, not app-role scoped.
 admin.use("/api/admin/observability/*", requireHandsAdmin);

--- a/worker/src/lib/agent_login.ts
+++ b/worker/src/lib/agent_login.ts
@@ -40,13 +40,22 @@ export interface AgentLoginIdentity {
   app_scope?: string | null;
 }
 
-/** Closed error set (mirrors RFC 057 exchange errors). */
+/**
+ * Closed error set — the frozen RFC 057 codes (verified against slock commit
+ * 2cb55a4e, rfcs/057-...). Exchange failures use the `grant_*` codes; refresh
+ * failures use the `refresh_*` codes; `temporarily_unavailable` is the only
+ * retryable one (a concurrent rotation loser).
+ */
 export type AgentLoginErrorCode =
-  | "invalid"
-  | "expired"
-  | "consumed"
-  | "binding_mismatch"
+  | "grant_invalid"
+  | "grant_expired"
+  | "grant_consumed"
+  | "grant_binding_mismatch"
   | "grant_proof_mismatch"
+  | "refresh_invalid"
+  | "refresh_expired"
+  | "refresh_reused"
+  | "refresh_revoked"
   | "temporarily_unavailable";
 
 export interface AgentTokens {
@@ -73,6 +82,30 @@ function base64Url(bytes: Uint8Array): string {
 /** High-entropy opaque token (32 bytes → base64url). */
 export function randomOpaqueToken(): string {
   return base64Url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+/**
+ * RFC 057 S256 challenge validation (verified against slock 2cb55a4e rfcs/057):
+ * strict base64url charset with NO padding, decodes to EXACTLY 32 bytes, and
+ * canonical round-trip (re-encoding the decoded bytes yields the same string —
+ * this rejects non-canonical trailing bits that a length check alone would miss).
+ * The caller separately enforces `code_challenge_method === "S256"`.
+ */
+export function isValidS256Challenge(challenge: unknown): challenge is string {
+  if (typeof challenge !== "string" || !/^[A-Za-z0-9_-]+$/.test(challenge)) {
+    return false;
+  }
+  let bytes: Uint8Array;
+  try {
+    const b64 = challenge.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const binary = atob(padded);
+    bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+  } catch {
+    return false;
+  }
+  if (bytes.length !== 32) return false;
+  return base64Url(bytes) === challenge; // canonical round-trip
 }
 
 /** SHA-256 → base64url. Used for grant/refresh digests AND PKCE S256 challenge. */
@@ -149,7 +182,7 @@ export async function exchangeAgentGrant(
   codeVerifier: string,
   now: number = Date.now(),
 ): Promise<ExchangeResult> {
-  if (!grant || !codeVerifier) return { ok: false, code: "invalid" };
+  if (!grant || !codeVerifier) return { ok: false, code: "grant_invalid" };
   const grantDigest = await sha256Base64Url(grant);
   const row = await env.DB.prepare(
     `SELECT server_id, agent_id, integration, service,
@@ -167,9 +200,9 @@ export async function exchangeAgentGrant(
       consumed_at: number | null;
     }>();
 
-  if (!row) return { ok: false, code: "invalid" };
-  if (row.consumed_at !== null) return { ok: false, code: "consumed" };
-  if (row.expires_at <= now) return { ok: false, code: "expired" };
+  if (!row) return { ok: false, code: "grant_invalid" };
+  if (row.consumed_at !== null) return { ok: false, code: "grant_consumed" };
+  if (row.expires_at <= now) return { ok: false, code: "grant_expired" };
 
   // Proof check BEFORE consuming: a wrong verifier must not burn the grant (so a
   // stolen-grant attacker without the verifier can't DoS the legitimate CLI).
@@ -241,7 +274,7 @@ export async function exchangeAgentGrant(
   // Session INSERT wrote 1 row ⇒ we won the atomic consume. 0 ⇒ a concurrent exchange
   // won (the whole batch rolls back on any error, so we never burn a grant tokenlessly).
   if ((results[1]?.meta?.changes ?? 0) !== 1) {
-    return { ok: false, code: "consumed" };
+    return { ok: false, code: "grant_consumed" };
   }
   return {
     ok: true,
@@ -347,7 +380,7 @@ export async function rotateAgentRefresh(
   refreshToken: string,
   now: number = Date.now(),
 ): Promise<RotateResult> {
-  if (!refreshToken) return { ok: false, code: "invalid" };
+  if (!refreshToken) return { ok: false, code: "refresh_invalid" };
   const refreshHash = await sha256Base64Url(refreshToken);
   const row = await env.DB.prepare(
     `SELECT id, server_id, agent_id, integration, service, app_scope,
@@ -368,7 +401,7 @@ export async function rotateAgentRefresh(
       children: number;
     }>();
 
-  if (!row) return { ok: false, code: "invalid" };
+  if (!row) return { ok: false, code: "refresh_invalid" };
   // Reuse detection FIRST: a normal rotation marks the old token revoked AND gives it
   // a child, so the revoked_at check would otherwise shadow reuse. Presenting an
   // already-rotated token again is a compromise signal → revoke the identity's chain.
@@ -378,10 +411,10 @@ export async function rotateAgentRefresh(
       agent_id: row.agent_id,
       service: row.service,
     }, now);
-    return { ok: false, code: "consumed" };
+    return { ok: false, code: "refresh_reused" };
   }
-  if (row.revoked_at !== null) return { ok: false, code: "consumed" };
-  if (row.expires_at <= now) return { ok: false, code: "expired" };
+  if (row.revoked_at !== null) return { ok: false, code: "refresh_revoked" };
+  if (row.expires_at <= now) return { ok: false, code: "refresh_expired" };
 
   const identity: AgentLoginIdentity = {
     server_id: row.server_id,

--- a/worker/src/lib/agent_login.ts
+++ b/worker/src/lib/agent_login.ts
@@ -1,0 +1,343 @@
+/**
+ * Agent CLI login (generic RFC 057, Hands first instance) — server-side primitives.
+ *
+ * Flow (design doc: docs/agent-cli-login-hands-instance.md):
+ *   1. `agent-login` action (Hands-executed): the CLI sends only a PKCE S256
+ *      `code_challenge`; Hands issues an opaque single-use `grant` bound to the
+ *      authenticated identity + challenge, and stores only the grant DIGEST.
+ *   2. exchange: the CLI sends `{ grant, code_verifier }`; Hands atomically consumes
+ *      the grant (single-use), verifies SHA-256(verifier) == challenge, and mints a
+ *      short access JWT + a revocable/rotating refresh token.
+ *   3. refresh: rotate the refresh token; reuse of a rotated token revokes the chain.
+ *
+ * Security invariants enforced here:
+ *   - Raw grant / refresh token are never stored — only digests/hashes.
+ *   - The verifier is only checked here; it is never persisted or logged.
+ *   - Single-use consume is atomic (conditional UPDATE bound by changes()==1).
+ *   - Identity comes from the caller (the handler reads the pre-org-switch
+ *     `authenticated_account`); this module never trusts request-body identity.
+ */
+
+import { createSignedJwt } from "../routes/auth";
+
+// `Env` is an ambient global (worker/env.d.ts); used directly, not imported.
+
+// Grant lives at most 5 minutes (RFC 057: `expires_at` <= 300s from issue).
+export const AGENT_GRANT_TTL_MS = 5 * 60 * 1000;
+// Short access token; refresh handles longevity (Codex-isomorphic short/long split).
+export const AGENT_ACCESS_TTL_MS = 15 * 60 * 1000;
+export const AGENT_REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Authenticated identity a grant/refresh binds to (from `authenticated_account`). */
+export interface AgentLoginIdentity {
+  server_id: string;
+  agent_id: string; // the Raft principal subject (agent), not the DB row id
+  integration: string;
+  service: string; // "hands"
+  app_scope?: string | null;
+}
+
+/** Closed error set (mirrors RFC 057 exchange errors). */
+export type AgentLoginErrorCode =
+  | "invalid"
+  | "expired"
+  | "consumed"
+  | "binding_mismatch"
+  | "grant_proof_mismatch"
+  | "temporarily_unavailable";
+
+export interface AgentTokens {
+  access_token: string;
+  refresh_token: string;
+  access_expires_at: number;
+}
+
+type ConsumeResult =
+  | { ok: true; identity: AgentLoginIdentity }
+  | { ok: false; code: AgentLoginErrorCode };
+
+type RotateResult =
+  | { ok: true; tokens: AgentTokens }
+  | { ok: false; code: AgentLoginErrorCode };
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+/** High-entropy opaque token (32 bytes → base64url). */
+export function randomOpaqueToken(): string {
+  return base64Url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+/** SHA-256 → base64url. Used for grant/refresh digests AND PKCE S256 challenge. */
+export async function sha256Base64Url(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return base64Url(new Uint8Array(digest));
+}
+
+/**
+ * `agent-login` action: mint an opaque grant bound to `identity` + `codeChallenge`.
+ * Stores only the digest. Returns the raw grant (returned to the CLI once) + expiry.
+ */
+export async function issueAgentGrant(
+  env: Env,
+  identity: AgentLoginIdentity,
+  codeChallenge: string,
+  now: number = Date.now(),
+): Promise<{ grant: string; expires_at: number }> {
+  const grant = randomOpaqueToken();
+  const grantDigest = await sha256Base64Url(grant);
+  const expiresAt = now + AGENT_GRANT_TTL_MS;
+  await env.DB.prepare(
+    `INSERT INTO agent_login_grants
+       (grant_digest, server_id, agent_id, integration, service,
+        code_challenge, nonce, issued_at, expires_at, consumed_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)`,
+  )
+    .bind(
+      grantDigest,
+      identity.server_id,
+      identity.agent_id,
+      identity.integration,
+      identity.service,
+      codeChallenge,
+      crypto.randomUUID(),
+      now,
+      expiresAt,
+    )
+    .run();
+  return { grant, expires_at: expiresAt };
+}
+
+/**
+ * exchange step 1: verify the proof and atomically consume the grant (single-use).
+ * Returns the bound identity on success, or a typed closed-set error.
+ * The verifier is checked here and never stored/logged.
+ */
+export async function consumeAgentGrant(
+  env: Env,
+  grant: string,
+  codeVerifier: string,
+  now: number = Date.now(),
+): Promise<ConsumeResult> {
+  if (!grant || !codeVerifier) return { ok: false, code: "invalid" };
+  const grantDigest = await sha256Base64Url(grant);
+  const row = await env.DB.prepare(
+    `SELECT server_id, agent_id, integration, service,
+            code_challenge, expires_at, consumed_at
+       FROM agent_login_grants WHERE grant_digest = ?1`,
+  )
+    .bind(grantDigest)
+    .first<{
+      server_id: string;
+      agent_id: string;
+      integration: string;
+      service: string;
+      code_challenge: string;
+      expires_at: number;
+      consumed_at: number | null;
+    }>();
+
+  if (!row) return { ok: false, code: "invalid" };
+  if (row.consumed_at !== null) return { ok: false, code: "consumed" };
+  if (row.expires_at <= now) return { ok: false, code: "expired" };
+
+  // Proof check BEFORE consuming: a wrong verifier must not burn the grant (so a
+  // stolen-grant attacker without the verifier can't DoS the legitimate CLI).
+  const challengeFromVerifier = await sha256Base64Url(codeVerifier);
+  if (challengeFromVerifier !== row.code_challenge) {
+    return { ok: false, code: "grant_proof_mismatch" };
+  }
+
+  // Atomic single-use consume: only one exchange wins the WHERE consumed_at IS NULL.
+  const consumed = await env.DB.prepare(
+    `UPDATE agent_login_grants SET consumed_at = ?2
+       WHERE grant_digest = ?1 AND consumed_at IS NULL AND expires_at > ?3`,
+  )
+    .bind(grantDigest, now, now)
+    .run();
+  if (consumed.meta.changes !== 1) return { ok: false, code: "consumed" };
+
+  return {
+    ok: true,
+    identity: {
+      server_id: row.server_id,
+      agent_id: row.agent_id,
+      integration: row.integration,
+      service: row.service,
+    },
+  };
+}
+
+async function mintTokens(
+  env: Env,
+  identity: AgentLoginIdentity,
+  now: number,
+): Promise<AgentTokens> {
+  const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
+  // Reuse the existing Hands JWT signer; the access token's subject is the agent
+  // account. NOTE: handler passes the account row id as agent_id when it needs the
+  // JWT `sub` to match `raft_accounts.id` — see handler wiring (CP2 checkpoint 2).
+  const accessToken = await createSignedJwt(
+    env,
+    identity.agent_id,
+    now,
+    accessExpiresAt,
+    crypto.randomUUID(),
+  );
+  const refreshToken = randomOpaqueToken();
+  const refreshHash = await sha256Base64Url(refreshToken);
+  await env.DB.prepare(
+    `INSERT INTO agent_refresh_tokens
+       (id, token_hash, server_id, agent_id, integration, service, app_scope,
+        created_at, expires_at, rotated_from, revoked_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL)`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      refreshHash,
+      identity.server_id,
+      identity.agent_id,
+      identity.integration,
+      identity.service,
+      identity.app_scope ?? null,
+      now,
+      now + AGENT_REFRESH_TTL_MS,
+    )
+    .run();
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    access_expires_at: accessExpiresAt,
+  };
+}
+
+/** exchange step 2: mint access + refresh for a proven identity. */
+export async function issueAgentTokens(
+  env: Env,
+  identity: AgentLoginIdentity,
+  now: number = Date.now(),
+): Promise<AgentTokens> {
+  return mintTokens(env, identity, now);
+}
+
+/**
+ * refresh: rotate the refresh token. Reuse of an already-rotated (or revoked)
+ * token revokes the whole identity's live tokens (compromise signal) and fails.
+ */
+export async function rotateAgentRefresh(
+  env: Env,
+  refreshToken: string,
+  now: number = Date.now(),
+): Promise<RotateResult> {
+  if (!refreshToken) return { ok: false, code: "invalid" };
+  const refreshHash = await sha256Base64Url(refreshToken);
+  const row = await env.DB.prepare(
+    `SELECT id, server_id, agent_id, integration, service, app_scope,
+            expires_at, revoked_at,
+            (SELECT COUNT(*) FROM agent_refresh_tokens c WHERE c.rotated_from = agent_refresh_tokens.id) AS children
+       FROM agent_refresh_tokens WHERE token_hash = ?1`,
+  )
+    .bind(refreshHash)
+    .first<{
+      id: string;
+      server_id: string;
+      agent_id: string;
+      integration: string;
+      service: string;
+      app_scope: string | null;
+      expires_at: number;
+      revoked_at: number | null;
+      children: number;
+    }>();
+
+  if (!row) return { ok: false, code: "invalid" };
+  if (row.revoked_at !== null) return { ok: false, code: "consumed" };
+  if (row.expires_at <= now) return { ok: false, code: "expired" };
+  if (row.children > 0) {
+    // Reuse of an already-rotated token: revoke the whole identity's chain.
+    await revokeAgentTokensForIdentity(env, {
+      server_id: row.server_id,
+      agent_id: row.agent_id,
+      service: row.service,
+    }, now);
+    return { ok: false, code: "consumed" };
+  }
+
+  // Mark old rotated, then mint the successor bound to rotated_from.
+  await env.DB.prepare(
+    `UPDATE agent_refresh_tokens SET revoked_at = ?2 WHERE id = ?1 AND revoked_at IS NULL`,
+  )
+    .bind(row.id, now)
+    .run();
+  const tokens = await mintTokensRotated(env, {
+    server_id: row.server_id,
+    agent_id: row.agent_id,
+    integration: row.integration,
+    service: row.service,
+    app_scope: row.app_scope,
+  }, row.id, now);
+  return { ok: true, tokens };
+}
+
+async function mintTokensRotated(
+  env: Env,
+  identity: AgentLoginIdentity,
+  rotatedFrom: string,
+  now: number,
+): Promise<AgentTokens> {
+  const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
+  const accessToken = await createSignedJwt(
+    env,
+    identity.agent_id,
+    now,
+    accessExpiresAt,
+    crypto.randomUUID(),
+  );
+  const refreshToken = randomOpaqueToken();
+  const refreshHash = await sha256Base64Url(refreshToken);
+  await env.DB.prepare(
+    `INSERT INTO agent_refresh_tokens
+       (id, token_hash, server_id, agent_id, integration, service, app_scope,
+        created_at, expires_at, rotated_from, revoked_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL)`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      refreshHash,
+      identity.server_id,
+      identity.agent_id,
+      identity.integration,
+      identity.service,
+      identity.app_scope ?? null,
+      now,
+      now + AGENT_REFRESH_TTL_MS,
+      rotatedFrom,
+    )
+    .run();
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    access_expires_at: accessExpiresAt,
+  };
+}
+
+/** Revoke all live refresh tokens for an identity (lifecycle / admin / reuse). */
+export async function revokeAgentTokensForIdentity(
+  env: Env,
+  identity: Pick<AgentLoginIdentity, "server_id" | "agent_id" | "service">,
+  now: number = Date.now(),
+): Promise<number> {
+  const res = await env.DB.prepare(
+    `UPDATE agent_refresh_tokens SET revoked_at = ?4
+       WHERE server_id = ?1 AND agent_id = ?2 AND service = ?3 AND revoked_at IS NULL`,
+  )
+    .bind(identity.server_id, identity.agent_id, identity.service, now)
+    .run();
+  return res.meta.changes ?? 0;
+}

--- a/worker/src/lib/agent_login.ts
+++ b/worker/src/lib/agent_login.ts
@@ -31,7 +31,10 @@ export const AGENT_REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 /** Authenticated identity a grant/refresh binds to (from `authenticated_account`). */
 export interface AgentLoginIdentity {
   server_id: string;
-  agent_id: string; // the Raft principal subject (agent), not the DB row id
+  // The `raft_accounts.id` of the authenticated agent account. Used as the access
+  // JWT `sub` and the `raft_sessions.account_id`, so the minted access token
+  // resolves through the normal auth middleware. Also the binding/revoke key.
+  agent_id: string;
   integration: string;
   service: string; // "hands"
   app_scope?: string | null;
@@ -78,6 +81,20 @@ export async function sha256Base64Url(input: string): Promise<string> {
     new TextEncoder().encode(input),
   );
   return base64Url(new Uint8Array(digest));
+}
+
+/**
+ * SHA-256 → lowercase hex. MUST match the auth middleware's session lookup format
+ * (it hashes the bearer as hex), so the minted access token resolves to its session.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 /**
@@ -174,15 +191,18 @@ export async function consumeAgentGrant(
   };
 }
 
-async function mintTokens(
+/**
+ * Mint a short access token: a Hands JWT (subject = agent account row id) backed by
+ * a `raft_sessions` row, so it resolves through the normal auth middleware
+ * (which looks the bearer up by its hex SHA-256 in raft_sessions). Agent sessions
+ * carry no encrypted Raft token (NULL) — that field is only for hands-admin.
+ */
+async function mintAccessToken(
   env: Env,
   identity: AgentLoginIdentity,
   now: number,
-): Promise<AgentTokens> {
-  const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
-  // Reuse the existing Hands JWT signer; the access token's subject is the agent
-  // account. NOTE: handler passes the account row id as agent_id when it needs the
-  // JWT `sub` to match `raft_accounts.id` — see handler wiring (CP2 checkpoint 2).
+  accessExpiresAt: number,
+): Promise<string> {
   const accessToken = await createSignedJwt(
     env,
     identity.agent_id,
@@ -190,6 +210,30 @@ async function mintTokens(
     accessExpiresAt,
     crypto.randomUUID(),
   );
+  await env.DB.prepare(
+    `INSERT INTO raft_sessions
+       (id, account_id, token_hash, created_at, expires_at, last_seen_at,
+        revoked_at, raft_access_token_ciphertext)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL)`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      identity.agent_id,
+      await sha256Hex(accessToken),
+      now,
+      accessExpiresAt,
+    )
+    .run();
+  return accessToken;
+}
+
+async function mintTokens(
+  env: Env,
+  identity: AgentLoginIdentity,
+  now: number,
+): Promise<AgentTokens> {
+  const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
+  const accessToken = await mintAccessToken(env, identity, now, accessExpiresAt);
   const refreshToken = randomOpaqueToken();
   const refreshHash = await sha256Base64Url(refreshToken);
   await env.DB.prepare(
@@ -257,10 +301,10 @@ export async function rotateAgentRefresh(
     }>();
 
   if (!row) return { ok: false, code: "invalid" };
-  if (row.revoked_at !== null) return { ok: false, code: "consumed" };
-  if (row.expires_at <= now) return { ok: false, code: "expired" };
+  // Reuse detection FIRST: a normal rotation marks the old token revoked AND gives it
+  // a child, so the revoked_at check would otherwise shadow reuse. Presenting an
+  // already-rotated token again is a compromise signal → revoke the identity's chain.
   if (row.children > 0) {
-    // Reuse of an already-rotated token: revoke the whole identity's chain.
     await revokeAgentTokensForIdentity(env, {
       server_id: row.server_id,
       agent_id: row.agent_id,
@@ -268,6 +312,8 @@ export async function rotateAgentRefresh(
     }, now);
     return { ok: false, code: "consumed" };
   }
+  if (row.revoked_at !== null) return { ok: false, code: "consumed" };
+  if (row.expires_at <= now) return { ok: false, code: "expired" };
 
   // Mark old rotated, then mint the successor bound to rotated_from.
   await env.DB.prepare(
@@ -292,13 +338,7 @@ async function mintTokensRotated(
   now: number,
 ): Promise<AgentTokens> {
   const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
-  const accessToken = await createSignedJwt(
-    env,
-    identity.agent_id,
-    now,
-    accessExpiresAt,
-    crypto.randomUUID(),
-  );
+  const accessToken = await mintAccessToken(env, identity, now, accessExpiresAt);
   const refreshToken = randomOpaqueToken();
   const refreshHash = await sha256Base64Url(refreshToken);
   await env.DB.prepare(

--- a/worker/src/lib/agent_login.ts
+++ b/worker/src/lib/agent_login.ts
@@ -31,12 +31,15 @@ export const AGENT_REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 /** Authenticated identity a grant/refresh binds to (from `authenticated_account`). */
 export interface AgentLoginIdentity {
   server_id: string;
-  // The `raft_accounts.id` of the authenticated agent account. Used as the access
-  // JWT `sub` and the `raft_sessions.account_id`, so the minted access token
-  // resolves through the normal auth middleware. Also the binding/revoke key.
+  // Raft agent identity = authenticated_account.provider_subject. The grant/refresh
+  // BINDING and per-agent revoke key. NOT the session account. (XX-frozen mapping.)
   agent_id: string;
+  // Hands-local account row = authenticated_account.id. Used as the access JWT `sub`
+  // and raft_sessions.account_id so the minted access token resolves through normal
+  // auth middleware. Stored on the session, never as the binding/revoke key.
+  account_id: string;
   integration: string;
-  service: string; // "hands"
+  service: string; // exact installed client key, e.g. "hands-4cc7a2"
   app_scope?: string | null;
 }
 
@@ -146,14 +149,15 @@ export async function issueAgentGrant(
   const expiresAt = now + AGENT_GRANT_TTL_MS;
   await env.DB.prepare(
     `INSERT INTO agent_login_grants
-       (grant_digest, server_id, agent_id, integration, service,
+       (grant_digest, server_id, agent_id, account_id, integration, service,
         code_challenge, nonce, issued_at, expires_at, consumed_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)`,
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL)`,
   )
     .bind(
       grantDigest,
       identity.server_id,
       identity.agent_id,
+      identity.account_id,
       identity.integration,
       identity.service,
       codeChallenge,
@@ -185,7 +189,7 @@ export async function exchangeAgentGrant(
   if (!grant || !codeVerifier) return { ok: false, code: "grant_invalid" };
   const grantDigest = await sha256Base64Url(grant);
   const row = await env.DB.prepare(
-    `SELECT server_id, agent_id, integration, service,
+    `SELECT server_id, agent_id, account_id, integration, service,
             code_challenge, expires_at, consumed_at
        FROM agent_login_grants WHERE grant_digest = ?1`,
   )
@@ -193,6 +197,7 @@ export async function exchangeAgentGrant(
     .first<{
       server_id: string;
       agent_id: string;
+      account_id: string;
       integration: string;
       service: string;
       code_challenge: string;
@@ -213,20 +218,21 @@ export async function exchangeAgentGrant(
 
   const identity: AgentLoginIdentity = {
     server_id: row.server_id,
-    agent_id: row.agent_id,
+    agent_id: row.agent_id, // Raft provider_subject (binding key)
+    account_id: row.account_id, // Hands account row (session subject)
     integration: row.integration,
     service: row.service,
-    // Grants carry no app scope (login-time); refresh tokens default to null and can
-    // be scoped later once the RFC 057 binding (#5) lands. TODO(XX): app_scope source.
+    // Grants carry no app scope (login-time); refresh defaults to null.
     app_scope: null,
   };
   const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
   const refreshExpiresAt = now + AGENT_REFRESH_TTL_MS;
   // One id is BOTH the JWT `jti` and the raft_sessions row id (session ≡ token).
   const sessionId = crypto.randomUUID();
+  // Access token subject = Hands account_id, so it resolves via the normal middleware.
   const accessToken = await createSignedJwt(
     env,
-    identity.agent_id,
+    identity.account_id,
     now,
     accessExpiresAt,
     sessionId,
@@ -243,25 +249,27 @@ export async function exchangeAgentGrant(
          WHERE grant_digest = ?1 AND consumed_at IS NULL AND expires_at > ?2`,
     ).bind(grantDigest, now),
     // 2) session — inserted only if THIS call set consumed_at = now (won the consume).
+    //    raft_sessions.account_id = Hands account_id (session subject), NOT agent_id.
     env.DB.prepare(
       `INSERT INTO raft_sessions
          (id, account_id, token_hash, created_at, expires_at, last_seen_at,
           revoked_at, raft_access_token_ciphertext)
        SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
         WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?6) = ?4`,
-    ).bind(sessionId, identity.agent_id, accessHash, now, accessExpiresAt, grantDigest),
-    // 3) refresh — same win-guard.
+    ).bind(sessionId, identity.account_id, accessHash, now, accessExpiresAt, grantDigest),
+    // 3) refresh — same win-guard. Binds agent_id (provider_subject) + account_id.
     env.DB.prepare(
       `INSERT INTO agent_refresh_tokens
-         (id, token_hash, server_id, agent_id, integration, service, app_scope,
+         (id, token_hash, server_id, agent_id, account_id, integration, service, app_scope,
           created_at, expires_at, rotated_from, revoked_at)
-       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL
-        WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?10) = ?8`,
+       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL
+        WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?11) = ?9`,
     ).bind(
       refreshId,
       refreshHash,
       identity.server_id,
       identity.agent_id,
+      identity.account_id,
       identity.integration,
       identity.service,
       identity.app_scope ?? null,
@@ -304,7 +312,7 @@ async function mintAccessToken(
   const sessionId = crypto.randomUUID();
   const accessToken = await createSignedJwt(
     env,
-    identity.agent_id,
+    identity.account_id,
     now,
     accessExpiresAt,
     sessionId,
@@ -317,7 +325,7 @@ async function mintAccessToken(
   )
     .bind(
       sessionId,
-      identity.agent_id,
+      identity.account_id,
       await sha256Hex(accessToken),
       now,
       accessExpiresAt,
@@ -338,15 +346,16 @@ async function mintTokens(
   const refreshHash = await sha256Base64Url(refreshToken);
   await env.DB.prepare(
     `INSERT INTO agent_refresh_tokens
-       (id, token_hash, server_id, agent_id, integration, service, app_scope,
+       (id, token_hash, server_id, agent_id, account_id, integration, service, app_scope,
         created_at, expires_at, rotated_from, revoked_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL)`,
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL)`,
   )
     .bind(
       crypto.randomUUID(),
       refreshHash,
       identity.server_id,
       identity.agent_id,
+      identity.account_id,
       identity.integration,
       identity.service,
       identity.app_scope ?? null,
@@ -383,7 +392,7 @@ export async function rotateAgentRefresh(
   if (!refreshToken) return { ok: false, code: "refresh_invalid" };
   const refreshHash = await sha256Base64Url(refreshToken);
   const row = await env.DB.prepare(
-    `SELECT id, server_id, agent_id, integration, service, app_scope,
+    `SELECT id, server_id, agent_id, account_id, integration, service, app_scope,
             expires_at, revoked_at,
             (SELECT COUNT(*) FROM agent_refresh_tokens c WHERE c.rotated_from = agent_refresh_tokens.id) AS children
        FROM agent_refresh_tokens WHERE token_hash = ?1`,
@@ -393,6 +402,7 @@ export async function rotateAgentRefresh(
       id: string;
       server_id: string;
       agent_id: string;
+      account_id: string;
       integration: string;
       service: string;
       app_scope: string | null;
@@ -418,7 +428,8 @@ export async function rotateAgentRefresh(
 
   const identity: AgentLoginIdentity = {
     server_id: row.server_id,
-    agent_id: row.agent_id,
+    agent_id: row.agent_id, // Raft provider_subject (binding key), carried forward
+    account_id: row.account_id, // Hands account row (session subject), carried forward
     integration: row.integration,
     service: row.service,
     app_scope: row.app_scope,
@@ -428,7 +439,7 @@ export async function rotateAgentRefresh(
   const sessionId = crypto.randomUUID();
   const accessToken = await createSignedJwt(
     env,
-    identity.agent_id,
+    identity.account_id,
     now,
     accessExpiresAt,
     sessionId,
@@ -453,18 +464,19 @@ export async function rotateAgentRefresh(
           revoked_at, raft_access_token_ciphertext)
        SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
         WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?6) = ?4`,
-    ).bind(sessionId, identity.agent_id, accessHash, now, accessExpiresAt, row.id),
+    ).bind(sessionId, identity.account_id, accessHash, now, accessExpiresAt, row.id),
     env.DB.prepare(
       `INSERT INTO agent_refresh_tokens
-         (id, token_hash, server_id, agent_id, integration, service, app_scope,
+         (id, token_hash, server_id, agent_id, account_id, integration, service, app_scope,
           created_at, expires_at, rotated_from, revoked_at)
-       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL
-        WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?10) = ?8`,
+       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL
+        WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?11) = ?9`,
     ).bind(
       newRefreshId,
       newRefreshHash,
       identity.server_id,
       identity.agent_id,
+      identity.account_id,
       identity.integration,
       identity.service,
       identity.app_scope ?? null,

--- a/worker/src/lib/agent_login.ts
+++ b/worker/src/lib/agent_login.ts
@@ -53,10 +53,11 @@ export interface AgentTokens {
   access_token: string;
   refresh_token: string;
   access_expires_at: number;
+  refresh_expires_at: number;
 }
 
-type ConsumeResult =
-  | { ok: true; identity: AgentLoginIdentity }
+type ExchangeResult =
+  | { ok: true; tokens: AgentTokens }
   | { ok: false; code: AgentLoginErrorCode };
 
 type RotateResult =
@@ -132,16 +133,22 @@ export async function issueAgentGrant(
 }
 
 /**
- * exchange step 1: verify the proof and atomically consume the grant (single-use).
- * Returns the bound identity on success, or a typed closed-set error.
- * The verifier is checked here and never stored/logged.
+ * exchange: verify the proof, then ATOMICALLY consume the grant (single-use) and mint
+ * the access session + refresh token in ONE transaction (D1 batch). Either all three
+ * happen or none do — fixes the CP2 non-atomic exchange (a burned grant with no
+ * tokens on a mid-exchange failure). The verifier is checked here, never stored/logged.
+ *
+ * Concurrency: the session/refresh INSERTs are guarded on "this call won the consume"
+ * (grant.consumed_at == now, set by the same-batch UPDATE). A concurrent loser's
+ * UPDATE matches 0 rows, so its guarded INSERTs write nothing; we detect the win via
+ * the session INSERT's changes count.
  */
-export async function consumeAgentGrant(
+export async function exchangeAgentGrant(
   env: Env,
   grant: string,
   codeVerifier: string,
   now: number = Date.now(),
-): Promise<ConsumeResult> {
+): Promise<ExchangeResult> {
   if (!grant || !codeVerifier) return { ok: false, code: "invalid" };
   const grantDigest = await sha256Base64Url(grant);
   const row = await env.DB.prepare(
@@ -171,22 +178,78 @@ export async function consumeAgentGrant(
     return { ok: false, code: "grant_proof_mismatch" };
   }
 
-  // Atomic single-use consume: only one exchange wins the WHERE consumed_at IS NULL.
-  const consumed = await env.DB.prepare(
-    `UPDATE agent_login_grants SET consumed_at = ?2
-       WHERE grant_digest = ?1 AND consumed_at IS NULL AND expires_at > ?3`,
-  )
-    .bind(grantDigest, now, now)
-    .run();
-  if (consumed.meta.changes !== 1) return { ok: false, code: "consumed" };
+  const identity: AgentLoginIdentity = {
+    server_id: row.server_id,
+    agent_id: row.agent_id,
+    integration: row.integration,
+    service: row.service,
+    // Grants carry no app scope (login-time); refresh tokens default to null and can
+    // be scoped later once the RFC 057 binding (#5) lands. TODO(XX): app_scope source.
+    app_scope: null,
+  };
+  const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
+  const refreshExpiresAt = now + AGENT_REFRESH_TTL_MS;
+  // One id is BOTH the JWT `jti` and the raft_sessions row id (session ≡ token).
+  const sessionId = crypto.randomUUID();
+  const accessToken = await createSignedJwt(
+    env,
+    identity.agent_id,
+    now,
+    accessExpiresAt,
+    sessionId,
+  );
+  const accessHash = await sha256Hex(accessToken);
+  const refreshId = crypto.randomUUID();
+  const refreshToken = randomOpaqueToken();
+  const refreshHash = await sha256Base64Url(refreshToken);
 
+  const results = await env.DB.batch([
+    // 1) single-use consume — only one exchange matches `consumed_at IS NULL`.
+    env.DB.prepare(
+      `UPDATE agent_login_grants SET consumed_at = ?2
+         WHERE grant_digest = ?1 AND consumed_at IS NULL AND expires_at > ?2`,
+    ).bind(grantDigest, now),
+    // 2) session — inserted only if THIS call set consumed_at = now (won the consume).
+    env.DB.prepare(
+      `INSERT INTO raft_sessions
+         (id, account_id, token_hash, created_at, expires_at, last_seen_at,
+          revoked_at, raft_access_token_ciphertext)
+       SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
+        WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?6) = ?4`,
+    ).bind(sessionId, identity.agent_id, accessHash, now, accessExpiresAt, grantDigest),
+    // 3) refresh — same win-guard.
+    env.DB.prepare(
+      `INSERT INTO agent_refresh_tokens
+         (id, token_hash, server_id, agent_id, integration, service, app_scope,
+          created_at, expires_at, rotated_from, revoked_at)
+       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL
+        WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?10) = ?8`,
+    ).bind(
+      refreshId,
+      refreshHash,
+      identity.server_id,
+      identity.agent_id,
+      identity.integration,
+      identity.service,
+      identity.app_scope ?? null,
+      now,
+      refreshExpiresAt,
+      grantDigest,
+    ),
+  ]);
+
+  // Session INSERT wrote 1 row ⇒ we won the atomic consume. 0 ⇒ a concurrent exchange
+  // won (the whole batch rolls back on any error, so we never burn a grant tokenlessly).
+  if ((results[1]?.meta?.changes ?? 0) !== 1) {
+    return { ok: false, code: "consumed" };
+  }
   return {
     ok: true,
-    identity: {
-      server_id: row.server_id,
-      agent_id: row.agent_id,
-      integration: row.integration,
-      service: row.service,
+    tokens: {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      access_expires_at: accessExpiresAt,
+      refresh_expires_at: refreshExpiresAt,
     },
   };
 }
@@ -203,12 +266,15 @@ async function mintAccessToken(
   now: number,
   accessExpiresAt: number,
 ): Promise<string> {
+  // One id is BOTH the JWT `jti` and the raft_sessions row id, so a session and its
+  // access token are the same principal (simpler revoke/audit correlation — Volta CP2).
+  const sessionId = crypto.randomUUID();
   const accessToken = await createSignedJwt(
     env,
     identity.agent_id,
     now,
     accessExpiresAt,
-    crypto.randomUUID(),
+    sessionId,
   );
   await env.DB.prepare(
     `INSERT INTO raft_sessions
@@ -217,7 +283,7 @@ async function mintAccessToken(
      VALUES (?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL)`,
   )
     .bind(
-      crypto.randomUUID(),
+      sessionId,
       identity.agent_id,
       await sha256Hex(accessToken),
       now,
@@ -233,6 +299,7 @@ async function mintTokens(
   now: number,
 ): Promise<AgentTokens> {
   const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
+  const refreshExpiresAt = now + AGENT_REFRESH_TTL_MS;
   const accessToken = await mintAccessToken(env, identity, now, accessExpiresAt);
   const refreshToken = randomOpaqueToken();
   const refreshHash = await sha256Base64Url(refreshToken);
@@ -251,13 +318,14 @@ async function mintTokens(
       identity.service,
       identity.app_scope ?? null,
       now,
-      now + AGENT_REFRESH_TTL_MS,
+      refreshExpiresAt,
     )
     .run();
   return {
     access_token: accessToken,
     refresh_token: refreshToken,
     access_expires_at: accessExpiresAt,
+    refresh_expires_at: refreshExpiresAt,
   };
 }
 
@@ -315,55 +383,77 @@ export async function rotateAgentRefresh(
   if (row.revoked_at !== null) return { ok: false, code: "consumed" };
   if (row.expires_at <= now) return { ok: false, code: "expired" };
 
-  // Mark old rotated, then mint the successor bound to rotated_from.
-  await env.DB.prepare(
-    `UPDATE agent_refresh_tokens SET revoked_at = ?2 WHERE id = ?1 AND revoked_at IS NULL`,
-  )
-    .bind(row.id, now)
-    .run();
-  const tokens = await mintTokensRotated(env, {
+  const identity: AgentLoginIdentity = {
     server_id: row.server_id,
     agent_id: row.agent_id,
     integration: row.integration,
     service: row.service,
     app_scope: row.app_scope,
-  }, row.id, now);
-  return { ok: true, tokens };
-}
-
-async function mintTokensRotated(
-  env: Env,
-  identity: AgentLoginIdentity,
-  rotatedFrom: string,
-  now: number,
-): Promise<AgentTokens> {
+  };
   const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
-  const accessToken = await mintAccessToken(env, identity, now, accessExpiresAt);
-  const refreshToken = randomOpaqueToken();
-  const refreshHash = await sha256Base64Url(refreshToken);
-  await env.DB.prepare(
-    `INSERT INTO agent_refresh_tokens
-       (id, token_hash, server_id, agent_id, integration, service, app_scope,
-        created_at, expires_at, rotated_from, revoked_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL)`,
-  )
-    .bind(
-      crypto.randomUUID(),
-      refreshHash,
+  const refreshExpiresAt = now + AGENT_REFRESH_TTL_MS;
+  const sessionId = crypto.randomUUID();
+  const accessToken = await createSignedJwt(
+    env,
+    identity.agent_id,
+    now,
+    accessExpiresAt,
+    sessionId,
+  );
+  const accessHash = await sha256Hex(accessToken);
+  const newRefreshId = crypto.randomUUID();
+  const newRefreshToken = randomOpaqueToken();
+  const newRefreshHash = await sha256Base64Url(newRefreshToken);
+
+  // Atomic rotation: fence (revoke old) + mint successor in ONE transaction. The mint
+  // INSERTs are guarded on winning the fence (old.revoked_at == now, set by the
+  // same-batch UPDATE); a concurrent second rotation of the SAME token matches 0 rows
+  // on the fence and mints nothing (no double-issue). A mint failure rolls the fence
+  // back too (no crash-lockout: we never revoke the old token without a successor).
+  const results = await env.DB.batch([
+    env.DB.prepare(
+      `UPDATE agent_refresh_tokens SET revoked_at = ?2 WHERE id = ?1 AND revoked_at IS NULL`,
+    ).bind(row.id, now),
+    env.DB.prepare(
+      `INSERT INTO raft_sessions
+         (id, account_id, token_hash, created_at, expires_at, last_seen_at,
+          revoked_at, raft_access_token_ciphertext)
+       SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
+        WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?6) = ?4`,
+    ).bind(sessionId, identity.agent_id, accessHash, now, accessExpiresAt, row.id),
+    env.DB.prepare(
+      `INSERT INTO agent_refresh_tokens
+         (id, token_hash, server_id, agent_id, integration, service, app_scope,
+          created_at, expires_at, rotated_from, revoked_at)
+       SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL
+        WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?10) = ?8`,
+    ).bind(
+      newRefreshId,
+      newRefreshHash,
       identity.server_id,
       identity.agent_id,
       identity.integration,
       identity.service,
       identity.app_scope ?? null,
       now,
-      now + AGENT_REFRESH_TTL_MS,
-      rotatedFrom,
-    )
-    .run();
+      refreshExpiresAt,
+      row.id,
+    ),
+  ]);
+
+  // Session INSERT wrote 1 row ⇒ we won the fence. 0 ⇒ a concurrent rotation of the
+  // same token won; ask the client to retry (it must serialize refreshes, OAuth-style).
+  if ((results[1]?.meta?.changes ?? 0) !== 1) {
+    return { ok: false, code: "temporarily_unavailable" };
+  }
   return {
-    access_token: accessToken,
-    refresh_token: refreshToken,
-    access_expires_at: accessExpiresAt,
+    ok: true,
+    tokens: {
+      access_token: accessToken,
+      refresh_token: newRefreshToken,
+      access_expires_at: accessExpiresAt,
+      refresh_expires_at: refreshExpiresAt,
+    },
   };
 }
 

--- a/worker/src/lib/agent_login.ts
+++ b/worker/src/lib/agent_login.ts
@@ -111,6 +111,20 @@ export function isValidS256Challenge(challenge: unknown): challenge is string {
   return base64Url(bytes) === challenge; // canonical round-trip
 }
 
+/**
+ * RFC 7636 code_verifier: 43–128 chars from the unreserved set
+ * [A-Za-z0-9-._~]. Enforced BEFORE hashing so a low-entropy / illegal / wrong-length
+ * verifier can never be exchanged even if its hash happens to match a challenge.
+ */
+export function isValidCodeVerifier(verifier: unknown): verifier is string {
+  return typeof verifier === "string" && /^[A-Za-z0-9\-._~]{43,128}$/.test(verifier);
+}
+
+/** RFC 057 service slug: `^[a-z0-9][a-z0-9._-]{0,79}$` (e.g. "hands-4cc7a2"). */
+export function isValidServiceSlug(service: unknown): service is string {
+  return typeof service === "string" && /^[a-z0-9][a-z0-9._-]{0,79}$/.test(service);
+}
+
 /** SHA-256 → base64url. Used for grant/refresh digests AND PKCE S256 challenge. */
 export async function sha256Base64Url(input: string): Promise<string> {
   const digest = await crypto.subtle.digest(
@@ -186,7 +200,9 @@ export async function exchangeAgentGrant(
   codeVerifier: string,
   now: number = Date.now(),
 ): Promise<ExchangeResult> {
-  if (!grant || !codeVerifier) return { ok: false, code: "grant_invalid" };
+  // RFC 7636 verifier format enforced BEFORE hashing (low-entropy/illegal/wrong-length
+  // verifiers can never be exchanged, even if a hash collided).
+  if (!grant || !isValidCodeVerifier(codeVerifier)) return { ok: false, code: "grant_invalid" };
   const grantDigest = await sha256Base64Url(grant);
   const row = await env.DB.prepare(
     `SELECT server_id, agent_id, account_id, integration, service,
@@ -208,6 +224,17 @@ export async function exchangeAgentGrant(
   if (!row) return { ok: false, code: "grant_invalid" };
   if (row.consumed_at !== null) return { ok: false, code: "grant_consumed" };
   if (row.expires_at <= now) return { ok: false, code: "grant_expired" };
+
+  // Binding: the grant must still be for THIS exact service (current RAFT_CLIENT_ID)
+  // and a well-formed slug. A grant issued for a different client cannot be exchanged
+  // here — keeps cross-service redemption fail-closed.
+  if (
+    !isValidServiceSlug(row.service) ||
+    !env.RAFT_CLIENT_ID ||
+    row.service !== env.RAFT_CLIENT_ID
+  ) {
+    return { ok: false, code: "grant_binding_mismatch" };
+  }
 
   // Proof check BEFORE consuming: a wrong verifier must not burn the grant (so a
   // stolen-grant attacker without the verifier can't DoS the legitimate CLI).
@@ -242,28 +269,33 @@ export async function exchangeAgentGrant(
   const refreshToken = randomOpaqueToken();
   const refreshHash = await sha256Base64Url(refreshToken);
 
+  // Unique per-attempt ownership token. The winner stamps it on the grant; the mint
+  // INSERTs guard on it. This is what makes single-use hold under same-millisecond
+  // concurrency — the timestamp is shared between racers, this id is not.
+  const attemptId = crypto.randomUUID();
   const results = await env.DB.batch([
-    // 1) single-use consume — only one exchange matches `consumed_at IS NULL`.
+    // 1) single-use consume — only one exchange matches `consumed_at IS NULL`; the
+    //    winner stamps its unique attempt id as the ownership token (NOT the timestamp).
     env.DB.prepare(
-      `UPDATE agent_login_grants SET consumed_at = ?2
+      `UPDATE agent_login_grants SET consumed_at = ?2, consumed_by = ?3
          WHERE grant_digest = ?1 AND consumed_at IS NULL AND expires_at > ?2`,
-    ).bind(grantDigest, now),
-    // 2) session — inserted only if THIS call set consumed_at = now (won the consume).
+    ).bind(grantDigest, now, attemptId),
+    // 2) session — inserted only if THIS call's attempt id won the consume.
     //    raft_sessions.account_id = Hands account_id (session subject), NOT agent_id.
     env.DB.prepare(
       `INSERT INTO raft_sessions
          (id, account_id, token_hash, created_at, expires_at, last_seen_at,
           revoked_at, raft_access_token_ciphertext)
        SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
-        WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?6) = ?4`,
-    ).bind(sessionId, identity.account_id, accessHash, now, accessExpiresAt, grantDigest),
-    // 3) refresh — same win-guard. Binds agent_id (provider_subject) + account_id.
+        WHERE (SELECT consumed_by FROM agent_login_grants WHERE grant_digest = ?6) = ?7`,
+    ).bind(sessionId, identity.account_id, accessHash, now, accessExpiresAt, grantDigest, attemptId),
+    // 3) refresh — same attempt-id win-guard. Binds agent_id (provider_subject) + account_id.
     env.DB.prepare(
       `INSERT INTO agent_refresh_tokens
          (id, token_hash, server_id, agent_id, account_id, integration, service, app_scope,
           created_at, expires_at, rotated_from, revoked_at)
        SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL
-        WHERE (SELECT consumed_at FROM agent_login_grants WHERE grant_digest = ?11) = ?9`,
+        WHERE (SELECT consumed_by FROM agent_login_grants WHERE grant_digest = ?11) = ?12`,
     ).bind(
       refreshId,
       refreshHash,
@@ -276,12 +308,16 @@ export async function exchangeAgentGrant(
       now,
       refreshExpiresAt,
       grantDigest,
+      attemptId,
     ),
   ]);
 
-  // Session INSERT wrote 1 row ⇒ we won the atomic consume. 0 ⇒ a concurrent exchange
-  // won (the whole batch rolls back on any error, so we never burn a grant tokenlessly).
-  if ((results[1]?.meta?.changes ?? 0) !== 1) {
+  // We won iff the consume UPDATE and BOTH guarded INSERTs each changed exactly one
+  // row. Any other combination = a concurrent exchange won (even at the same ms, since
+  // ownership is the unique attempt id, not the timestamp) → mint nothing here. The
+  // batch rolls back on any error, so a grant is never burned without issuing tokens.
+  const changed = (i: number) => (results[i]?.meta?.changes ?? 0) === 1;
+  if (!changed(0) || !changed(1) || !changed(2)) {
     return { ok: false, code: "grant_consumed" };
   }
   return {
@@ -293,91 +329,6 @@ export async function exchangeAgentGrant(
       refresh_expires_at: refreshExpiresAt,
     },
   };
-}
-
-/**
- * Mint a short access token: a Hands JWT (subject = agent account row id) backed by
- * a `raft_sessions` row, so it resolves through the normal auth middleware
- * (which looks the bearer up by its hex SHA-256 in raft_sessions). Agent sessions
- * carry no encrypted Raft token (NULL) — that field is only for hands-admin.
- */
-async function mintAccessToken(
-  env: Env,
-  identity: AgentLoginIdentity,
-  now: number,
-  accessExpiresAt: number,
-): Promise<string> {
-  // One id is BOTH the JWT `jti` and the raft_sessions row id, so a session and its
-  // access token are the same principal (simpler revoke/audit correlation — Volta CP2).
-  const sessionId = crypto.randomUUID();
-  const accessToken = await createSignedJwt(
-    env,
-    identity.account_id,
-    now,
-    accessExpiresAt,
-    sessionId,
-  );
-  await env.DB.prepare(
-    `INSERT INTO raft_sessions
-       (id, account_id, token_hash, created_at, expires_at, last_seen_at,
-        revoked_at, raft_access_token_ciphertext)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL)`,
-  )
-    .bind(
-      sessionId,
-      identity.account_id,
-      await sha256Hex(accessToken),
-      now,
-      accessExpiresAt,
-    )
-    .run();
-  return accessToken;
-}
-
-async function mintTokens(
-  env: Env,
-  identity: AgentLoginIdentity,
-  now: number,
-): Promise<AgentTokens> {
-  const accessExpiresAt = now + AGENT_ACCESS_TTL_MS;
-  const refreshExpiresAt = now + AGENT_REFRESH_TTL_MS;
-  const accessToken = await mintAccessToken(env, identity, now, accessExpiresAt);
-  const refreshToken = randomOpaqueToken();
-  const refreshHash = await sha256Base64Url(refreshToken);
-  await env.DB.prepare(
-    `INSERT INTO agent_refresh_tokens
-       (id, token_hash, server_id, agent_id, account_id, integration, service, app_scope,
-        created_at, expires_at, rotated_from, revoked_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL)`,
-  )
-    .bind(
-      crypto.randomUUID(),
-      refreshHash,
-      identity.server_id,
-      identity.agent_id,
-      identity.account_id,
-      identity.integration,
-      identity.service,
-      identity.app_scope ?? null,
-      now,
-      refreshExpiresAt,
-    )
-    .run();
-  return {
-    access_token: accessToken,
-    refresh_token: refreshToken,
-    access_expires_at: accessExpiresAt,
-    refresh_expires_at: refreshExpiresAt,
-  };
-}
-
-/** exchange step 2: mint access + refresh for a proven identity. */
-export async function issueAgentTokens(
-  env: Env,
-  identity: AgentLoginIdentity,
-  now: number = Date.now(),
-): Promise<AgentTokens> {
-  return mintTokens(env, identity, now);
 }
 
 /**
@@ -454,23 +405,28 @@ export async function rotateAgentRefresh(
   // same-batch UPDATE); a concurrent second rotation of the SAME token matches 0 rows
   // on the fence and mints nothing (no double-issue). A mint failure rolls the fence
   // back too (no crash-lockout: we never revoke the old token without a successor).
+  // Unique per-attempt ownership token, stamped by the fence and required by the mint
+  // INSERTs — same-millisecond concurrent rotations can't both win (the timestamp is
+  // shared, this id is not).
+  const attemptId = crypto.randomUUID();
   const results = await env.DB.batch([
     env.DB.prepare(
-      `UPDATE agent_refresh_tokens SET revoked_at = ?2 WHERE id = ?1 AND revoked_at IS NULL`,
-    ).bind(row.id, now),
+      `UPDATE agent_refresh_tokens SET revoked_at = ?2, revoked_by = ?3
+         WHERE id = ?1 AND revoked_at IS NULL`,
+    ).bind(row.id, now, attemptId),
     env.DB.prepare(
       `INSERT INTO raft_sessions
          (id, account_id, token_hash, created_at, expires_at, last_seen_at,
           revoked_at, raft_access_token_ciphertext)
        SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
-        WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?6) = ?4`,
-    ).bind(sessionId, identity.account_id, accessHash, now, accessExpiresAt, row.id),
+        WHERE (SELECT revoked_by FROM agent_refresh_tokens WHERE id = ?6) = ?7`,
+    ).bind(sessionId, identity.account_id, accessHash, now, accessExpiresAt, row.id, attemptId),
     env.DB.prepare(
       `INSERT INTO agent_refresh_tokens
          (id, token_hash, server_id, agent_id, account_id, integration, service, app_scope,
           created_at, expires_at, rotated_from, revoked_at)
        SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL
-        WHERE (SELECT revoked_at FROM agent_refresh_tokens WHERE id = ?11) = ?9`,
+        WHERE (SELECT revoked_by FROM agent_refresh_tokens WHERE id = ?11) = ?12`,
     ).bind(
       newRefreshId,
       newRefreshHash,
@@ -483,12 +439,16 @@ export async function rotateAgentRefresh(
       now,
       refreshExpiresAt,
       row.id,
+      attemptId,
     ),
   ]);
 
-  // Session INSERT wrote 1 row ⇒ we won the fence. 0 ⇒ a concurrent rotation of the
-  // same token won; ask the client to retry (it must serialize refreshes, OAuth-style).
-  if ((results[1]?.meta?.changes ?? 0) !== 1) {
+  // Won iff fence + both mint INSERTs each changed exactly one row. Otherwise a
+  // concurrent rotation of the same token won (even at the same ms — ownership is the
+  // attempt id, not the timestamp); ask the client to retry (it must serialize
+  // refreshes and re-read the store, never overwrite a newer session with an older one).
+  const changed = (i: number) => (results[i]?.meta?.changes ?? 0) === 1;
+  if (!changed(0) || !changed(1) || !changed(2)) {
     return { ok: false, code: "temporarily_unavailable" };
   }
   return {

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -52,6 +52,11 @@ export type AdminAccount = {
 export type AdminEnv = {
   Variables: {
     admin_account?: AdminAccount;
+    // The session-authenticated account BEFORE any x-hands-org-id org-switch.
+    // Set only on the valid Hands-session branch (never for the deploy-token
+    // fallback). Endpoints that must bind to "who authenticated" (e.g. agent-login
+    // grant issuance) read this, NOT the org-switchable admin_account.
+    authenticated_account?: AdminAccount;
     admin_deploy_token?: AppDeployToken;
     admin_actor?: string;
     org_id?: string;
@@ -181,6 +186,10 @@ export const authMiddleware: MiddlewareHandler<AdminEnv & { Bindings: Env }> =
       sessionToken,
     );
     if (sessionAccount) {
+      // Expose the pre-org-switch authenticated identity for endpoints that must
+      // bind to who actually authenticated (agent-login), independent of the
+      // client-controlled x-hands-org-id header.
+      c.set("authenticated_account", sessionAccount);
       const account = await accountForRequestedOrg(
         c.env,
         sessionAccount,

--- a/worker/src/routes/agent_login.ts
+++ b/worker/src/routes/agent_login.ts
@@ -14,13 +14,31 @@ import type { Context } from "hono";
 import type { AdminContext } from "../lib/permissions";
 import {
   exchangeAgentGrant,
+  isValidS256Challenge,
   issueAgentGrant,
   rotateAgentRefresh,
   type AgentLoginErrorCode,
   type AgentLoginIdentity,
+  type AgentTokens,
 } from "../lib/agent_login";
 
 const SERVICE = "hands";
+
+/** Build the frozen RFC 057 `raft-cli-agent-session.v1` wire response. Expiry
+ *  timestamps are RFC3339 UTC (authoritative service facts). */
+function sessionResponse(tokens: AgentTokens) {
+  return {
+    schema: "raft-cli-agent-session.v1",
+    token_type: "Bearer",
+    access_token: tokens.access_token,
+    access_expires_at: new Date(tokens.access_expires_at).toISOString(),
+    refresh_token: tokens.refresh_token,
+    refresh_expires_at:
+      tokens.refresh_expires_at === null
+        ? null
+        : new Date(tokens.refresh_expires_at).toISOString(),
+  };
+}
 // The recorded integration attribute. Not part of the security binding (which is
 // server_id + agent_id + service); an audit/label field. TODO(confirm w/ XX):
 // whether this should carry the exact Raft integration slug instead of the service.
@@ -30,13 +48,17 @@ const INTEGRATION = "hands";
 // retryable one; everything else is a terminal client-side failure.
 function statusFor(code: AgentLoginErrorCode): 400 | 401 | 409 | 503 {
   switch (code) {
-    case "expired":
-    case "consumed":
+    case "grant_expired":
+    case "grant_consumed":
+    case "refresh_expired":
+    case "refresh_reused":
+    case "refresh_revoked":
       return 409;
     case "temporarily_unavailable":
       return 503;
     default:
-      return 400; // invalid | binding_mismatch | grant_proof_mismatch
+      // grant_invalid | grant_binding_mismatch | grant_proof_mismatch | refresh_invalid
+      return 400;
   }
 }
 
@@ -63,12 +85,17 @@ export async function handleAgentLoginAction(c: AdminContext): Promise<Response>
   if (!body || body.schema !== "raft-cli-agent-login-request.v1") {
     return c.json({ error: "bad request", code: "invalid_schema" }, 400);
   }
+  // Closed input (RFC 057): reject extension fields.
+  const allowed = new Set(["schema", "code_challenge", "code_challenge_method"]);
+  if (Object.keys(body).some((k) => !allowed.has(k))) {
+    return c.json({ error: "unexpected fields (closed input)", code: "invalid_schema" }, 400);
+  }
   if (body.code_challenge_method !== "S256") {
     return c.json({ error: "code_challenge_method must be S256", code: "invalid_challenge_method" }, 400);
   }
-  // S256 challenge = SHA-256 (32 bytes) → unpadded base64url = exactly 43 chars.
-  if (typeof body.code_challenge !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(body.code_challenge)) {
-    return c.json({ error: "code_challenge must be an unpadded base64url SHA-256 (43 chars)", code: "invalid_challenge" }, 400);
+  // RFC 057: strict base64url (no padding), decodes to exactly 32 bytes, canonical.
+  if (!isValidS256Challenge(body.code_challenge)) {
+    return c.json({ error: "code_challenge must be an unpadded base64url SHA-256 decoding to 32 bytes", code: "invalid_challenge" }, 400);
   }
 
   // Tooth 3: identity (incl. audit actor) derives from the authenticated account,
@@ -99,14 +126,14 @@ export async function handleAgentExchange(
     return c.json({ error: "bad request", code: "invalid_schema" }, 400);
   }
   if (typeof body.grant !== "string" || typeof body.code_verifier !== "string") {
-    return c.json({ error: "grant and code_verifier are required", code: "invalid" }, 400);
+    return c.json({ error: "grant and code_verifier are required", code: "grant_invalid" }, 400);
   }
   // Atomic consume+mint: never burns a grant without issuing tokens.
   const result = await exchangeAgentGrant(c.env, body.grant, body.code_verifier);
   if (!result.ok) {
     return c.json({ error: result.code, code: result.code }, statusFor(result.code));
   }
-  return c.json(result.tokens);
+  return c.json(sessionResponse(result.tokens));
 }
 
 /** Public refresh: `{ refresh_token }` → rotated access + refresh. */
@@ -116,12 +143,15 @@ export async function handleAgentRefresh(
   const body = (await c.req.json().catch(() => null)) as
     | { schema?: unknown; refresh_token?: unknown }
     | null;
-  if (!body || typeof body.refresh_token !== "string") {
-    return c.json({ error: "refresh_token is required", code: "invalid" }, 400);
+  if (!body || body.schema !== "raft-cli-agent-refresh.v1") {
+    return c.json({ error: "bad request", code: "invalid_schema" }, 400);
+  }
+  if (typeof body.refresh_token !== "string") {
+    return c.json({ error: "refresh_token is required", code: "refresh_invalid" }, 400);
   }
   const result = await rotateAgentRefresh(c.env, body.refresh_token);
   if (!result.ok) {
     return c.json({ error: result.code, code: result.code }, statusFor(result.code));
   }
-  return c.json(result.tokens);
+  return c.json(sessionResponse(result.tokens));
 }

--- a/worker/src/routes/agent_login.ts
+++ b/worker/src/routes/agent_login.ts
@@ -22,8 +22,6 @@ import {
   type AgentTokens,
 } from "../lib/agent_login";
 
-const SERVICE = "hands";
-
 /** Build the frozen RFC 057 `raft-cli-agent-session.v1` wire response. Expiry
  *  timestamps are RFC3339 UTC (authoritative service facts). */
 function sessionResponse(tokens: AgentTokens) {
@@ -39,10 +37,6 @@ function sessionResponse(tokens: AgentTokens) {
         : new Date(tokens.refresh_expires_at).toISOString(),
   };
 }
-// The recorded integration attribute. Not part of the security binding (which is
-// server_id + agent_id + service); an audit/label field. TODO(confirm w/ XX):
-// whether this should carry the exact Raft integration slug instead of the service.
-const INTEGRATION = "hands";
 
 // Map a closed-set error to an HTTP status. temporarily_unavailable is the only
 // retryable one; everything else is a terminal client-side failure.
@@ -98,18 +92,27 @@ export async function handleAgentLoginAction(c: AdminContext): Promise<Response>
     return c.json({ error: "code_challenge must be an unpadded base64url SHA-256 decoding to 32 bytes", code: "invalid_challenge" }, 400);
   }
 
+  // The exact installed Raft client key (e.g. "hands-4cc7a2"), NOT the brand "hands".
+  // Same value the manifest advertises (RAFT_CLIENT_ID); the CLI selects the service
+  // by this exact key, so the grant must bind to it. Fail closed if unset — never
+  // fall back to a brand, since revoke/audit/cross-service fail-closed depend on it.
+  const service = c.env.RAFT_CLIENT_ID;
+  if (!service) {
+    return c.json({ error: "service identity unavailable", code: "temporarily_unavailable" }, 503);
+  }
   // Tooth 3: identity (incl. audit actor) derives from the authenticated account,
-  // NOT the org-switched admin_account/admin_actor.
+  // NOT the org-switched admin_account/admin_actor. `integration` mirrors the exact
+  // client key as a non-binding label (binding is server_id + agent_id + service).
   const identity: AgentLoginIdentity = {
     server_id: authed.server_id,
     agent_id: authed.id,
-    integration: INTEGRATION,
-    service: SERVICE,
+    integration: service,
+    service,
   };
   const { grant, expires_at } = await issueAgentGrant(c.env, identity, body.code_challenge);
   return c.json({
     schema: "raft-cli-agent-login-grant.v1",
-    service: SERVICE,
+    service,
     grant,
     expires_at: new Date(expires_at).toISOString(),
   });

--- a/worker/src/routes/agent_login.ts
+++ b/worker/src/routes/agent_login.ts
@@ -94,18 +94,24 @@ export async function handleAgentLoginAction(c: AdminContext): Promise<Response>
 
   // The exact installed Raft client key (e.g. "hands-4cc7a2"), NOT the brand "hands".
   // Same value the manifest advertises (RAFT_CLIENT_ID); the CLI selects the service
-  // by this exact key, so the grant must bind to it. Fail closed if unset — never
-  // fall back to a brand, since revoke/audit/cross-service fail-closed depend on it.
+  // by this exact key, so the grant must bind to it.
   const service = c.env.RAFT_CLIENT_ID;
-  if (!service) {
-    return c.json({ error: "service identity unavailable", code: "temporarily_unavailable" }, 503);
+  // Fail closed if ANY required server-side identity value is missing (XX-frozen
+  // mapping): identity is derived only here, never supplied/overridable by CLI/body,
+  // and revoke/audit/cross-service fail-closed all depend on these being exact.
+  if (!service || !authed.server_id || !authed.provider_subject || !authed.id) {
+    return c.json({ error: "service or agent identity unavailable", code: "temporarily_unavailable" }, 503);
   }
-  // Tooth 3: identity (incl. audit actor) derives from the authenticated account,
-  // NOT the org-switched admin_account/admin_actor. `integration` mirrors the exact
-  // client key as a non-binding label (binding is server_id + agent_id + service).
+  // Tooth 3: identity derives from the pre-org-switch authenticated account, NOT the
+  // org-switchable admin_account. XX-frozen split:
+  //   agent_id   = provider_subject (Raft agent identity) → grant/refresh binding key
+  //   account_id = account row id (Hands local)           → raft_sessions.account_id / JWT sub
+  // `integration` mirrors the exact client key (non-binding label; binding is
+  // server_id + agent_id + service).
   const identity: AgentLoginIdentity = {
     server_id: authed.server_id,
-    agent_id: authed.id,
+    agent_id: authed.provider_subject,
+    account_id: authed.id,
     integration: service,
     service,
   };

--- a/worker/src/routes/agent_login.ts
+++ b/worker/src/routes/agent_login.ts
@@ -1,0 +1,127 @@
+/**
+ * Agent CLI login (RFC 057, Hands first instance) — HTTP handlers.
+ *
+ * - agent-login action (AUTHENTICATED, manifest action reached via `integration
+ *   invoke`): binds a proof-key grant to the pre-org-switch authenticated agent.
+ * - exchange / refresh (PUBLIC token endpoints): the grant+verifier / refresh token
+ *   IS the credential, like an OAuth token endpoint — no prior session required.
+ *
+ * See docs/agent-cli-login-hands-instance.md. The verifier is checked in the lib
+ * and never stored/logged.
+ */
+
+import type { Context } from "hono";
+import type { AdminContext } from "../lib/permissions";
+import {
+  consumeAgentGrant,
+  issueAgentGrant,
+  issueAgentTokens,
+  rotateAgentRefresh,
+  type AgentLoginErrorCode,
+  type AgentLoginIdentity,
+} from "../lib/agent_login";
+
+const SERVICE = "hands";
+// The recorded integration attribute. Not part of the security binding (which is
+// server_id + agent_id + service); an audit/label field. TODO(confirm w/ XX):
+// whether this should carry the exact Raft integration slug instead of the service.
+const INTEGRATION = "hands";
+
+// Map a closed-set error to an HTTP status. temporarily_unavailable is the only
+// retryable one; everything else is a terminal client-side failure.
+function statusFor(code: AgentLoginErrorCode): 400 | 401 | 409 | 503 {
+  switch (code) {
+    case "expired":
+    case "consumed":
+      return 409;
+    case "temporarily_unavailable":
+      return 503;
+    default:
+      return 400; // invalid | binding_mismatch | grant_proof_mismatch
+  }
+}
+
+/**
+ * `agent-login` manifest action. Requires an authenticated AGENT session; binds the
+ * grant to the pre-org-switch identity (never the org-switchable admin_account, and
+ * never request-body identity).
+ */
+export async function handleAgentLoginAction(c: AdminContext): Promise<Response> {
+  // Tooth 1: only the valid-session branch sets this; deploy-token fallback does
+  // not. Absent ⇒ fail closed.
+  const authed = c.get("authenticated_account");
+  if (!authed) {
+    return c.json({ error: "unauthorized", code: "unauthenticated" }, 401);
+  }
+  // Tooth 2: human sessions cannot mint an agent grant.
+  if (authed.principal_type !== "agent") {
+    return c.json({ error: "forbidden", code: "agent_principal_required" }, 403);
+  }
+
+  const body = (await c.req.json().catch(() => null)) as
+    | { schema?: unknown; code_challenge?: unknown; code_challenge_method?: unknown }
+    | null;
+  if (!body || body.schema !== "raft-cli-agent-login-request.v1") {
+    return c.json({ error: "bad request", code: "invalid_schema" }, 400);
+  }
+  if (body.code_challenge_method !== "S256") {
+    return c.json({ error: "code_challenge_method must be S256", code: "invalid_challenge_method" }, 400);
+  }
+  if (typeof body.code_challenge !== "string" || body.code_challenge.length < 43) {
+    return c.json({ error: "code_challenge must be a base64url SHA-256", code: "invalid_challenge" }, 400);
+  }
+
+  // Tooth 3: identity (incl. audit actor) derives from the authenticated account,
+  // NOT the org-switched admin_account/admin_actor.
+  const identity: AgentLoginIdentity = {
+    server_id: authed.server_id,
+    agent_id: authed.id,
+    integration: INTEGRATION,
+    service: SERVICE,
+  };
+  const { grant, expires_at } = await issueAgentGrant(c.env, identity, body.code_challenge);
+  return c.json({
+    schema: "raft-cli-agent-login-grant.v1",
+    service: SERVICE,
+    grant,
+    expires_at: new Date(expires_at).toISOString(),
+  });
+}
+
+/** Public exchange: `{ grant, code_verifier }` → access + refresh. */
+export async function handleAgentExchange(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  const body = (await c.req.json().catch(() => null)) as
+    | { schema?: unknown; grant?: unknown; code_verifier?: unknown }
+    | null;
+  if (!body || body.schema !== "raft-cli-agent-login-exchange.v1") {
+    return c.json({ error: "bad request", code: "invalid_schema" }, 400);
+  }
+  if (typeof body.grant !== "string" || typeof body.code_verifier !== "string") {
+    return c.json({ error: "grant and code_verifier are required", code: "invalid" }, 400);
+  }
+  const result = await consumeAgentGrant(c.env, body.grant, body.code_verifier);
+  if (!result.ok) {
+    return c.json({ error: result.code, code: result.code }, statusFor(result.code));
+  }
+  const tokens = await issueAgentTokens(c.env, result.identity);
+  return c.json(tokens);
+}
+
+/** Public refresh: `{ refresh_token }` → rotated access + refresh. */
+export async function handleAgentRefresh(
+  c: Context<{ Bindings: Env }>,
+): Promise<Response> {
+  const body = (await c.req.json().catch(() => null)) as
+    | { schema?: unknown; refresh_token?: unknown }
+    | null;
+  if (!body || typeof body.refresh_token !== "string") {
+    return c.json({ error: "refresh_token is required", code: "invalid" }, 400);
+  }
+  const result = await rotateAgentRefresh(c.env, body.refresh_token);
+  if (!result.ok) {
+    return c.json({ error: result.code, code: result.code }, statusFor(result.code));
+  }
+  return c.json(result.tokens);
+}

--- a/worker/src/routes/agent_login.ts
+++ b/worker/src/routes/agent_login.ts
@@ -13,9 +13,8 @@
 import type { Context } from "hono";
 import type { AdminContext } from "../lib/permissions";
 import {
-  consumeAgentGrant,
+  exchangeAgentGrant,
   issueAgentGrant,
-  issueAgentTokens,
   rotateAgentRefresh,
   type AgentLoginErrorCode,
   type AgentLoginIdentity,
@@ -67,8 +66,9 @@ export async function handleAgentLoginAction(c: AdminContext): Promise<Response>
   if (body.code_challenge_method !== "S256") {
     return c.json({ error: "code_challenge_method must be S256", code: "invalid_challenge_method" }, 400);
   }
-  if (typeof body.code_challenge !== "string" || body.code_challenge.length < 43) {
-    return c.json({ error: "code_challenge must be a base64url SHA-256", code: "invalid_challenge" }, 400);
+  // S256 challenge = SHA-256 (32 bytes) → unpadded base64url = exactly 43 chars.
+  if (typeof body.code_challenge !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(body.code_challenge)) {
+    return c.json({ error: "code_challenge must be an unpadded base64url SHA-256 (43 chars)", code: "invalid_challenge" }, 400);
   }
 
   // Tooth 3: identity (incl. audit actor) derives from the authenticated account,
@@ -101,12 +101,12 @@ export async function handleAgentExchange(
   if (typeof body.grant !== "string" || typeof body.code_verifier !== "string") {
     return c.json({ error: "grant and code_verifier are required", code: "invalid" }, 400);
   }
-  const result = await consumeAgentGrant(c.env, body.grant, body.code_verifier);
+  // Atomic consume+mint: never burns a grant without issuing tokens.
+  const result = await exchangeAgentGrant(c.env, body.grant, body.code_verifier);
   if (!result.ok) {
     return c.json({ error: result.code, code: result.code }, statusFor(result.code));
   }
-  const tokens = await issueAgentTokens(c.env, result.identity);
-  return c.json(tokens);
+  return c.json(result.tokens);
 }
 
 /** Public refresh: `{ refresh_token }` → rotated access + refresh. */

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -957,10 +957,18 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         description:
           "Agent CLI bootstrap. Send a PKCE S256 code_challenge; receive a one-time, <=5 min grant bound to your authenticated agent identity, then exchange it (with your code_verifier) at POST /api/auth/agent/exchange for a short access token + a refresh token. Requires an authenticated agent session; humans/CI keep the browser/deploy-token login.",
         endpoint: { method: "POST", path: "/api/auth/agent/login" },
+        // RFC 057 manifest-action semantics (verified against slock 2cb55a4e rfcs/057).
+        authority: { principal: "agent_session" },
+        effect: "create",
+        idempotency: { mode: "non_idempotent" },
+        readback: { mode: "not_supported" },
+        rollback: { mode: "not_applicable" },
         parameters: {
-          code_challenge: { type: "string", in: "body", required: true, description: "base64url SHA-256 of a locally-generated high-entropy code_verifier." },
+          schema: { type: "string", in: "body", required: true, description: "Must be \"raft-cli-agent-login-request.v1\". Closed input: extension fields are rejected." },
+          code_challenge: { type: "string", in: "body", required: true, description: "Unpadded base64url SHA-256 (S256) of a locally-generated high-entropy code_verifier; must decode to exactly 32 bytes." },
           code_challenge_method: { type: "string", in: "body", required: true, description: "Must be \"S256\"." },
         },
+        returns: { schema: "raft-cli-agent-login-grant.v1", description: "One-time grant bound to the authenticated agent identity + challenge. expires_at is RFC3339 UTC, strictly future, and <=300s after this response." },
       },
       {
         name: "help",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -953,6 +953,16 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
     // returning provider credentials or interpreting raw attachments.
     actions: [
       {
+        name: "agent-login",
+        description:
+          "Agent CLI bootstrap. Send a PKCE S256 code_challenge; receive a one-time, <=5 min grant bound to your authenticated agent identity, then exchange it (with your code_verifier) at POST /api/auth/agent/exchange for a short access token + a refresh token. Requires an authenticated agent session; humans/CI keep the browser/deploy-token login.",
+        endpoint: { method: "POST", path: "/api/auth/agent/login" },
+        parameters: {
+          code_challenge: { type: "string", in: "body", required: true, description: "base64url SHA-256 of a locally-generated high-entropy code_verifier." },
+          code_challenge_method: { type: "string", in: "body", required: true, description: "Must be \"S256\"." },
+        },
+      },
+      {
         name: "help",
         description:
           "Start here — how to authenticate, what each action does, common crash/feedback flows, and docs links.",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -953,22 +953,24 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
     // returning provider credentials or interpreting raw attachments.
     actions: [
       {
+        // NOTE: kept as valid raft-agent-manifest.v0 (name/description/endpoint/parameters
+        // only). The RFC 057 action semantics (authority.principal=agent_session,
+        // effect=create, idempotency=non_idempotent, readback=not_supported,
+        // rollback=not_applicable) and the response schema are documented in prose here
+        // and ENFORCED by the handler; they are NOT structured fields because the landed
+        // v0 manifest parser ignores them (and rejects a non-{type} `returns`). A full
+        // v0→v1 manifest migration is tracked separately; until then CP3 strictly
+        // validates the invoke outer success + exact service/action + grant result schema
+        // client-side rather than relying on the manifest for output enforcement.
         name: "agent-login",
         description:
-          "Agent CLI bootstrap. Send a PKCE S256 code_challenge; receive a one-time, <=5 min grant bound to your authenticated agent identity, then exchange it (with your code_verifier) at POST /api/auth/agent/exchange for a short access token + a refresh token. Requires an authenticated agent session; humans/CI keep the browser/deploy-token login.",
+          "Agent CLI bootstrap (RFC 057). Send raft-cli-agent-login-request.v1 with a PKCE S256 code_challenge; receive a one-time, <=5 min raft-cli-agent-login-grant.v1 grant bound to your authenticated agent identity, then exchange it (with your code_verifier) at POST /api/auth/agent/exchange for a raft-cli-agent-session.v1 (short access token + rotating refresh). Non-idempotent create; no readback; not rollbackable. Requires an authenticated agent session; humans/CI keep the browser/deploy-token login.",
         endpoint: { method: "POST", path: "/api/auth/agent/login" },
-        // RFC 057 manifest-action semantics (verified against slock 2cb55a4e rfcs/057).
-        authority: { principal: "agent_session" },
-        effect: "create",
-        idempotency: { mode: "non_idempotent" },
-        readback: { mode: "not_supported" },
-        rollback: { mode: "not_applicable" },
         parameters: {
           schema: { type: "string", in: "body", required: true, description: "Must be \"raft-cli-agent-login-request.v1\". Closed input: extension fields are rejected." },
           code_challenge: { type: "string", in: "body", required: true, description: "Unpadded base64url SHA-256 (S256) of a locally-generated high-entropy code_verifier; must decode to exactly 32 bytes." },
           code_challenge_method: { type: "string", in: "body", required: true, description: "Must be \"S256\"." },
         },
-        returns: { schema: "raft-cli-agent-login-grant.v1", description: "One-time grant bound to the authenticated agent identity + challenge. expires_at is RFC3339 UTC, strictly future, and <=300s after this response." },
       },
       {
         name: "help",

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -930,11 +930,53 @@ export async function handleAgentHelp(c: Context<{ Bindings: Env }>) {
   });
 }
 
+/**
+ * `migration-help` action target. English guidance for agents/humans still calling
+ * the deprecated `raft integration invoke` actions: how to install the Hands CLI,
+ * authenticate once with `hands login`, and map each old action to its native command.
+ */
+export async function handleAgentMigrationHelp(c: Context<{ Bindings: Env }>) {
+  const origin = appOrigin(c);
+  c.header("Cache-Control", "no-store");
+  return c.json({
+    service: "hands",
+    summary:
+      "These `raft integration invoke` actions are deprecated. Install the Hands CLI and use its native commands; you authenticate once and subsequent commands use the Hands token directly.",
+    install: [
+      "npm install -g @botiverse/hands-cli",
+      "Then run `hands --help` for the full command list, or see the CLI reference below.",
+    ],
+    login: {
+      agents:
+        "Inside a managed Raft agent, run `hands login` — it detects the agent environment, exchanges a one-time grant via the `agent-login` action, stores a Hands token under $SLOCK_HOME, and auto-refreshes for later commands. No browser, no paste.",
+      humans:
+        "Run `hands login` (browser flow). The Hands token is stored at ~/.config/hands/auth.json (a legacy ~/.config/quiver/auth.json is migrated automatically on first use).",
+      ci: "Set HANDS_AUTH_TOKEN=<deploy token> and call `hands` directly.",
+    },
+    migration: [
+      "Replace `raft integration invoke --service hands-4cc7a2 --action <name>` with the matching `hands` command.",
+      "e.g. whoami → `hands whoami`; list-apps → `hands apps list`; list-feedback → `hands feedback list <app>`. Run `hands --help` for the complete mapping.",
+    ],
+    docs: {
+      cli_reference: `${origin}/docs/cli-reference`,
+      agent_guide: `${origin}/docs/agent-guide/`,
+    },
+  });
+}
+
 export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
   const origin = appOrigin(c);
   // Never edge-cache the manifest — the integration daemon must always see the
   // current action list (a stale cached copy makes schema changes invisible).
   c.header("Cache-Control", "no-store");
+  // Deprecation notice prepended to every EXISTING action (all but the two new ones):
+  // keep the machine contract unchanged, just point callers at `migration-help`.
+  const service = c.env.RAFT_CLIENT_ID || "hands-4cc7a2";
+  const DEPRECATION_PREFIX = `Deprecated — run raft integration invoke --service ${service} --action migration-help for Hands CLI installation and migration guidance. `;
+  const NEW_ACTIONS = new Set(["agent-login", "migration-help"]);
+  const applyDeprecation = (
+    list: Array<{ name: string; description: string; [k: string]: unknown }>,
+  ) => list.map((a) => (NEW_ACTIONS.has(a.name) ? a : { ...a, description: DEPRECATION_PREFIX + a.description }));
   return c.json({
     schema: "raft-agent-manifest.v0",
     service: c.env.RAFT_CLIENT_ID || "quiver",
@@ -951,7 +993,10 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
     // Paths are relative to execution.base_url. Actions cover release,
     // TestFlight/AppGallery, exact QA artifacts, and feedback triage without
     // returning provider credentials or interpreting raw attachments.
-    actions: [
+    // All EXISTING actions are retained with unchanged machine contracts; their
+    // descriptions are prefixed `Deprecated — … migration-help …` (see applyDeprecation).
+    // Only `agent-login` and `migration-help` are new and un-prefixed.
+    actions: applyDeprecation([
       {
         // NOTE: kept as valid raft-agent-manifest.v0 (name/description/endpoint/parameters
         // only). The RFC 057 action semantics (authority.principal=agent_session,
@@ -1820,6 +1865,13 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
           internal: { type: "boolean", in: "body", required: false, description: "true = staff-only internal note; omitted/false = visible to the reporter." },
         },
       },
-    ],
+      {
+        // New (un-prefixed): where deprecated actions point for CLI install + migration.
+        name: "migration-help",
+        description:
+          "How to install the Hands CLI, authenticate once (`hands login`), and migrate each deprecated action to its native `hands` command. Read this if you are still calling actions via `raft integration invoke`.",
+        endpoint: { method: "GET", path: "/api/agent/migration-help" },
+      },
+    ]),
   });
 }

--- a/worker/test/agent_login.test.ts
+++ b/worker/test/agent_login.test.ts
@@ -8,10 +8,10 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   issueAgentGrant,
   exchangeAgentGrant,
-  issueAgentTokens,
   rotateAgentRefresh,
   revokeAgentTokensForIdentity,
   isValidS256Challenge,
+  isValidCodeVerifier,
   sha256Base64Url,
   sha256Hex,
   type AgentLoginIdentity,
@@ -29,13 +29,13 @@ function makeDb() {
       grant_digest TEXT PRIMARY KEY, server_id TEXT NOT NULL, agent_id TEXT NOT NULL,
       account_id TEXT NOT NULL, integration TEXT NOT NULL, service TEXT NOT NULL,
       code_challenge TEXT NOT NULL, nonce TEXT NOT NULL, issued_at INTEGER NOT NULL,
-      expires_at INTEGER NOT NULL, consumed_at INTEGER
+      expires_at INTEGER NOT NULL, consumed_at INTEGER, consumed_by TEXT
     );
     CREATE TABLE agent_refresh_tokens (
       id TEXT PRIMARY KEY, token_hash TEXT NOT NULL UNIQUE, server_id TEXT NOT NULL,
       agent_id TEXT NOT NULL, account_id TEXT NOT NULL, integration TEXT NOT NULL,
       service TEXT NOT NULL, app_scope TEXT, created_at INTEGER NOT NULL,
-      expires_at INTEGER NOT NULL, rotated_from TEXT, revoked_at INTEGER
+      expires_at INTEGER NOT NULL, rotated_from TEXT, revoked_at INTEGER, revoked_by TEXT
     );
     CREATE TABLE raft_sessions (
       id TEXT PRIMARY KEY, account_id TEXT NOT NULL, token_hash TEXT NOT NULL,
@@ -93,10 +93,24 @@ const IDENTITY: AgentLoginIdentity = {
 };
 const T0 = 1_700_000_000_000;
 
+// RFC 7636 code_verifier: 43–128 chars from the unreserved set [A-Za-z0-9-._~].
+const VERIFIER = "test-verifier-0123456789-abcdefghijklmnopqrstuvwxyz_.~"; // 54 chars, valid
+// A different but still valid-format verifier for proof-mismatch tests.
+const WRONG_VERIFIER = "wrong-verifier-0123456789-abcdefghijklmnopqrstuvwxyz_.~"; // 55 chars, valid
+
 async function pkce() {
-  const verifier = "verifier-" + Math.abs(Math.sin(T0)).toString(36) + "-highentropy-fixed";
-  const challenge = await sha256Base64Url(verifier);
-  return { verifier, challenge };
+  const challenge = await sha256Base64Url(VERIFIER);
+  return { verifier: VERIFIER, challenge };
+}
+
+// Build initial tokens through the real grant→exchange path (the non-atomic bypass
+// issueAgentTokens/mintTokens was removed — tests must not fabricate token state).
+async function mintViaExchange(env: any, identity: AgentLoginIdentity, now: number) {
+  const { verifier, challenge } = await pkce();
+  const { grant } = await issueAgentGrant(env, identity, challenge, now);
+  const res = await exchangeAgentGrant(env, grant, verifier, now);
+  if (!res.ok) throw new Error("exchange failed: " + res.code);
+  return res.tokens;
 }
 
 describe("agent_login primitives", () => {
@@ -130,7 +144,7 @@ describe("agent_login primitives", () => {
   it("rejects a wrong verifier (grant_proof_mismatch) without burning the grant or minting", async () => {
     const { verifier, challenge } = await pkce();
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
-    const bad = await exchangeAgentGrant(env, grant, "wrong-verifier", T0 + 1000);
+    const bad = await exchangeAgentGrant(env, grant, WRONG_VERIFIER, T0 + 1000);
     expect(bad).toEqual({ ok: false, code: "grant_proof_mismatch" });
     // No tokens minted on a failed proof, and the grant is not burned.
     expect(await countRows("raft_sessions")).toBe(0);
@@ -158,7 +172,7 @@ describe("agent_login primitives", () => {
   });
 
   it("mints an access token backed by a raft_sessions row, plus a refresh token", async () => {
-    const tokens = await issueAgentTokens(env, IDENTITY, T0);
+    const tokens = await mintViaExchange(env, IDENTITY, T0);
     expect(tokens.access_expires_at).toBe(T0 + 15 * 60 * 1000);
     expect(tokens.refresh_expires_at).toBe(T0 + 30 * 24 * 60 * 60 * 1000);
     // Access token resolves via a session row keyed by its hex SHA-256.
@@ -186,7 +200,7 @@ describe("agent_login primitives", () => {
   });
 
   it("rotates a refresh token, and revokes the chain on reuse of a rotated token", async () => {
-    const first = await issueAgentTokens(env, IDENTITY, T0);
+    const first = await mintViaExchange(env, IDENTITY, T0);
     const rotated = await rotateAgentRefresh(env, first.refresh_token, T0 + 1000);
     expect(rotated.ok).toBe(true);
     // Reusing the now-rotated original must fail and revoke the identity's chain.
@@ -200,11 +214,59 @@ describe("agent_login primitives", () => {
   });
 
   it("revokes all live refresh tokens for an identity", async () => {
-    await issueAgentTokens(env, IDENTITY, T0);
-    const t2 = await issueAgentTokens(env, IDENTITY, T0 + 10);
+    await mintViaExchange(env, IDENTITY, T0);
+    const t2 = await mintViaExchange(env, IDENTITY, T0 + 10);
     const n = await revokeAgentTokensForIdentity(env, IDENTITY, T0 + 20);
     expect(n).toBeGreaterThanOrEqual(2);
     expect((await rotateAgentRefresh(env, t2.refresh_token, T0 + 30)).ok).toBe(false);
+  });
+
+  it("rejects a malformed code_verifier before proof check (RFC 7636)", async () => {
+    const { challenge } = await pkce();
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
+    // too short (< 43) — must be grant_invalid, and the grant is not burned.
+    const short = await exchangeAgentGrant(env, grant, "too-short", T0 + 1000);
+    expect(short).toEqual({ ok: false, code: "grant_invalid" });
+    expect(await countRows("agent_refresh_tokens")).toBe(0);
+    // illegal charset (space) at valid length — also grant_invalid.
+    const illegal = await exchangeAgentGrant(env, grant, "x".repeat(20) + " " + "y".repeat(30), T0 + 1000);
+    expect(illegal).toEqual({ ok: false, code: "grant_invalid" });
+    // the real verifier still works afterward (grant never burned by bad input).
+    expect((await exchangeAgentGrant(env, grant, VERIFIER, T0 + 2000)).ok).toBe(true);
+  });
+
+  it("rejects a grant bound to a different service (grant_binding_mismatch)", async () => {
+    const { verifier, challenge } = await pkce();
+    // Grant issued for a DIFFERENT client key than the current env RAFT_CLIENT_ID.
+    const otherIdentity = { ...IDENTITY, service: "hands-deadbe", integration: "hands-deadbe" };
+    const { grant } = await issueAgentGrant(env, otherIdentity, challenge, T0);
+    const res = await exchangeAgentGrant(env, grant, verifier, T0 + 1000);
+    expect(res).toEqual({ ok: false, code: "grant_binding_mismatch" });
+    expect(await countRows("agent_refresh_tokens")).toBe(0);
+  });
+
+  it("same-timestamp loser cannot mint: the consume UPDATE picks one winner", async () => {
+    // White-box guard test: the mint INSERT is gated on the unique consumed_by attempt
+    // id, NOT the timestamp — so a loser sharing the winner's exact `now` inserts nothing.
+    const { challenge } = await pkce();
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
+    const grantDigest = await sha256Base64Url(grant);
+    const now = T0 + 1000;
+    // Winner consumes with attempt "win".
+    await env.DB
+      .prepare("UPDATE agent_login_grants SET consumed_at = ?2, consumed_by = ?3 WHERE grant_digest = ?1 AND consumed_at IS NULL")
+      .bind(grantDigest, now, "win")
+      .run();
+    // Loser, SAME now, different attempt id, runs the guarded session INSERT.
+    const loser = await env.DB
+      .prepare(
+        `INSERT INTO raft_sessions (id, account_id, token_hash, created_at, expires_at, last_seen_at, revoked_at, raft_access_token_ciphertext)
+         SELECT ?1, ?2, ?3, ?4, ?5, ?4, NULL, NULL
+          WHERE (SELECT consumed_by FROM agent_login_grants WHERE grant_digest = ?6) = ?7`,
+      )
+      .bind("loser-session", "acct-1", "hash", now, now + 1, grantDigest, "lose")
+      .run();
+    expect(loser.meta.changes).toBe(0); // guard on attempt id, not the shared timestamp
   });
 });
 
@@ -313,6 +375,15 @@ describe("RFC 057 wire — session.v1 + challenge validation", () => {
     expect(isValidS256Challenge(challenge.slice(0, 42) + "=")).toBe(false); // padding rejected
   });
 
+  it("validates the RFC 7636 code_verifier (43–128 unreserved chars)", async () => {
+    expect(isValidCodeVerifier(VERIFIER)).toBe(true);
+    expect(isValidCodeVerifier("too-short")).toBe(false); // < 43
+    expect(isValidCodeVerifier("a".repeat(129))).toBe(false); // > 128
+    expect(isValidCodeVerifier("a".repeat(20) + " " + "b".repeat(30))).toBe(false); // space
+    expect(isValidCodeVerifier("a".repeat(20) + "+" + "b".repeat(30))).toBe(false); // '+' not unreserved
+    expect(isValidCodeVerifier(123 as any)).toBe(false); // non-string
+  });
+
   it("exchange handler returns raft-cli-agent-session.v1 (Bearer + RFC3339 expiries)", async () => {
     const env = makeEnv();
     const { verifier, challenge } = await pkce();
@@ -337,7 +408,7 @@ describe("RFC 057 wire — session.v1 + challenge validation", () => {
     const { challenge } = await pkce();
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge);
     const res = await handleAgentExchange(
-      fakeCtx({ env, body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: "wrong-verifier" } }),
+      fakeCtx({ env, body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: WRONG_VERIFIER } }),
     );
     expect(res.status).toBe(400);
     expect(((await res.json()) as any).code).toBe("grant_proof_mismatch");

--- a/worker/test/agent_login.test.ts
+++ b/worker/test/agent_login.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the agent CLI login primitives (RFC 057, Hands first instance).
+ * In-memory better-sqlite3 mimics D1's bind/run/first + meta.changes (same shim
+ * shape as routes.test.ts; `?N` numbered placeholders normalized to `?`).
+ */
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  issueAgentGrant,
+  consumeAgentGrant,
+  issueAgentTokens,
+  rotateAgentRefresh,
+  revokeAgentTokensForIdentity,
+  sha256Base64Url,
+  sha256Hex,
+  type AgentLoginIdentity,
+} from "../src/lib/agent_login";
+import { handleAgentLoginAction } from "../src/routes/agent_login";
+
+function makeDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(`
+    CREATE TABLE agent_login_grants (
+      grant_digest TEXT PRIMARY KEY, server_id TEXT NOT NULL, agent_id TEXT NOT NULL,
+      integration TEXT NOT NULL, service TEXT NOT NULL, code_challenge TEXT NOT NULL,
+      nonce TEXT NOT NULL, issued_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,
+      consumed_at INTEGER
+    );
+    CREATE TABLE agent_refresh_tokens (
+      id TEXT PRIMARY KEY, token_hash TEXT NOT NULL UNIQUE, server_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL, integration TEXT NOT NULL, service TEXT NOT NULL,
+      app_scope TEXT, created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,
+      rotated_from TEXT, revoked_at INTEGER
+    );
+    CREATE TABLE raft_sessions (
+      id TEXT PRIMARY KEY, account_id TEXT NOT NULL, token_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL, last_seen_at INTEGER,
+      revoked_at INTEGER, raft_access_token_ciphertext TEXT
+    );
+  `);
+  return {
+    _sqlite: sqlite,
+    prepare(sql: string) {
+      const indexSequence: number[] = [];
+      const normSql = sql.replace(/\?(\d+)/g, (_m, n) => {
+        indexSequence.push(Number(n));
+        return "?";
+      });
+      const stmt = sqlite.prepare(normSql);
+      const bind = (...params: any[]) => {
+        const expanded =
+          indexSequence.length > 0 ? indexSequence.map((n) => params[n - 1]) : params;
+        return {
+          run: async () => ({ success: true, meta: { changes: stmt.run(...expanded).changes } }),
+          all: async () => ({ results: stmt.all(...expanded), success: true }),
+          first: async () => (stmt.all(...expanded)[0] ?? null),
+        };
+      };
+      return { bind, run: () => bind().run(), all: () => bind().all(), first: () => bind().first() };
+    },
+  };
+}
+
+function makeEnv() {
+  return { DB: makeDb() as any, SIGNED_URL_SECRET: "test-secret", ENVIRONMENT: "development" } as any;
+}
+
+const IDENTITY: AgentLoginIdentity = {
+  server_id: "srv-A",
+  agent_id: "acct-1",
+  integration: "hands",
+  service: "hands",
+};
+const T0 = 1_700_000_000_000;
+
+async function pkce() {
+  const verifier = "verifier-" + Math.abs(Math.sin(T0)).toString(36) + "-highentropy-fixed";
+  const challenge = await sha256Base64Url(verifier);
+  return { verifier, challenge };
+}
+
+describe("agent_login primitives", () => {
+  let env: any;
+  beforeEach(() => {
+    env = makeEnv();
+  });
+
+  it("issues a grant and consumes it with the matching verifier", async () => {
+    const { verifier, challenge } = await pkce();
+    const { grant, expires_at } = await issueAgentGrant(env, IDENTITY, challenge, T0);
+    expect(expires_at).toBe(T0 + 5 * 60 * 1000);
+    const res = await consumeAgentGrant(env, grant, verifier, T0 + 1000);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.identity).toMatchObject({ server_id: "srv-A", agent_id: "acct-1", service: "hands" });
+  });
+
+  it("rejects a wrong verifier (grant_proof_mismatch) without burning the grant", async () => {
+    const { verifier, challenge } = await pkce();
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
+    const bad = await consumeAgentGrant(env, grant, "wrong-verifier", T0 + 1000);
+    expect(bad).toEqual({ ok: false, code: "grant_proof_mismatch" });
+    // Not burned: the legitimate verifier still works afterward.
+    const good = await consumeAgentGrant(env, grant, verifier, T0 + 2000);
+    expect(good.ok).toBe(true);
+  });
+
+  it("rejects an expired grant", async () => {
+    const { verifier, challenge } = await pkce();
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
+    const res = await consumeAgentGrant(env, grant, verifier, T0 + 6 * 60 * 1000);
+    expect(res).toEqual({ ok: false, code: "expired" });
+  });
+
+  it("is single-use: a second consume returns consumed", async () => {
+    const { verifier, challenge } = await pkce();
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
+    expect((await consumeAgentGrant(env, grant, verifier, T0 + 1000)).ok).toBe(true);
+    const again = await consumeAgentGrant(env, grant, verifier, T0 + 2000);
+    expect(again).toEqual({ ok: false, code: "consumed" });
+  });
+
+  it("mints an access token backed by a raft_sessions row, plus a refresh token", async () => {
+    const tokens = await issueAgentTokens(env, IDENTITY, T0);
+    expect(tokens.access_expires_at).toBe(T0 + 15 * 60 * 1000);
+    // Access token resolves via a session row keyed by its hex SHA-256.
+    const session = await env.DB
+      .prepare("SELECT account_id, expires_at FROM raft_sessions WHERE token_hash = ?1")
+      .bind(await sha256Hex(tokens.access_token))
+      .first();
+    expect(session).toMatchObject({ account_id: "acct-1", expires_at: T0 + 15 * 60 * 1000 });
+    const refreshRow = await env.DB
+      .prepare("SELECT agent_id FROM agent_refresh_tokens WHERE token_hash = ?1")
+      .bind(await sha256Base64Url(tokens.refresh_token))
+      .first();
+    expect(refreshRow).toMatchObject({ agent_id: "acct-1" });
+  });
+
+  it("rotates a refresh token, and revokes the chain on reuse of a rotated token", async () => {
+    const first = await issueAgentTokens(env, IDENTITY, T0);
+    const rotated = await rotateAgentRefresh(env, first.refresh_token, T0 + 1000);
+    expect(rotated.ok).toBe(true);
+    // Reusing the now-rotated original must fail and revoke the identity's chain.
+    const reuse = await rotateAgentRefresh(env, first.refresh_token, T0 + 2000);
+    expect(reuse).toEqual({ ok: false, code: "consumed" });
+    // The successor is revoked too (chain revoke).
+    if (rotated.ok) {
+      const successor = await rotateAgentRefresh(env, rotated.tokens.refresh_token, T0 + 3000);
+      expect(successor.ok).toBe(false);
+    }
+  });
+
+  it("revokes all live refresh tokens for an identity", async () => {
+    await issueAgentTokens(env, IDENTITY, T0);
+    const t2 = await issueAgentTokens(env, IDENTITY, T0 + 10);
+    const n = await revokeAgentTokensForIdentity(env, IDENTITY, T0 + 20);
+    expect(n).toBeGreaterThanOrEqual(2);
+    expect((await rotateAgentRefresh(env, t2.refresh_token, T0 + 30)).ok).toBe(false);
+  });
+});
+
+/** Minimal AdminContext stub exercising the handler's identity-binding teeth. */
+function fakeCtx(opts: { env: any; body?: any; vars?: Record<string, any> }): any {
+  const vars = opts.vars ?? {};
+  return {
+    env: opts.env,
+    get: (k: string) => vars[k],
+    req: { json: async () => opts.body },
+    json: (obj: any, status = 200) =>
+      new Response(JSON.stringify(obj), { status, headers: { "content-type": "application/json" } }),
+  };
+}
+
+describe("agent-login action — identity-binding teeth", () => {
+  it("binds the grant to the pre-org-switch authenticated account, never the x-hands-org-id-switched one", async () => {
+    const env = makeEnv();
+    const { challenge } = await pkce();
+    const res = await handleAgentLoginAction(
+      fakeCtx({
+        env,
+        body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
+        vars: {
+          // Server A authenticated; an x-hands-org-id switched admin_account to server B.
+          authenticated_account: { id: "acct-A", server_id: "srv-A", principal_type: "agent" },
+          admin_account: { id: "acct-B", server_id: "srv-B", principal_type: "agent" },
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const row = await env.DB
+      .prepare("SELECT server_id, agent_id FROM agent_login_grants LIMIT 1")
+      .first();
+    expect(row).toMatchObject({ server_id: "srv-A", agent_id: "acct-A" }); // NEVER srv-B/acct-B
+  });
+
+  it("rejects a human session (agent principal required)", async () => {
+    const { challenge } = await pkce();
+    const res = await handleAgentLoginAction(
+      fakeCtx({
+        env: makeEnv(),
+        body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
+        vars: { authenticated_account: { id: "h", server_id: "s", principal_type: "human" } },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("fails closed when authenticated_account is absent (e.g. deploy-token fallback)", async () => {
+    const { challenge } = await pkce();
+    const res = await handleAgentLoginAction(
+      fakeCtx({
+        env: makeEnv(),
+        body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
+        vars: {}, // no authenticated_account
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/worker/test/agent_login.test.ts
+++ b/worker/test/agent_login.test.ts
@@ -27,15 +27,15 @@ function makeDb() {
   sqlite.exec(`
     CREATE TABLE agent_login_grants (
       grant_digest TEXT PRIMARY KEY, server_id TEXT NOT NULL, agent_id TEXT NOT NULL,
-      integration TEXT NOT NULL, service TEXT NOT NULL, code_challenge TEXT NOT NULL,
-      nonce TEXT NOT NULL, issued_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,
-      consumed_at INTEGER
+      account_id TEXT NOT NULL, integration TEXT NOT NULL, service TEXT NOT NULL,
+      code_challenge TEXT NOT NULL, nonce TEXT NOT NULL, issued_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL, consumed_at INTEGER
     );
     CREATE TABLE agent_refresh_tokens (
       id TEXT PRIMARY KEY, token_hash TEXT NOT NULL UNIQUE, server_id TEXT NOT NULL,
-      agent_id TEXT NOT NULL, integration TEXT NOT NULL, service TEXT NOT NULL,
-      app_scope TEXT, created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,
-      rotated_from TEXT, revoked_at INTEGER
+      agent_id TEXT NOT NULL, account_id TEXT NOT NULL, integration TEXT NOT NULL,
+      service TEXT NOT NULL, app_scope TEXT, created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL, rotated_from TEXT, revoked_at INTEGER
     );
     CREATE TABLE raft_sessions (
       id TEXT PRIMARY KEY, account_id TEXT NOT NULL, token_hash TEXT NOT NULL,
@@ -86,9 +86,10 @@ function makeEnv() {
 
 const IDENTITY: AgentLoginIdentity = {
   server_id: "srv-A",
-  agent_id: "acct-1",
-  integration: "hands",
-  service: "hands",
+  agent_id: "raft-agent-1", // provider_subject (binding key)
+  account_id: "acct-1", // Hands account row (session subject)
+  integration: "hands-4cc7a2",
+  service: "hands-4cc7a2",
 };
 const T0 = 1_700_000_000_000;
 
@@ -166,16 +167,22 @@ describe("agent_login primitives", () => {
       .bind(await sha256Hex(tokens.access_token))
       .first();
     expect(session).toMatchObject({ account_id: "acct-1", expires_at: T0 + 15 * 60 * 1000 });
+    // Session subject is the Hands account_id, and the JWT `sub` matches it.
+    const sub = JSON.parse(
+      Buffer.from(tokens.access_token.split(".")[1] ?? "", "base64url").toString("utf8"),
+    ).sub;
+    expect(sub).toBe("acct-1");
     // jti unification: the JWT `jti` equals the raft_sessions row id (session ≡ token).
     const jti = JSON.parse(
       Buffer.from(tokens.access_token.split(".")[1] ?? "", "base64url").toString("utf8"),
     ).jti;
     expect(jti).toBe(session.id);
+    // Refresh binds to the Raft agent identity (provider_subject), not the account id.
     const refreshRow = await env.DB
-      .prepare("SELECT agent_id FROM agent_refresh_tokens WHERE token_hash = ?1")
+      .prepare("SELECT agent_id, account_id FROM agent_refresh_tokens WHERE token_hash = ?1")
       .bind(await sha256Base64Url(tokens.refresh_token))
       .first();
-    expect(refreshRow).toMatchObject({ agent_id: "acct-1" });
+    expect(refreshRow).toMatchObject({ agent_id: "raft-agent-1", account_id: "acct-1" });
   });
 
   it("rotates a refresh token, and revokes the chain on reuse of a rotated token", async () => {
@@ -223,16 +230,18 @@ describe("agent-login action — identity-binding teeth", () => {
         body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
         vars: {
           // Server A authenticated; an x-hands-org-id switched admin_account to server B.
-          authenticated_account: { id: "acct-A", server_id: "srv-A", principal_type: "agent" },
-          admin_account: { id: "acct-B", server_id: "srv-B", principal_type: "agent" },
+          authenticated_account: { id: "acct-A", provider_subject: "raft-agent-A", server_id: "srv-A", principal_type: "agent" },
+          admin_account: { id: "acct-B", provider_subject: "raft-agent-B", server_id: "srv-B", principal_type: "agent" },
         },
       }),
     );
     expect(res.status).toBe(200);
     const row = await env.DB
-      .prepare("SELECT server_id, agent_id, service, integration FROM agent_login_grants LIMIT 1")
+      .prepare("SELECT server_id, agent_id, account_id, service, integration FROM agent_login_grants LIMIT 1")
       .first();
-    expect(row).toMatchObject({ server_id: "srv-A", agent_id: "acct-A" }); // NEVER srv-B/acct-B
+    // XX-frozen split, bound to the PRE-org-switch account (never srv-B/acct-B):
+    //   agent_id = provider_subject, account_id = account row id.
+    expect(row).toMatchObject({ server_id: "srv-A", agent_id: "raft-agent-A", account_id: "acct-A" });
     // Grant binds to the exact installed client key, not the brand "hands".
     expect(row).toMatchObject({ service: "hands-4cc7a2", integration: "hands-4cc7a2" });
   });
@@ -245,7 +254,7 @@ describe("agent-login action — identity-binding teeth", () => {
       fakeCtx({
         env,
         body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
-        vars: { authenticated_account: { id: "a", server_id: "s", principal_type: "agent" } },
+        vars: { authenticated_account: { id: "a", provider_subject: "raft-agent-a", server_id: "s", principal_type: "agent" } },
       }),
     );
     expect(res.status).toBe(503);
@@ -340,5 +349,50 @@ describe("RFC 057 wire — session.v1 + challenge validation", () => {
     );
     expect(res.status).toBe(400);
     expect(((await res.json()) as any).code).toBe("invalid_schema");
+  });
+});
+
+describe("agent-login end-to-end (real handlers, XX-frozen identity split)", () => {
+  it("login → exchange → refresh: session subject = account_id, binding = provider_subject", async () => {
+    const env = makeEnv();
+    const { verifier, challenge } = await pkce();
+    const authed = { id: "acct-A", provider_subject: "raft-agent-A", server_id: "srv-A", principal_type: "agent" };
+
+    // 1) agent-login action issues a grant bound to the authed identity.
+    const loginRes = await handleAgentLoginAction(
+      fakeCtx({
+        env,
+        body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
+        vars: { authenticated_account: authed },
+      }),
+    );
+    expect(loginRes.status).toBe(200);
+    const grant = ((await loginRes.json()) as any).grant;
+    expect(typeof grant).toBe("string");
+
+    // 2) exchange → session.v1
+    const exRes = await handleAgentExchange(
+      fakeCtx({ env, body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier } }),
+    );
+    expect(exRes.status).toBe(200);
+    const session1 = (await exRes.json()) as any;
+    expect(session1.schema).toBe("raft-cli-agent-session.v1");
+
+    // 3) refresh → new session.v1, rotated refresh token
+    const rfRes = await handleAgentRefresh(
+      fakeCtx({ env, body: { schema: "raft-cli-agent-refresh.v1", refresh_token: session1.refresh_token } }),
+    );
+    expect(rfRes.status).toBe(200);
+    const session2 = (await rfRes.json()) as any;
+    expect(session2.schema).toBe("raft-cli-agent-session.v1");
+    expect(session2.refresh_token).not.toBe(session1.refresh_token);
+
+    // Identity split persisted across the whole chain:
+    //  - every access session's account_id = Hands account (acct-A)
+    //  - every refresh binds to the Raft agent identity (raft-agent-A)
+    const sessions = await env.DB.prepare("SELECT DISTINCT account_id FROM raft_sessions").all();
+    expect(sessions.results.map((r: any) => r.account_id)).toEqual(["acct-A"]);
+    const refreshes = await env.DB.prepare("SELECT DISTINCT agent_id, account_id FROM agent_refresh_tokens").all();
+    expect(refreshes.results).toEqual([{ agent_id: "raft-agent-A", account_id: "acct-A" }]);
   });
 });

--- a/worker/test/agent_login.test.ts
+++ b/worker/test/agent_login.test.ts
@@ -7,7 +7,7 @@ import Database from "better-sqlite3";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   issueAgentGrant,
-  consumeAgentGrant,
+  exchangeAgentGrant,
   issueAgentTokens,
   rotateAgentRefresh,
   revokeAgentTokensForIdentity,
@@ -51,12 +51,20 @@ function makeDb() {
         const expanded =
           indexSequence.length > 0 ? indexSequence.map((n) => params[n - 1]) : params;
         return {
+          // __exec is the synchronous run used inside batch()'s transaction.
+          __exec: () => ({ meta: { changes: stmt.run(...expanded).changes } }),
           run: async () => ({ success: true, meta: { changes: stmt.run(...expanded).changes } }),
           all: async () => ({ results: stmt.all(...expanded), success: true }),
           first: async () => (stmt.all(...expanded)[0] ?? null),
         };
       };
       return { bind, run: () => bind().run(), all: () => bind().all(), first: () => bind().first() };
+    },
+    // D1 batch: run all statements in one transaction, rolling back on any error
+    // (better-sqlite3 transaction()). Returns per-statement { meta: { changes } }.
+    batch(stmts: any[]) {
+      const txn = sqlite.transaction((ss: any[]) => ss.map((s) => s.__exec()));
+      return Promise.resolve(txn(stmts));
     },
   };
 }
@@ -85,49 +93,73 @@ describe("agent_login primitives", () => {
     env = makeEnv();
   });
 
-  it("issues a grant and consumes it with the matching verifier", async () => {
+  async function countRows(table: string): Promise<number> {
+    const r = await env.DB.prepare(`SELECT COUNT(*) AS n FROM ${table}`).first();
+    return Number(r.n);
+  }
+
+  it("exchanges a grant atomically: matching verifier → access + refresh + rows", async () => {
     const { verifier, challenge } = await pkce();
     const { grant, expires_at } = await issueAgentGrant(env, IDENTITY, challenge, T0);
     expect(expires_at).toBe(T0 + 5 * 60 * 1000);
-    const res = await consumeAgentGrant(env, grant, verifier, T0 + 1000);
+    const res = await exchangeAgentGrant(env, grant, verifier, T0 + 1000);
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.identity).toMatchObject({ server_id: "srv-A", agent_id: "acct-1", service: "hands" });
+    if (res.ok) {
+      expect(res.tokens.access_token).toBeTruthy();
+      expect(res.tokens.refresh_token).toBeTruthy();
+      expect(res.tokens.access_expires_at).toBe(T0 + 1000 + 15 * 60 * 1000);
+      expect(res.tokens.refresh_expires_at).toBe(T0 + 1000 + 30 * 24 * 60 * 60 * 1000);
+    }
+    // Atomic mint: exactly one session and one refresh row were created together.
+    expect(await countRows("raft_sessions")).toBe(1);
+    expect(await countRows("agent_refresh_tokens")).toBe(1);
   });
 
-  it("rejects a wrong verifier (grant_proof_mismatch) without burning the grant", async () => {
+  it("rejects a wrong verifier (grant_proof_mismatch) without burning the grant or minting", async () => {
     const { verifier, challenge } = await pkce();
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
-    const bad = await consumeAgentGrant(env, grant, "wrong-verifier", T0 + 1000);
+    const bad = await exchangeAgentGrant(env, grant, "wrong-verifier", T0 + 1000);
     expect(bad).toEqual({ ok: false, code: "grant_proof_mismatch" });
-    // Not burned: the legitimate verifier still works afterward.
-    const good = await consumeAgentGrant(env, grant, verifier, T0 + 2000);
+    // No tokens minted on a failed proof, and the grant is not burned.
+    expect(await countRows("raft_sessions")).toBe(0);
+    expect(await countRows("agent_refresh_tokens")).toBe(0);
+    const good = await exchangeAgentGrant(env, grant, verifier, T0 + 2000);
     expect(good.ok).toBe(true);
   });
 
   it("rejects an expired grant", async () => {
     const { verifier, challenge } = await pkce();
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
-    const res = await consumeAgentGrant(env, grant, verifier, T0 + 6 * 60 * 1000);
+    const res = await exchangeAgentGrant(env, grant, verifier, T0 + 6 * 60 * 1000);
     expect(res).toEqual({ ok: false, code: "expired" });
+    expect(await countRows("raft_sessions")).toBe(0);
   });
 
-  it("is single-use: a second consume returns consumed", async () => {
+  it("is single-use: a second exchange returns consumed and mints nothing extra", async () => {
     const { verifier, challenge } = await pkce();
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
-    expect((await consumeAgentGrant(env, grant, verifier, T0 + 1000)).ok).toBe(true);
-    const again = await consumeAgentGrant(env, grant, verifier, T0 + 2000);
+    expect((await exchangeAgentGrant(env, grant, verifier, T0 + 1000)).ok).toBe(true);
+    const again = await exchangeAgentGrant(env, grant, verifier, T0 + 2000);
     expect(again).toEqual({ ok: false, code: "consumed" });
+    expect(await countRows("raft_sessions")).toBe(1);
+    expect(await countRows("agent_refresh_tokens")).toBe(1);
   });
 
   it("mints an access token backed by a raft_sessions row, plus a refresh token", async () => {
     const tokens = await issueAgentTokens(env, IDENTITY, T0);
     expect(tokens.access_expires_at).toBe(T0 + 15 * 60 * 1000);
+    expect(tokens.refresh_expires_at).toBe(T0 + 30 * 24 * 60 * 60 * 1000);
     // Access token resolves via a session row keyed by its hex SHA-256.
     const session = await env.DB
-      .prepare("SELECT account_id, expires_at FROM raft_sessions WHERE token_hash = ?1")
+      .prepare("SELECT id, account_id, expires_at FROM raft_sessions WHERE token_hash = ?1")
       .bind(await sha256Hex(tokens.access_token))
       .first();
     expect(session).toMatchObject({ account_id: "acct-1", expires_at: T0 + 15 * 60 * 1000 });
+    // jti unification: the JWT `jti` equals the raft_sessions row id (session ≡ token).
+    const jti = JSON.parse(
+      Buffer.from(tokens.access_token.split(".")[1] ?? "", "base64url").toString("utf8"),
+    ).jti;
+    expect(jti).toBe(session.id);
     const refreshRow = await env.DB
       .prepare("SELECT agent_id FROM agent_refresh_tokens WHERE token_hash = ?1")
       .bind(await sha256Base64Url(tokens.refresh_token))

--- a/worker/test/agent_login.test.ts
+++ b/worker/test/agent_login.test.ts
@@ -11,11 +11,16 @@ import {
   issueAgentTokens,
   rotateAgentRefresh,
   revokeAgentTokensForIdentity,
+  isValidS256Challenge,
   sha256Base64Url,
   sha256Hex,
   type AgentLoginIdentity,
 } from "../src/lib/agent_login";
-import { handleAgentLoginAction } from "../src/routes/agent_login";
+import {
+  handleAgentLoginAction,
+  handleAgentExchange,
+  handleAgentRefresh,
+} from "../src/routes/agent_login";
 
 function makeDb() {
   const sqlite = new Database(":memory:");
@@ -131,7 +136,7 @@ describe("agent_login primitives", () => {
     const { verifier, challenge } = await pkce();
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
     const res = await exchangeAgentGrant(env, grant, verifier, T0 + 6 * 60 * 1000);
-    expect(res).toEqual({ ok: false, code: "expired" });
+    expect(res).toEqual({ ok: false, code: "grant_expired" });
     expect(await countRows("raft_sessions")).toBe(0);
   });
 
@@ -140,7 +145,7 @@ describe("agent_login primitives", () => {
     const { grant } = await issueAgentGrant(env, IDENTITY, challenge, T0);
     expect((await exchangeAgentGrant(env, grant, verifier, T0 + 1000)).ok).toBe(true);
     const again = await exchangeAgentGrant(env, grant, verifier, T0 + 2000);
-    expect(again).toEqual({ ok: false, code: "consumed" });
+    expect(again).toEqual({ ok: false, code: "grant_consumed" });
     expect(await countRows("raft_sessions")).toBe(1);
     expect(await countRows("agent_refresh_tokens")).toBe(1);
   });
@@ -173,7 +178,7 @@ describe("agent_login primitives", () => {
     expect(rotated.ok).toBe(true);
     // Reusing the now-rotated original must fail and revoke the identity's chain.
     const reuse = await rotateAgentRefresh(env, first.refresh_token, T0 + 2000);
-    expect(reuse).toEqual({ ok: false, code: "consumed" });
+    expect(reuse).toEqual({ ok: false, code: "refresh_reused" });
     // The successor is revoked too (chain revoke).
     if (rotated.ok) {
       const successor = await rotateAgentRefresh(env, rotated.tokens.refresh_token, T0 + 3000);
@@ -246,5 +251,72 @@ describe("agent-login action — identity-binding teeth", () => {
       }),
     );
     expect(res.status).toBe(401);
+  });
+
+  it("rejects extension fields on the login request (closed input)", async () => {
+    const { challenge } = await pkce();
+    const res = await handleAgentLoginAction(
+      fakeCtx({
+        env: makeEnv(),
+        body: {
+          schema: "raft-cli-agent-login-request.v1",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          extra: "nope",
+        },
+        vars: { authenticated_account: { id: "a", server_id: "s", principal_type: "agent" } },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).code).toBe("invalid_schema");
+  });
+});
+
+describe("RFC 057 wire — session.v1 + challenge validation", () => {
+  it("validates the S256 challenge: canonical 32-byte base64url only", async () => {
+    const { challenge } = await pkce();
+    expect(isValidS256Challenge(challenge)).toBe(true); // 43-char canonical
+    expect(isValidS256Challenge("short")).toBe(false); // decodes to < 32 bytes
+    expect(isValidS256Challenge(challenge + "A")).toBe(false); // 33 bytes → wrong length
+    expect(isValidS256Challenge("****" + challenge.slice(4))).toBe(false); // bad charset
+    expect(isValidS256Challenge(challenge.slice(0, 42) + "=")).toBe(false); // padding rejected
+  });
+
+  it("exchange handler returns raft-cli-agent-session.v1 (Bearer + RFC3339 expiries)", async () => {
+    const env = makeEnv();
+    const { verifier, challenge } = await pkce();
+    // Handler uses real Date.now(); issue the grant at real time so it isn't expired.
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge);
+    const res = await handleAgentExchange(
+      fakeCtx({ env, body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: verifier } }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.schema).toBe("raft-cli-agent-session.v1");
+    expect(json.token_type).toBe("Bearer");
+    expect(typeof json.access_token).toBe("string");
+    expect(typeof json.refresh_token).toBe("string");
+    // RFC3339 UTC timestamps, not epoch milliseconds.
+    expect(json.access_expires_at).toMatch(/^\d{4}-\d\d-\d\dT.*Z$/);
+    expect(json.refresh_expires_at).toMatch(/^\d{4}-\d\d-\d\dT.*Z$/);
+  });
+
+  it("exchange handler maps a bad verifier to grant_proof_mismatch (400)", async () => {
+    const env = makeEnv();
+    const { challenge } = await pkce();
+    const { grant } = await issueAgentGrant(env, IDENTITY, challenge);
+    const res = await handleAgentExchange(
+      fakeCtx({ env, body: { schema: "raft-cli-agent-login-exchange.v1", grant, code_verifier: "wrong-verifier" } }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).code).toBe("grant_proof_mismatch");
+  });
+
+  it("refresh handler requires the raft-cli-agent-refresh.v1 schema", async () => {
+    const res = await handleAgentRefresh(
+      fakeCtx({ env: makeEnv(), body: { refresh_token: "whatever" } }), // missing schema
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).code).toBe("invalid_schema");
   });
 });

--- a/worker/test/agent_login.test.ts
+++ b/worker/test/agent_login.test.ts
@@ -75,7 +75,13 @@ function makeDb() {
 }
 
 function makeEnv() {
-  return { DB: makeDb() as any, SIGNED_URL_SECRET: "test-secret", ENVIRONMENT: "development" } as any;
+  return {
+    DB: makeDb() as any,
+    SIGNED_URL_SECRET: "test-secret",
+    ENVIRONMENT: "development",
+    // The exact installed Raft client key (Argus live probe: hands-4cc7a2), NOT "hands".
+    RAFT_CLIENT_ID: "hands-4cc7a2",
+  } as any;
 }
 
 const IDENTITY: AgentLoginIdentity = {
@@ -224,9 +230,25 @@ describe("agent-login action — identity-binding teeth", () => {
     );
     expect(res.status).toBe(200);
     const row = await env.DB
-      .prepare("SELECT server_id, agent_id FROM agent_login_grants LIMIT 1")
+      .prepare("SELECT server_id, agent_id, service, integration FROM agent_login_grants LIMIT 1")
       .first();
     expect(row).toMatchObject({ server_id: "srv-A", agent_id: "acct-A" }); // NEVER srv-B/acct-B
+    // Grant binds to the exact installed client key, not the brand "hands".
+    expect(row).toMatchObject({ service: "hands-4cc7a2", integration: "hands-4cc7a2" });
+  });
+
+  it("fails closed (503) when RAFT_CLIENT_ID (exact service key) is unset", async () => {
+    const env = makeEnv();
+    delete (env as any).RAFT_CLIENT_ID;
+    const { challenge } = await pkce();
+    const res = await handleAgentLoginAction(
+      fakeCtx({
+        env,
+        body: { schema: "raft-cli-agent-login-request.v1", code_challenge: challenge, code_challenge_method: "S256" },
+        vars: { authenticated_account: { id: "a", server_id: "s", principal_type: "agent" } },
+      }),
+    );
+    expect(res.status).toBe(503);
   });
 
   it("rejects a human session (agent principal required)", async () => {

--- a/worker/test/agent_login_routes.test.ts
+++ b/worker/test/agent_login_routes.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Route-level tests for the agent-login action — they go through the REAL
+ * `authMiddleware` (session lookup, x-hands-org-id org switch, deploy-token branch)
+ * and `app.request`, not a Context stub. This is what proves the handler binds the
+ * grant to the pre-org-switch authenticated identity even when the middleware puts a
+ * different (org-switched) account in `admin_account`.
+ *
+ * Real migrations are applied so 0066 (grants/refresh with account_id) is exercised.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { authMiddleware } from "../src/middleware/auth";
+import { handleAgentLoginAction } from "../src/routes/agent_login";
+import { handleCreateAppDeployToken } from "../src/routes/deploy_tokens";
+import { sha256Base64Url, sha256Hex } from "../src/lib/agent_login";
+
+const MIGRATION_DIR = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+const VERIFIER = "test-verifier-0123456789-abcdefghijklmnopqrstuvwxyz_.~";
+
+/** D1 shim over better-sqlite3 with batch() (mirrors deploy_token_issuance.test.ts). */
+function d1(db: Database.Database) {
+  const prepare = (sql: string) => {
+    const indexes: number[] = [];
+    const normalized = sql.replace(/\?(\d+)/g, (_m, i) => { indexes.push(Number(i)); return "?"; });
+    const statement = db.prepare(normalized);
+    const bind = (...input: unknown[]) => {
+      const params = (indexes.length ? indexes.map((i) => input[i - 1]) : input)
+        .map((v) => (v === undefined ? null : v));
+      const execute = () => statement.reader
+        ? { results: statement.all(...params), success: true as const, meta: { changes: 0 } }
+        : { results: [], success: true as const, meta: { changes: statement.run(...params).changes } };
+      return {
+        _execute: execute,
+        run: async () => execute(),
+        all: async () => execute(),
+        first: async <T>() => (statement.get(...params) as T | undefined) ?? null,
+      };
+    };
+    return { bind, run: () => bind().run(), all: () => bind().all(), first: <T>() => bind().first<T>() };
+  };
+  return {
+    prepare,
+    batch: async (sts: { _execute: () => unknown }[]) =>
+      db.transaction(() => sts.map((s) => s._execute()))(),
+  };
+}
+
+function environment() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  for (const name of readdirSync(MIGRATION_DIR).sort()) {
+    if (name.endsWith(".sql")) sqlite.exec(readFileSync(`${MIGRATION_DIR}${name}`, "utf8"));
+  }
+  const env = {
+    DB: d1(sqlite),
+    RAFT_CLIENT_ID: "hands-4cc7a2",
+    SIGNED_URL_SECRET: "test-secret",
+    ENVIRONMENT: "production", // dev-token bypass OFF
+  } as unknown as Env;
+  return { sqlite, env };
+}
+
+function seedAccount(
+  sqlite: Database.Database,
+  a: { id: string; subject: string; serverId: string; principal: "agent" | "human" },
+) {
+  sqlite
+    .prepare(
+      `INSERT INTO raft_accounts
+         (id, provider, provider_subject, server_id, server_slug, principal_type,
+          server_role, username, display_name, avatar_url, raw_profile,
+          created_at, updated_at, last_login_at)
+       VALUES (?, 'raft', ?, ?, ?, ?, NULL, ?, ?, NULL, '{}', 1, 1, 1)`,
+    )
+    .run(a.id, a.subject, a.serverId, a.serverId, a.principal, a.id, a.id);
+}
+
+async function seedSession(sqlite: Database.Database, token: string, accountId: string) {
+  const hash = await sha256Hex(token);
+  sqlite
+    .prepare(
+      `INSERT INTO raft_sessions (id, account_id, token_hash, created_at, expires_at, last_seen_at)
+       VALUES (?, ?, ?, 1, 9999999999999, 1)`,
+    )
+    .run(`sess-${accountId}`, accountId, hash);
+}
+
+function app() {
+  const a = new Hono();
+  a.post("/api/auth/agent/login", authMiddleware as any, handleAgentLoginAction as any);
+  return a;
+}
+
+async function loginBody() {
+  return JSON.stringify({
+    schema: "raft-cli-agent-login-request.v1",
+    code_challenge: await sha256Base64Url(VERIFIER),
+    code_challenge_method: "S256",
+  });
+}
+
+describe("agent-login route (real authMiddleware)", () => {
+  it("binds the grant to the authenticated agent's provider_subject + account id", async () => {
+    const { sqlite, env } = environment();
+    seedAccount(sqlite, { id: "acctA", subject: "raftAgentA", serverId: "serverA", principal: "agent" });
+    await seedSession(sqlite, "token-A", "acctA");
+
+    const res = await app().request(
+      "/api/auth/agent/login",
+      { method: "POST", headers: { authorization: "Bearer token-A", "content-type": "application/json" }, body: await loginBody() },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const row = sqlite.prepare("SELECT server_id, agent_id, account_id, service FROM agent_login_grants LIMIT 1").get() as any;
+    expect(row).toMatchObject({
+      server_id: "serverA",
+      agent_id: "raftAgentA", // provider_subject
+      account_id: "acctA", // account row id
+      service: "hands-4cc7a2", // exact RAFT_CLIENT_ID, not brand
+    });
+  });
+
+  it("with x-hands-org-id switching admin_account to a linked org, still binds the PRE-switch account", async () => {
+    const { sqlite, env } = environment();
+    // Two accounts sharing the same provider_subject on different servers (the linked
+    // identity the org switch resolves to). Account B is a member of orgB.
+    seedAccount(sqlite, { id: "acctA", subject: "raftAgentX", serverId: "serverA", principal: "agent" });
+    seedAccount(sqlite, { id: "acctB", subject: "raftAgentX", serverId: "serverB", principal: "agent" });
+    sqlite.prepare(
+      `INSERT INTO organizations (id, slug, name, external_provider, external_id, archived, created_at)
+       VALUES ('orgB','orgb','Org B','raft','serverB',0,1)`,
+    ).run();
+    sqlite.prepare(
+      `INSERT INTO org_members (org_id, account_id, org_role, joined_at) VALUES ('orgB','acctB','admin',1)`,
+    ).run();
+    await seedSession(sqlite, "token-A", "acctA");
+
+    const res = await app().request(
+      "/api/auth/agent/login",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer token-A",
+          "x-hands-org-id": "orgB", // switches admin_account to acctB/serverB
+          "content-type": "application/json",
+        },
+        body: await loginBody(),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const row = sqlite.prepare("SELECT server_id, account_id FROM agent_login_grants LIMIT 1").get() as any;
+    // Bound to the AUTHENTICATED account (A/serverA), never the org-switched B/serverB.
+    expect(row).toMatchObject({ server_id: "serverA", account_id: "acctA" });
+  });
+
+  it("rejects a human session (403) — no grant issued", async () => {
+    const { sqlite, env } = environment();
+    seedAccount(sqlite, { id: "human1", subject: "raftHuman", serverId: "serverA", principal: "human" });
+    await seedSession(sqlite, "token-H", "human1");
+    const res = await app().request(
+      "/api/auth/agent/login",
+      { method: "POST", headers: { authorization: "Bearer token-H", "content-type": "application/json" }, body: await loginBody() },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect((sqlite.prepare("SELECT COUNT(*) AS n FROM agent_login_grants").get() as any).n).toBe(0);
+  });
+
+  it("rejects an unauthenticated request (401)", async () => {
+    const { env } = environment();
+    const res = await app().request(
+      "/api/auth/agent/login",
+      { method: "POST", headers: { "content-type": "application/json" }, body: await loginBody() },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("a deploy token cannot mint a grant (scoped → app-boundary 403; unscoped → no authenticated_account 401)", async () => {
+    const { sqlite, env } = environment();
+    // Seed an app + issue a real deploy token through the production issuance path.
+    sqlite.prepare(
+      `INSERT INTO organizations (id, slug, name, external_provider, external_id, archived, created_at)
+       VALUES ('org','org','Org','raft','serverA',0,1)`,
+    ).run();
+    sqlite.prepare(
+      `INSERT INTO apps (id, org_id, slug, name, platform, client_key, created_at)
+       VALUES ('app-a','org','app-a','App A','electron','ck',1)`,
+    ).run();
+    let issued: any;
+    await handleCreateAppDeployToken({
+      env,
+      req: { param: (n: string) => (n === "appId" ? "app-a" : ""), json: async () => ({ name: "ci", scopes: ["feedback:read"] }) },
+      json: (data: unknown, s = 200) => { issued = { status: s, data }; return new Response("{}"); },
+      get: () => undefined,
+    } as any);
+    expect(issued.status).toBe(201);
+    const deployToken = issued.data.token as string;
+
+    const res = await app().request(
+      "/api/auth/agent/login",
+      { method: "POST", headers: { authorization: `Bearer ${deployToken}`, "content-type": "application/json" }, body: await loginBody() },
+      env,
+    );
+    // A scoped token is blocked at the app-boundary (403) before reaching the action;
+    // an unscoped one would reach it but has no authenticated_account (401). Either way
+    // the deploy-token path can never mint an agent grant.
+    expect([401, 403]).toContain(res.status);
+    expect((sqlite.prepare("SELECT COUNT(*) AS n FROM agent_login_grants").get() as any).n).toBe(0);
+  });
+});

--- a/worker/test/agent_login_routes.test.ts
+++ b/worker/test/agent_login_routes.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
 import { authMiddleware } from "../src/middleware/auth";
 import { handleAgentLoginAction } from "../src/routes/agent_login";
+import { handleAgentManifest, handleAgentMigrationHelp } from "../src/routes/auth";
 import { handleCreateAppDeployToken } from "../src/routes/deploy_tokens";
 import { sha256Base64Url, sha256Hex } from "../src/lib/agent_login";
 
@@ -211,5 +212,34 @@ describe("agent-login route (real authMiddleware)", () => {
     // the deploy-token path can never mint an agent grant.
     expect([401, 403]).toContain(res.status);
     expect((sqlite.prepare("SELECT COUNT(*) AS n FROM agent_login_grants").get() as any).n).toBe(0);
+  });
+});
+
+describe("manifest: actions retained + deprecated, migration-help added", () => {
+  it("keeps existing actions, adds agent-login + migration-help, prefixes old actions", async () => {
+    const app = new Hono();
+    app.get("/.well-known/raft-agent-manifest.json", handleAgentManifest as any);
+    const res = await app.request("/.well-known/raft-agent-manifest.json", {}, { RAFT_CLIENT_ID: "hands-4cc7a2" } as any);
+    const body = (await res.json()) as any;
+    const names = body.actions.map((a: any) => a.name);
+    // existing actions retained + the two new ones present
+    for (const n of ["help", "whoami", "list-apps", "agent-login", "migration-help"]) expect(names).toContain(n);
+    const prefix = "Deprecated — run raft integration invoke --service hands-4cc7a2 --action migration-help";
+    // every OLD action is prefixed; the two NEW actions are not
+    expect(body.actions.find((a: any) => a.name === "help").description.startsWith(prefix)).toBe(true);
+    expect(body.actions.find((a: any) => a.name === "whoami").description.startsWith(prefix)).toBe(true);
+    expect(body.actions.find((a: any) => a.name === "agent-login").description.startsWith("Deprecated")).toBe(false);
+    expect(body.actions.find((a: any) => a.name === "migration-help").description.startsWith("Deprecated")).toBe(false);
+    // machine contract unchanged: help still GET /api/agent/help
+    expect(body.actions.find((a: any) => a.name === "help").endpoint).toEqual({ method: "GET", path: "/api/agent/help" });
+  });
+
+  it("migration-help endpoint returns install + login guidance", async () => {
+    const app = new Hono();
+    app.get("/api/agent/migration-help", handleAgentMigrationHelp as any);
+    const res = await app.request("/api/agent/migration-help", {}, {} as any);
+    const body = (await res.json()) as any;
+    expect(JSON.stringify(body.install)).toContain("@botiverse/hands-cli");
+    expect(body.login.agents).toMatch(/hands login/);
   });
 });


### PR DESCRIPTION
RFC 057 Hands CLI agent-login: a managed Raft agent runs `hands login` and gets a Hands session via a PKCE-proofed grant exchange, with auto-refreshing tokens — no browser, no pasted token.

## Server (CP2)
- Migration `0066_agent_login_tokens` (agent_login_grants + agent_refresh_tokens; account_id + attempt-id ownership `consumed_by`/`revoked_by`).
- `/api/auth/agent/{login,exchange,refresh}` — atomic exchange + fenced rotate; identity mapping frozen with XX (agent_id=provider_subject, account_id=id, service=RAFT_CLIENT_ID `hands-4cc7a2`).
- Manifest: `agent-login` + `migration-help` actions; old actions deprecation-prefixed.

## CLI (CP3)
- `hands login` agent path: env admission tri-state, compiled-fixed service, strict non-leaking invoke parse (closed envelope), PKCE, **independent** exchange (no old Bearer / no auto-refresh — the recovery path), strict-future session, hardened atomic store.
- Auto-refresh + cross-process single-flight: proactive + one-401; deadline covers full read + bounded body; `redirect:"manual"` on both token endpoints; lock broken only when owner PID is provably dead, under an **exclusive reaper fence** (acquire-under-fence, no auto-recovery of a leftover fence) so concurrent recoverers never double-rotate.
- Uniform agent-aware request (`agentAwareFetch`) across `apiRequest`/`apiUploadFile`/`hands api`; `whoami` no-creds hint → `hands login`.

## Review / tests
- Owner review GO (Volta) on `ce236f4`, iterated across CP2 + 4 CP3 rounds (concurrency/security hardening); Volta independently ran CLI **88/88** + tsc green, incl. a real two-process dead-lock-recovery race test (exactly one refresh).
- Remaining gates before merge: security review + PR Hosted + owner authorization. Signed-off-by added pre-merge (tree-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)