### PR TITLE
chore(cli): bump to 0.5.18 to publish apps-list full-UUID fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",


### PR DESCRIPTION
Publishes the `hands apps list` full-app-UUID output that landed in #468 (already on main). Version-bump only (0.5.17 → 0.5.18); no code change.

On merge, tag `cli-v0.5.18` triggers `publish-cli.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)