### PR TITLE
feat(node): send device identity for update selection

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-node",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Hands logging, redaction, and policy-governed log collection for Node.js.",
   "author": {
     "name": "jiacheng",

--- a/packages/node/src/updater/index.test.ts
+++ b/packages/node/src/updater/index.test.ts
@@ -54,11 +54,24 @@ describe("Hands updater", () => {
     const updater = createHandsUpdater({ appSlug: "raft-computer", apiOrigin: "https://hands.example", fetch });
     const input = { currentVersion: "1.0.18", channel: "main" as const, target: { platform: "linux" as const, arch: "x64" } };
     await updater.checkUpdate(input);
-    for (const deviceId of ["", " ", "contains space", "x".repeat(257)]) {
+    for (const deviceId of ["", " ", "contains space", "\0", "\x01", "\x7f", "x".repeat(257)]) {
       await expect(updater.checkUpdate({ ...input, deviceId }))
         .rejects.toEqual(expect.objectContaining<Partial<HandsUpdateError>>({ code: "UPDATE_RESPONSE_INVALID" }));
     }
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["unpublished release", (response: ReturnType<typeof fixture>["response"]) => { response.release.published_at = null as never; }],
+    ["malformed artifact", (response: ReturnType<typeof fixture>["response"]) => { response.artifact.sha256 = "not-a-sha256"; }],
+  ])("keeps %s response validation when a device id is present", async (_name, mutate) => {
+    const { response } = fixture();
+    mutate(response);
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => Response.json(response));
+    const updater = createHandsUpdater({ appSlug: "raft-computer", apiOrigin: "https://hands.example", fetch });
+    await expect(updater.checkUpdate({
+      currentVersion: "1.0.18", channel: "main", target: { platform: "linux", arch: "x64" }, deviceId: "machine-stable-1",
+    })).rejects.toEqual(expect.objectContaining<Partial<HandsUpdateError>>({ code: "UPDATE_RESPONSE_INVALID" }));
   });
 
   it("checks and atomically stages a size/SHA-256 verified candidate", async () => {

--- a/packages/node/src/updater/index.test.ts
+++ b/packages/node/src/updater/index.test.ts
@@ -24,6 +24,43 @@ function fixture(bytes = Buffer.from("verified computer binary")) {
 }
 
 describe("Hands updater", () => {
+  it.each(["main", "alpha", "pinned:1.0.19"] as const)(
+    "sends the exact device id for %s selection without changing channel semantics",
+    async (channel) => {
+      const { response } = fixture();
+      const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+        const url = new URL(String(input));
+        expect(new Headers(init?.headers).get("X-Hands-Device-Id")).toBe("machine-stable-1");
+        expect(url.searchParams.get("channel")).toBe(channel.startsWith("pinned:") ? "main" : channel);
+        expect(url.searchParams.get("version")).toBe(channel.startsWith("pinned:") ? "1.0.19" : null);
+        return Response.json(response);
+      });
+      const updater = createHandsUpdater({ appSlug: "raft-computer", apiOrigin: "https://hands.example", fetch });
+      await updater.checkUpdate({
+        currentVersion: "1.0.18",
+        channel,
+        target: { platform: "linux", arch: "x64" },
+        deviceId: "machine-stable-1",
+      });
+    },
+  );
+
+  it("omits the device header when deviceId is absent and rejects malformed ids before network", async () => {
+    const { response } = fixture();
+    const fetch = vi.fn<typeof globalThis.fetch>(async (_input, init) => {
+      expect(new Headers(init?.headers).has("X-Hands-Device-Id")).toBe(false);
+      return Response.json(response);
+    });
+    const updater = createHandsUpdater({ appSlug: "raft-computer", apiOrigin: "https://hands.example", fetch });
+    const input = { currentVersion: "1.0.18", channel: "main" as const, target: { platform: "linux" as const, arch: "x64" } };
+    await updater.checkUpdate(input);
+    for (const deviceId of ["", " ", "contains space", "x".repeat(257)]) {
+      await expect(updater.checkUpdate({ ...input, deviceId }))
+        .rejects.toEqual(expect.objectContaining<Partial<HandsUpdateError>>({ code: "UPDATE_RESPONSE_INVALID" }));
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("checks and atomically stages a size/SHA-256 verified candidate", async () => {
     const { bytes, response } = fixture();
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) =>

--- a/packages/node/src/updater/index.ts
+++ b/packages/node/src/updater/index.ts
@@ -143,8 +143,8 @@ export function createHandsUpdater(options: HandsUpdaterOptions): HandsUpdater {
 
   async function checkUpdate(input: UpdateCheckInput): Promise<UpdateCheckResult> {
     if (!SEMVER.test(input.currentVersion)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "currentVersion must be semver");
-    if (input.deviceId !== undefined && !/^\S{1,256}$/u.test(input.deviceId)) {
-      throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "deviceId must be 1-256 non-whitespace characters");
+    if (input.deviceId !== undefined && !/^[\x21-\x7e]{1,256}$/u.test(input.deviceId)) {
+      throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "deviceId must be 1-256 printable ASCII characters");
     }
     const pinned = input.channel.startsWith("pinned:") ? input.channel.slice(7) : null;
     if (pinned && !SEMVER.test(pinned)) throw new HandsUpdateError("UPDATE_CHANNEL_UNSUPPORTED", "pinned channel requires semver");

--- a/packages/node/src/updater/index.ts
+++ b/packages/node/src/updater/index.ts
@@ -4,7 +4,7 @@ import { basename, resolve } from "node:path";
 
 export type UpdateChannel = "main" | "alpha" | `pinned:${string}`;
 export interface RuntimeTarget { platform: NodeJS.Platform; arch: string }
-export interface UpdateCheckInput { currentVersion: string; channel: UpdateChannel; target: RuntimeTarget; signal?: AbortSignal }
+export interface UpdateCheckInput { currentVersion: string; channel: UpdateChannel; target: RuntimeTarget; deviceId?: string; signal?: AbortSignal }
 
 export interface UpdateCandidate {
   appId: string;
@@ -85,7 +85,7 @@ export interface HandsUpdater {
 
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
-export const HANDS_NODE_SDK_VERSION = "0.3.0";
+export const HANDS_NODE_SDK_VERSION = "0.4.0";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "update response must be an object");
@@ -143,6 +143,9 @@ export function createHandsUpdater(options: HandsUpdaterOptions): HandsUpdater {
 
   async function checkUpdate(input: UpdateCheckInput): Promise<UpdateCheckResult> {
     if (!SEMVER.test(input.currentVersion)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "currentVersion must be semver");
+    if (input.deviceId !== undefined && !/^\S{1,256}$/u.test(input.deviceId)) {
+      throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "deviceId must be 1-256 non-whitespace characters");
+    }
     const pinned = input.channel.startsWith("pinned:") ? input.channel.slice(7) : null;
     if (pinned && !SEMVER.test(pinned)) throw new HandsUpdateError("UPDATE_CHANNEL_UNSUPPORTED", "pinned channel requires semver");
     const channel = pinned ? "main" : input.channel;
@@ -161,7 +164,10 @@ export function createHandsUpdater(options: HandsUpdaterOptions): HandsUpdater {
     try {
       const token = await options.credentialProvider?.();
       const requestInit: RequestInit = { signal: controller.signal };
-      if (token) requestInit.headers = { authorization: `Bearer ${token}` };
+      requestInit.headers = {
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        ...(input.deviceId !== undefined ? { "X-Hands-Device-Id": input.deviceId } : {}),
+      };
       const response = await fetchImpl(url, requestInit);
       const body = await response.json().catch(() => null) as unknown;
       if (!response.ok) {


### PR DESCRIPTION
## Summary

- add optional `deviceId` to the Hands Node updater check contract
- validate it before network and send it exactly as `X-Hands-Device-Id`
- preserve main, alpha, and pinned version selection semantics
- bump the Node SDK to 0.4.0

## Verification

- Hands Node 21/21 tests
- Hands Node TypeScript build
- npm pack dry-run (0.4.0, 20 files)
- header-removal mutation RED on all three channel cases
- `git diff --check`

Task #139. Device identity is a rollout-selection input only; it is not an authorization or artifact-integrity signal.
