### PR TITLE
fix(node): align SDK version carrier with package

### DIFF
--- a/.github/lint-fixtures/test-publish-cli-workflow.py
+++ b/.github/lint-fixtures/test-publish-cli-workflow.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+workflow = yaml.safe_load((ROOT / ".github/workflows/publish-cli.yml").read_text())
+steps = workflow["jobs"]["publish"]["steps"]
+verify = next(step for step in steps if step.get("name") == "Verify Hands Node SDK dependency is published")
+run = verify["run"]
+assert "scripts/resolve-workspace-dependency-version.mjs" in run
+assert 'npm view "@botiverse/hands-node@${version}" version' in run
+version = subprocess.check_output([
+    "node", "scripts/resolve-workspace-dependency-version.mjs",
+    "packages/cli/package.json", "@botiverse/hands-node", "packages/node/package.json",
+], cwd=ROOT, text=True)
+assert version == "0.5.0"
+print("Publish CLI dependency contract clean: workspace:* resolves to exact published Node package version.")

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -69,8 +69,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          dependency="$(node -p "require('./packages/cli/package.json').dependencies['@botiverse/hands-node']")"
-          version="${dependency#workspace:^}"
+          version="$(node scripts/resolve-workspace-dependency-version.mjs \
+            packages/cli/package.json @botiverse/hands-node packages/node/package.json)"
           npm view "@botiverse/hands-node@${version}" version
 
       - name: Build Node SDK and CLI

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -180,3 +180,6 @@ jobs:
 
       - name: Check workflow failure notification contract
         run: python3 .github/lint-fixtures/test-notification-workflow.py
+
+      - name: Check CLI publish dependency contract
+        run: python3 .github/lint-fixtures/test-publish-cli-workflow.py

--- a/packages/node/src/updater/index.test.ts
+++ b/packages/node/src/updater/index.test.ts
@@ -3,7 +3,9 @@ import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { HandsUpdateError, createHandsUpdater } from "./index.js";
+import { HandsUpdateError, HANDS_NODE_SDK_VERSION, createHandsUpdater } from "./index.js";
+import { createRequire } from "node:module";
+const packageJson = createRequire(import.meta.url)("../../package.json") as { version: string };
 
 const directories: string[] = [];
 afterEach(async () => {
@@ -24,6 +26,9 @@ function fixture(bytes = Buffer.from("verified computer binary")) {
 }
 
 describe("Hands updater", () => {
+  it("keeps package and runtime SDK version carriers identical", () => {
+    expect(HANDS_NODE_SDK_VERSION).toBe(packageJson.version);
+  });
   it.each(["main", "alpha", "pinned:1.0.19"] as const)(
     "sends the exact device id for %s selection without changing channel semantics",
     async (channel) => {

--- a/packages/node/src/updater/index.ts
+++ b/packages/node/src/updater/index.ts
@@ -85,7 +85,7 @@ export interface HandsUpdater {
 
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
-export const HANDS_NODE_SDK_VERSION = "0.4.0";
+export const HANDS_NODE_SDK_VERSION = "0.5.0";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "update response must be an object");

--- a/scripts/resolve-workspace-dependency-version.mjs
+++ b/scripts/resolve-workspace-dependency-version.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+const [consumerPath, dependencyName, dependencyPath] = process.argv.slice(2);
+if (!consumerPath || !dependencyName || !dependencyPath) throw new Error("consumer, dependency name, and dependency package are required");
+const consumer = JSON.parse(await readFile(consumerPath, "utf8"));
+const dependency = JSON.parse(await readFile(dependencyPath, "utf8"));
+const specifier = consumer.dependencies?.[dependencyName];
+if (specifier !== "workspace:*") throw new Error(`${dependencyName} must use workspace:*`);
+if (typeof dependency.version !== "string" || dependency.version.length === 0) throw new Error(`${dependencyName} package version is missing`);
+process.stdout.write(dependency.version);


### PR DESCRIPTION
## Summary
- set `HANDS_NODE_SDK_VERSION` to the landed package version `0.5.0`
- add a permanent test comparing the runtime carrier to `packages/node/package.json`

## Validation
- updater tests 11/11
- node TypeScript check
- diff check

## Scope
Source correction only. No npm publish or Computer action.
