### PR TITLE
fix(admin): drop deleted tauri-updater.md from the docs manifest

### DIFF
--- a/admin/scripts/build-docs.mjs
+++ b/admin/scripts/build-docs.mjs
@@ -107,13 +107,6 @@ const pages = [
     source: "feedback-react.md",
   },
   {
-    slug: "tauri-updater",
-    title: "Tauri Updater",
-    category: "SDKs & API",
-    description: "Publish signed Tauri v2 updater bundles and serve channel-specific dynamic update endpoints.",
-    source: "tauri-updater.md",
-  },
-  {
     slug: "public-api-reference",
     title: "Public API Reference",
     category: "SDKs & API",


### PR DESCRIPTION
#483 removed docs/public/tauri-updater.md but admin/scripts/build-docs.mjs still listed it — admin build ENOENT on fresh builds, breaking the deploy checks step a second time (run 32655498141; failed safely, production untouched). Removed the manifest entry; verified all remaining 14 sources exist and the full workflow checks sequence (worker test / worker build / cli... build / admin build) passes in a fresh clone with frozen lockfile.