### PR TITLE
fix(agent-login): clock-skew tolerance on the grant TTL ceiling (real-login flake)

### DIFF
--- a/packages/cli/src/agent_login.test.ts
+++ b/packages/cli/src/agent_login.test.ts
@@ -140,10 +140,22 @@ describe("V4 strict, non-leaking invoke parse", () => {
     // invokeEnvelope(over) spreads `over` into `data`, so this adds a 5th data key.
     expect(() => parseAgentLoginInvoke(invokeEnvelope({ extra: "x" }), HANDS_SERVICE, T0)).toThrow(/data has unexpected fields/);
   });
-  it("validates expires_at: RFC3339, strictly future, <=300s", () => {
+  it("validates expires_at: RFC3339, strictly future, within the skew-tolerant ceiling", () => {
     expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: "nope" }), HANDS_SERVICE, T0)).toThrow(/RFC3339/);
+    // Non-canonical shapes a lenient Date.parse would accept are still rejected by the strict parser:
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 200_000).toISOString().replace("T", " ") }), HANDS_SERVICE, T0)).toThrow(/RFC3339/); // space instead of "T"
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 200_000).toISOString().replace(/(\.\d+)?Z$/, "") }), HANDS_SERVICE, T0)).toThrow(/RFC3339/); // no timezone
     expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 - 1000).toISOString() }), HANDS_SERVICE, T0)).toThrow(/already expired/);
-    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 400_000).toISOString() }), HANDS_SERVICE, T0)).toThrow(/300s/);
+    // A server-issued 300s grant parsed with the server clock slightly ahead (real skew)
+    // is ACCEPTED — no zero-tolerance flake at the exact boundary (the login bug this fixes).
+    expect(
+      parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 300_000 + 5_000).toISOString() }), HANDS_SERVICE, T0).expires_at,
+    ).toBeTruthy();
+    // Boundary is locked: exactly 300s + 120s skew is accepted, one ms over is rejected.
+    expect(
+      parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 420_000).toISOString() }), HANDS_SERVICE, T0).expires_at,
+    ).toBeTruthy();
+    expect(() => parseAgentLoginInvoke(invokeEnvelope({}, { expires_at: new Date(T0 + 420_001).toISOString() }), HANDS_SERVICE, T0)).toThrow(/ceiling/);
   });
   it("NEVER echoes raw stdout in error messages (no credential leak)", () => {
     const secret = "SECRET-grant-payload-should-not-appear";

--- a/packages/cli/src/lib/agent_auth.ts
+++ b/packages/cli/src/lib/agent_auth.ts
@@ -6,7 +6,10 @@
  *   2. Run the EXACT wrapper `$SLOCK_CLI_TRANSPORT_DIR/raft integration invoke
  *      --action agent-login --json` (never PATH `raft`); require exit 0; STRICTLY
  *      validate the result (outer success + exact service/action/status + closed grant
- *      result schema + RFC3339/future/<=300s expiry). Errors carry only stable reasons
+ *      result schema + RFC3339/future expiry within a bounded client sanity window). The
+ *      server issues a 300s TTL (RFC 057) and enforces the real expiry; the client accepts
+ *      up to 300s + clock-skew headroom so a boundary grant is not rejected under skew.
+ *      Errors carry only stable reasons
  *      — never the raw stdout/stderr/body (which could contain grant/action payload).
  *   3. Exchange { grant, code_verifier } at the Hands PUBLIC endpoint for a
  *      raft-cli-agent-session.v1; strictly validate it (closed keys + RFC3339 expiries).
@@ -49,6 +52,12 @@ function parseRfc3339(s: unknown): number | null {
   const t = Date.parse(s);
   return Number.isFinite(t) ? t : null;
 }
+
+// Client-side sanity ceiling on the grant lifetime: the server issues expiry =
+// server_now + 300s (RFC 057). We allow generous clock-skew headroom above that so a
+// legitimate grant is never rejected at the exact boundary; the server enforces the
+// real, shorter expiry, so this bound only rejects an absurdly long-lived grant.
+const AGENT_GRANT_TTL_CEILING_MS = 300_000 + 120_000; // 300s + 120s skew
 
 /**
  * Strictly validate a `raft integration invoke --action agent-login --json` result.
@@ -94,7 +103,10 @@ export function parseAgentLoginInvoke(
   const exp = parseRfc3339(result.expires_at);
   if (exp === null) throw new Error("agent-login: grant expires_at is not an RFC3339 timestamp");
   if (exp <= now) throw new Error("agent-login: grant is already expired");
-  if (exp > now + 300_000) throw new Error("agent-login: grant expiry exceeds the 300s ceiling");
+  // The server issues expiry = server_now + 300s (RFC 057). The client parses it later and
+  // its clock may differ, so a zero-tolerance ceiling flakes at the exact boundary. This is
+  // a sanity bound (the server enforces the real expiry), so allow clock-skew headroom.
+  if (exp > now + AGENT_GRANT_TTL_CEILING_MS) throw new Error("agent-login: grant expiry exceeds the ceiling");
   return { grant: result.grant, expires_at: result.expires_at };
 }
 


### PR DESCRIPTION
The real `hands login` e2e (agent mode, against the just-deployed hands-4cc7a2) caught an intermittent failure the controlled-`now` unit tests couldn't.

## Runtime receipt (honest sequence — NOT first-try)
1. **First real `hands login` FAILED:** `✘ Agent login failed: agent-login: grant expiry exceeds the 300s ceiling`.
2. Measured the real grant: `exp - client_now` jittered around the 300000 boundary across calls (observed 300284 and 299716) — the server issues `server_now + 300s` and clock skew crosses the boundary either way.
3. Applied the fix below.
4. **Re-ran → SUCCEEDED:** `✔ Agent login complete (service hands-4cc7a2)`; then `hands whoami` authenticated against https://hands.build and returned the agent account (Rhea Rafferty / @Hands-Rhea, server botiverse, org member).

## Root cause
The CLI rejected `exp > client_now + 300000` with **zero tolerance**. The 300s ceiling is a client sanity bound; the **server** enforces the real, shorter expiry (and atomic single-use at exchange).

## Fix (CLI only; server + migration 0066 unchanged)
Allow bounded clock-skew headroom: `exp > now + 300000 + 120000`. Does NOT extend the grant's real validity. Boundary locked by tests: 300s+120s exactly accepted, +1ms rejected; already-expired rejected; non-canonical RFC3339 rejected; exchange still adjudicated server-side.

CLI 88/88, tsc clean. Minimal diff vs landed main: 2 files (agent_auth.ts + agent_login.test.ts).

Signed-off-by: Rhea Rafferty <hands-rhea@mail.build>

🤖 Generated with [Claude Code](https://claude.com/claude-code)