### PR TITLE
fix(ci): resolve notifier profile from exact directory

### DIFF
--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -45,6 +45,7 @@ def main() -> None:
 
     job = notifier["jobs"]["notify"]
     assert job["environment"] == "raft-workflow-notifications"
+    assert job["env"]["RAFT_PROFILE_DIR"] == "/tmp/raft-profiles/hands-workflow-notifier"
     permissions = job.get("permissions", notifier.get("permissions"))
     assert permissions == {"contents": "read"}
     assert {"failure", "cancelled", "timed_out"} <= {
@@ -64,6 +65,7 @@ def main() -> None:
     }
     post = next(step for step in steps if step.get("name") == "Post structured failure alert")
     assert 'message send --target "#proj-hands"' in post["run"]
+    assert "$RAFT_PROFILE_DIR/credential.json" in materialize["run"]
 
     health = load(HEALTH)
     assert health["on"]["schedule"] == [{"cron": "17 3 * * *"}]
@@ -71,15 +73,20 @@ def main() -> None:
     assert synthetic["type"] == "boolean" and synthetic["default"] == "false"
     health_job = health["jobs"]["health"]
     assert health_job["environment"] == "raft-workflow-notifications"
+    assert health_job["env"]["RAFT_PROFILE_DIR"] == job["env"]["RAFT_PROFILE_DIR"]
     assert health_job["env"]["RAFT_CREDENTIAL_JSON"] == "${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}"
     health_steps = health_job["steps"]
     verify = next(step for step in health_steps if step.get("name") == "Verify notifier credential")
     assert "agent login status" in verify["run"]
+    assert '--profile-dir "$RAFT_PROFILE_DIR"' in verify["run"]
     synthetic_post = next(
         step for step in health_steps if step.get("name") == "Send synthetic notifier alert"
     )
     assert "inputs.send_synthetic_alert" in synthetic_post["if"]
     assert 'message send --target "#proj-hands"' in synthetic_post["run"]
+    assert "$RAFT_PROFILE_DIR/credential.json" in next(
+        step for step in health_steps if step.get("name") == "Materialize isolated profile"
+    )["run"]
 
     print(
         "Notification contract clean: "

--- a/.github/workflows/notify-hands-workflow-failures.yml
+++ b/.github/workflows/notify-hands-workflow-failures.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       RAFT_SERVER: https://app.raft.build
       RAFT_PROFILE: hands-workflow-notifier
-      RAFT_PROFILE_DIR: /tmp/raft-profiles
+      RAFT_PROFILE_DIR: /tmp/raft-profiles/hands-workflow-notifier
       RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
       RUN_ID: ${{ github.event.workflow_run.id }}
       RUN_NAME: ${{ github.event.workflow_run.name }}
@@ -51,18 +51,17 @@ jobs:
           set -euo pipefail
           test -n "$RAFT_CREDENTIAL_JSON"
           umask 077
-          profile_dir="$RAFT_PROFILE_DIR/$RAFT_PROFILE"
-          mkdir -p "$profile_dir"
-          printf '%s' "$RAFT_CREDENTIAL_JSON" > "$profile_dir/credential.json"
-          test "$(stat -c '%a' "$profile_dir/credential.json")" = 600
+          mkdir -p "$RAFT_PROFILE_DIR"
+          printf '%s' "$RAFT_CREDENTIAL_JSON" > "$RAFT_PROFILE_DIR/credential.json"
+          test "$(stat -c '%a' "$RAFT_PROFILE_DIR/credential.json")" = 600
 
       - name: Verify notifier credential
         shell: bash
         run: |
           set -euo pipefail
           "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" agent login status \
-            --server "$RAFT_SERVER" --agent "$(node -e 'const c=require(process.env.RAFT_PROFILE_DIR+"/"+process.env.RAFT_PROFILE+"/credential.json"); process.stdout.write(c.agentId)')" \
-            --profile-slug "$RAFT_PROFILE" --profile-dir "$RAFT_PROFILE_DIR/$RAFT_PROFILE"
+            --server "$RAFT_SERVER" --agent "$(node -e 'const c=require(process.env.RAFT_PROFILE_DIR+"/credential.json"); process.stdout.write(c.agentId)')" \
+            --profile-slug "$RAFT_PROFILE" --profile-dir "$RAFT_PROFILE_DIR"
 
       - name: Post structured failure alert
         shell: bash

--- a/.github/workflows/raft-notifier-health.yml
+++ b/.github/workflows/raft-notifier-health.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       RAFT_SERVER: https://app.raft.build
       RAFT_PROFILE: hands-workflow-notifier
-      RAFT_PROFILE_DIR: /tmp/raft-profiles
+      RAFT_PROFILE_DIR: /tmp/raft-profiles/hands-workflow-notifier
       RAFT_CREDENTIAL_JSON: ${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}
     steps:
       - name: Install pinned Raft CLI
@@ -36,19 +36,18 @@ jobs:
           set -euo pipefail
           test -n "$RAFT_CREDENTIAL_JSON"
           umask 077
-          profile_dir="$RAFT_PROFILE_DIR/$RAFT_PROFILE"
-          mkdir -p "$profile_dir"
-          printf '%s' "$RAFT_CREDENTIAL_JSON" > "$profile_dir/credential.json"
-          test "$(stat -c '%a' "$profile_dir/credential.json")" = 600
+          mkdir -p "$RAFT_PROFILE_DIR"
+          printf '%s' "$RAFT_CREDENTIAL_JSON" > "$RAFT_PROFILE_DIR/credential.json"
+          test "$(stat -c '%a' "$RAFT_PROFILE_DIR/credential.json")" = 600
 
       - name: Verify notifier credential
         shell: bash
         run: |
           set -euo pipefail
-          agent_id="$(node -e 'const c=require(process.env.RAFT_PROFILE_DIR+"/"+process.env.RAFT_PROFILE+"/credential.json"); process.stdout.write(c.agentId)')"
+          agent_id="$(node -e 'const c=require(process.env.RAFT_PROFILE_DIR+"/credential.json"); process.stdout.write(c.agentId)')"
           "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" agent login status \
             --server "$RAFT_SERVER" --agent "$agent_id" \
-            --profile-slug "$RAFT_PROFILE" --profile-dir "$RAFT_PROFILE_DIR/$RAFT_PROFILE"
+            --profile-slug "$RAFT_PROFILE" --profile-dir "$RAFT_PROFILE_DIR"
 
       - name: Send synthetic notifier alert
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.send_synthetic_alert }}


### PR DESCRIPTION
## Summary

- make `RAFT_PROFILE_DIR` point at the profile directory itself, matching the CLI's strict resolution contract
- use that exact directory consistently in credential materialization, login-status verification, failure alerts, and synthetic alerts
- add contract assertions so verify and send cannot drift to different profile paths again

## Verification

- notification contract test
- workflow checker
- pinned actionlint 1.7.7
- `git diff --check`

Follow-up to #488 / task #138. The first synthetic run failed closed with `PROFILE_FILE_UNREADABLE`; no message or Publish/Deploy action occurred.
