### PR TITLE
ci: add isolated notifier health check

### DIFF
--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -9,6 +9,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 NOTIFIER = WORKFLOWS / "notify-hands-workflow-failures.yml"
+HEALTH = WORKFLOWS / "raft-notifier-health.yml"
 
 
 class _Yaml12SafeLoader(yaml.SafeLoader):
@@ -64,9 +65,26 @@ def main() -> None:
     post = next(step for step in steps if step.get("name") == "Post structured failure alert")
     assert 'message send --target "#proj-hands"' in post["run"]
 
+    health = load(HEALTH)
+    assert health["on"]["schedule"] == [{"cron": "17 3 * * *"}]
+    synthetic = health["on"]["workflow_dispatch"]["inputs"]["send_synthetic_alert"]
+    assert synthetic["type"] == "boolean" and synthetic["default"] == "false"
+    health_job = health["jobs"]["health"]
+    assert health_job["environment"] == "raft-workflow-notifications"
+    assert health_job["env"]["RAFT_CREDENTIAL_JSON"] == "${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}"
+    health_steps = health_job["steps"]
+    verify = next(step for step in health_steps if step.get("name") == "Verify notifier credential")
+    assert "agent login status" in verify["run"]
+    synthetic_post = next(
+        step for step in health_steps if step.get("name") == "Send synthetic notifier alert"
+    )
+    assert "inputs.send_synthetic_alert" in synthetic_post["if"]
+    assert 'message send --target "#proj-hands"' in synthetic_post["run"]
+
     print(
         "Notification contract clean: "
-        f"{len(watched_names)} Publish/Deploy workflows, isolated credential, pinned CLI."
+        f"{len(watched_names)} Publish/Deploy workflows, isolated credential, pinned CLI, "
+        "daily health + explicit synthetic alert."
     )
 
 

--- a/.github/workflows/raft-notifier-health.yml
+++ b/.github/workflows/raft-notifier-health.yml
@@ -1,0 +1,65 @@
+name: Raft workflow notifier health
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      send_synthetic_alert:
+        description: Send one clearly labelled test alert after credential validation
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    environment: raft-workflow-notifications
+    env:
+      RAFT_SERVER: https://app.raft.build
+      RAFT_PROFILE: hands-workflow-notifier
+      RAFT_PROFILE_DIR: /tmp/raft-profiles
+      RAFT_CREDENTIAL_JSON: ${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}
+    steps:
+      - name: Install pinned Raft CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-save --ignore-scripts --prefix "$RUNNER_TEMP/raft-cli" @botiverse/raft@0.0.17
+
+      - name: Materialize isolated profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$RAFT_CREDENTIAL_JSON"
+          umask 077
+          profile_dir="$RAFT_PROFILE_DIR/$RAFT_PROFILE"
+          mkdir -p "$profile_dir"
+          printf '%s' "$RAFT_CREDENTIAL_JSON" > "$profile_dir/credential.json"
+          test "$(stat -c '%a' "$profile_dir/credential.json")" = 600
+
+      - name: Verify notifier credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          agent_id="$(node -e 'const c=require(process.env.RAFT_PROFILE_DIR+"/"+process.env.RAFT_PROFILE+"/credential.json"); process.stdout.write(c.agentId)')"
+          "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" agent login status \
+            --server "$RAFT_SERVER" --agent "$agent_id" \
+            --profile-slug "$RAFT_PROFILE" --profile-dir "$RAFT_PROFILE_DIR/$RAFT_PROFILE"
+
+      - name: Send synthetic notifier alert
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.send_synthetic_alert }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf -v body '%s\n' \
+            "Hands workflow notifier synthetic alert: success" \
+            "repository: ${GITHUB_REPOSITORY}" \
+            "workflow: ${GITHUB_WORKFLOW}" \
+            "run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "run_id: ${GITHUB_RUN_ID}" \
+            "head_sha: ${GITHUB_SHA}"
+          "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" message send --target "#proj-hands" <<<"$body"


### PR DESCRIPTION
## Summary

- verify the dedicated Raft workflow-notifier credential every day
- provide an explicit `workflow_dispatch` synthetic alert that does not fail or invoke any Publish/Deploy workflow
- extend the notification contract test to pin the schedule, environment, secret, login-status check, and opt-in alert

## Verification

- notification contract test
- repository workflow checker
- pinned actionlint 1.7.7 with repository checksum
- `git diff --check`

Task #138. No publish/deploy workflow was triggered.
