### PR TITLE
fix(ci): guarantee notifier alert delivery

### DIFF
--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -64,8 +64,9 @@ def main() -> None:
         "RAFT_CREDENTIAL_JSON": "${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}"
     }
     post = next(step for step in steps if step.get("name") == "Post structured failure alert")
-    assert 'message send --target "#proj-hands"' in post["run"]
-    assert 'saved as a draft' in post["run"] and 'Message (sent|queued)' in post["run"]
+    assert 'message send --anyway --target "#proj-hands"' in post["run"]
+    assert "--send-draft" not in post["run"]
+    assert 'Message (sent|queued)' in post["run"]
     assert "$RAFT_PROFILE_DIR/credential.json" in materialize["run"]
 
     health = load(HEALTH)
@@ -84,8 +85,9 @@ def main() -> None:
         step for step in health_steps if step.get("name") == "Send synthetic notifier alert"
     )
     assert "inputs.send_synthetic_alert" in synthetic_post["if"]
-    assert 'message send --target "#proj-hands"' in synthetic_post["run"]
-    assert 'saved as a draft' in synthetic_post["run"] and 'Message (sent|queued)' in synthetic_post["run"]
+    assert 'message send --anyway --target "#proj-hands"' in synthetic_post["run"]
+    assert "--send-draft" not in synthetic_post["run"]
+    assert 'Message (sent|queued)' in synthetic_post["run"]
     assert "$RAFT_PROFILE_DIR/credential.json" in next(
         step for step in health_steps if step.get("name") == "Materialize isolated profile"
     )["run"]

--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -65,6 +65,7 @@ def main() -> None:
     }
     post = next(step for step in steps if step.get("name") == "Post structured failure alert")
     assert 'message send --target "#proj-hands"' in post["run"]
+    assert 'saved as a draft' in post["run"] and 'Message (sent|queued)' in post["run"]
     assert "$RAFT_PROFILE_DIR/credential.json" in materialize["run"]
 
     health = load(HEALTH)
@@ -84,6 +85,7 @@ def main() -> None:
     )
     assert "inputs.send_synthetic_alert" in synthetic_post["if"]
     assert 'message send --target "#proj-hands"' in synthetic_post["run"]
+    assert 'saved as a draft' in synthetic_post["run"] and 'Message (sent|queued)' in synthetic_post["run"]
     assert "$RAFT_PROFILE_DIR/credential.json" in next(
         step for step in health_steps if step.get("name") == "Materialize isolated profile"
     )["run"]

--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -64,8 +64,9 @@ def main() -> None:
         "RAFT_CREDENTIAL_JSON": "${{ secrets.RAFT_NOTIFY_CREDENTIAL_JSON }}"
     }
     post = next(step for step in steps if step.get("name") == "Post structured failure alert")
-    assert 'message send --anyway --target "#proj-hands"' in post["run"]
-    assert "--send-draft" not in post["run"]
+    assert 'message check' in post["run"]
+    assert 'message send --target "#proj-hands"' in post["run"]
+    assert 'message send --send-draft --anyway --target "#proj-hands"' in post["run"]
     assert 'Message (sent|queued)' in post["run"]
     assert "$RAFT_PROFILE_DIR/credential.json" in materialize["run"]
 
@@ -85,8 +86,9 @@ def main() -> None:
         step for step in health_steps if step.get("name") == "Send synthetic notifier alert"
     )
     assert "inputs.send_synthetic_alert" in synthetic_post["if"]
