### PR TITLE
Make release shares permanent by default

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -136,6 +136,67 @@ describe("apiRequest", () => {
 });
 
 describe("release share commands", () => {
+  it("creates permanent shares by default and sends expiry only when explicitly requested", async () => {
+    const requests: Array<{ method: string; url: string; body?: unknown }> = [];
+    const server = createServer(async (req, res) => {
+      let body: unknown;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      if (req.url?.startsWith("/api/apps/app-1/releases/release-1/shares")) {
+        return res.end(JSON.stringify({
+          id: "share-1",
+          release_id: "release-1",
+          expires_at: body && typeof body === "object" && "ttl_seconds" in body
+            ? Date.now() + Number((body as { ttl_seconds: number }).ttl_seconds) * 1000
+            : null,
+          revoked_at: null,
+        }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    const originalApi = process.env.HANDS_API;
+    const originalToken = process.env.HANDS_BEARER_TOKEN;
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+    try {
+      const { registerReleaseCommands } = await import("../src/commands/releases.js");
+      const run = async (...args: string[]) => {
+        const program = new Command();
+        registerReleaseCommands(program);
+        await program.parseAsync(["node", "hands", "releases", ...args]);
+      };
+
+      await run("share", "raft-android", "release-1");
+      await run("share", "raft-android", "release-1", "--ttl-seconds", "3600");
+      await run("update-share", "raft-android", "release-1", "share-1", "--never-expires");
+
+      const mutations = requests.filter((request) => request.method === "POST" || request.method === "PATCH");
+      expect(mutations).toEqual([
+        { method: "POST", url: "/api/apps/app-1/releases/release-1/shares", body: {} },
+        { method: "POST", url: "/api/apps/app-1/releases/release-1/shares", body: { ttl_seconds: 3600 } },
+        { method: "PATCH", url: "/api/apps/app-1/releases/release-1/shares/share-1", body: { expires_at: null } },
+      ]);
+    } finally {
+      if (originalApi === undefined) delete process.env.HANDS_API;
+      else process.env.HANDS_API = originalApi;
+      if (originalToken === undefined) delete process.env.HANDS_BEARER_TOKEN;
+      else process.env.HANDS_BEARER_TOKEN = originalToken;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("rebinds through the closed API with an explicit expected current release", async () => {
     const requests: Array<{ method: string; url: string; body?: unknown }> = [];
     const server = createServer(async (req, res) => {

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -17,7 +17,7 @@ interface ReleaseShare {
   release_id: string;
   share_url?: string;
   created_at?: number;
-  expires_at: number;
+  expires_at: number | null;
   revoked_at: number | null;
 }
 
@@ -27,8 +27,6 @@ interface ReleaseScope {
 }
 
 const RELEASE_SCOPE_TYPES = new Set(["full", "platform", "user_cohort", "ip_range", "device_group"]);
-
-const DEFAULT_SHARE_TTL_SECONDS = "604800";
 
 function collectRepeated(value: string, previous: string[] = []): string[] {
   return [...previous, value];
@@ -307,8 +305,8 @@ export function registerReleaseCommands(program: Command): void {
 
   releases
     .command("share <appIdOrSlug> <releaseId>")
-    .description("Create a revocable public share page for a release.")
-    .option("--ttl-seconds <seconds>", "Share lifetime in seconds.", DEFAULT_SHARE_TTL_SECONDS)
+    .description("Create a revocable public share page for a release (permanent until revoked by default).")
+    .option("--ttl-seconds <seconds>", "Optional share lifetime in seconds.")
     .option("--expires-at <millis>", "Absolute expiration as Unix milliseconds.")
     .option(
       "--password <password>",
@@ -325,8 +323,8 @@ export function registerReleaseCommands(program: Command): void {
         const body: { ttl_seconds?: number; expires_at?: number; password?: string } = {};
         if (opts.expiresAt) {
           body.expires_at = parsePositiveNumber(opts.expiresAt, "--expires-at");
-        } else {
-          body.ttl_seconds = parsePositiveNumber(opts.ttlSeconds ?? DEFAULT_SHARE_TTL_SECONDS, "--ttl-seconds");
+        } else if (opts.ttlSeconds !== undefined) {
+          body.ttl_seconds = parsePositiveNumber(opts.ttlSeconds, "--ttl-seconds");
         }
         const password = opts.password ?? readEnv("SHARE_PASSWORD");
         if (password) body.password = password;
@@ -340,7 +338,7 @@ export function registerReleaseCommands(program: Command): void {
         }
         console.log(`Created release share ${share.id}`);
         console.log(`  url:        ${share.share_url ?? ""}`);
-        console.log(`  expires_at: ${new Date(share.expires_at).toISOString()}`);
+        console.log(`  expires_at: ${share.expires_at === null ? "never" : new Date(share.expires_at).toISOString()}`);
         if (body.password) console.log("  password:   protected");
       },
     );
@@ -368,31 +366,43 @@ export function registerReleaseCommands(program: Command): void {
           return;
         }
         for (const share of res.shares) {
-          const state = share.revoked_at ? "revoked" : Date.now() >= share.expires_at ? "expired" : "active";
-          console.log(`${share.id}  ${state}  expires=${new Date(share.expires_at).toISOString()}`);
+          const state = share.revoked_at
+            ? "revoked"
+            : share.expires_at !== null && Date.now() >= share.expires_at
+              ? "expired"
+              : "active";
+          console.log(`${share.id}  ${state}  expires=${share.expires_at === null ? "never" : new Date(share.expires_at).toISOString()}`);
         }
       },
     );
 
   releases
     .command("update-share <appIdOrSlug> <releaseId> <shareId>")
-    .description("Renew or change a public release share expiration.")
-    .option("--ttl-seconds <seconds>", "New lifetime in seconds from now.", DEFAULT_SHARE_TTL_SECONDS)
+    .description("Renew or change a public release share expiration; omit expiry to leave it unchanged.")
+    .option("--ttl-seconds <seconds>", "New lifetime in seconds from now.")
     .option("--expires-at <millis>", "Absolute expiration as Unix milliseconds.")
+    .option("--never-expires", "Make the share permanent until revoked.", false)
     .option("--json", "Output JSON.", false)
     .action(
       async (
         appIdOrSlug: string,
         releaseId: string,
         shareId: string,
-        opts: { ttlSeconds?: string; expiresAt?: string; json?: boolean },
+        opts: { ttlSeconds?: string; expiresAt?: string; neverExpires?: boolean; json?: boolean },
       ) => {
         const appId = await resolveAppId(appIdOrSlug);
-        const body: { ttl_seconds?: number; expires_at?: number } = {};
+        const body: { ttl_seconds?: number; expires_at?: number | null } = {};
+        if (opts.neverExpires && (opts.expiresAt !== undefined || opts.ttlSeconds !== undefined)) {
+          throw new Error("--never-expires cannot be combined with --expires-at or --ttl-seconds");
+        }
         if (opts.expiresAt) {
           body.expires_at = parsePositiveNumber(opts.expiresAt, "--expires-at");
+        } else if (opts.neverExpires) {
+          body.expires_at = null;
+        } else if (opts.ttlSeconds !== undefined) {
+          body.ttl_seconds = parsePositiveNumber(opts.ttlSeconds, "--ttl-seconds");
         } else {
-          body.ttl_seconds = parsePositiveNumber(opts.ttlSeconds ?? DEFAULT_SHARE_TTL_SECONDS, "--ttl-seconds");
+          throw new Error("nothing to update: pass --ttl-seconds, --expires-at, or --never-expires");
         }
         const share = await apiRequest<ReleaseShare>(
           `/api/apps/${appId}/releases/${releaseId}/shares/${shareId}`,
@@ -403,7 +413,7 @@ export function registerReleaseCommands(program: Command): void {
           return;
         }
         console.log(`Updated release share ${share.id}`);
-        console.log(`  expires_at: ${new Date(share.expires_at).toISOString()}`);
+        console.log(`  expires_at: ${share.expires_at === null ? "never" : new Date(share.expires_at).toISOString()}`);
       },
     );
 


### PR DESCRIPTION
## Problem
The Hands CLI historically defaulted both `share` and `update-share` to a seven-day TTL, while the API treats omitted `ttl_seconds` as no expiry.

## Changes
- omit `ttl_seconds` for default `share`
- add explicit `--never-expires` for permanent updates
- render nullable `expires_at` safely in share output/listing
- add CLI coverage for omitted TTL, explicit TTL, and permanent update

## Testing
- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli test -- --run src/cli.test.ts` (42 passed)
- CLI build passed
- lint could not run because this checkout has no ESLint flat config

No release or share mutation was performed.