### PR TITLE
chore(cli): bump to 0.5.16 to publish agent-login clock-skew fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",


### PR DESCRIPTION
## What

Bump `@botiverse/hands-cli` `0.5.15 → 0.5.16` so the agent-login clock-skew fix can be published to npm.

## Why

- #463 (*clock-skew tolerance on the grant TTL ceiling — real-login flake*) is merged to `main`, but npm still serves **0.5.15**, which **predates** the fix (0.5.15 was published for #457).
- `publish-cli.yml` requires `packages/cli/package.json` version to match the tag/dispatch input and to be a **new** (unpublished) version. 0.5.15 is already on npm, so a bump is required to ship the fix.

## Scope

- Version-only change to `packages/cli/package.json`. No code changes.
- `@botiverse/hands-node@0.1.0` dependency precondition already satisfied (published).

## Verification (this tree)

- `pnpm --filter @botiverse/hands-node build` + `pnpm --filter @botiverse/hands-cli build` — clean.
- `vitest run agent_login.test.ts agent_refresh.test.ts` — **47/47 pass** (skew-fix regression incl.).

## Publish (follow-up, gated)

After merge: trigger `publish-cli.yml` (tag `cli-v0.5.16` or `workflow_dispatch version=0.5.16`). Publish runs in GitHub Actions with `secrets.NPM_TOKEN` + OIDC trusted publishing — no local npm creds involved. Trigger is outward-facing/irreversible → will confirm with @artin at that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)