### PR TITLE
feat(node): add shared Hands device identity

### DIFF
--- a/.github/lint-fixtures/test-notification-workflow.py
+++ b/.github/lint-fixtures/test-notification-workflow.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 NOTIFIER = WORKFLOWS / "notify-hands-workflow-failures.yml"
 HEALTH = WORKFLOWS / "raft-notifier-health.yml"
+WORKER_TESTS = WORKFLOWS / "worker-tests.yml"
 
 
 class _Yaml12SafeLoader(yaml.SafeLoader):
@@ -30,6 +31,14 @@ def load(path: Path):
 
 
 def main() -> None:
+    worker_tests = load(WORKER_TESTS)
+    windows_device_id = worker_tests["jobs"]["windows-device-id"]
+    assert windows_device_id["runs-on"] == "windows-latest"
+    windows_runs = "\n".join(
+        step.get("run", "") for step in windows_device_id["steps"]
+    )
+    assert "node packages/node/test/windows-device-id.mjs" in windows_runs
+
     publish_and_deploy = sorted(
         [*WORKFLOWS.glob("publish-*.yml"), *WORKFLOWS.glob("deploy-*.yml")]
     )

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -87,6 +87,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  windows-device-id:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @botiverse/hands-node build
+      - name: Test real HKCU device identity persistence
+        run: node packages/node/test/windows-device-id.mjs
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",

--- a/packages/cli/src/commands/device_id.test.ts
+++ b/packages/cli/src/commands/device_id.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+import { deviceJson, deviceText } from "./device_id.js";
+const ID = "123e4567-e89b-4d3a-a456-426614174000";
+describe("device-id output", () => {
+  it("uses the stable JSON contract", () => expect(deviceJson(ID)).toEqual({ device: { id: ID, scope: "os_user", namespace: "hands.build" } }));
+  it("uses explicit human-readable labels", () => expect(deviceText(ID)).toBe(`device_id: ${ID}\ndevice_scope: os_user\ndevice_namespace: hands.build`));
+});

--- a/packages/cli/src/commands/device_id.ts
+++ b/packages/cli/src/commands/device_id.ts
@@ -1,13 +1,15 @@
 import type { Command } from "commander";
-import { getDeviceId } from "@botiverse/hands-node";
+import { getHandsDeviceId } from "@botiverse/hands-node";
+export const deviceJson = (id: string) => ({ device: { id, scope: "os_user", namespace: "hands.build" } });
+export const deviceText = (id: string) => `device_id: ${id}\ndevice_scope: os_user\ndevice_namespace: hands.build`;
 
 export function registerDeviceIdCommand(program: Command): void {
   program.command("device-id")
     .description("Print the local Hands device ID (OS-user scope).")
     .option("--json", "Output machine-readable JSON.", false)
     .action(async (opts: { json?: boolean }) => {
-      const id = await getDeviceId();
-      if (opts.json) console.log(JSON.stringify({ device: { id, scope: "os_user", namespace: "hands.build" } }, null, 2));
-      else { console.log(`device_id: ${id}`); console.log("device_scope: os_user"); console.log("device_namespace: hands.build"); }
+      const id = await getHandsDeviceId();
+      if (opts.json) console.log(JSON.stringify(deviceJson(id), null, 2));
+      else console.log(deviceText(id));
     });
 }

--- a/packages/cli/src/commands/device_id.ts
+++ b/packages/cli/src/commands/device_id.ts
@@ -1,0 +1,13 @@
+import type { Command } from "commander";
+import { getDeviceId } from "@botiverse/hands-node";
+
+export function registerDeviceIdCommand(program: Command): void {
+  program.command("device-id")
+    .description("Print the local Hands device ID (OS-user scope).")
+    .option("--json", "Output machine-readable JSON.", false)
+    .action(async (opts: { json?: boolean }) => {
+      const id = await getDeviceId();
+      if (opts.json) console.log(JSON.stringify({ device: { id, scope: "os_user", namespace: "hands.build" } }, null, 2));
+      else { console.log(`device_id: ${id}`); console.log("device_scope: os_user"); console.log("device_namespace: hands.build"); }
+    });
+}

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -6,7 +6,8 @@ import type { Command } from "commander";
 import { apiRequest, QuiverApiError, getApiBase } from "../lib/api.js";
 import { resolveAuthToken } from "../lib/config.js";
 import { readEnv } from "../lib/env.js";
