### PR TITLE
feat(worker): unify /public/v2 latest assets with sha256 and external build targets

### DIFF
--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -37,9 +37,21 @@ const PublicAsset = z
     platform: z.string(),
     arch: z.string().nullable().optional(),
     variant: z.string().nullable().optional(),
-    filetype: z.string(),
+    filetype: z.string().openapi({
+      description: "Artifact kind, e.g. `apk`. Externally-hosted builds report `binary`.",
+    }),
     size_bytes: z.number().int(),
-    download_url: z.string().url(),
+    sha256: z.string().openapi({
+      description:
+        "Lowercase hex SHA-256 of the artifact bytes as registered at release time. " +
+        "Clients should verify downloaded bytes against it.",
+    }),
+    download_url: z.string().url().openapi({
+      description:
+        "For uploaded assets a signed, time-limited URL; for externally-hosted builds the " +
+        "immutable release-bound `/dl/{slug}/releases/{releaseId}/{target}` route " +
+        "(302 to the declared source URL).",
+    }),
   })
   .openapi("PublicAsset");
 
@@ -173,7 +185,11 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     tags: ["Public update"],
     summary: "Check latest release for an app",
     description:
-      "Resolves the best active release for a client on a channel, optionally filtered by product type and scoped by platform/cohort/IP.",
+      "Resolves the best active release for a client on a channel, optionally filtered by product type and scoped by platform/cohort/IP. " +
+      "`assets` has one unified shape regardless of where the bytes live: uploaded build assets are served via signed URLs, while " +
+      "externally-hosted builds (e.g. `cli-binary` Node SEA, whose bytes stay on the declaring CDN) are projected from their registered " +
+      "targets with `platform`/`arch` derived from the target name and `download_url` pointing at the immutable release-bound `/dl` route. " +
+      "Every entry carries the `sha256` registered at release time so installers can verify downloaded bytes against the identity Hands resolved.",
     request: {
       params: SlugParam,
       query: z.object({

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -47,6 +47,7 @@ type PublicAssetResponse = {
   variant: string | null;
   filetype: string;
   size_bytes: number;
+  sha256: string;
   download_url: string;
 };
 
@@ -280,16 +281,55 @@ export async function handlePublicV2Latest(c: Context<{ Bindings: Env }>) {
 
   const ttl = Number(c.env.SIGNED_URL_TTL_SECONDS ?? "3600");
   const origin = publicRequestOrigin(c);
-  const assetsWithUrls = await Promise.all(
+  let assetsWithUrls: PublicAssetResponse[] = await Promise.all(
     filteredAssets.map(async (a) => ({
       platform: a.platform,
       arch: a.arch,
       variant: a.variant,
       filetype: a.filetype,
       size_bytes: a.size_bytes,
+      sha256: a.file_hash,
       download_url: await generateSignedR2Url(c.env, a.r2_key, ttl, origin),
     })),
   );
+
+  // Externally-hosted builds (source = 'external', e.g. Node SEA binaries)
+  // have no R2-backed build_assets rows; their per-target identity lives in
+  // external_build_targets. Project those targets into the same asset shape so
+  // /latest returns unified version info regardless of where the bytes live.
+  // download_url is the immutable release-bound /dl route (302 to the declared
+  // source URL) — the same surface updates/check hands out.
+  if (assets.results.length === 0) {
+    const { results: externalTargets } = await c.env.DB.prepare(
+      `SELECT target, raw_sha256, raw_size_bytes
+       FROM external_build_targets
+       WHERE build_id = ?1
+       ORDER BY target ASC`,
+    )
+      .bind(build.id)
+      .all<{ target: string; raw_sha256: string; raw_size_bytes: number }>();
+    const requested = splitPlatformArch(clientPlatform);
+    assetsWithUrls = externalTargets
+      .map((t) => {
+        const separator = t.target.indexOf("-");
+        const platform = separator > 0 ? t.target.slice(0, separator) : t.target;
+        const arch = separator > 0 ? t.target.slice(separator + 1) : null;
+        return {
+          platform,
+          arch,
+          variant: null,
+          filetype: "binary",
+          size_bytes: t.raw_size_bytes,
+          sha256: t.raw_sha256,
+          download_url: `${origin}/dl/${encodeURIComponent(app.slug)}/releases/${encodeURIComponent(winner.release_id)}/${encodeURIComponent(t.target)}`,
+        };
+      })
+      .filter((a) => {
+        if (!requested.platform) return true;
+        if (a.platform !== requested.platform) return false;
+        return requested.arch === null || a.arch === requested.arch;
+      });
+  }
 
   // Optional fallback_release: if the winner is NOT `full`, look for the
   // next-most-specific `full` match for the same client so we can warn

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -7354,6 +7354,110 @@ describe("quiver public API v2 — scope resolution", () => {
     });
   });
 
+  it("latest exposes asset sha256 so installers can verify Hands identity against CDN bytes", async () => {
+    const env = makeEnv();
+    configureR2Presign(env);
+    const now = Date.now();
+    await seedRelease(env, "rel-sha-surface", "build-sha-surface", [["full", "all"]], {
+      createdAt: now,
+      versionCode: 30,
+    });
+    await seedAsset(env, "build-sha-surface", "asset-sha-surface", {
+      arch: "arm64-v8a",
+      fileHash: "e".repeat(64),
+      sizeBytes: 4321,
+    });
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+
+    const response = await handlePublicV2Latest(makePublicContext(env, {
+      channel: "production",
+      product_type: "android-apk",
+      platform: "android",
+      arch: "arm64-v8a",
+    }));
+    expect(response.status).toBe(200);
+    const body = await responseJson<any>(response);
+    expect(body.assets).toHaveLength(1);
+    expect(body.assets[0]).toMatchObject({
+      platform: "android",
+      arch: "arm64-v8a",
+      filetype: "apk",
+      size_bytes: 4321,
+      sha256: "e".repeat(64),
+    });
+    expect(body.assets[0].download_url).toMatch(/^https:\/\//);
+  });
+
+  it("latest projects external build targets into the unified asset shape", async () => {
+    // Externally-hosted builds (Node SEA / cli-binary) have no R2 build_assets
+    // rows, so before this arm existed /latest resolved the release but
+    // returned assets: []. Installers doing cold installs off /latest need the
+    // same shape either way: platform/arch/size/sha256/download_url.
+    const env = makeEnv();
+    const now = Date.now();
+    await seedRelease(env, "rel-ext-latest", "build-ext-latest", [["full", "all"]], {
+      createdAt: now,
+      productType: "cli-binary",
+      versionName: "1.0.19",
+      versionCode: 40,
+    });
+    await env.DB.prepare("UPDATE builds SET source = 'external' WHERE id = 'build-ext-latest'").run();
+    for (const [target, sha] of [["darwin-arm64", "a".repeat(64)], ["linux-x64", "b".repeat(64)]] as const) {
+      await env.DB.prepare(
+        `INSERT INTO external_build_targets
+         (id, app_id, build_id, version_name, target, source_url, raw_sha256, raw_size_bytes,
+          node_version, metadata_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
+        `ext-latest-${target}`,
+        "app-scope",
+        "build-ext-latest",
+        "1.0.19",
+        target,
+        `https://cdn.test/1.0.19/${target}`,
+        sha,
+        119,
+        "24.15.0",
+        "{}",
+        now,
+        now,
+      ).run();
+    }
+    const { handlePublicV2Latest } = await import("../src/routes/public_v2");
+
+    const filtered = await handlePublicV2Latest(makePublicContext(env, {
+      channel: "production",
+      product_type: "cli-binary",
+      platform: "linux-x64",
+    }));
+    expect(filtered.status).toBe(200);
+    const filteredBody = await responseJson<any>(filtered);
+    expect(filteredBody.build).toMatchObject({ version: "1.0.19", version_code: 40 });
+    expect(filteredBody.assets).toEqual([{
+      platform: "linux",
+      arch: "x64",
+      variant: null,
+      filetype: "binary",
+      size_bytes: 119,
+      sha256: "b".repeat(64),
+      // Immutable release-bound /dl route — the same download surface
+      // updates/check hands out — not the raw source URL.
+      download_url: "https://quiver-worker.test/dl/scope-app/releases/rel-ext-latest/linux-x64",
+    }]);
+
+    const unfiltered = await handlePublicV2Latest(makePublicContext(env, {
+      channel: "production",
+      product_type: "cli-binary",
+    }));
+    expect(unfiltered.status).toBe(200);
+    const unfilteredBody = await responseJson<any>(unfiltered);
+    expect(unfilteredBody.assets.map((a: any) => `${a.platform}-${a.arch}`)).toEqual([
+      "darwin-arm64",
+      "linux-x64",
+    ]);
+    expect(unfilteredBody.assets.every((a: any) => /^[a-f0-9]{64}$/.test(a.sha256))).toBe(true);
+  });
+
   it("updates/check returns no update without exposing assets when current version is latest", async () => {
     const env = makeEnv();
     const { handlePublicV2UpdateCheck } = await import("../src/routes/public_v2");


### PR DESCRIPTION
Raft task #170 (consistency tooth for the Computer installer Hands migration, task #504), per artin's ruling that `/latest` should just return unified version info.

## What changes

`GET /public/v2/apps/:slug/latest` asset entries now have one unified shape regardless of where the bytes live:

1. **sha256 projection (internal arm).** `build_assets.file_hash` was already selected by the asset query but silently dropped in the response projection. It is now returned as `sha256` on every asset entry, so installers can verify downloaded bytes against the identity Hands registered at release time.
2. **External arm.** Builds with externally-hosted bytes (`cli-binary` Node SEA — `source = 'external'`, deliberately no R2 `build_assets` rows) previously resolved the release fine but returned `assets: []`. They are now projected from `external_build_targets` into the same shape: `platform`/`arch` split from `target`, `size_bytes = raw_size_bytes`, `sha256 = raw_sha256`, `variant: null`, `filetype: "binary"`, and `download_url` pointing at the immutable release-bound `/dl/{slug}/releases/{releaseId}/{target}` route — the same download surface `updates/check` already hands out (302 to the declared source URL), not the raw source URL.

The `platform`/`client_platform` query filter applies to both arms identically. No behavior change for release resolution, scoping, rollout, or fallback logic.

## Requirement Challenge

- **Could sha256 be skipped?** artin questioned this in #proj-raft-computer; the field costs nothing (already stored and validated at registration; this is a projection, not new computation) and is the only way an installer can bind "what Hands says is current" to "what the CDN served". Kept, and trivially removable if artin rules otherwise.
- **Could the external arm masquerade as build_assets rows instead?** No — migration 0044 explicitly rules that out ("These rows deliberately do not masquerade as R2 assets"). Projection at the read surface is the simplest unification that respects that boundary.
- **Simplest viable version:** no new endpoint, no schema change, no new query when internal assets exist (the external query only runs when the build has zero installable assets).

## Tests

- `latest exposes asset sha256 …`: pins the internal-arm projection (platform/arch/filetype/size/sha256, signed URL present).
- `latest projects external build targets into the unified asset shape`: pins the external arm end-to-end — exact asset object including the immutable `/dl` URL, client-platform filtering (`linux-x64` excludes `darwin-arm64`), and deterministic target ordering when unfiltered.

`npm run build` (tsc) clean; `npx vitest run` 515/516 — the one failure is `feedback_closure_reason_migration.test.ts`, which shells out to `/usr/bin/sqlite3` and fails ENOENT on my machine (pre-existing environment gap, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)