### PR TITLE
ci: notify Hands workflow failures in Raft

### DIFF
--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Keep the failure notifier aligned with the workflows it is meant to watch."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+NOTIFIER = WORKFLOWS / "notify-hands-workflow-failures.yml"
+
+
+class _Yaml12SafeLoader(yaml.SafeLoader):
+    """Do not treat the GitHub Actions key `on` as a YAML 1.1 boolean."""
+
+
+for first_char, resolvers in list(_Yaml12SafeLoader.yaml_implicit_resolvers.items()):
+    _Yaml12SafeLoader.yaml_implicit_resolvers[first_char] = [
+        resolver
+        for resolver in resolvers
+        if resolver[0] != "tag:yaml.org,2002:bool"
+    ]
+
+
+def load(path: Path):
+    with path.open(encoding="utf-8") as stream:
+        return yaml.load(stream, Loader=_Yaml12SafeLoader)
+
+
+def main() -> None:
+    publish_and_deploy = sorted(
+        [*WORKFLOWS.glob("publish-*.yml"), *WORKFLOWS.glob("deploy-*.yml")]
+    )
+    expected_names = {load(path)["name"] for path in publish_and_deploy}
+
+    notifier = load(NOTIFIER)
+    watched_names = set(notifier["on"]["workflow_run"]["workflows"])
+    assert watched_names == expected_names, (
+        "workflow_run monitor drift: "
+        f"missing={sorted(expected_names - watched_names)}, "
+        f"unexpected={sorted(watched_names - expected_names)}"
+    )
+
+    job = notifier["jobs"]["notify"]
+    assert job["environment"] == "raft-workflow-notifications"
+    permissions = job.get("permissions", notifier.get("permissions"))
+    assert permissions == {"contents": "read"}
+    assert {"failure", "cancelled", "timed_out"} <= {
+        conclusion
+        for conclusion in ("failure", "cancelled", "timed_out")
+        if f"== '{conclusion}'" in job["if"]
+    }
+
+    steps = job["steps"]
+    install = next(step for step in steps if step.get("name") == "Install pinned Raft CLI")
+    assert "@botiverse/raft@0.0.17" in install["run"]
+    materialize = next(
+        step for step in steps if step.get("name") == "Materialize isolated profile credential"
+    )
+    assert materialize["env"] == {
+        "RAFT_CREDENTIAL_JSON": "${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}"
+    }
+    post = next(step for step in steps if step.get("name") == "Post structured failure alert")
+    assert 'message send --target "#proj-hands"' in post["run"]
+
+    print(
+        "Notification contract clean: "
+        f"{len(watched_names)} Publish/Deploy workflows, isolated credential, pinned CLI."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/notify-hands-workflow-failures.yml
+++ b/.github/workflows/notify-hands-workflow-failures.yml
@@ -1,0 +1,78 @@
+name: Notify Hands workflow failures
+
+on:
+  workflow_run:
+    workflows:
+      - Publish Android SDK
+      - Publish CLI
+      - Publish Electron SDK
+      - Publish Hands Node SDK
+      - Publish OHOS SDK
+      - Deploy Hands Server
+      - Deploy Quiver Server
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hands-workflow-alert-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    # This workflow only reports terminal failures/cancellations. Success is
+    # intentionally silent so the channel does not become a stream of heartbeats.
+    if: ${{ github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled' || github.event.workflow_run.conclusion == 'timed_out' }}
+    runs-on: ubuntu-latest
+    environment: raft-workflow-notifications
+    env:
+      RAFT_SERVER: https://app.raft.build
+      RAFT_PROFILE: hands-workflow-notifier
+      RAFT_PROFILE_DIR: /tmp/raft-profiles
+      RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      RUN_NAME: ${{ github.event.workflow_run.name }}
+      RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+      REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}
+    steps:
+      - name: Install pinned Raft CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-save --ignore-scripts --prefix "$RUNNER_TEMP/raft-cli" @botiverse/raft@0.0.17
+
+      - name: Materialize isolated profile credential
+        env:
+          RAFT_CREDENTIAL_JSON: ${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$RAFT_CREDENTIAL_JSON"
+          umask 077
+          profile_dir="$RAFT_PROFILE_DIR/$RAFT_PROFILE"
+          mkdir -p "$profile_dir"
+          printf '%s' "$RAFT_CREDENTIAL_JSON" > "$profile_dir/credential.json"
+          test "$(stat -c '%a' "$profile_dir/credential.json")" = 600
+
+      - name: Verify notifier credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" agent login status \
+            --server "$RAFT_SERVER" --agent "$(node -e 'const c=require(process.env.RAFT_PROFILE_DIR+"/"+process.env.RAFT_PROFILE+"/credential.json"); process.stdout.write(c.agentId)')" \
+            --profile-slug "$RAFT_PROFILE" --profile-dir "$RAFT_PROFILE_DIR/$RAFT_PROFILE"
+
+      - name: Post structured failure alert
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf -v body '%s\n' \
+            "Hands workflow alert: ${RUN_CONCLUSION}" \
+            "repository: ${REPOSITORY}" \
+            "workflow: ${RUN_NAME}" \
+            "run: ${RUN_URL}" \
+            "run_id: ${RUN_ID}" \
+            "head_sha: ${RUN_HEAD_SHA}"
+          "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" message send --target "#proj-hands" <<<"$body"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -177,3 +177,6 @@ jobs:
           # that pattern matched the comment describing it.
           echo "No interpolation in executable text, no duplicate keys, no unscanned carriers,"
           echo "across ${#targets[@]} of ${#present[@]} YAML files under .github/."
+
+      - name: Check workflow failure notification contract
+        run: python3 .github/lint-fixtures/test-notification-workflow.py


### PR DESCRIPTION
## Summary
- monitor all current Hands Publish and Deploy workflows via `workflow_run`
- send failure, cancellation, and timeout alerts to `#proj-hands` as a dedicated external Raft agent
- isolate the credential behind the `raft-workflow-notifications` GitHub environment
- pin `@botiverse/raft@0.0.17`, validate the profile before sending, and avoid expression interpolation in shell
- add a contract check that fails if Publish/Deploy workflow names drift out of the monitor list

## Validation
- `python3 .github/lint-fixtures/check-workflows.py .github/workflows/*.yml`
- `python3 .github/lint-fixtures/test-notification-workflow.py`
- actionlint 1.7.7
- `git diff --check`

## Non-goals / rollout gate
This source PR does not create an agent, mint a credential, create the GitHub environment, provision a secret, or enable production notifications. Those remain a separate authorized setup step after review/merge. The setup must use a new dedicated external agent profile, never a managed-runner proxy credential or an existing identity.
