### PR TITLE
chore(cli): bump version to 0.5.19

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",


### PR DESCRIPTION
## Problem
The permanent-share CLI fix landed in 0.5.18 source but npm currently serves 0.5.18, so users cannot receive it as a new release.

## Changes
- bump `@botiverse/hands-cli` to `0.5.19`
- no source behavior changes; merge base contains PR #475 permanent-share implementation

## Testing
- `pnpm --filter @botiverse/hands-node build`
- `pnpm --filter @botiverse/hands-cli test -- --run src/cli.test.ts` (42 passed)
- `pnpm --filter @botiverse/hands-cli build`

After merge, publish workflow will verify the published Hands Node dependency, build, pack, and publish this exact package. No Android release or rollout mutation.