### PR TITLE
fix(cli): preserve global JSON for device identity commands

### DIFF
--- a/.github/lint-fixtures/test-publish-cli-workflow.py
+++ b/.github/lint-fixtures/test-publish-cli-workflow.py
@@ -14,5 +14,8 @@ version = subprocess.check_output([
     "node", "scripts/resolve-workspace-dependency-version.mjs",
     "packages/cli/package.json", "@botiverse/hands-node", "packages/node/package.json",
 ], cwd=ROOT, text=True)
-assert version == "0.5.0"
+assert version == "0.5.1"
+installed_json = next(step for step in steps if step.get("name") == "Verify installed device JSON commands")
+assert 'node packages/cli/test/installed-device-json.mjs "$PACKAGE_PATH"' in installed_json["run"]
+assert installed_json["env"]["PACKAGE_PATH"] == "${{ steps.pack.outputs.path }}"
 print("Publish CLI dependency contract clean: workspace:* resolves to exact published Node package version.")

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -90,6 +90,11 @@ jobs:
           test -n "${package_path}"
           echo "path=${package_path}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify installed device JSON commands
+        run: node packages/cli/test/installed-device-json.mjs "$PACKAGE_PATH"
+        env:
+          PACKAGE_PATH: ${{ steps.pack.outputs.path }}
+
       - name: Publish dry run
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: npm publish "$PACKAGE_PATH" --access public --dry-run

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -174,3 +174,16 @@ jobs:
         run: |
           pnpm --filter @botiverse/hands-cli... build
           pnpm --filter @botiverse/hands-admin build
