### PR TITLE
fix(cli): read --version from package.json so it can't drift (0.5.17)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,13 +31,21 @@ import { getConfig } from "./lib/config.js";
 import { readEnv } from "./lib/env.js";
 import { setApiBase } from "./lib/api.js";
 import { recordCliEvent } from "./lib/logging.js";
+import { createRequire } from "node:module";
+
+// Single source of truth for the CLI version: read it from package.json at runtime so
+// `--version` can never drift from the published package version. (Previously the string
+// was hardcoded here and had to be bumped in lockstep with package.json by hand.)
+const { version: CLI_VERSION } = createRequire(import.meta.url)(
+  "../package.json",
+) as { version: string };
 
 const program = new Command();
 
 program
   .name("hands")
   .description("Hands CLI — manage apps, builds, releases from the terminal.")
-  .version("0.5.15")
+  .version(CLI_VERSION)
   .option(
     "--api <url>",
     "Hands business API URL (default: https://hands.build or $HANDS_API)",


### PR DESCRIPTION
## What & why

`0.5.16` shipped with `hands --version` still printing **0.5.15**. The CLI version was **hardcoded** in `src/index.ts` (`.version("0.5.15")`) separately from `package.json`; the repo convention had been to bump both by hand (see #457), and the 0.5.16 bump updated only `package.json`. My miss — caught by running the actually-published artifact.

## Fix

- Read the version from `package.json` at runtime via `createRequire(import.meta.url)("../package.json")` and pass it to `.version(...)`, so `--version` can never drift from the published package version again.
- Bump `0.5.16 → 0.5.17`.

`createRequire` (not a static JSON import) is used deliberately: `tsconfig` has `rootDir: ./src`, so a static `import ... from "../package.json"` sits outside rootDir. The runtime require resolves `../package.json` from `dist/index.js` → package root in both dev and the published layout.

## Verification

- Packed the tarball, installed it **with deps** into a scratch project, ran the installed binary → `hands --version` prints **0.5.17** (real published layout).
- CLI suite **88/88**; `tsc` clean.

## Follow-up

After merge, publish `0.5.17` via `publish-cli.yml` (same gated flow as 0.5.16). The clock-skew fix is already live in 0.5.16; this only corrects the reported version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)