### PR TITLE
chore(node): bump @botiverse/hands-node to 0.2.0 to publish the updater

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Hands logging, redaction, and policy-governed log collection for Node.js.",
   "author": {
     "name": "jiacheng",

--- a/packages/node/src/updater/index.ts
+++ b/packages/node/src/updater/index.ts
@@ -97,7 +97,7 @@ export interface HandsUpdater {
 
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
-export const HANDS_NODE_SDK_VERSION = "0.1.0";
+export const HANDS_NODE_SDK_VERSION = "0.2.0";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "update response must be an object");


### PR DESCRIPTION
npm already serves 0.1.0, so the updater publish (from merge b7e2cd5a) needs a bump. Minor: new backwards-compatible export. Both version carriers bumped together (package.json + HANDS_NODE_SDK_VERSION). Tests 21/21, tsc clean. On merge: tag node-v0.2.0 triggers publish-node.yml.