### PR TITLE
docs(testflight): preserve notification receipts

### DIFF
--- a/docs/public/agent-guide.md
+++ b/docs/public/agent-guide.md
@@ -278,6 +278,18 @@ External Beta App Review can take hours,
 so agents should return the submission state and recheck with
 `get-testflight-publish-status` rather than holding a Raft turn open.
 
+If the requested completion boundary includes tester notification, retain the
+`publish-testflight-build` action response as the mutation receipt and require
+`notification=sent` or `already_sent`. Then call the read-only
+`get-testflight-publish-status` action until the exact build reports
+`external_build_state=IN_BETA_TESTING`. `not_requested` and `scheduled` are not
+completion states. For `scheduled`, wait for the exact testing state, replay
+the same idempotent publish action to retain `already_sent`, and read status
+again. Never infer notification from `VALID`, group assignment,
+`BETA_APPROVED`, or `auto_notify_enabled=false`; the last field is scheduling
+policy, not notification history. TestFlight notification does not activate a
+Hands release or publish an App Store production version.
+
 ### Exact iOS simulator QA artifacts
 
 Use this lane for a zipped `.app` bundle that Stamp or another agent must

--- a/docs/public/cli-reference.md
+++ b/docs/public/cli-reference.md
@@ -230,22 +230,39 @@ hands builds testflight-publish raft-ios <hands-build-id> \
   --group-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
   --what-to-test-file en-US=./testflight.en.txt \
   --what-to-test-file zh-Hans=./testflight.zh.txt \
-  --notify-testers
+  --notify-testers \
+  --json > testflight-publish-receipt.json
 ```
 
-External review can take longer than a normal CLI session. Omit `--wait` to
-submit and return immediately, then inspect the live state later:
+Preserve that mutation response: `notification=sent` or `already_sent` is the
+notification operation receipt. Do not add `--wait` to this receipt-producing
+call. With `--wait --json`, the CLI prints the later polled GET status instead
+of the original POST response, so `notification` and `operation_id` are not
+preserved.
+
+External review can take longer than a normal CLI session. Inspect the live
+state separately:
 
 ```bash
 hands builds testflight-status raft-ios <hands-build-id> \
-  --distribution external
+  --distribution external \
+  --json
 ```
 
-When `--wait` is useful, tune its bounded poll contract with
+When `--wait` is useful and the POST operation receipt is not part of the
+acceptance contract, tune its bounded poll contract with
 `--poll-interval-seconds` and `--timeout-seconds` (defaults: 15 and 3600).
 Terminal failure/rejection/expiry states fail the command. External mode
 requires an existing or supplied What to Test localization; selected group ids
 must all match the requested internal/external mode.
+
+Notification values are `not_requested`, `scheduled`, `sent`, and
+`already_sent`. Only `sent`/`already_sent`, paired with a fresh exact-build
+`external_build_state=IN_BETA_TESTING`, prove notification completion. If the
+first response is `scheduled`, wait for that exact testing state, replay the
+same publish without `--wait` to preserve `already_sent`, then fresh-read the
+status again. `VALID`, group assignment, `BETA_APPROVED`, and
+`auto_notify_enabled=false` are not notification receipts.
 
 Hands follows Apple's role boundary: uploading the IPA requires Hands app
 admin; TestFlight group distribution requires Hands app publisher. The stored

--- a/docs/public/ios-testflight.md
+++ b/docs/public/ios-testflight.md
@@ -110,6 +110,50 @@ These endpoints and the matching CLI/integration actions are TestFlight-only.
 They never activate a Hands release and never create, submit, or release an
 App Store production version.
 
+## Publication receipts and common pitfalls
+
+Treat upload, review, tester notification, and App Store production as four
+different boundaries:
+
+- Build Upload `COMPLETE` and ASC build `VALID` prove only that Apple accepted
+  and processed the binary.
+- Group assignment, What to Test, `BETA_APPROVED`, or
+  `approved_not_notified` prove eligibility, not tester notification.
+- `auto_notify_enabled` is a scheduling-policy field, not an event log.
+  `false` can appear before or after a manual notification and cannot prove
+  that notification did not happen.
+- TestFlight tester notification never activates a Hands release and never
+  publishes an App Store production version.
+
+For an external publish that must notify testers, preserve two independent
+receipts:
+
+1. The mutation response from `testflight-publish` must have
+   `notification=sent` or `notification=already_sent`.
+2. A fresh, separate `testflight-status` read must show
+   `external_build_state=IN_BETA_TESTING` for the exact ASC build.
+
+Do not add `--wait` to the receipt-producing CLI call. The current
+`testflight-publish --wait --json` implementation prints the final polled GET
+status instead of the original POST response; GET status does not contain the
+POST `notification` or `operation_id`. Use the publish command without
+`--wait`, save its JSON, and poll separately with `testflight-status`.
+
+The `notification` enum is deliberate:
+
+| Value | Meaning | Notification complete? |
+| --- | --- | --- |
+| `not_requested` | No notification requested | No |
+| `scheduled` | Auto-notify is pending review/testing | No |
+| `sent` | Manual notification operation succeeded | Yes, with fresh `IN_BETA_TESTING` |
+| `already_sent` | Idempotent replay found notification already complete | Yes, with fresh `IN_BETA_TESTING` |
+
+When the first mutation returns `scheduled`, wait until the exact build reaches
+`IN_BETA_TESTING`, then replay the same publish without `--wait`. Preserve the
+expected `already_sent` receipt and fresh-read the exact status once more. If
+either receipt is missing after a bounded recheck, report notification as
+unverified rather than calling the build published or sent.
+
 ## One-time setup (app admin)
 
 Store the App Store Connect API credential in Hands: console → App →
@@ -153,11 +197,14 @@ CLI:
 ```sh
 hands builds testflight-groups <app> <hands-build-id>
 hands builds testflight-publish <app> <hands-build-id> \
-  --distribution internal \
+  --distribution external \
   --group-id <asc-beta-group-id> \
   --what-to-test en-US="Verify the release candidate." \
-  --wait
-hands builds testflight-status <app> <hands-build-id> --distribution internal
+  --notify-testers \
+  --json > testflight-publish-receipt.json
+hands builds testflight-status <app> <hands-build-id> \
+  --distribution external \
+  --json
 ```
 
 Raft integration actions:


### PR DESCRIPTION
## Summary
- document why `testflight-publish --wait --json` cannot preserve the POST notification receipt
- separate the mutation receipt from the read-only TestFlight status polling flow
- classify all notification enum values and the `scheduled` idempotent replay path
- clarify that VALID/review/groups/auto-notify are not tester-notification evidence

## Validation
- `git diff --check`
- docs generator completed: 16 pages + 15 markdown twins + docs index
- full admin build could not start Vite because this isolated docs worktree has no `node_modules` (`vite: command not found`); no dependency install was performed

No TestFlight, Hands release, App Store, deploy, or production mutation was executed.
