### PR TITLE
fix(testflight): distinguish "never uploaded" from "Apple is processing"

### DIFF
--- a/packages/cli/src/commands/builds.ts
+++ b/packages/cli/src/commands/builds.ts
@@ -435,6 +435,15 @@ async function getTestflightPublishStatus(
 }
 
 function assertTestflightStatusHealthy(status: TestflightPublishStatus): void {
+  // `not_uploaded` means Apple has no record of this build AND no upload ever
+  // succeeded. Polling cannot resolve it — only an upload can — so it must stop
+  // the wait loop instead of looking like one more slow round.
+  if (status.state === "not_uploaded") {
+    throw new Error(
+      "TestFlight build was never uploaded to Apple — run `hands builds testflight-upload` first; "
+        + "waiting will not change this",
+    );
+  }
   if (
     status.state === "processing_failed" ||
     status.state === "expired" ||

--- a/worker/src/routes/testflight.ts
+++ b/worker/src/routes/testflight.ts
@@ -433,6 +433,40 @@ async function readTestflightSnapshot(
   };
 }
 
+/**
+ * Has this build ever been uploaded to Apple?
+ *
+ * WHY THIS EXISTS: when App Store Connect returns no build record, that single
+ * observation covers two OPPOSITE situations — nobody ever uploaded, or the
+ * upload succeeded and Apple has not surfaced it yet. Reporting both as
+ * `waiting_for_processing` told an operator to wait for something that would
+ * never happen, and the CLI's poll loop treats non-terminal states as "keep
+ * waiting", so the wrong one waits forever.
+ *
+ * The two are distinguishable from data we already keep: a successful upload
+ * writes an `operation_logs` row with kind `testflight-upload` whose input
+ * names the build. Absence of that row is what makes "not uploaded" a FACT
+ * rather than a guess.
+ */
+async function hasSucceededTestflightUpload(
+  db: D1Database,
+  appId: string,
+  buildId: string,
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT id FROM operation_logs
+        WHERE app_id = ?1
+          AND kind = 'testflight-upload'
+          AND status = 'success'
+          AND json_extract(input, '$.build_id') = ?2
+        LIMIT 1`,
+    )
+    .bind(appId, buildId)
+    .first<{ id: string }>();
+  return row !== null && row !== undefined;
+}
+
 function publishState(
   build: AscBuildResource,
   snapshot: TestflightSnapshot | null,
@@ -881,6 +915,14 @@ export async function handleTestflightPublishStatus(c: AdminContext) {
       buildNumber: String(build.version_code),
     });
     if (!ascBuild) {
+      // Apple has no record of this build. That is NOT the same as "processing":
+      // it is only worth waiting for if we actually uploaded. Decide from the
+      // upload operation, not from the absence of the ASC record.
+      const uploaded = await hasSucceededTestflightUpload(
+        c.env.DB,
+        appId,
+        build.id,
+      );
       return c.json({
         hands_build_id: build.id,
         bundle_id: bundleId,
@@ -888,7 +930,11 @@ export async function handleTestflightPublishStatus(c: AdminContext) {
         asc_build_id: null,
         version: build.version_name,
         build_number: String(build.version_code),
-        state: "waiting_for_processing",
+        state: uploaded ? "waiting_for_processing" : "not_uploaded",
+        detail: uploaded
+          ? "uploaded to Apple; the build has not appeared in App Store Connect yet"
+          : "this build has never been uploaded to Apple — run testflight-upload; "
+            + "waiting will not change this",
         distribution: distribution ?? null,
       });
     }
@@ -1355,14 +1401,24 @@ export async function handleTestflightPublish(c: AdminContext) {
       buildNumber: String(build.version_code),
     });
     if (!ascBuild) {
+      // Same distinction as the status endpoint: "never uploaded" and "uploaded,
+      // Apple still processing" need different actions, so the detail must not
+      // claim processing when nothing was ever sent.
+      const uploaded = await hasSucceededTestflightUpload(
+        c.env.DB,
+        appId,
+        build.id,
+      );
       throw new TestflightPublishError(
         409,
-        "ASC_BUILD_NOT_AVAILABLE",
-        "the exact App Store Connect build is not available yet; upload it and wait for processing",
+        uploaded ? "ASC_BUILD_NOT_AVAILABLE" : "ASC_BUILD_NOT_UPLOADED",
+        uploaded
+          ? "the exact App Store Connect build is not available yet; wait for Apple to finish processing"
+          : "this build has never been uploaded to Apple — run testflight-upload first",
         {
           version: build.version_name,
           build_number: String(build.version_code),
-          state: "waiting_for_processing",
+          state: uploaded ? "waiting_for_processing" : "not_uploaded",
         },
       );
     }

--- a/worker/test/testflight_not_uploaded.test.ts
+++ b/worker/test/testflight_not_uploaded.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Only the credential store is stubbed: it needs real encrypted material at
+// rest, which is not what these tests are about. The handler, the ASC HTTP
+// calls and the upload-log query all run for real.
+vi.mock("../src/lib/asc_credentials", () => ({
+  getAscCredentials: vi.fn(async () => ({
+    issuerId: "issuer-1",
+    keyId: "key-1",
+    privateKey: {} as CryptoKey,
+  })),
+}));
+vi.mock("../src/lib/asc_api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/asc_api")>();
+  return {
+    ...actual,
+    // The ASC app exists; the BUILD does not. That single "no build" reading is
+    // exactly the ambiguity under test.
+    resolveAscAppId: vi.fn(async () => "asc-app-1"),
+    resolveAscBuild: vi.fn(async () => null),
+  };
+});
+
+import { handleTestflightPublishStatus } from "../src/routes/testflight";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// App Store Connect returning NO build record covers two opposite situations:
+// nobody ever uploaded, and the upload succeeded but Apple has not surfaced it.
+// They need opposite actions (upload vs wait), so the status must not collapse
+// them into one `waiting_for_processing`. These tests drive both arms through
+// the real handler and differ ONLY in whether a succeeded upload operation row
+// exists — nothing else in the fixture changes.
+function makeDb(opts: { uploadSucceeded: boolean }) {
+  let uploadLookups = 0;
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind() {
+          return this;
+        },
+        async all() {
+          if (sql.includes("FROM builds")) {
+            return {
+              results: [
+                {
+                  id: "build-1",
+                  product_type: "ios-ipa",
+                  version_name: "1.0.0",
+                  version_code: 1000021,
+                  build_metadata_json: JSON.stringify({ bundle_id: "build.raft.app" }),
+                },
+              ],
+            };
+          }
+          return { results: [] };
+        },
+        async first() {
+          if (sql.includes("kind = 'testflight-upload'")) {
+            uploadLookups += 1;
+            return opts.uploadSucceeded ? { id: "op-1" } : null;
+          }
+          return null;
+        },
+        async run() {
+          return { success: true };
+        },
+      };
+    },
+  };
+  return { db: db as unknown as D1Database, uploads: () => uploadLookups };
+}
+
+async function statusFor(uploadSucceeded: boolean) {
+  const { db, uploads } = makeDb({ uploadSucceeded });
+  const app = new Hono();
+  app.get("/api/apps/:appId/builds/:buildId/testflight-status", async (c) => {
+    (c as any).env = { DB: db, ASC_CRED_ENC_KEY: "test-enc-key" };
+    return handleTestflightPublishStatus(c as any);
+  });
+  const res = await app.request("/api/apps/app-1/builds/build-1/testflight-status");
+  return { res, body: (await res.json()) as any, uploads: uploads() };
+}
+
+describe("TestFlight status when App Store Connect has no build record", () => {
+  it("reports not_uploaded when no upload ever succeeded — waiting cannot fix it", async () => {
+    const { body, uploads } = await statusFor(false);
+    expect(uploads).toBeGreaterThan(0); // the decision consulted the upload log
+    expect(body.state).toBe("not_uploaded");
+    expect(body.state).not.toBe("waiting_for_processing");
+    expect(String(body.detail)).toMatch(/never been uploaded/i);
+  });
+
+  it("reports waiting_for_processing only when an upload actually succeeded", async () => {
+    const { body } = await statusFor(true);
+    expect(body.state).toBe("waiting_for_processing");
+  });
+});


### PR DESCRIPTION
## Problem

When App Store Connect returns no build record, the status endpoint reported
`waiting_for_processing`. That one observation covers two **opposite**
situations — nobody ever uploaded, or the upload succeeded and Apple has not
surfaced the build yet — and they call for opposite actions (upload vs wait).

It is not only wording. The CLI's wait loop treats every non-terminal state as
"keep polling", so a build that was never uploaded polls **forever**, waiting
for something that cannot happen. This misread a real release: 1000021 was
reported as processing while no upload had run.

## Changes

- Decide from the upload log rather than from the absence of the ASC record. A
  succeeded `testflight-upload` operation naming the build is what makes
  "uploaded" a fact; absent that row the state is `not_uploaded`, with a detail
  stating an upload is required and that waiting will not help.
- Same split on the publish path: `ASC_BUILD_NOT_UPLOADED` (409) when nothing
  was uploaded, distinct from `ASC_BUILD_NOT_AVAILABLE`.
- Treat `not_uploaded` as terminal in the CLI wait loop. A correct status the
  client ignores is not a fix.

## Follow-up

`not_uploaded` is a new state string. Older CLI builds do not know it and will
keep polling exactly as they do today — no regression, but they do not gain the
early exit until they update.

## Testing

- `worker/test/testflight_not_uploaded.test.ts` drives both arms through the
  real handler; the fixtures differ only in whether a succeeded upload row
  exists.
- Mutation-verified: restoring the old unconditional `waiting_for_processing`
  turns the not-uploaded case red.
- worker 51 files green, CLI 3 files green, `tsc --noEmit` clean for both.