-    assert 'message send --anyway --target "#proj-hands"' in synthetic_post["run"]
-    assert "--send-draft" not in synthetic_post["run"]
+    assert 'message check' in synthetic_post["run"]
+    assert 'message send --target "#proj-hands"' in synthetic_post["run"]
+    assert 'message send --send-draft --anyway --target "#proj-hands"' in synthetic_post["run"]
     assert 'Message (sent|queued)' in synthetic_post["run"]
     assert "$RAFT_PROFILE_DIR/credential.json" in next(
         step for step in health_steps if step.get("name") == "Materialize isolated profile"

--- a/.github/workflows/notify-hands-workflow-failures.yml
+++ b/.github/workflows/notify-hands-workflow-failures.yml
@@ -75,7 +75,18 @@ jobs:
             "run_id: ${RUN_ID}" \
             "head_sha: ${RUN_HEAD_SHA}"
           cli="$RUNNER_TEMP/raft-cli/node_modules/.bin/raft"
-          if ! output=$("$cli" message send --anyway --target "#proj-hands" <<<"$body" 2>&1); then
+          "$cli" message check >/dev/null
+          set +e
+          output=$("$cli" message send --target "#proj-hands" <<<"$body" 2>&1)
+          send_status=$?
+          set -e
+          if grep -q "saved as a draft" <<<"$output"; then
+            set +e
+            output=$("$cli" message send --send-draft --anyway --target "#proj-hands" 2>&1)
+            send_status=$?
+            set -e
+          fi
+          if (( send_status != 0 )); then
             printf '%s\n' "$output" >&2
             exit 1
           fi

--- a/.github/workflows/notify-hands-workflow-failures.yml
+++ b/.github/workflows/notify-hands-workflow-failures.yml
@@ -74,4 +74,19 @@ jobs:
             "run: ${RUN_URL}" \
             "run_id: ${RUN_ID}" \
             "head_sha: ${RUN_HEAD_SHA}"
-          "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" message send --target "#proj-hands" <<<"$body"
+          cli="$RUNNER_TEMP/raft-cli/node_modules/.bin/raft"
+          if ! output=$("$cli" message send --target "#proj-hands" <<<"$body" 2>&1); then
+            printf '%s\n' "$output" >&2
+            exit 1
+          fi
+          if grep -q "saved as a draft" <<<"$output"; then
+            if ! output=$("$cli" message send --send-draft --target "#proj-hands" 2>&1); then
+              printf '%s\n' "$output" >&2
+              exit 1
+            fi
+          fi
+          grep -Eq "Message (sent|queued)" <<<"$output" || {
+            printf 'Notifier delivery was not accepted:\n%s\n' "$output" >&2
+            exit 1
+          }
+          printf '%s\n' "$output"

--- a/.github/workflows/notify-hands-workflow-failures.yml
+++ b/.github/workflows/notify-hands-workflow-failures.yml
@@ -75,15 +75,9 @@ jobs:
             "run_id: ${RUN_ID}" \
             "head_sha: ${RUN_HEAD_SHA}"
           cli="$RUNNER_TEMP/raft-cli/node_modules/.bin/raft"
-          if ! output=$("$cli" message send --target "#proj-hands" <<<"$body" 2>&1); then
+          if ! output=$("$cli" message send --anyway --target "#proj-hands" <<<"$body" 2>&1); then
             printf '%s\n' "$output" >&2
             exit 1
-          fi
-          if grep -q "saved as a draft" <<<"$output"; then
-            if ! output=$("$cli" message send --send-draft --target "#proj-hands" 2>&1); then
-              printf '%s\n' "$output" >&2
-              exit 1
-            fi
           fi
           grep -Eq "Message (sent|queued)" <<<"$output" || {
             printf 'Notifier delivery was not accepted:\n%s\n' "$output" >&2

--- a/.github/workflows/raft-notifier-health.yml
+++ b/.github/workflows/raft-notifier-health.yml
@@ -61,4 +61,19 @@ jobs:
             "run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             "run_id: ${GITHUB_RUN_ID}" \
             "head_sha: ${GITHUB_SHA}"
-          "$RUNNER_TEMP/raft-cli/node_modules/.bin/raft" message send --target "#proj-hands" <<<"$body"
+          cli="$RUNNER_TEMP/raft-cli/node_modules/.bin/raft"
+          if ! output=$("$cli" message send --target "#proj-hands" <<<"$body" 2>&1); then
+            printf '%s\n' "$output" >&2
+            exit 1
+          fi
+          if grep -q "saved as a draft" <<<"$output"; then
+            if ! output=$("$cli" message send --send-draft --target "#proj-hands" 2>&1); then
+              printf '%s\n' "$output" >&2
+              exit 1
+            fi
+          fi
+          grep -Eq "Message (sent|queued)" <<<"$output" || {
+            printf 'Notifier delivery was not accepted:\n%s\n' "$output" >&2
+            exit 1
+          }
+          printf '%s\n' "$output"

--- a/.github/workflows/raft-notifier-health.yml
+++ b/.github/workflows/raft-notifier-health.yml
@@ -62,15 +62,9 @@ jobs:
             "run_id: ${GITHUB_RUN_ID}" \
             "head_sha: ${GITHUB_SHA}"
           cli="$RUNNER_TEMP/raft-cli/node_modules/.bin/raft"
-          if ! output=$("$cli" message send --target "#proj-hands" <<<"$body" 2>&1); then
+          if ! output=$("$cli" message send --anyway --target "#proj-hands" <<<"$body" 2>&1); then
             printf '%s\n' "$output" >&2
             exit 1
-          fi
-          if grep -q "saved as a draft" <<<"$output"; then
-            if ! output=$("$cli" message send --send-draft --target "#proj-hands" 2>&1); then
-              printf '%s\n' "$output" >&2
-              exit 1
-            fi
           fi
           grep -Eq "Message (sent|queued)" <<<"$output" || {
             printf 'Notifier delivery was not accepted:\n%s\n' "$output" >&2

--- a/.github/workflows/raft-notifier-health.yml
+++ b/.github/workflows/raft-notifier-health.yml
@@ -62,7 +62,18 @@ jobs:
             "run_id: ${GITHUB_RUN_ID}" \
             "head_sha: ${GITHUB_SHA}"
           cli="$RUNNER_TEMP/raft-cli/node_modules/.bin/raft"
-          if ! output=$("$cli" message send --anyway --target "#proj-hands" <<<"$body" 2>&1); then
+          "$cli" message check >/dev/null
+          set +e
+          output=$("$cli" message send --target "#proj-hands" <<<"$body" 2>&1)
+          send_status=$?
+          set -e
+          if grep -q "saved as a draft" <<<"$output"; then
+            set +e
+            output=$("$cli" message send --send-draft --anyway --target "#proj-hands" 2>&1)
+            send_status=$?
+            set -e
+          fi
+          if (( send_status != 0 )); then
             printf '%s\n' "$output" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- consume synced notifier context before posting
- recover a freshness-held send only through the CLI-supported `--send-draft --anyway` path
- require an accepted `Message sent`/`Message queued` receipt before the job can pass
- apply the same delivery contract to synthetic health alerts and real Publish/Deploy failure alerts

## Validation
- `python3 .github/lint-fixtures/test-notification-workflow.py`
- `python3 .github/lint-fixtures/check-workflows.py`
- `/tmp/actionlint .github/workflows/notify-hands-workflow-failures.yml .github/workflows/raft-notifier-health.yml` (actionlint 1.7.7)
- `git diff --check`

## Scope
Safe synthetic validation only after merge. This PR does not trigger or fail a real Publish/Deploy workflow.