-import { getDeviceId } from "@botiverse/hands-node";
+import { getHandsDeviceId } from "@botiverse/hands-node";
+import { deviceJson } from "./device_id.js";
 
 const NO_AUTH_HELP =
   "Not authenticated. Choose one:\n" +
@@ -51,11 +52,11 @@ export function registerWhoamiCommand(program: Command): void {
           process.exit(1);
         }
         if (opts.json) {
-          console.log(JSON.stringify({ ...me, device: { id: await getDeviceId(), scope: "os_user", namespace: "hands.build" } }, null, 2));
+          console.log(JSON.stringify({ ...me, ...deviceJson(await getHandsDeviceId()) }, null, 2));
           return;
         }
         const a = me.account;
-        const deviceId = await getDeviceId();
+        const deviceId = await getHandsDeviceId();
         console.log(`${a.display_name}  (${a.principal_type})`);
         console.log(`  server:  ${a.server_slug ?? a.server_id}`);
         console.log(`  username: @${a.username ?? "(none)"}`);

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -6,6 +6,7 @@ import type { Command } from "commander";
 import { apiRequest, QuiverApiError, getApiBase } from "../lib/api.js";
 import { resolveAuthToken } from "../lib/config.js";
 import { readEnv } from "../lib/env.js";
+import { getDeviceId } from "@botiverse/hands-node";
 
 const NO_AUTH_HELP =
   "Not authenticated. Choose one:\n" +
@@ -50,16 +51,19 @@ export function registerWhoamiCommand(program: Command): void {
           process.exit(1);
         }
         if (opts.json) {
-          console.log(JSON.stringify(me, null, 2));
+          console.log(JSON.stringify({ ...me, device: { id: await getDeviceId(), scope: "os_user", namespace: "hands.build" } }, null, 2));
           return;
         }
         const a = me.account;
+        const deviceId = await getDeviceId();
         console.log(`${a.display_name}  (${a.principal_type})`);
         console.log(`  server:  ${a.server_slug ?? a.server_id}`);
         console.log(`  username: @${a.username ?? "(none)"}`);
         console.log(`  org_id:  ${a.org_id ?? "(none)"}`);
         console.log(`  org_role: ${a.org_role ?? "(none)"}`);
         console.log(`  api:     ${getApiBase()}`);
