### PR TITLE
fix(cli): use workspace:* for the hands-node dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "lint:fix": "eslint --fix src/"
   },
   "dependencies": {
-    "@botiverse/hands-node": "workspace:^0.1.0",
+    "@botiverse/hands-node": "workspace:*",
     "commander": "^12.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
   packages/cli:
     dependencies:
       '@botiverse/hands-node':
-        specifier: workspace:^0.1.0
+        specifier: workspace:*
         version: link:../node
       commander:
         specifier: ^12.1.0


### PR DESCRIPTION
The pinned `workspace:^0.1.0` range stopped matching after hands-node was bumped to 0.3.0 (#483), so fresh installs (CI runners, `--frozen-lockfile`) could not link the workspace package and the CLI build failed with TS2307 — breaking the deploy workflow's checks step (run 32655023163; failed safely before any migration/deploy). Local machines passed on stale node_modules symlinks, which is why every local build was green. `workspace:*` matches any workspace version, so internal version bumps can never break the link again.

Verified runner-faithfully: fresh clone → `pnpm install --frozen-lockfile` → `pnpm --filter @botiverse/hands-cli... build` all green.