### PR TITLE
fix(admin): audit the authenticated identity; lock the human+agent access contract

### DIFF
--- a/worker/src/middleware/hands_admin.ts
+++ b/worker/src/middleware/hands_admin.ts
@@ -34,6 +34,12 @@ export const requireHandsAdmin: MiddlewareHandler<AdminEnv & { Bindings: Env }> 
   const account = c.get("authenticated_account") as AdminAccount | undefined;
   if (!account) return deny(c, 401, "AUTH_REQUIRED");
 
+  // Intentionally NOT restricted by principal_type: BOTH human and agent identities
+  // qualify if they are owner/admin on an allowed server (artin's decision 2026-08-20).
+  // The guarded endpoint is read-only, global-aggregate observability (not user content),
+  // and every access is recorded in hands_admin_access_audit (actor id + type). Do not
+  // add a human-only gate here without an explicit decision to reverse that — the test
+  // suite asserts an owner/admin agent is admitted, so such a change fails loudly.
   const allowedServers = (c.env.HANDS_ADMIN_ALLOWED_SERVER_IDS || "")
     .split(",").map((value) => value.trim()).filter(Boolean);
   const role = (account.server_role || "").toLowerCase();

--- a/worker/src/routes/hands_admin.ts
+++ b/worker/src/routes/hands_admin.ts
@@ -1,9 +1,16 @@
 import type { Context } from "hono";
 import { getCachedHandsObservabilityOverview } from "../observability_rpc";
-import { currentActorInfo, type AdminEnv } from "../middleware/auth";
+import { type AdminEnv } from "../middleware/auth";
 
 export async function handleHandsAdminOverview(c: Context<AdminEnv & { Bindings: Env }>) {
-  const actor = currentActorInfo(c);
+  // Audit the identity the authorization decision actually used —
+  // authenticated_account (the session identity), NOT admin_account / currentActorInfo,
+  // which reflect the org-switchable (x-hands-org-id) view. requireHandsAdmin gates on
+  // authenticated_account, so the actor and server recorded here must match it, or a
+  // row could name an identity/server that was never the authorized one.
+  const authed = c.get("authenticated_account") as {
+    id: string; principal_type: "human" | "agent"; server_id: string;
+  };
   const measured = await getCachedHandsObservabilityOverview(c.env);
   await c.env.DB.prepare(
     `INSERT INTO hands_admin_access_audit
@@ -11,9 +18,9 @@ export async function handleHandsAdminOverview(c: Context<AdminEnv & { Bindings:
      VALUES (?1, ?2, ?3, ?4, 'overview.view', ?5)`,
   ).bind(
     crypto.randomUUID(),
-    actor.id,
-    actor.type,
-    (c.get("admin_account") as { server_id: string }).server_id,
+    authed.id,
+    authed.principal_type,
+    authed.server_id,
     Date.now(),
   ).run();
   return c.json(measured);

--- a/worker/test/hands_admin_access.test.ts
+++ b/worker/test/hands_admin_access.test.ts
@@ -77,4 +77,10 @@ describe("requireHandsAdmin (unified — session identity's login-time role, no 
 
   it("does not touch the DB, decrypt, or call Raft — a valid admin passes with none of them in env", async () =>
     expect((await request(withRole("owner"))).status).toBe(200));
+
+  // Contract (artin 2026-08-20): admin access is NOT restricted by principal_type — an
+  // owner/admin AGENT identity is admitted, same as a human. This test locks that
+  // decision: adding a human-only gate would fail here loudly.
+  it.each(["owner", "admin"])("admits an %s AGENT identity (human/agent not distinguished)", async (role) =>
+    expect((await request({ ...withRole(role), principal_type: "agent" })).status).toBe(200));
 });