+        console.log(`  device_id: ${deviceId}`);
+        console.log("  device_scope: os_user");
       } catch (e) {
         if (e instanceof QuiverApiError && e.status === 401) {
           console.error(NO_AUTH_HELP);

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -65,6 +65,7 @@ export function registerWhoamiCommand(program: Command): void {
         console.log(`  api:     ${getApiBase()}`);
         console.log(`  device_id: ${deviceId}`);
         console.log("  device_scope: os_user");
+        console.log("  device_namespace: hands.build");
       } catch (e) {
         if (e instanceof QuiverApiError && e.status === 401) {
           console.error(NO_AUTH_HELP);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import { readEnv } from "./lib/env.js";
 import { setApiBase } from "./lib/api.js";
 import { recordCliEvent } from "./lib/logging.js";
 import { createRequire } from "node:module";
+import { DeviceIdError } from "@botiverse/hands-node";
 
 // Single source of truth for the CLI version: read it from package.json at runtime so
 // `--version` can never drift from the published package version. (Previously the string
@@ -134,6 +135,11 @@ program.parseAsync(process.argv).catch((err) => {
     if (readEnv("VERBOSE") === "1" && err.stack) {
       console.error(err.stack);
     }
+    process.exit(1);
+  }
+  if (err instanceof DeviceIdError) {
+    console.error(`Error: ${err.message}`);
+    console.error(`Code: ${err.code}`);
     process.exit(1);
   }
   console.error(err instanceof Error ? err.message : String(err));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import { registerReleaseCommands } from "./commands/releases.js";
 import { registerFeedbackCommands } from "./commands/feedback.js";
 import { registerDeployTokenCommands } from "./commands/deploy_tokens.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
+import { registerDeviceIdCommand } from "./commands/device_id.js";
 import { registerLogsCommands } from "./commands/logs.js";
 import { registerDeviceGroupCommands } from "./commands/device_groups.js";
 import { registerApiCommand } from "./commands/api.js";
@@ -94,6 +95,7 @@ program.hook("postAction", (_rootCommand, actionCommand) => {
 // --- Subcommand groups ---
 registerLoginCommands(program);
 registerWhoamiCommand(program);
+registerDeviceIdCommand(program);
 registerAppCommands(program);
 registerBuildCommands(program);
 registerReleaseCommands(program);

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -15,5 +15,5 @@ The signed collect-policy, bundle, and redaction contracts are exported from
 
 `getHandsDeviceId()` returns the Hands-owned OS-user scoped UUID v4 shared by
 Hands clients. It is a rollout hint, not hardware identity or a credential.
-Use `resetHandsDeviceId()` only for deliberate state reset; malformed state
-fails with a typed error rather than silently rotating.
+Deleting the Hands state or OS user profile is the v1 rotation boundary;
+malformed state fails with a typed error rather than silently rotating.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -11,3 +11,9 @@ logger.info("auth", "login completed", { provider: "raft" }, "login_ok");
 
 The signed collect-policy, bundle, and redaction contracts are exported from
 `@botiverse/hands-node/logs/schema`.
+# Shared Hands device identity
+
+`getHandsDeviceId()` returns the Hands-owned OS-user scoped UUID v4 shared by
+Hands clients. It is a rollout hint, not hardware identity or a credential.
+Use `resetHandsDeviceId()` only for deliberate state reset; malformed state
+fails with a typed error rather than silently rotating.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-node",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Hands logging, redaction, and policy-governed log collection for Node.js.",
   "author": {
     "name": "jiacheng",

--- a/packages/node/src/device-id.test.ts
+++ b/packages/node/src/device-id.test.ts
@@ -2,25 +2,26 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { DeviceIdError, deviceIdPath, getDeviceId, resetDeviceId } from "./device-id.js";
+import { DeviceIdError, getHandsDeviceId, handsDeviceIdLocation, resetHandsDeviceId } from "./device-id.js";
 
 describe("Hands device id", () => {
   it("uses the Hands namespace on all supported platforms", () => {
-    expect(deviceIdPath({ platform: "win32", homeDir: "C:\\Users\\u" })).toBe("HKCU\\Software\\hands.build\\deviceid");
-    expect(deviceIdPath({ platform: "darwin", homeDir: "/u" })).toBe("/u/Library/Application Support/hands.build/deviceid");
-    expect(deviceIdPath({ platform: "linux", homeDir: "/u", env: {} })).toBe("/u/.local/state/hands.build/deviceid");
+    expect(handsDeviceIdLocation({ platform: "win32", homeDir: "C:\\Users\\u" })).toBe("HKCU\\Software\\hands.build\\deviceid");
+    expect(handsDeviceIdLocation({ platform: "darwin", homeDir: "/u" })).toBe("/u/Library/Application Support/hands.build/deviceid");
+    expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u", env: {} })).toBe("/u/.local/state/hands.build/deviceid");
+    expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u", env: { XDG_STATE_HOME: "/state" } })).toBe("/state/hands.build/deviceid");
   });
 
   it("atomically reuses, resets, and rejects malformed state", async () => {
     const home = await mkdtemp(join(tmpdir(), "hands-device-"));
     try {
       const options = { platform: "linux" as const, homeDir: home, env: {} };
-      const ids = await Promise.all(Array.from({ length: 12 }, () => getDeviceId(options)));
+      const ids = await Promise.all(Array.from({ length: 12 }, () => getHandsDeviceId(options)));
       expect(new Set(ids).size).toBe(1);
-      await resetDeviceId(options);
-      expect(await getDeviceId(options)).not.toBe(ids[0]);
-      await writeFile(deviceIdPath(options), "not-a-uuid\n");
-      await expect(getDeviceId(options)).rejects.toBeInstanceOf(DeviceIdError);
+      await resetHandsDeviceId(options);
+      expect(await getHandsDeviceId(options)).not.toBe(ids[0]);
+      await writeFile(handsDeviceIdLocation(options), "not-a-uuid\n");
+      await expect(getHandsDeviceId(options)).rejects.toMatchObject({ code: "DEVICE_ID_INVALID" });
     } finally { await rm(home, { recursive: true, force: true }); }
   });
 });

--- a/packages/node/src/device-id.test.ts
+++ b/packages/node/src/device-id.test.ts
@@ -9,6 +9,7 @@ describe("Hands device id", () => {
     expect(handsDeviceIdLocation({ platform: "win32", homeDir: "C:\\Users\\u" })).toBe("HKCU\\Software\\hands.build\\deviceid");
     expect(handsDeviceIdLocation({ platform: "darwin", homeDir: "/u" })).toBe("/u/Library/Application Support/hands.build/deviceid");
     expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u", env: {} })).toBe("/u/.local/state/hands.build/deviceid");
+    expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u", env: { XDG_STATE_HOME: "" } })).toBe("/u/.local/state/hands.build/deviceid");
     expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u", env: { XDG_STATE_HOME: "/state" } })).toBe("/state/hands.build/deviceid");
   });
 

--- a/packages/node/src/device-id.test.ts
+++ b/packages/node/src/device-id.test.ts
@@ -1,0 +1,26 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DeviceIdError, deviceIdPath, getDeviceId, resetDeviceId } from "./device-id.js";
+
+describe("Hands device id", () => {
+  it("uses the Hands namespace on all supported platforms", () => {
+    expect(deviceIdPath({ platform: "win32", homeDir: "C:\\Users\\u" })).toBe("HKCU\\Software\\hands.build\\deviceid");
+    expect(deviceIdPath({ platform: "darwin", homeDir: "/u" })).toBe("/u/Library/Application Support/hands.build/deviceid");
+    expect(deviceIdPath({ platform: "linux", homeDir: "/u", env: {} })).toBe("/u/.local/state/hands.build/deviceid");
+  });
+
+  it("atomically reuses, resets, and rejects malformed state", async () => {
+    const home = await mkdtemp(join(tmpdir(), "hands-device-"));
+    try {
+      const options = { platform: "linux" as const, homeDir: home, env: {} };
+      const ids = await Promise.all(Array.from({ length: 12 }, () => getDeviceId(options)));
+      expect(new Set(ids).size).toBe(1);
+      await resetDeviceId(options);
+      expect(await getDeviceId(options)).not.toBe(ids[0]);
+      await writeFile(deviceIdPath(options), "not-a-uuid\n");
+      await expect(getDeviceId(options)).rejects.toBeInstanceOf(DeviceIdError);
+    } finally { await rm(home, { recursive: true, force: true }); }
+  });
+});

--- a/packages/node/src/device-id.test.ts
+++ b/packages/node/src/device-id.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { DeviceIdError, getHandsDeviceId, handsDeviceIdLocation, resetHandsDeviceId } from "./device-id.js";
+import { getHandsDeviceId, handsDeviceIdLocation } from "./device-id.js";
 
 describe("Hands device id", () => {
   it("uses the Hands namespace on all supported platforms", () => {
@@ -18,7 +18,7 @@ describe("Hands device id", () => {
       const options = { platform: "linux" as const, homeDir: home, env: {} };
       const ids = await Promise.all(Array.from({ length: 12 }, () => getHandsDeviceId(options)));
       expect(new Set(ids).size).toBe(1);
-      await resetHandsDeviceId(options);
+      await rm(handsDeviceIdLocation(options));
       expect(await getHandsDeviceId(options)).not.toBe(ids[0]);
       await writeFile(handsDeviceIdLocation(options), "not-a-uuid\n");
       await expect(getHandsDeviceId(options)).rejects.toMatchObject({ code: "DEVICE_ID_INVALID" });

--- a/packages/node/src/device-id.ts
+++ b/packages/node/src/device-id.ts
@@ -31,7 +31,7 @@ async function readWindows(): Promise<string | undefined> {
     return value;
   } catch (error) {
     if (error instanceof DeviceIdError) throw error;
-    if ((error as NodeJS.ErrnoException).code === "1") return undefined;
+    if ((error as { code?: string | number }).code === 1) return undefined;
     throw new DeviceIdError("DEVICE_ID_READ_FAILED", "Hands device ID could not be read");
   }
 }
@@ -99,7 +99,7 @@ export async function getHandsDeviceId(options: DeviceIdOptions = {}): Promise<s
 export async function resetHandsDeviceId(options: DeviceIdOptions = {}): Promise<void> {
   if ((options.platform ?? platform()) === "win32") {
     try { await exec("reg.exe", ["delete", WINDOWS_KEY, "/v", "deviceid", "/f"], { windowsHide: true }); return; }
-    catch (error) { if ((error as NodeJS.ErrnoException).code !== "1") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset"); return; }
+    catch (error) { if ((error as { code?: string | number }).code !== 1) throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset"); return; }
   }
   try { await rm(handsDeviceIdLocation(options)); } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset");

--- a/packages/node/src/device-id.ts
+++ b/packages/node/src/device-id.ts
@@ -95,13 +95,3 @@ export async function getHandsDeviceId(options: DeviceIdOptions = {}): Promise<s
   }
   throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID creation remained contended");
 }
-
-export async function resetHandsDeviceId(options: DeviceIdOptions = {}): Promise<void> {
-  if ((options.platform ?? platform()) === "win32") {
-    try { await exec("reg.exe", ["delete", WINDOWS_KEY, "/v", "deviceid", "/f"], { windowsHide: true }); return; }
-    catch (error) { if ((error as { code?: string | number }).code !== 1) throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset"); return; }
-  }
-  try { await rm(handsDeviceIdLocation(options)); } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset");
-  }
-}

--- a/packages/node/src/device-id.ts
+++ b/packages/node/src/device-id.ts
@@ -20,7 +20,7 @@ export function handsDeviceIdLocation(options: DeviceIdOptions = {}): string {
   const home = options.homeDir ?? homedir();
   if (os === "win32") return `${WINDOWS_KEY}\\deviceid`;
   if (os === "darwin") return join(home, "Library", "Application Support", "hands.build", "deviceid");
-  return join(options.env?.XDG_STATE_HOME ?? join(home, ".local", "state"), "hands.build", "deviceid");
+  return join(options.env?.XDG_STATE_HOME || join(home, ".local", "state"), "hands.build", "deviceid");
 }
 
 async function readWindows(): Promise<string | undefined> {

--- a/packages/node/src/device-id.ts
+++ b/packages/node/src/device-id.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { chmod, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+export type DeviceIdErrorCode = "DEVICE_ID_INVALID" | "DEVICE_ID_READ_FAILED" | "DEVICE_ID_PERSIST_FAILED";
+export class DeviceIdError extends Error {
+  constructor(readonly code: DeviceIdErrorCode, message: string) { super(message); this.name = "DeviceIdError"; }
+}
+
+export interface DeviceIdOptions { platform?: NodeJS.Platform; homeDir?: string; env?: NodeJS.ProcessEnv }
+const exec = promisify(execFile);
+const WINDOWS_KEY = "HKCU\\Software\\hands.build";
+
+export function deviceIdPath(options: DeviceIdOptions = {}): string {
+  const os = options.platform ?? platform();
+  const home = options.homeDir ?? homedir();
+  if (os === "win32") return `${WINDOWS_KEY}\\deviceid`;
+  if (os === "darwin") return join(home, "Library", "Application Support", "hands.build", "deviceid");
+  return join(options.env?.XDG_STATE_HOME ?? join(home, ".local", "state"), "hands.build", "deviceid");
+}
+
+async function readWindows(): Promise<string | undefined> {
+  try {
+    const { stdout } = await exec("reg.exe", ["query", WINDOWS_KEY, "/v", "deviceid"], { windowsHide: true });
+    const value = stdout.match(/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/iu)?.[0]?.toLowerCase();
+    if (!value || !UUID.test(value)) throw new DeviceIdError("DEVICE_ID_INVALID", "Hands device ID is malformed");
+    return value;
+  } catch (error) {
+    if (error instanceof DeviceIdError) throw error;
+    if ((error as NodeJS.ErrnoException).code === "1") return undefined;
+    throw new DeviceIdError("DEVICE_ID_READ_FAILED", "Hands device ID could not be read");
+  }
+}
+
+async function readValid(path: string): Promise<string | undefined> {
+  try {
+    const value = (await readFile(path, "utf8")).trim();
+    if (!UUID.test(value)) throw new DeviceIdError("DEVICE_ID_INVALID", "Hands device ID is malformed");
+    return value;
+  } catch (error) {
+    if (error instanceof DeviceIdError) throw error;
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return undefined;
+    throw new DeviceIdError("DEVICE_ID_READ_FAILED", "Hands device ID could not be read");
+  }
+}
+
+export async function getDeviceId(options: DeviceIdOptions = {}): Promise<string> {
+  const os = options.platform ?? platform();
+  const path = deviceIdPath(options);
+  const dir = os === "win32"
+    ? join(options.env?.LOCALAPPDATA ?? join(options.homeDir ?? homedir(), "AppData", "Local"), "hands.build")
+    : dirname(path);
+  const lock = join(dir, "deviceid.lock");
+  await mkdir(dir, { recursive: true, mode: 0o700 }).catch(() => {
+    throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID directory could not be created");
+  });
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const existing = os === "win32" ? await readWindows() : await readValid(path);
+    if (existing) return existing;
+    let acquired = false;
+    try {
+      await mkdir(lock);
+      acquired = true;
+      const afterLock = os === "win32" ? await readWindows() : await readValid(path);
+      if (afterLock) return afterLock;
+      const value = randomUUID().toLowerCase();
+      if (os === "win32") {
+        await exec("reg.exe", ["add", WINDOWS_KEY, "/v", "deviceid", "/t", "REG_SZ", "/d", value, "/f"], { windowsHide: true });
+        return value;
+      }
+      const temp = `${path}.${process.pid}.${Date.now()}.tmp`;
+      const handle = await open(temp, "wx", 0o600);
+      await handle.writeFile(`${value}\n`, "utf8");
+      await handle.sync();
+      await handle.close();
+      await chmod(temp, 0o600);
+      await rename(temp, path);
+      return value;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error instanceof DeviceIdError ? error : new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be persisted");
+      }
+    } finally { if (acquired) await rm(lock, { recursive: true, force: true }); }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID creation remained contended");
+}
+
+export async function resetDeviceId(options: DeviceIdOptions = {}): Promise<void> {
+  if ((options.platform ?? platform()) === "win32") {
+    try { await exec("reg.exe", ["delete", WINDOWS_KEY, "/v", "deviceid", "/f"], { windowsHide: true }); return; }
+    catch (error) { if ((error as NodeJS.ErrnoException).code !== "1") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset"); return; }
+  }
+  try { await rm(deviceIdPath(options)); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset");
+  }
+}

--- a/packages/node/src/device-id.ts
+++ b/packages/node/src/device-id.ts
@@ -15,7 +15,7 @@ export interface DeviceIdOptions { platform?: NodeJS.Platform; homeDir?: string;
 const exec = promisify(execFile);
 const WINDOWS_KEY = "HKCU\\Software\\hands.build";
 
-export function deviceIdPath(options: DeviceIdOptions = {}): string {
+export function handsDeviceIdLocation(options: DeviceIdOptions = {}): string {
   const os = options.platform ?? platform();
   const home = options.homeDir ?? homedir();
   if (os === "win32") return `${WINDOWS_KEY}\\deviceid`;
@@ -49,15 +49,18 @@ async function readValid(path: string): Promise<string | undefined> {
   }
 }
 
-export async function getDeviceId(options: DeviceIdOptions = {}): Promise<string> {
+export async function getHandsDeviceId(options: DeviceIdOptions = {}): Promise<string> {
   const os = options.platform ?? platform();
-  const path = deviceIdPath(options);
+  const path = handsDeviceIdLocation(options);
   const dir = os === "win32"
     ? join(options.env?.LOCALAPPDATA ?? join(options.homeDir ?? homedir(), "AppData", "Local"), "hands.build")
     : dirname(path);
   const lock = join(dir, "deviceid.lock");
   await mkdir(dir, { recursive: true, mode: 0o700 }).catch(() => {
     throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID directory could not be created");
+  });
+  if (os !== "win32") await chmod(dir, 0o700).catch(() => {
+    throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID directory permissions could not be set");
   });
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const existing = os === "win32" ? await readWindows() : await readValid(path);
@@ -80,6 +83,8 @@ export async function getDeviceId(options: DeviceIdOptions = {}): Promise<string
       await handle.close();
       await chmod(temp, 0o600);
       await rename(temp, path);
+      const directory = await open(dir, "r");
+      try { await directory.sync(); } finally { await directory.close(); }
       return value;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
@@ -91,12 +96,12 @@ export async function getDeviceId(options: DeviceIdOptions = {}): Promise<string
   throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID creation remained contended");
 }
 
-export async function resetDeviceId(options: DeviceIdOptions = {}): Promise<void> {
+export async function resetHandsDeviceId(options: DeviceIdOptions = {}): Promise<void> {
   if ((options.platform ?? platform()) === "win32") {
     try { await exec("reg.exe", ["delete", WINDOWS_KEY, "/v", "deviceid", "/f"], { windowsHide: true }); return; }
     catch (error) { if ((error as NodeJS.ErrnoException).code !== "1") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset"); return; }
   }
-  try { await rm(deviceIdPath(options)); } catch (error) {
+  try { await rm(handsDeviceIdLocation(options)); } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw new DeviceIdError("DEVICE_ID_PERSIST_FAILED", "Hands device ID could not be reset");
   }
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -33,3 +33,5 @@ export {
   type UploadLogBundleOptions,
   type VerifyPolicyOptions,
 } from "./collect.js";
+export { DeviceIdError, deviceIdPath, getDeviceId, resetDeviceId } from "./device-id.js";
+export type { DeviceIdErrorCode, DeviceIdOptions } from "./device-id.js";

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -33,5 +33,5 @@ export {
   type UploadLogBundleOptions,
   type VerifyPolicyOptions,
 } from "./collect.js";
-export { DeviceIdError, getHandsDeviceId, handsDeviceIdLocation, resetHandsDeviceId } from "./device-id.js";
+export { DeviceIdError, getHandsDeviceId, handsDeviceIdLocation } from "./device-id.js";
 export type { DeviceIdErrorCode, DeviceIdOptions } from "./device-id.js";

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -33,5 +33,5 @@ export {
   type UploadLogBundleOptions,
   type VerifyPolicyOptions,
 } from "./collect.js";
-export { DeviceIdError, deviceIdPath, getDeviceId, resetDeviceId } from "./device-id.js";
+export { DeviceIdError, getHandsDeviceId, handsDeviceIdLocation, resetHandsDeviceId } from "./device-id.js";
 export type { DeviceIdErrorCode, DeviceIdOptions } from "./device-id.js";

--- a/packages/node/test/windows-device-id.mjs
+++ b/packages/node/test/windows-device-id.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { execFile, execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { getHandsDeviceId, handsDeviceIdLocation } from "../dist/index.js";
+
+if (process.platform !== "win32") throw new Error("Windows device ID test requires Windows");
+const exec = promisify(execFile);
+const key = "HKCU\\Software\\hands.build";
+const localAppData = await mkdtemp(join(tmpdir(), "hands-device-win-"));
+const clean = () => { try { execFileSync("reg.exe", ["delete", key, "/f"], { stdio: "ignore" }); } catch {} };
+try {
+  clean();
+  assert.equal(handsDeviceIdLocation(), `${key}\\deviceid`, "unexpected Windows namespace");
+  const moduleUrl = new URL("../dist/index.js", import.meta.url).href;
+  const script = `import {getHandsDeviceId} from ${JSON.stringify(moduleUrl)};process.stdout.write(await getHandsDeviceId());`;
+  const env = { ...process.env, LOCALAPPDATA: localAppData };
+  const results = await Promise.all(Array.from({ length: 8 }, () => exec(process.execPath, ["--input-type=module", "--eval", script], { env, windowsHide: true })));
+  assert.equal(new Set(results.map(({ stdout }) => stdout)).size, 1, "concurrent processes returned different IDs");
+  assert.equal(await getHandsDeviceId({ env }), results[0].stdout, "reopen did not reuse committed ID");
+  execFileSync("reg.exe", ["add", key, "/v", "deviceid", "/t", "REG_SZ", "/d", "malformed", "/f"], { stdio: "ignore" });
+  await assert.rejects(getHandsDeviceId({ env }), (error) => error?.code === "DEVICE_ID_INVALID");
+} finally { clean(); await rm(localAppData, { recursive: true, force: true }); }


### PR DESCRIPTION
## Summary
- add Hands-owned `hands.build` OS-user device ID primitive
- persist lowercase UUID v4 with atomic first creation, validation, reset, and typed failures
- use Windows HKCU, macOS Application Support, Linux XDG state paths
- expose `hands device-id`; include same device object in authenticated `hands whoami`

## Validation
- TypeScript no-emit checks for `@botiverse/hands-node` and `@botiverse/hands-cli`
- node package emit build followed by CLI typecheck

## Scope
No Computer changes, server deploy, or release publication. Independent review and npm publication are separate gates.
