### PR TITLE
fix(admin): renew browser session in place instead of a rotting admin credential (task #6)

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -473,9 +473,11 @@ export interface Invite {
 
 // When the Worker reports SESSION_REAUTH_REQUIRED, the browser session's Raft
 // re-check credential rotted or expired (the ~1h Raft access token, or a key
-// change). Renew the whole browser session with one full-page Login-with-Raft:
-// if the user's Raft session is still alive this returns without interaction and
-// replaces the Hands session atomically; if it isn't, a real login is shown.
+// change). Renew it with one full-page Login-with-Raft: if the user's Raft session
+// is still alive this returns without interaction and the browser switches to the
+// new Hands session (the callback stores a fresh token); if it isn't, a real login
+// is shown. This is a client-side switch to a new session — it does not revoke the
+// old D1 session server-side (that row simply expires).
 const REAUTH_AT_KEY = "hands:admin-reauth-at";
 const REAUTH_MIN_INTERVAL_MS = 30_000;
 

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -471,6 +471,33 @@ export interface Invite {
   invite_url?: string;
 }
 
+// When the Worker reports SESSION_REAUTH_REQUIRED, the browser session's Raft
+// re-check credential rotted or expired (the ~1h Raft access token, or a key
+// change). Renew the whole browser session with one full-page Login-with-Raft:
+// if the user's Raft session is still alive this returns without interaction and
+// replaces the Hands session atomically; if it isn't, a real login is shown.
+const REAUTH_AT_KEY = "hands:admin-reauth-at";
+const REAUTH_MIN_INTERVAL_MS = 30_000;
+
+function triggerSessionReauth(): Promise<never> | null {
+  // Loop guard / single-flight: if we renewed moments ago and are still being told
+  // to, the renewal did not fix it (user removed from the server, or Raft not logged
+  // in so the redirect bounced straight back). Fall through to the normal error so
+  // the manual "Sign in again" page shows instead of redirect-looping.
+  try {
+    const last = Number(window.sessionStorage.getItem(REAUTH_AT_KEY) || 0);
+    if (Date.now() - last < REAUTH_MIN_INTERVAL_MS) return null;
+    window.sessionStorage.setItem(REAUTH_AT_KEY, String(Date.now()));
+  } catch {
+    return null; // no sessionStorage → don't risk a loop; show the manual page
+  }
+  clearAuthToken();
+  const back = window.location.pathname + window.location.search;
+  window.location.href = `/api/auth/login?return=${encodeURIComponent(back)}`;
+  // Navigation is underway; never resolve so callers don't flash an error first.
+  return new Promise<never>(() => {});
+}
+
 async function request<T>(
   path: string,
   init: RequestInit & { admin?: boolean } = {},
@@ -492,6 +519,15 @@ async function request<T>(
     // non-JSON body; leave as text
   }
   if (!res.ok) {
+    if (
+      res.status === 401 &&
+      typeof body === "object" &&
+      body &&
+      (body as any).code === "SESSION_REAUTH_REQUIRED"
+    ) {
+      const reauth = triggerSessionReauth();
+      if (reauth) return reauth as unknown as Promise<T>;
+    }
     const msg =
       typeof body === "object" && body && "error" in body
         ? String((body as any).error)

--- a/admin/src/lib/apiReauth.dom.test.ts
+++ b/admin/src/lib/apiReauth.dom.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// The shared request layer renews the browser session on SESSION_REAUTH_REQUIRED
+// (the admin console's "one layer, no half-session" fix). These tests lock the four
+// gates: it redirects only on that code, carries the return path, is single-flight /
+// loop-guarded, and never redirects on config errors or 403.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let hrefLog: string[] = [];
+
+function setLocation(pathname: string, search = "") {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      pathname,
+      search,
+      hash: "",
+      get href() {
+        return hrefLog[hrefLog.length - 1] ?? "";
+      },
+      set href(v: string) {
+        hrefLog.push(v);
+      },
+    },
+  });
+}
+
+function mockJson(status: number, body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } })),
+  );
+}
+
+// Fresh module per test so the module-load consumeAuthTokenFromUrl() and closures reset.
+async function loadApi() {
+  vi.resetModules();
+  return import("./api");
+}
+
+beforeEach(() => {
+  hrefLog = [];
+  setLocation("/admin", "?x=1");
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("SESSION_REAUTH_REQUIRED renewal (shared request layer)", () => {
+  it("redirects to Login with Raft carrying the current path as return", async () => {
+    const api = await loadApi();
+    mockJson(401, { error: "unauthorized", code: "SESSION_REAUTH_REQUIRED" });
+    // The renewal returns a never-resolving promise; assert the side effect instead.
+    void api.getHandsAdminOverview();
+    await vi.waitFor(() => expect(hrefLog.length).toBe(1));
+    expect(hrefLog[0]).toBe(`/api/auth/login?return=${encodeURIComponent("/admin?x=1")}`);
+  });
+
+  it("is single-flight / loop-guarded: a second SESSION_REAUTH_REQUIRED within the window does not redirect again, it errors", async () => {
+    const api = await loadApi();
+    mockJson(401, { error: "unauthorized", code: "SESSION_REAUTH_REQUIRED" });
+    void api.getHandsAdminOverview();
+    await vi.waitFor(() => expect(hrefLog.length).toBe(1));
+    // Second call, still SESSION_REAUTH_REQUIRED: the 30s guard blocks a re-redirect,
+    // so it surfaces the error (→ the manual "Sign in again" fallback) instead of looping.
+    await expect(api.getHandsAdminOverview()).rejects.toMatchObject({ status: 401 });
+    expect(hrefLog.length).toBe(1);
+  });
+
+  it("does NOT redirect on ADMIN_AUTH_UNAVAILABLE (server config, not a login problem)", async () => {
+    const api = await loadApi();
+    mockJson(401, { error: "unauthorized", code: "ADMIN_AUTH_UNAVAILABLE" });
+    await expect(api.getHandsAdminOverview()).rejects.toMatchObject({ status: 401 });
+    expect(hrefLog.length).toBe(0);
+  });
+
+  it("does NOT redirect on 403 (not an administrator)", async () => {
+    const api = await loadApi();
+    mockJson(403, { error: "forbidden", code: "HANDS_ADMIN_REQUIRED" });
+    await expect(api.getHandsAdminOverview()).rejects.toMatchObject({ status: 403 });
+    expect(hrefLog.length).toBe(0);
+  });
+
+  it("does NOT redirect on the legacy ADMIN_RELOGIN_REQUIRED (agent/no-credential — never browser-renew)", async () => {
+    const api = await loadApi();
+    mockJson(401, { error: "unauthorized", code: "ADMIN_RELOGIN_REQUIRED" });
+    await expect(api.getHandsAdminOverview()).rejects.toMatchObject({ status: 401 });
+    expect(hrefLog.length).toBe(0);
+  });
+});

--- a/admin/src/lib/apiReauth.dom.test.ts
+++ b/admin/src/lib/apiReauth.dom.test.ts
@@ -81,6 +81,13 @@ describe("SESSION_REAUTH_REQUIRED renewal (shared request layer)", () => {
     expect(hrefLog.length).toBe(0);
   });
 
+  it("does NOT redirect on 503 ADMIN_VERIFICATION_UNAVAILABLE (transient Raft outage — retry, not re-login)", async () => {
+    const api = await loadApi();
+    mockJson(503, { error: "unavailable", code: "ADMIN_VERIFICATION_UNAVAILABLE" });
+    await expect(api.getHandsAdminOverview()).rejects.toMatchObject({ status: 503 });
+    expect(hrefLog.length).toBe(0);
+  });
+
   it("does NOT redirect on the legacy ADMIN_RELOGIN_REQUIRED (agent/no-credential — never browser-renew)", async () => {
     const api = await loadApi();
     mockJson(401, { error: "unauthorized", code: "ADMIN_RELOGIN_REQUIRED" });

--- a/admin/src/pages/HandsAdmin.tsx
+++ b/admin/src/pages/HandsAdmin.tsx
@@ -26,7 +26,16 @@ export function HandsAdmin() {
   const overview = useQuery({ queryKey: ["hands-admin", "overview"], queryFn: getHandsAdminOverview, retry: false });
   if (overview.isPending) return <main className="p-8 text-sm text-slate-500">Loading observability…</main>;
   if (overview.error instanceof ApiError && overview.error.status === 401) {
-    return <main className="p-8"><h1 className="text-xl font-semibold">Sign in again</h1><p className="mt-2 text-sm text-slate-600">A fresh Raft session is required for live administrator verification.</p><a className="mt-4 inline-block text-sky-700" href="/api/auth/login?return=%2Fadmin">Continue with Raft</a></main>;
+    const code = (overview.error.body as { code?: string } | null)?.code;
+    if (code === "ADMIN_AUTH_UNAVAILABLE") {
+      // Server-side configuration problem (missing secret / Raft origin). Re-login
+      // cannot fix it — do not send the operator into a login loop.
+      return <main className="p-8"><h1 className="text-xl font-semibold">Admin verification unavailable</h1><p className="mt-2 text-sm text-slate-600">Live administrator verification is temporarily unavailable because of a server configuration issue. This is not a login problem — please contact an operator.</p></main>;
+    }
+    // SESSION_REAUTH_REQUIRED is normally renewed in the API layer before it reaches
+    // here; this manual page is the fallback when the loop guard tripped (Raft not
+    // logged in, or the user is no longer a member of the server).
+    return <main className="p-8"><h1 className="text-xl font-semibold">Sign in again</h1><p className="mt-2 text-sm text-slate-600">Your administrator session needs a fresh Raft sign-in.</p><a className="mt-4 inline-block text-sky-700" href="/api/auth/login?return=%2Fadmin">Continue with Raft</a></main>;
   }
   if (overview.error instanceof ApiError && overview.error.status === 403) {
     return <main className="p-8"><h1 className="text-xl font-semibold">Administrator access required</h1><p className="mt-2 text-sm text-slate-600">This page is limited to administrators of an approved Raft server.</p></main>;

--- a/worker/src/middleware/hands_admin.ts
+++ b/worker/src/middleware/hands_admin.ts
@@ -34,7 +34,18 @@ export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> 
       LIMIT 1`,
   ).bind(await sha256Hex(sessionToken), account.id, Date.now())
     .first<{ raft_access_token_ciphertext: string | null }>();
-  if (!session?.raft_access_token_ciphertext) return deny(c, 401, "ADMIN_RELOGIN_REQUIRED");
+  if (!session?.raft_access_token_ciphertext) {
+    // A human browser session with no stored Raft credential (a legacy session, or
+    // one from before the credential was captured) is recoverable by renewing the
+    // browser session — a fresh Login-with-Raft stores one. An agent/CLI session
+    // legitimately never has this credential and must NOT be sent through a browser
+    // re-auth; it just cannot use the admin console.
+    return deny(
+      c,
+      401,
+      account.principal_type === "agent" ? "ADMIN_RELOGIN_REQUIRED" : "SESSION_REAUTH_REQUIRED",
+    );
+  }
 
   const secret = c.env.SIGNED_URL_SECRET || c.env.RAFT_CLIENT_SECRET;
   if (!secret || !c.env.RAFT_API_ORIGIN) return deny(c, 401, "ADMIN_AUTH_UNAVAILABLE");

--- a/worker/src/middleware/hands_admin.ts
+++ b/worker/src/middleware/hands_admin.ts
@@ -14,8 +14,9 @@ type LiveRaftUser = {
   server_role?: string;
 };
 
-function deny(c: Context, status: 401 | 403, code: string) {
-  return c.json({ error: status === 401 ? "unauthorized" : "forbidden", code }, status);
+function deny(c: Context, status: 401 | 403 | 503, code: string) {
+  const error = status === 401 ? "unauthorized" : status === 403 ? "forbidden" : "unavailable";
+  return c.json({ error, code }, status);
 }
 
 export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> = async (c, next) => {
@@ -64,12 +65,21 @@ export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> 
   const response = await fetch(new URL("/api/oauth/userinfo", c.env.RAFT_API_ORIGIN), {
     headers: { authorization: `Bearer ${accessToken}` },
   });
-  // Raft rejects an expired token (the ~1h access token) — and also a user removed
-  // from the server. Both are recoverable by a browser session renewal: a valid user
-  // gets a fresh token and continues; a removed user gets a fresh token whose userinfo
-  // still fails, so the frontend's loop guard falls back to the manual page (still
-  // denied — role revocation stays immediate).
-  if (!response.ok) return deny(c, 401, "SESSION_REAUTH_REQUIRED");
+  // Distinguish WHY Raft refused — three different world states must not collapse into
+  // one reading, or transient outages and permission denials drag normal users into
+  // repeated logins:
+  //   401 — token invalid/expired (or the user was removed): recoverable by a browser
+  //         session renewal (a valid user continues; a removed user's renewed token
+  //         still fails userinfo, so the frontend loop guard falls back to the manual
+  //         page — still denied, role revocation stays immediate).
+  //   403 — a permission decision: not a login problem, do not renew.
+  //   429 / 5xx / anything else — a transient Raft outage: re-login would not help and
+  //         retrying worsens rate-limiting, so surface "temporarily unavailable".
+  if (!response.ok) {
+    if (response.status === 401) return deny(c, 401, "SESSION_REAUTH_REQUIRED");
+    if (response.status === 403) return deny(c, 403, "HANDS_ADMIN_REQUIRED");
+    return deny(c, 503, "ADMIN_VERIFICATION_UNAVAILABLE");
+  }
 
   const live = await response.json<LiveRaftUser>();
   const allowedServers = (c.env.HANDS_ADMIN_ALLOWED_SERVER_IDS || "")

--- a/worker/src/middleware/hands_admin.ts
+++ b/worker/src/middleware/hands_admin.ts
@@ -43,12 +43,22 @@ export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> 
   try {
     accessToken = await decryptAdminRaftToken(secret, session.raft_access_token_ciphertext);
   } catch {
-    return deny(c, 401, "ADMIN_RELOGIN_REQUIRED");
+    // A non-NULL ciphertext that won't decrypt is a browser session whose Raft
+    // credential rotted (e.g. the encryption key changed). It is recoverable by
+    // renewing the browser session (a fresh Login-with-Raft re-encrypts with the
+    // current key) — signal that, not the generic relogin. Agent/API sessions hit
+    // the NULL-ciphertext branch above and are never told to re-auth.
+    return deny(c, 401, "SESSION_REAUTH_REQUIRED");
   }
   const response = await fetch(new URL("/api/oauth/userinfo", c.env.RAFT_API_ORIGIN), {
     headers: { authorization: `Bearer ${accessToken}` },
   });
-  if (!response.ok) return deny(c, 401, "AUTH_EXPIRED");
+  // Raft rejects an expired token (the ~1h access token) — and also a user removed
+  // from the server. Both are recoverable by a browser session renewal: a valid user
+  // gets a fresh token and continues; a removed user gets a fresh token whose userinfo
+  // still fails, so the frontend's loop guard falls back to the manual page (still
+  // denied — role revocation stays immediate).
+  if (!response.ok) return deny(c, 401, "SESSION_REAUTH_REQUIRED");
 
   const live = await response.json<LiveRaftUser>();
   const allowedServers = (c.env.HANDS_ADMIN_ALLOWED_SERVER_IDS || "")

--- a/worker/test/hands_admin_access.test.ts
+++ b/worker/test/hands_admin_access.test.ts
@@ -21,7 +21,7 @@ async function request(
   role: string,
   serverId = "server-allowed",
   ciphertext?: string | null,
-  opts: { userinfoOk?: boolean; secret?: string | null } = {},
+  opts: { userinfoOk?: boolean; secret?: string | null; principalType?: "human" | "agent" } = {},
 ) {
   const secret = "test-secret";
   const encrypted = ciphertext === undefined ? await encryptAdminRaftToken(secret, "raft-token") : ciphertext;
@@ -33,7 +33,10 @@ async function request(
     { status: userinfoOk ? 200 : 401, headers: { "content-type": "application/json" } },
   )));
   const app = new Hono<any>();
-  app.use("*", async (c, next) => { c.set("admin_account", account); await next(); });
+  app.use("*", async (c, next) => {
+    c.set("admin_account", { ...account, principal_type: opts.principalType ?? account.principal_type });
+    await next();
+  });
   app.use("/admin/*", requireHandsAdmin);
   app.get("/admin/overview", (c) => c.json({ ok: true }));
   const env = {
@@ -51,8 +54,14 @@ describe("requireHandsAdmin", () => {
   it.each(["member", "viewer"])("denies live server role %s before the handler", async (role) => expect((await request(role)).status).toBe(403));
   it("denies another Raft server", async () => expect((await request("admin", "other-server")).status).toBe(403));
   it("requires a fresh login for sessions without a live Raft credential", async () => expect((await request("admin", "server-allowed", null)).status).toBe(401));
-  it("does NOT tell a no-credential session to re-auth (agent-safe: NULL ciphertext is legitimate for agent sessions)", async () => {
-    const res = await request("admin", "server-allowed", null);
+  it("renews a HUMAN browser session with no stored credential (legacy/missing-ciphertext — the current lock-out shape)", async () => {
+    const res = await request("admin", "server-allowed", null, { principalType: "human" });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized", code: "SESSION_REAUTH_REQUIRED" });
+  });
+  it("does NOT tell an AGENT/CLI session to re-auth (NULL ciphertext is legitimate for agents — never browser-renew)", async () => {
+    const res = await request("admin", "server-allowed", null, { principalType: "agent" });
+    expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "unauthorized", code: "ADMIN_RELOGIN_REQUIRED" });
   });
   it("renews the browser session when the stored credential can't be decrypted (key rotated)", async () => {

--- a/worker/test/hands_admin_access.test.ts
+++ b/worker/test/hands_admin_access.test.ts
@@ -21,16 +21,17 @@ async function request(
   role: string,
   serverId = "server-allowed",
   ciphertext?: string | null,
-  opts: { userinfoOk?: boolean; secret?: string | null; principalType?: "human" | "agent" } = {},
+  opts: { userinfoOk?: boolean; userinfoStatus?: number; secret?: string | null; principalType?: "human" | "agent" } = {},
 ) {
   const secret = "test-secret";
   const encrypted = ciphertext === undefined ? await encryptAdminRaftToken(secret, "raft-token") : ciphertext;
-  const userinfoOk = opts.userinfoOk !== false;
+  const userinfoStatus = opts.userinfoStatus ?? (opts.userinfoOk === false ? 401 : 200);
+  const userinfoOk = userinfoStatus >= 200 && userinfoStatus < 300;
   vi.stubGlobal("fetch", vi.fn(async () => new Response(
     userinfoOk
       ? JSON.stringify({ sub: account.provider_subject, server_id: serverId, server_role: role })
-      : "unauthorized",
-    { status: userinfoOk ? 200 : 401, headers: { "content-type": "application/json" } },
+      : "error",
+    { status: userinfoStatus, headers: { "content-type": "application/json" } },
   )));
   const app = new Hono<any>();
   app.use("*", async (c, next) => {
@@ -74,6 +75,16 @@ describe("requireHandsAdmin", () => {
     const res = await request("admin", "server-allowed", undefined, { userinfoOk: false });
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "unauthorized", code: "SESSION_REAUTH_REQUIRED" });
+  });
+  it("does NOT renew on a Raft 403 (permission decision, not a login problem) — maps to admin-required", async () => {
+    const res = await request("admin", "server-allowed", undefined, { userinfoStatus: 403 });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "forbidden", code: "HANDS_ADMIN_REQUIRED" });
+  });
+  it.each([429, 500, 502, 503])("does NOT renew on a transient Raft %i — surfaces verification-unavailable, not re-login", async (status) => {
+    const res = await request("admin", "server-allowed", undefined, { userinfoStatus: status });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "unavailable", code: "ADMIN_VERIFICATION_UNAVAILABLE" });
   });
   it("reports config-unavailable (not a re-login) when the admin secret is missing", async () => {
     const res = await request("admin", "server-allowed", "irrelevant-ciphertext", { secret: null });

--- a/worker/test/hands_admin_access.test.ts
+++ b/worker/test/hands_admin_access.test.ts
@@ -17,18 +17,29 @@ function database(ciphertext: string | null) {
   } as unknown as D1Database;
 }
 
-async function request(role: string, serverId = "server-allowed", ciphertext?: string | null) {
+async function request(
+  role: string,
+  serverId = "server-allowed",
+  ciphertext?: string | null,
+  opts: { userinfoOk?: boolean; secret?: string | null } = {},
+) {
   const secret = "test-secret";
   const encrypted = ciphertext === undefined ? await encryptAdminRaftToken(secret, "raft-token") : ciphertext;
-  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
-    sub: account.provider_subject, server_id: serverId, server_role: role,
-  }), { headers: { "content-type": "application/json" } })));
+  const userinfoOk = opts.userinfoOk !== false;
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(
+    userinfoOk
+      ? JSON.stringify({ sub: account.provider_subject, server_id: serverId, server_role: role })
+      : "unauthorized",
+    { status: userinfoOk ? 200 : 401, headers: { "content-type": "application/json" } },
+  )));
   const app = new Hono<any>();
   app.use("*", async (c, next) => { c.set("admin_account", account); await next(); });
   app.use("/admin/*", requireHandsAdmin);
   app.get("/admin/overview", (c) => c.json({ ok: true }));
   const env = {
-    DB: database(encrypted), SIGNED_URL_SECRET: secret, RAFT_API_ORIGIN: "https://api.raft.build",
+    DB: database(encrypted),
+    SIGNED_URL_SECRET: opts.secret === undefined ? secret : (opts.secret ?? undefined),
+    RAFT_API_ORIGIN: "https://api.raft.build",
     HANDS_ADMIN_ALLOWED_SERVER_IDS: "server-allowed",
   } as unknown as Env;
   return app.request("https://app.hands.build/admin/overview", { headers: { authorization: "Bearer hands-session" } }, env);
@@ -40,6 +51,26 @@ describe("requireHandsAdmin", () => {
   it.each(["member", "viewer"])("denies live server role %s before the handler", async (role) => expect((await request(role)).status).toBe(403));
   it("denies another Raft server", async () => expect((await request("admin", "other-server")).status).toBe(403));
   it("requires a fresh login for sessions without a live Raft credential", async () => expect((await request("admin", "server-allowed", null)).status).toBe(401));
+  it("does NOT tell a no-credential session to re-auth (agent-safe: NULL ciphertext is legitimate for agent sessions)", async () => {
+    const res = await request("admin", "server-allowed", null);
+    expect(await res.json()).toEqual({ error: "unauthorized", code: "ADMIN_RELOGIN_REQUIRED" });
+  });
+  it("renews the browser session when the stored credential can't be decrypted (key rotated)", async () => {
+    const wrongKey = await encryptAdminRaftToken("rotated-secret", "raft-token");
+    const res = await request("admin", "server-allowed", wrongKey);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized", code: "SESSION_REAUTH_REQUIRED" });
+  });
+  it("renews the browser session when Raft rejects the token (expired, or member removed)", async () => {
+    const res = await request("admin", "server-allowed", undefined, { userinfoOk: false });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized", code: "SESSION_REAUTH_REQUIRED" });
+  });
+  it("reports config-unavailable (not a re-login) when the admin secret is missing", async () => {
+    const res = await request("admin", "server-allowed", "irrelevant-ciphertext", { secret: null });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized", code: "ADMIN_AUTH_UNAVAILABLE" });
+  });
   it("does not confuse app admin role with Raft server admin role", async () => {
     // The stored account is an org/app admin, but live Raft says only member.
     const response = await request("member");


### PR DESCRIPTION
## Problem (task #6 — admin 401, `ADMIN_RELOGIN_REQUIRED`)

The admin console does a live Raft role re-check by storing the user's Raft access token (`raft_access_token_ciphertext`) on the session and calling `/api/oauth/userinfo` each request. That credential **rots independently** of the 14-day Hands session: Raft's token lives ~1h and issues **no `refresh_token`**, and a `SIGNED_URL_SECRET` rotation makes the ciphertext undecryptable. Result: the outer session stays valid (app pages work) while `/admin` 401s forever — "logged in but can't enter admin" — and the SPA collapsed six distinct 401 codes into one misleading "sign in again".

## Design (confirmed against the Raft OAuth contract)

Raft's token response is `{access_token, token_type, expires_in:3600}` — **no refresh_token** (D0 out); `server_role` comes only from user-token-scoped userinfo/serverinfo — **no service-credential role endpoint** (D2 out). So the fix is **in-place browser-session renewal** (Yaoheng's refined option 3 / Argus's silent re-auth): when the credential rots, renew the whole session with one full-page Login-with-Raft, which is seamless while the user's Raft session is alive.

## Changes

- **`worker/src/middleware/hands_admin.ts`** — return `SESSION_REAUTH_REQUIRED` for the browser-recoverable failures (ciphertext won't decrypt = key rotated; Raft rejects the token = expired/member-removed). The **NULL-ciphertext branch stays `ADMIN_RELOGIN_REQUIRED`** so agent/API sessions (for which NULL is legitimate) are never told to re-auth.
- **`admin/src/lib/api.ts`** — on `SESSION_REAUTH_REQUIRED` the shared request layer does one full-page renewal (`/api/auth/login?return=<path>`) that atomically replaces the browser session. **Single-flight + 30s loop guard**: a renewal that comes back still-failing (Raft not logged in, or user removed) falls through to the manual page instead of redirect-looping.
- **`admin/src/pages/HandsAdmin.tsx`** — distinguish `ADMIN_AUTH_UNAVAILABLE` (server config → contact ops, no login) from the recoverable re-login fallback.

## Gates (Yaoheng's acceptance)

1. Only browser sessions renew; agent/API never redirect (SPA is browser-only; NULL-ciphertext stays a non-reauth code). ✅
2. Single-flight + loop guard. ✅
3. Config/403 never re-login. ✅
4. Renew → `/admin` 200 and per-request live role revocation still immediate (existing owner/admin→200, member/viewer→403 tests). ✅

## Verification

- `worker/test/hands_admin_access.test.ts` **+4** (agent-safe NULL → `ADMIN_RELOGIN_REQUIRED`; decrypt-fail & Raft-reject → `SESSION_REAUTH_REQUIRED`; config → `ADMIN_AUTH_UNAVAILABLE`) — 11/11.
- Worker `tsc` + admin `tsc` + admin `vite build` clean; full worker suite green (the one `sqlite3-ENOENT` failure is environment-only — absent locally, green in CI).

## Honest residual constraint

Raft's 1h token + no refresh means active admin use hits a **seamless auto-renewal ~hourly** (a brief redirect, no password/consent while Raft is logged in). A truly gap-free admin session would need a Raft-side **service-role endpoint** or a longer token — a cross-Raft ask, out of scope here.

Not deployed by this PR — deploy runs through the migration/deploy gate after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 (Yaoheng) — fixed at `52625446`

- **human+NULL now renews:** `hands_admin.ts` branches the NULL-ciphertext case by `principal_type` — human+NULL → `SESSION_REAUTH_REQUIRED` (the likely shape of artin's *current* lock-out), agent+NULL → `ADMIN_RELOGIN_REQUIRED` (never browser-renew an agent).
- **frontend reauth tests:** `admin/src/lib/apiReauth.dom.test.ts` (jsdom, +5) locks the 4 gates.
- **wording:** the renewal is a *client-side switch* to a new session (localStorage token), **not** a server-side atomic replace; the old D1 row just expires.

## Gate ⑤ — pre-deploy verification (REQUIRED before task #6 is marked done)

This PR fixes the credential **rot** (Box A: artin's current `ADMIN_RELOGIN_REQUIRED`). It does **not** touch the separate, still-unexplained **"re-login *also* fails"** (Box B) — a fresh login always writes a ciphertext (`auth.ts:577`), so it never hits the NULL branch. Box B is verified only empirically, by a **test admin (e.g. Artea), not artin**, on prod (no staging exists):

> **Steps:** fully log out (clear `hands_session` / `hands:auth-token`) → open `/admin` → Continue with Raft → complete the flow → land on `/admin`.
> - **`/admin` 200** ⇒ the fresh-login path is healthy ⇒ **Box B is not a general bug**; artin's "re-login fails" was his own stale session/cookie, which this PR's human+NULL renewal handles. **This PR closes the incident.**
> - **Fails** (`400 "Missing or invalid browser login proof"`, or a 401 loop) ⇒ **Box B is a real fresh-login bug** (prime suspect: the #460 browser-login proof cookie — 10-min state TTL / browser cookie policy / prod cookie domain). **This PR alone does not resolve artin** → a separate fix is required.

Do not mark task #6 done on Box A alone.