--- a/worker/test/hands_admin_audit.test.ts
+++ b/worker/test/hands_admin_audit.test.ts
@@ -1,0 +1,82 @@
+import Database from "better-sqlite3";
+import { describe, expect, it, vi } from "vitest";
+
+// The overview handler does its own DB work via this helper; stub it so the test can
+// focus on the audit write.
+vi.mock("../src/observability_rpc", () => ({
+  getCachedHandsObservabilityOverview: vi.fn(async () => ({ summary: {}, storage: {} })),
+}));
+
+import { handleHandsAdminOverview } from "../src/routes/hands_admin";
+
+// Minimal D1 shim over better-sqlite3 (same `?N`-normalization as routes.test.ts) so the
+// handler's real INSERT executes against a real SQLite table and we can read the row back.
+function makeDb() {
+  const sqlite = new Database(":memory:");
+  // Real 0063 shape (FK to raft_accounts omitted — not under test; the CHECKs are kept).
+  sqlite.exec(`
+    CREATE TABLE hands_admin_access_audit (
+      id                TEXT PRIMARY KEY,
+      actor_account_id  TEXT,
+      actor_type        TEXT NOT NULL CHECK (actor_type IN ('human', 'agent')),
+      server_id         TEXT NOT NULL,
+      action            TEXT NOT NULL CHECK (action = 'overview.view'),
+      created_at        INTEGER NOT NULL
+    );
+  `);
+  const d1 = {
+    prepare(sql: string) {
+      const seq: number[] = [];
+      const norm = sql.replace(/\?(\d+)/g, (_m, n) => {
+        seq.push(Number(n));
+        return "?";
+      });
+      const stmt = sqlite.prepare(norm);
+      const bind = (...p: unknown[]) => {
+        const ex = seq.length ? seq.map((n) => p[n - 1]) : p;
+        return {
+          run: async () => ({ success: true, meta: { changes: stmt.run(...ex).changes } }),
+          all: async () => ({ results: stmt.all(...ex), success: true }),
+          first: async () => (stmt.all(...ex)[0] ?? null),
+        };
+      };
+      return { bind, run: () => bind().run(), all: () => bind().all(), first: () => bind().first() };
+    },
+  };
+  return { d1, sqlite };
+}
+
+// The audit must record the identity the authorization decision actually used —
+// authenticated_account (the session identity) — NOT admin_account, which is the
+// org-switchable (x-hands-org-id) view. This sets the two DIFFERENT, runs the real INSERT,
+// and reads the row back. Mutating the handler to admin_account records the switched
+// id/server and fails this (verified: the CHANGES-requested tooth).
+describe("handleHandsAdminOverview audit (D1 readback)", () => {
+  it("writes exactly one audit row recording authenticated_account, not the org-switched admin_account", async () => {
+    const { d1, sqlite } = makeDb();
+    const authed = { id: "authed-1", principal_type: "agent", server_id: "server-authed" };
+    const switched = { id: "switched-2", principal_type: "human", server_id: "server-switched" };
+    const c = {
+      get: (k: string) =>
+        k === "authenticated_account" ? authed : k === "admin_account" ? switched : undefined,
+      env: { DB: d1 },
+      json: (x: unknown) => x,
+    } as unknown as Parameters<typeof handleHandsAdminOverview>[0];
+
+    await handleHandsAdminOverview(c);
+
+    const rows = sqlite
+      .prepare("SELECT actor_account_id, actor_type, server_id, action FROM hands_admin_access_audit")
+      .all() as Array<{ actor_account_id: string; actor_type: string; server_id: string; action: string }>;
+    expect(rows).toHaveLength(1); // "actually wrote" coverage
+    const row = rows[0];
+    if (!row) throw new Error("expected exactly one audit row");
+    expect(row.actor_account_id).toBe("authed-1"); // authenticated identity, NOT switched-2
+    expect(row.actor_type).toBe("agent");
+    expect(row.server_id).toBe("server-authed"); // authenticated server, NOT server-switched
+    expect(row.action).toBe("overview.view");
+    // Explicit anti-regression: the org-switched view must NOT be what's recorded.
+    expect(row.actor_account_id).not.toBe("switched-2");
+    expect(row.server_id).not.toBe("server-switched");
+  });
+});


### PR DESCRIPTION
Two follow-ups to the admin auth-unify (#473), from CC/Yaoheng review + artin's 2026-08-20 decision. No behavior change to who can access /admin.

## 1. Audit fidelity (CC found)
`hands_admin_access_audit` recorded `actor_account_id` / `actor_type` / `server_id` from `admin_account` (via `currentActorInfo`) — the org-switchable (`x-hands-org-id`) view — while `requireHandsAdmin` now authorizes on `authenticated_account`. The two can diverge, so an audit row could name an identity/server that was never the authorized one. Now the audit records id/type/server_id from `authenticated_account`, matching the authorization decision.

## 2. Access contract lock (artin decision)
Admin access is intentionally **not** restricted by `principal_type` — an owner/admin **agent** identity is admitted, same as a human (the endpoint is read-only global-aggregate observability, not user content; every access is audited). This documents that in the middleware and adds a test asserting an owner/admin agent is admitted, so a future human-only gate fails loudly rather than silently reversing the decision.

## Testing
`worker/test/hands_admin_access.test.ts` 12/12 (incl. the 2 new owner/admin-agent cases); worker `tsc` clean. The audit change takes effect on the next Worker deploy — no urgency, no separate deploy needed.