+
+      - name: Pack and verify installed CLI device JSON commands
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/hands-cli-pack"
+          pnpm --dir packages/node pack --pack-destination "$RUNNER_TEMP/hands-cli-pack"
+          pnpm --dir packages/cli pack --pack-destination "$RUNNER_TEMP/hands-cli-pack"
+          cli_path="$(find "$RUNNER_TEMP/hands-cli-pack" -maxdepth 1 -name 'botiverse-hands-cli-*.tgz' -print -quit)"
+          node_path="$(find "$RUNNER_TEMP/hands-cli-pack" -maxdepth 1 -name 'botiverse-hands-node-*.tgz' -print -quit)"
+          test -n "${cli_path}"
+          test -n "${node_path}"
+          node packages/cli/test/installed-device-json.mjs "${cli_path}" "${node_path}"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-cli",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "Hands CLI \u2014 manage apps, builds, releases from the terminal.",
   "author": {
     "name": "jiacheng",

--- a/packages/cli/src/commands/device_id.test.ts
+++ b/packages/cli/src/commands/device_id.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { deviceJson, deviceText } from "./device_id.js";
+import { Command } from "commander";
+import { deviceJson, deviceText, jsonRequested, registerDeviceIdCommand } from "./device_id.js";
 const ID = "123e4567-e89b-4d3a-a456-426614174000";
 describe("device-id output", () => {
   it("uses the stable JSON contract", () => expect(deviceJson(ID)).toEqual({ device: { id: ID, scope: "os_user", namespace: "hands.build" } }));
   it("uses explicit human-readable labels", () => expect(deviceText(ID)).toBe(`device_id: ${ID}\ndevice_scope: os_user\ndevice_namespace: hands.build`));
+
+  it("honors --json on the real root argv path", async () => {
+    const output: string[] = [];
+    const write = console.log;
+    console.log = (value?: unknown) => output.push(String(value));
+    try {
+      const root = new Command().option("--json", "Output machine-readable JSON", false);
+      registerDeviceIdCommand(root);
+      const device = root.commands[0];
+      expect(jsonRequested(device, device.opts())).toBe(false);
+      await root.parseAsync(["node", "hands", "--json", "device-id"]);
+      expect(JSON.parse(output.at(-1)!)).toEqual({
+        device: { id: expect.any(String), scope: "os_user", namespace: "hands.build" },
+      });
+    } finally {
+      console.log = write;
+    }
+  });
 });

--- a/packages/cli/src/commands/device_id.ts
+++ b/packages/cli/src/commands/device_id.ts
@@ -3,13 +3,17 @@ import { getHandsDeviceId } from "@botiverse/hands-node";
 export const deviceJson = (id: string) => ({ device: { id, scope: "os_user", namespace: "hands.build" } });
 export const deviceText = (id: string) => `device_id: ${id}\ndevice_scope: os_user\ndevice_namespace: hands.build`;
 
+export function jsonRequested(command: Command, opts: { json?: boolean }): boolean {
+  return Boolean(opts.json || command.optsWithGlobals<{ json?: boolean }>().json);
+}
+
 export function registerDeviceIdCommand(program: Command): void {
   program.command("device-id")
     .description("Print the local Hands device ID (OS-user scope).")
     .option("--json", "Output machine-readable JSON.", false)
-    .action(async (opts: { json?: boolean }) => {
+    .action(async (opts: { json?: boolean }, command: Command) => {
       const id = await getHandsDeviceId();
-      if (opts.json) console.log(JSON.stringify(deviceJson(id), null, 2));
+      if (jsonRequested(command, opts)) console.log(JSON.stringify(deviceJson(id), null, 2));
       else console.log(deviceText(id));
     });
 }

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -7,7 +7,7 @@ import { apiRequest, QuiverApiError, getApiBase } from "../lib/api.js";
 import { resolveAuthToken } from "../lib/config.js";
 import { readEnv } from "../lib/env.js";
 import { getHandsDeviceId } from "@botiverse/hands-node";
-import { deviceJson } from "./device_id.js";
+import { deviceJson, jsonRequested } from "./device_id.js";
 
 const NO_AUTH_HELP =
   "Not authenticated. Choose one:\n" +
@@ -39,7 +39,7 @@ export function registerWhoamiCommand(program: Command): void {
     .command("whoami")
     .description("Print the currently authenticated account + roles.")
     .option("--json", "Output machine-readable JSON.", false)
-    .action(async (opts: { json?: boolean }) => {
+    .action(async (opts: { json?: boolean }, command: Command) => {
       const bearer = readEnv("AUTH_TOKEN") ?? readEnv("BEARER_TOKEN");
       if (!bearer && !resolveAuthToken()) {
         console.error(NO_AUTH_HELP);
@@ -51,7 +51,7 @@ export function registerWhoamiCommand(program: Command): void {
           console.error("Server returned no account info.");
           process.exit(1);
         }
-        if (opts.json) {
+        if (jsonRequested(command, opts)) {
           console.log(JSON.stringify({ ...me, ...deviceJson(await getHandsDeviceId()) }, null, 2));
           return;
         }

--- a/packages/cli/test/installed-device-json.mjs
+++ b/packages/cli/test/installed-device-json.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { homedir, tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+const tarball = process.argv[2];
+if (!tarball) throw new Error("usage: installed-device-json.mjs <cli-tarball>");
+const nodeTarball = process.argv[3];
+
+async function snapshot(path) {
+  try {
+    const metadata = await stat(path);
+    return { bytes: await readFile(path, "utf8"), mtimeMs: metadata.mtimeMs };
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+const root = await mkdtemp(join(tmpdir(), "hands-cli-installed-json-"));
+const install = join(root, "install");
+const state = join(root, "state");
+const server = createServer((request, response) => {
+  response.setHeader("content-type", "application/json");
+  if (request.url === "/api/auth/me") {
+    response.end(JSON.stringify({
+      account: {
+        id: "account-1",
+        provider: "test",
+        provider_subject: "subject-1",
+        server_id: "server-1",
+        server_slug: "test-server",
+        principal_type: "human",
+        server_role: "member",
+        username: "test-user",
+        display_name: "Test User",
+        avatar_url: null,
+        org_id: "org-1",
+        org_role: "member",
+      },
+    }));
+    return;
+  }
+  response.statusCode = 404;
+  response.end(JSON.stringify({ error: "not found" }));
+});
+
+try {
+  await exec("npm", [
+    "install", "--ignore-scripts", "--no-audit", "--no-fund", "--prefix", install,
+    ...(nodeTarball ? [nodeTarball] : []), tarball,
+  ]);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server has no TCP address");
+
+  const env = { ...process.env,
+    PATH: `${join(install, "node_modules", ".bin")}${delimiter}${process.env.PATH ?? ""}`,
+    XDG_STATE_HOME: state,
+    XDG_CONFIG_HOME: join(root, "config"),
+    HANDS_BEARER_TOKEN: "test-token",
+  };
+  delete env.SLOCK_CLI_TRANSPORT_DIR;
+  delete env.SLOCK_HOME;
+  delete env.SLOCK_AGENT_ID;
+
+  const xdgDevicePath = join(state, "hands.build", "deviceid");
+  const fallbackDevicePath = join(homedir(), ".local", "state", "hands.build", "deviceid");
+  const fallbackBefore = await snapshot(fallbackDevicePath);
+
+  let expectedDevice;
+  for (const bin of ["hands", "quiver"]) {
+    for (const args of [["--json", "device-id"], ["device-id", "--json"]]) {
+      const result = await exec(bin, args, { env });
+      assert.equal(result.stderr, "");
+      const parsed = JSON.parse(result.stdout);
+      assert.deepEqual(Object.keys(parsed), ["device"]);
+      assert.match(parsed.device.id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+      assert.equal(parsed.device.scope, "os_user");
+      assert.equal(parsed.device.namespace, "hands.build");
+      expectedDevice ??= parsed.device;
+      assert.deepEqual(parsed.device, expectedDevice);
+      assert.equal((await readFile(xdgDevicePath, "utf8")).trim(), parsed.device.id);
+    }
+
+    for (const args of [
+      ["--api", `http://127.0.0.1:${address.port}`, "--json", "whoami"],
+      ["--api", `http://127.0.0.1:${address.port}`, "whoami", "--json"],
+    ]) {
+      const result = await exec(bin, args, { env });
+      assert.equal(result.stderr, "");
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.account.id, "account-1");
+      assert.deepEqual(parsed.device, expectedDevice);
+    }
+  }
+
+  const deviceText = await exec("hands", ["device-id"], { env });
+  assert.match(deviceText.stdout, /^device_id: [0-9a-f-]+\ndevice_scope: os_user\ndevice_namespace: hands\.build\n$/);
+  const whoamiText = await exec("quiver", ["--api", `http://127.0.0.1:${address.port}`, "whoami"], { env });
+  assert.match(whoamiText.stdout, /\n  device_id: [0-9a-f-]+\n  device_scope: os_user\n  device_namespace: hands\.build\n$/);
+  assert.deepEqual(await snapshot(fallbackDevicePath), fallbackBefore);
+
+  await writeFile(xdgDevicePath, "malformed\n", { mode: 0o600 });
+  for (const [bin, args] of [
+    ["hands", ["--json", "device-id"]],
+    ["quiver", ["--api", `http://127.0.0.1:${address.port}`, "--json", "whoami"]],
+  ]) {
+    try {
+      await exec(bin, args, { env });
+      assert.fail(`${bin} unexpectedly accepted malformed device state`);
+    } catch (error) {
+      assert.equal(error.stdout, "");
+      assert.match(error.stderr, /DEVICE_ID_INVALID/);
+    }
+  }
+
+  console.log("Installed CLI contract clean: both bins preserve JSON/text routing and fail without partial output.");
+} finally {
+  server.close();
+  await rm(root, { recursive: true, force: true });
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/hands-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Hands logging, redaction, and policy-governed log collection for Node.js.",
   "author": {
     "name": "jiacheng",

--- a/packages/node/src/device-id.test.ts
+++ b/packages/node/src/device-id.test.ts
@@ -13,6 +13,17 @@ describe("Hands device id", () => {
     expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u", env: { XDG_STATE_HOME: "/state" } })).toBe("/state/hands.build/deviceid");
   });
 
+  it("uses process XDG_STATE_HOME for the real runtime default", () => {
+    const previous = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = "/runtime-state";
+    try {
+      expect(handsDeviceIdLocation({ platform: "linux", homeDir: "/u" })).toBe("/runtime-state/hands.build/deviceid");
+    } finally {
+      if (previous === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = previous;
+    }
+  });
+
   it("atomically reuses, resets, and rejects malformed state", async () => {
     const home = await mkdtemp(join(tmpdir(), "hands-device-"));
     try {

--- a/packages/node/src/device-id.ts
+++ b/packages/node/src/device-id.ts
@@ -20,7 +20,8 @@ export function handsDeviceIdLocation(options: DeviceIdOptions = {}): string {
   const home = options.homeDir ?? homedir();
   if (os === "win32") return `${WINDOWS_KEY}\\deviceid`;
   if (os === "darwin") return join(home, "Library", "Application Support", "hands.build", "deviceid");
-  return join(options.env?.XDG_STATE_HOME || join(home, ".local", "state"), "hands.build", "deviceid");
+  const env = options.env ?? process.env;
+  return join(env.XDG_STATE_HOME || join(home, ".local", "state"), "hands.build", "deviceid");
 }
 
 async function readWindows(): Promise<string | undefined> {

--- a/packages/node/src/updater/index.ts
+++ b/packages/node/src/updater/index.ts
@@ -85,7 +85,7 @@ export interface HandsUpdater {
 
 const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
-export const HANDS_NODE_SDK_VERSION = "0.5.0";
+export const HANDS_NODE_SDK_VERSION = "0.5.1";
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "update response must be an object");


### PR DESCRIPTION
## Problem
Installed CLI 0.5.21 consumed the root `--json` flag without passing it to `device-id`/`whoami`, so promised JSON output became human text.

## Changes
- read Commander global options on both device identity actions
- bump CLI to 0.5.22
- add real packed/installed argv contract test for both commands
- run that test in worker and publish workflows, with fixture lock

## Testing
- CLI tests: 89/89
- Node build and CLI build
- installed tarball `device-id` + authenticated `whoami` JSON readback
- workflow fixture and diff check

No publish or Computer action.