### PR TITLE
chore(cli): bump to 0.5.20 — 0.5.19 was already released from main (parallel bump #476)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",


### PR DESCRIPTION
Two parallel bump PRs claimed 0.5.19: #471 (the builds/deploy-tokens full-id fix, opened 08-20 morning) and #476 (bytemain's bump, merged + published from main on 08-20 evening — a normal main-based release, before #471 landed). npm's 0.5.19 therefore predates the #471 fix; npm versions are immutable, so the fix ships as **0.5.20**. Version-only bump; the CLI reads its version from package.json at runtime (post-#466), no second carrier.