### PR TITLE
fix(cli): print full ids in `builds list` and `deploy-tokens list` (0.5.19)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",

--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -594,7 +594,7 @@ export function registerBuildCommands(program: Command): void {
         for (const b of res.builds) {
           const flag = b.should_force_update ? "  [force]" : "";
           console.log(
-            `${b.version_name} (${b.version_code})  ${b.product_type}/${b.release_type}  status=${b.status}${flag}  id=${b.id.slice(0, 8)}`,
+            `${b.version_name} (${b.version_code})  ${b.product_type}/${b.release_type}  status=${b.status}${flag}  id=${b.id}`,
           );
         }
       },

--- a/packages/cli/src/commands/deploy_tokens.ts
+++ b/packages/cli/src/commands/deploy_tokens.ts
@@ -74,7 +74,7 @@ export function registerDeployTokenCommands(program: Command): void {
             t.token_prefix,
             t.expires_at ? new Date(t.expires_at).toISOString() : "never",
             t.revoked_at ? "yes" : "no",
-            t.id.slice(0, 8),
+            t.id,
           ].join("\t"),
         );
       }


### PR DESCRIPTION
## Problem
Same class as #468: `builds list` and `deploy-tokens list` truncated their id column to 8 chars (`id.slice(0, 8)`), so a copied build/token id could not be fed back to any command. (Raised by CC-Quiver-Owner: a feedback item should fix the class, not just the one case.)

## Changes
- `builds list`: print the full build id.
- `deploy-tokens list`: print the full token id.
- Version bump 0.5.18 → 0.5.19.

`feedback.js`'s `slice(0,8)` is an after-the-fact receipt ("Updated ticket xxx."), not a copy source — intentionally left alone.

## Follow-up
The #468 server-side shape gate only guards `:appId`; a truncated `buildId`/`tokenId` still yields the old misleading role/not-found failure. A matching shape gate for those params is a possible follow-up, not included here.

## Testing
CLI `tsc` clean. On merge, tag `cli-v0.5.19` triggers publish-cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)