### PR TITLE
fix(apps): full app UUID in `apps list`; reject partial app ids at authz boundary

### DIFF
--- a/packages/cli/src/commands/apps.ts
+++ b/packages/cli/src/commands/apps.ts
@@ -102,7 +102,7 @@ export function registerAppCommands(program: Command): void {
             a.platform,
             a.archived ? "yes" : "no",
             a.default_channel_slug ?? "—",
-            a.id.slice(0, 8),
+            a.id,
           ].join("\t"),
         );
       }

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -50,13 +50,15 @@ function devTokenBypass(c: AdminContext) {
 // explicit "use the full app id", instead of falling through to the role check
 // and returning a misleading INSUFFICIENT_APP_ROLE.
 //
-// This is a SHAPE check only: it rejects an id built solely from UUID characters
-// (hex + dashes) that is not a complete UUID — i.e. a truncated UUID. A
-// well-formed UUID that simply does not exist (or that the caller may not access)
-// is NOT rejected here; it continues to the normal indistinguishable role error,
-// so this never becomes an app-existence oracle. Anything containing a non-UUID
-// character (the synthetic slug-like ids used in tests, future schemes) is left
-// untouched.
+// This is a SHAPE check only and adds no existence signal of its own: it rejects
+// an id built solely from UUID characters (hex + dashes) that is not a complete
+// UUID — i.e. a truncated UUID. A well-formed UUID that simply does not exist (or
+// that the caller may not access) is NOT rejected here; it continues to the
+// normal role path exactly as before. Anything containing a non-UUID character
+// (the synthetic slug-like ids used in tests, future schemes) is left untouched.
+// (Note: whether the role path itself distinguishes existing vs absent apps — via
+// the org_id echoed in the forbidden response — is a separate pre-existing concern
+// this gate neither introduces nor fixes.)
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function appIdShapeError(c: AdminContext, appId: string) {
   if (UUID_RE.test(appId)) return null;

--- a/worker/src/lib/permissions.ts
+++ b/worker/src/lib/permissions.ts
@@ -44,6 +44,36 @@ function devTokenBypass(c: AdminContext) {
   return c.get("admin_actor") === "dev-token";
 }
 
+// App ids are UUIDs. A caller that passes a truncated/partial id (e.g. the
+// 8-char short id `hands apps list` used to print) must fail as a client error
+// AT THE RESOLUTION BOUNDARY — before any DB lookup or role check — with an
+// explicit "use the full app id", instead of falling through to the role check
+// and returning a misleading INSUFFICIENT_APP_ROLE.
+//
+// This is a SHAPE check only: it rejects an id built solely from UUID characters
+// (hex + dashes) that is not a complete UUID — i.e. a truncated UUID. A
+// well-formed UUID that simply does not exist (or that the caller may not access)
+// is NOT rejected here; it continues to the normal indistinguishable role error,
+// so this never becomes an app-existence oracle. Anything containing a non-UUID
+// character (the synthetic slug-like ids used in tests, future schemes) is left
+// untouched.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function appIdShapeError(c: AdminContext, appId: string) {
+  if (UUID_RE.test(appId)) return null;
+  if (!/^[0-9a-f-]+$/i.test(appId)) return null;
+  return c.json(
+    {
+      error: "invalid_app_id",
+      code: "EXACT_APP_ID_REQUIRED",
+      next_action:
+        `'${appId}' is not a complete app id. Pass the full app UUID ` +
+        `(the ID column of \`hands apps list\`), not a shortened or partial id.`,
+      app_id: appId,
+    },
+    400,
+  );
+}
+
 export function currentAccount(c: AdminContext): AdminAccount | null {
   return c.get("admin_account") ?? null;
 }
@@ -292,6 +322,8 @@ export async function ensureAppRole(
   opts?: { orgMinimum?: OrgRole },
 ) {
   if (devTokenBypass(c)) return { ok: true as const, app_role: "admin" as AppRole, org_role: "owner" as OrgRole };
+  const shapeError = appIdShapeError(c, appId);
+  if (shapeError) return { ok: false as const, response: shapeError };
   const deployToken = currentDeployToken(c);
   if (deployToken) {
     if (
@@ -370,6 +402,8 @@ export async function ensureAppPermission(
   opts?: { orgMinimum?: OrgRole },
 ) {
   if (devTokenBypass(c)) return { ok: true as const, app_permission: permission };
+  const shapeError = appIdShapeError(c, appId);
+  if (shapeError) return { ok: false as const, response: shapeError };
   const deployToken = currentDeployToken(c);
   if (deployToken) {
     if (deployToken.app_id !== appId || !hasDeployTokenPermission(deployToken, permission)) {

--- a/worker/test/app_id_shape_gate.test.ts
+++ b/worker/test/app_id_shape_gate.test.ts
@@ -5,9 +5,11 @@ import { requireAppRole } from "../src/lib/permissions";
 // A short/partial app id (the 8-char form `hands apps list` used to print) must
 // fail at the resolution boundary with an explicit "use the full app id", NOT
 // fall through to the role check and return a misleading INSUFFICIENT_APP_ROLE.
-// The gate is SHAPE-only: a well-formed UUID that does not exist still returns
-// the normal indistinguishable role error (no app-existence oracle), and
-// synthetic slug-like ids are untouched.
+// The gate is SHAPE-only: it adds no existence signal of its own — a well-formed
+// UUID is left to the normal role path exactly as before, and synthetic slug-like
+// ids are untouched. (Whether that role path itself distinguishes existing vs
+// absent apps is a SEPARATE pre-existing concern — the org_id echo in the
+// forbidden response — tracked outside this gate; not asserted here.)
 
 const account = {
   id: "account-1", provider: "raft", provider_subject: "subject-1",
@@ -49,7 +51,11 @@ describe("app id shape gate (requireAppRole / ensureAppRole)", () => {
     expect((await res.json<{ code: string }>()).code).toBe("EXACT_APP_ID_REQUIRED");
   });
 
-  it("accepts a full UUID shape — a non-existent one still returns the normal indistinguishable 403 (no existence oracle)", async () => {
+  it("does NOT shape-gate a full UUID — it passes through to the normal role check (here 403 INSUFFICIENT_APP_ROLE)", async () => {
+    // emptyDb() resolves no role, so this only proves the gate lets a well-formed
+    // UUID through to the role path. It intentionally does NOT assert existence
+    // indistinguishability of that role path (the org_id echo makes exists-vs-absent
+    // distinguishable today — a separate follow-up, not this gate's concern).
     const res = await hit("76304f16-fbf7-488f-8445-e16ffdd6cef8");
     expect(res.status).toBe(403);
     expect((await res.json<{ code: string }>()).code).toBe("INSUFFICIENT_APP_ROLE");

--- a/worker/test/app_id_shape_gate.test.ts
+++ b/worker/test/app_id_shape_gate.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { requireAppRole } from "../src/lib/permissions";
+
+// A short/partial app id (the 8-char form `hands apps list` used to print) must
+// fail at the resolution boundary with an explicit "use the full app id", NOT
+// fall through to the role check and return a misleading INSUFFICIENT_APP_ROLE.
+// The gate is SHAPE-only: a well-formed UUID that does not exist still returns
+// the normal indistinguishable role error (no app-existence oracle), and
+// synthetic slug-like ids are untouched.
+
+const account = {
+  id: "account-1", provider: "raft", provider_subject: "subject-1",
+  server_id: "s", server_slug: "s", principal_type: "human",
+  server_role: "member", username: "u", display_name: "U", avatar_url: null,
+  raw_profile: "{}", created_at: 1, updated_at: 1, last_login_at: 1,
+  org_id: null, org_role: null,
+};
+
+// DB that resolves no org and no role for anyone → any request that clears the
+// shape gate lands on the normal 403 role error.
+function emptyDb() {
+  return {
+    prepare: () => ({ bind: () => ({ first: async () => null, all: async () => ({ results: [] }) }) }),
+  } as unknown as D1Database;
+}
+
+async function hit(appId: string) {
+  const app = new Hono<any>();
+  app.use("*", async (c, next) => { c.set("admin_account", account); await next(); });
+  app.use("/api/apps/:appId/*", requireAppRole("viewer"));
+  app.get("/api/apps/:appId/thing", (c) => c.json({ ok: true }));
+  const env = { DB: emptyDb(), DASHBOARD_ORIGIN: "https://dashboard.example" } as unknown as Env;
+  return app.request(`https://app.hands.build/api/apps/${appId}/thing`, {}, env);
+}
+
+describe("app id shape gate (requireAppRole / ensureAppRole)", () => {
+  it("rejects an 8-char truncated UUID with 400 EXACT_APP_ID_REQUIRED before the role check", async () => {
+    const res = await hit("76304f16");
+    expect(res.status).toBe(400);
+    const body = await res.json<{ code: string; app_id: string }>();
+    expect(body.code).toBe("EXACT_APP_ID_REQUIRED");
+    expect(body.app_id).toBe("76304f16");
+  });
+
+  it("rejects a dashed partial UUID (hex+dash only, not a full UUID) with 400", async () => {
+    const res = await hit("76304f16-fbf7");
+    expect(res.status).toBe(400);
+    expect((await res.json<{ code: string }>()).code).toBe("EXACT_APP_ID_REQUIRED");
+  });
+
+  it("accepts a full UUID shape — a non-existent one still returns the normal indistinguishable 403 (no existence oracle)", async () => {
+    const res = await hit("76304f16-fbf7-488f-8445-e16ffdd6cef8");
+    expect(res.status).toBe(403);
+    expect((await res.json<{ code: string }>()).code).toBe("INSUFFICIENT_APP_ROLE");
+  });
+
+  it("does NOT shape-reject synthetic slug-like ids (contain non-hex chars) — they reach the normal role check", async () => {
+    for (const id of ["app-1", "guard-app", "legacy-app", "other"]) {
+      const res = await hit(id);
+      expect(res.status, `id ${id}`).toBe(403);
+      expect((await res.json<{ code: string }>()).code, `id ${id}`).toBe("INSUFFICIENT_APP_ROLE");
+    }
+  });
+});


### PR DESCRIPTION
## Problem
`hands apps list` printed only the first 8 chars of each app UUID (`a.id.slice(0, 8)`). Passing that short id to `/api/apps/:appId/...` (e.g. `testflight-upload`) never matched an app and fell through to the role check, returning a misleading `INSUFFICIENT_APP_ROLE` / `app_role=none` — looks like a permissions problem, is actually a bad identifier. Reported by @Codex-Android-DevOPS during a TestFlight upload (full UUID `76304f16-fbf7-488f-8445-e16ffdd6cef8` worked).

## Fix (two parts)
1. **CLI** (`packages/cli/src/commands/apps.ts`): `apps list` prints the full app id — the `ID` column is what other commands and the API expect. Removes the source of the bad input.
2. **Worker** (`worker/src/lib/permissions.ts`): shape gate at the **shared** authz boundary — `ensureAppRole` / `ensureAppPermission`, **before any DB lookup or role check**, so every `:appId` route benefits (not just testflight-upload). An id built solely from UUID characters (hex + dashes) that is not a complete UUID — a truncated/partial id — returns `400 EXACT_APP_ID_REQUIRED`.

### Scope of the shape gate
Shape-only check that **adds no existence signal of its own**: a well-formed UUID is left to the normal role path exactly as before, and synthetic slug-like ids (which contain non-hex characters) are untouched. It does not touch the DB.

> **Not oracle-free overall (per @CC-Quiver-Owner review):** the surrounding role path already distinguishes existing-vs-absent apps by echoing `org_id` in the forbidden response (`getAppOrgId` is a bare existence query). That is **pre-existing** and deliberately **out of scope** for this PR to keep the exact clean — tracked as a separate follow-up (backfill `org_id` on the failure path only when the caller has membership in that org). This PR's gate neither introduces nor fixes that.

## Tests
- New `worker/test/app_id_shape_gate.test.ts` (4): 8-char truncation → 400; dashed partial → 400; full UUID → not shape-gated, passes through to the normal role check (403); slug-like ids (`app-1`, `guard-app`, `legacy-app`, `other`) → normal role check, **not** shape-rejected.
- Full worker suite green (506 passed; the 1 failure is the pre-existing `sqlite3 ENOENT` env-only migration test, unrelated). worker + CLI `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)