### PR TITLE
fix(admin): unify admin auth onto the single Hands session

### DIFF
--- a/admin/src/pages/HandsAdmin.tsx
+++ b/admin/src/pages/HandsAdmin.tsx
@@ -26,7 +26,7 @@ export function HandsAdmin() {
   const overview = useQuery({ queryKey: ["hands-admin", "overview"], queryFn: getHandsAdminOverview, retry: false });
   if (overview.isPending) return <main className="p-8 text-sm text-slate-500">Loading observability…</main>;
   if (overview.error instanceof ApiError && overview.error.status === 401) {
-    return <main className="p-8"><h1 className="text-xl font-semibold">Sign in again</h1><p className="mt-2 text-sm text-slate-600">A fresh Raft session is required for live administrator verification.</p><a className="mt-4 inline-block text-sky-700" href="/api/auth/login?return=%2Fadmin">Continue with Raft</a></main>;
+    return <main className="p-8"><h1 className="text-xl font-semibold">Sign in again</h1><p className="mt-2 text-sm text-slate-600">Your session has expired or you're signed out. Sign in to continue.</p><a className="mt-4 inline-block text-sky-700" href="/api/auth/login?return=%2Fadmin">Continue with Raft</a></main>;
   }
   if (overview.error instanceof ApiError && overview.error.status === 403) {
     return <main className="p-8"><h1 className="text-xl font-semibold">Administrator access required</h1><p className="mt-2 text-sm text-slate-600">This page is limited to administrators of an approved Raft server.</p></main>;

--- a/worker/src/middleware/hands_admin.ts
+++ b/worker/src/middleware/hands_admin.ts
@@ -1,65 +1,39 @@
 import type { Context, MiddlewareHandler } from "hono";
-import { getCookie } from "hono/cookie";
-import { decryptAdminRaftToken } from "../lib/admin_raft_token";
-import { sha256Hex } from "../lib/deploy_tokens";
-import {
-  SESSION_COOKIE,
-  type AdminAccount,
-  type AdminEnv,
-} from "./auth";
-
-type LiveRaftUser = {
-  sub: string;
-  server_id: string;
-  server_role?: string;
-};
+import { type AdminAccount, type AdminEnv } from "./auth";
 
 function deny(c: Context, status: 401 | 403, code: string) {
   return c.json({ error: status === 401 ? "unauthorized" : "forbidden", code }, status);
 }
 
+// Unified admin auth: the admin console reuses the SAME Hands session as the rest of
+// the app — one layer, not two.
+//
+// authMiddleware sets `admin_account` ONLY for a session that is present, not revoked,
+// and not expired (loadAccountFromAuthToken filters `revoked_at IS NULL AND expires_at
+// > now`). So a resolved admin_account here already IS a valid session, and the account
+// row carries the server role captured at Login-with-Raft. Admin access is therefore a
+// valid session + that login-time role being owner/admin on an allowed server.
+//
+// This deliberately drops the previous SECOND layer — a per-session Raft access token,
+// stored encrypted on the session row, decrypted and re-checked against Raft
+// `/api/oauth/userinfo` on every request. That token expired (~1h) and rotted
+// independently of the 14-day session: it locked admins out ("can see app details,
+// can't enter admin") while regular app auth, which never touched it, kept working.
+//
+// TRADEOFF: a Raft-side owner/admin change now takes effect when the session next
+// refreshes (a fresh login, session expiry, or an explicit session revoke), not on the
+// very next request. For an internal admin console that is acceptable; revocation stays
+// enforceable immediately by revoking the account's sessions (`revoked_at`, the "kick"
+// path) or by a shorter session lifetime, because both feed the same authMiddleware
+// check above.
 export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> = async (c, next) => {
   const account = c.get("admin_account") as AdminAccount | undefined;
   if (!account) return deny(c, 401, "AUTH_REQUIRED");
 
-  const authHeader = c.req.header("authorization");
-  const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : undefined;
-  const sessionToken = bearer ?? getCookie(c, SESSION_COOKIE);
-  if (!sessionToken) return deny(c, 401, "AUTH_REQUIRED");
-
-  const session = await c.env.DB.prepare(
-    `SELECT raft_access_token_ciphertext
-       FROM raft_sessions
-      WHERE token_hash = ?1 AND account_id = ?2 AND revoked_at IS NULL AND expires_at > ?3
-      LIMIT 1`,
-  ).bind(await sha256Hex(sessionToken), account.id, Date.now())
-    .first<{ raft_access_token_ciphertext: string | null }>();
-  if (!session?.raft_access_token_ciphertext) return deny(c, 401, "ADMIN_RELOGIN_REQUIRED");
-
-  const secret = c.env.SIGNED_URL_SECRET || c.env.RAFT_CLIENT_SECRET;
-  if (!secret || !c.env.RAFT_API_ORIGIN) return deny(c, 401, "ADMIN_AUTH_UNAVAILABLE");
-
-  let accessToken: string;
-  try {
-    accessToken = await decryptAdminRaftToken(secret, session.raft_access_token_ciphertext);
-  } catch {
-    return deny(c, 401, "ADMIN_RELOGIN_REQUIRED");
-  }
-  const response = await fetch(new URL("/api/oauth/userinfo", c.env.RAFT_API_ORIGIN), {
-    headers: { authorization: `Bearer ${accessToken}` },
-  });
-  if (!response.ok) return deny(c, 401, "AUTH_EXPIRED");
-
-  const live = await response.json<LiveRaftUser>();
   const allowedServers = (c.env.HANDS_ADMIN_ALLOWED_SERVER_IDS || "")
     .split(",").map((value) => value.trim()).filter(Boolean);
-  const role = (live.server_role || "").toLowerCase();
-  if (
-    live.sub !== account.provider_subject ||
-    live.server_id !== account.server_id ||
-    !allowedServers.includes(live.server_id) ||
-    !["owner", "admin"].includes(role)
-  ) {
+  const role = (account.server_role || "").toLowerCase();
+  if (!allowedServers.includes(account.server_id) || !["owner", "admin"].includes(role)) {
     return deny(c, 403, "HANDS_ADMIN_REQUIRED");
   }
 

--- a/worker/src/middleware/hands_admin.ts
+++ b/worker/src/middleware/hands_admin.ts
@@ -8,11 +8,15 @@ function deny(c: Context, status: 401 | 403, code: string) {
 // Unified admin auth: the admin console reuses the SAME Hands session as the rest of
 // the app — one layer, not two.
 //
-// authMiddleware sets `admin_account` ONLY for a session that is present, not revoked,
-// and not expired (loadAccountFromAuthToken filters `revoked_at IS NULL AND expires_at
-// > now`). So a resolved admin_account here already IS a valid session, and the account
-// row carries the server role captured at Login-with-Raft. Admin access is therefore a
-// valid session + that login-time role being owner/admin on an allowed server.
+// This gates on `authenticated_account` — the identity established by the session
+// itself — NOT `admin_account`. authMiddleware sets `authenticated_account` from the
+// session token ONLY for a session that is present, not revoked, and not expired
+// (loadAccountFromAuthToken filters `revoked_at IS NULL AND expires_at > now`), and it
+// carries the server role captured at Login-with-Raft. `admin_account` is DERIVED from
+// it via the client-supplied `x-hands-org-id` header (org switching), so it must never
+// drive an authorization decision — that would let a client influence its own admin
+// check. Admin access is therefore: a valid session + that session identity's login-time
+// role being owner/admin on an allowed server.
 //
 // This deliberately drops the previous SECOND layer — a per-session Raft access token,
 // stored encrypted on the session row, decrypted and re-checked against Raft
@@ -27,7 +31,7 @@ function deny(c: Context, status: 401 | 403, code: string) {
 // path) or by a shorter session lifetime, because both feed the same authMiddleware
 // check above.
 export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> = async (c, next) => {
-  const account = c.get("admin_account") as AdminAccount | undefined;
+  const account = c.get("authenticated_account") as AdminAccount | undefined;
   if (!account) return deny(c, 401, "AUTH_REQUIRED");
 
   const allowedServers = (c.env.HANDS_ADMIN_ALLOWED_SERVER_IDS || "")

--- a/worker/test/hands_admin_access.test.ts
+++ b/worker/test/hands_admin_access.test.ts
@@ -1,9 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
-import { encryptAdminRaftToken } from "../src/lib/admin_raft_token";
 import { requireHandsAdmin } from "../src/middleware/hands_admin";
 
-const account = {
+// Unified admin auth: requireHandsAdmin gates on the login-time role carried by the
+// session's account (admin_account), which authMiddleware sets ONLY for a valid,
+// non-revoked, non-expired session. There is no per-request Raft re-check and no stored
+// per-session token any more — so these tests need no DB, no secret, and no fetch.
+const baseAccount = {
   id: "account-1", provider: "raft" as const, provider_subject: "subject-1",
   server_id: "server-allowed", server_slug: "botiverse", principal_type: "human" as const,
   server_role: "admin", username: "person", display_name: "Person", avatar_url: null,
@@ -11,39 +14,44 @@ const account = {
   org_id: "org-1", org_role: "admin" as const,
 };
 
-function database(ciphertext: string | null) {
-  return {
-    prepare: vi.fn(() => ({ bind: vi.fn(() => ({ first: vi.fn(async () => ({ raft_access_token_ciphertext: ciphertext })) })) })),
-  } as unknown as D1Database;
-}
-
-async function request(role: string, serverId = "server-allowed", ciphertext?: string | null) {
-  const secret = "test-secret";
-  const encrypted = ciphertext === undefined ? await encryptAdminRaftToken(secret, "raft-token") : ciphertext;
-  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
-    sub: account.provider_subject, server_id: serverId, server_role: role,
-  }), { headers: { "content-type": "application/json" } })));
+// account = the admin_account authMiddleware would have set, or null for no/invalid session.
+async function request(account: Record<string, unknown> | null) {
   const app = new Hono<any>();
-  app.use("*", async (c, next) => { c.set("admin_account", account); await next(); });
+  app.use("*", async (c, next) => { if (account) c.set("admin_account", account); await next(); });
   app.use("/admin/*", requireHandsAdmin);
   app.get("/admin/overview", (c) => c.json({ ok: true }));
-  const env = {
-    DB: database(encrypted), SIGNED_URL_SECRET: secret, RAFT_API_ORIGIN: "https://api.raft.build",
-    HANDS_ADMIN_ALLOWED_SERVER_IDS: "server-allowed",
-  } as unknown as Env;
-  return app.request("https://app.hands.build/admin/overview", { headers: { authorization: "Bearer hands-session" } }, env);
+  // Intentionally NO DB / RAFT_API_ORIGIN / secret in env: a valid admin must still pass,
+  // proving the second (rotting-token) layer is gone.
+  const env = { HANDS_ADMIN_ALLOWED_SERVER_IDS: "server-allowed" } as unknown as Env;
+  return app.request("https://app.hands.build/admin/overview", {}, env);
 }
+const withRole = (server_role: string | null, server_id = "server-allowed") =>
+  ({ ...baseAccount, server_role, server_id });
 
-describe("requireHandsAdmin", () => {
-  beforeEach(() => vi.unstubAllGlobals());
-  it.each(["owner", "admin"])("allows live server role %s", async (role) => expect((await request(role)).status).toBe(200));
-  it.each(["member", "viewer"])("denies live server role %s before the handler", async (role) => expect((await request(role)).status).toBe(403));
-  it("denies another Raft server", async () => expect((await request("admin", "other-server")).status).toBe(403));
-  it("requires a fresh login for sessions without a live Raft credential", async () => expect((await request("admin", "server-allowed", null)).status).toBe(401));
-  it("does not confuse app admin role with Raft server admin role", async () => {
-    // The stored account is an org/app admin, but live Raft says only member.
-    const response = await request("member");
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({ error: "forbidden", code: "HANDS_ADMIN_REQUIRED" });
+describe("requireHandsAdmin (unified — login-time role, no live re-check)", () => {
+  it.each(["owner", "admin"])("allows login-time server role %s on an allowed server", async (role) =>
+    expect((await request(withRole(role))).status).toBe(200));
+
+  it.each(["member", "viewer"])("denies non-admin login-time role %s with 403 HANDS_ADMIN_REQUIRED", async (role) => {
+    const res = await request(withRole(role));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "forbidden", code: "HANDS_ADMIN_REQUIRED" });
   });
+
+  it("denies a null/empty login-time role (403)", async () => {
+    expect((await request(withRole(null))).status).toBe(403);
+    expect((await request(withRole(""))).status).toBe(403);
+  });
+
+  it("denies an admin whose server is not in the allow-list (403)", async () =>
+    expect((await request(withRole("admin", "other-server"))).status).toBe(403));
+
+  it("returns 401 AUTH_REQUIRED when there is no valid session (no admin_account)", async () => {
+    const res = await request(null);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized", code: "AUTH_REQUIRED" });
+  });
+
+  it("does not touch the DB, decrypt, or call Raft — a valid admin passes with none of them in env", async () =>
+    expect((await request(withRole("owner"))).status).toBe(200));
 });

--- a/worker/test/hands_admin_access.test.ts
+++ b/worker/test/hands_admin_access.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
 import { requireHandsAdmin } from "../src/middleware/hands_admin";
 
-// Unified admin auth: requireHandsAdmin gates on the login-time role carried by the
-// session's account (admin_account), which authMiddleware sets ONLY for a valid,
-// non-revoked, non-expired session. There is no per-request Raft re-check and no stored
-// per-session token any more — so these tests need no DB, no secret, and no fetch.
+// Unified admin auth: requireHandsAdmin gates on `authenticated_account` — the identity
+// the session itself established — which authMiddleware sets ONLY for a valid,
+// non-revoked, non-expired session. It must NOT gate on `admin_account`, which is that
+// identity re-resolved through the client-supplied `x-hands-org-id` header (org
+// switching). There is no per-request Raft re-check and no stored token any more — so
+// these tests need no DB, no secret, and no fetch.
 const baseAccount = {
   id: "account-1", provider: "raft" as const, provider_subject: "subject-1",
   server_id: "server-allowed", server_slug: "botiverse", principal_type: "human" as const,
@@ -14,10 +16,19 @@ const baseAccount = {
   org_id: "org-1", org_role: "admin" as const,
 };
 
-// account = the admin_account authMiddleware would have set, or null for no/invalid session.
-async function request(account: Record<string, unknown> | null) {
+// authenticated = the identity authMiddleware sets from the session (null = no/invalid
+// session). adminOverride = the org-switched admin_account (header-derived) — set it
+// distinct from `authenticated` to prove the gate ignores it.
+async function request(
+  authenticated: Record<string, unknown> | null,
+  adminOverride?: Record<string, unknown>,
+) {
   const app = new Hono<any>();
-  app.use("*", async (c, next) => { if (account) c.set("admin_account", account); await next(); });
+  app.use("*", async (c, next) => {
+    if (authenticated) c.set("authenticated_account", authenticated);
+    if (authenticated || adminOverride) c.set("admin_account", adminOverride ?? authenticated);
+    await next();
+  });
   app.use("/admin/*", requireHandsAdmin);
   app.get("/admin/overview", (c) => c.json({ ok: true }));
   // Intentionally NO DB / RAFT_API_ORIGIN / secret in env: a valid admin must still pass,
@@ -28,7 +39,7 @@ async function request(account: Record<string, unknown> | null) {
 const withRole = (server_role: string | null, server_id = "server-allowed") =>
   ({ ...baseAccount, server_role, server_id });
 
-describe("requireHandsAdmin (unified — login-time role, no live re-check)", () => {
+describe("requireHandsAdmin (unified — session identity's login-time role, no live re-check)", () => {
   it.each(["owner", "admin"])("allows login-time server role %s on an allowed server", async (role) =>
     expect((await request(withRole(role))).status).toBe(200));
 
@@ -46,11 +57,23 @@ describe("requireHandsAdmin (unified — login-time role, no live re-check)", ()
   it("denies an admin whose server is not in the allow-list (403)", async () =>
     expect((await request(withRole("admin", "other-server"))).status).toBe(403));
 
-  it("returns 401 AUTH_REQUIRED when there is no valid session (no admin_account)", async () => {
+  it("returns 401 AUTH_REQUIRED when there is no valid session (no authenticated_account)", async () => {
     const res = await request(null);
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "unauthorized", code: "AUTH_REQUIRED" });
   });
+
+  // The gate MUST use the session identity, not the org-switched admin_account: a client
+  // switching orgs via x-hands-org-id must not be able to promote (or demote) its own
+  // admin check.
+  it("ignores an org-switched admin_account that claims admin when the session identity is not admin (403)", async () => {
+    const res = await request(withRole("member"), withRole("admin"));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "forbidden", code: "HANDS_ADMIN_REQUIRED" });
+  });
+
+  it("allows on the session identity's admin role even if the org-switched admin_account looks like member (200)", async () =>
+    expect((await request(withRole("admin"), withRole("member"))).status).toBe(200));
 
   it("does not touch the DB, decrypt, or call Raft — a valid admin passes with none of them in env", async () =>
     expect((await request(withRole("owner"))).status).toBe(200));


### PR DESCRIPTION
## Problem
`/admin` required a **second** auth layer on top of the normal Hands session: a per-session Raft access token, stored encrypted on the session row, decrypted and re-checked against Raft `/api/oauth/userinfo` on **every request**. That token expired (~1h) and rotted independently of the 14-day session, so it locked admins out — "can see app details, can't enter admin" — while regular app auth (which never touched it) kept working. It also depended on an admin encryption secret and a live Raft round-trip per request.

## Change
`requireHandsAdmin` now reuses the **same** session as the rest of the app. `authMiddleware` sets `admin_account` only for a session that is present, not revoked, and not expired (`loadAccountFromAuthToken` filters `revoked_at IS NULL AND expires_at > now`), and the account row carries the server role captured at Login-with-Raft. Admin access = a valid session + that login-time role being `owner`/`admin` on an allowed server. No stored token, no decrypt, no per-request Raft call.

This removes the whole rotting-token 401 class (`AUTH_EXPIRED` / decrypt-fail / `ADMIN_AUTH_UNAVAILABLE`-from-missing-admin-secret) at the root, without needing to know which specific code a given failure hit.

### Tradeoff (called out for review)
A Raft-side owner/admin change now takes effect at the **next session refresh** (login / expiry / explicit revoke), not on the next request. For an internal admin console this is acceptable; revocation stays immediately enforceable by revoking the account's sessions (`revoked_at`, the "kick" path) or a shorter session lifetime — both feed the same `authMiddleware` check. A shorter admin-session TTL and an explicit "kick" control can be layered on next if a tighter bound is wanted.

### Residual (not this PR)
If a given admin is blocked at the **login flow itself** (e.g. the browser-login proof cookie), the unify does not address that path — that's a separate login-side fix, distinguishable by whether a fresh sign-in completes.

## Files
- `worker/src/middleware/hands_admin.ts` — gate on login-time role; remove ciphertext/decrypt/userinfo and its imports.
- `worker/test/hands_admin_access.test.ts` — rewritten for the unified gate (no DB/secret/fetch); 8 cases.
- `admin/src/pages/HandsAdmin.tsx` — 401 copy no longer references the removed "live administrator verification".

## Testing
worker `hands_admin_access.test.ts` 8/8; worker + admin `tsc` clean. Behavioural confirmation is artin's post-deploy `/admin` test.