### PR TITLE
feat(public): list installable CLI versions

### DIFF
--- a/docs/hands-node-updater-v1.md
+++ b/docs/hands-node-updater-v1.md
@@ -6,7 +6,7 @@ or roll back the application.
 
 ## Integrity model
 
-Hands returns the exact active release and external build target for the
+Hands returns the exact eligible release and external build target for the
 requested channel, version, platform, and architecture. Every candidate must
 include a byte size and lowercase SHA-256 digest from the external-build
 ledger.
@@ -44,11 +44,12 @@ if (result.kind === "update") {
 }
 ```
 
-The check endpoint selects only `active`, non-hidden `cli-binary` releases
-whose build succeeded and whose full-release scope and rollout include the
-client. Exact pinned versions may resolve across channels; identical artifact
-identity prefers `main`, while divergent size/SHA-256 identity fails with
-`UPDATE_IDENTITY_CONFLICT`.
+For ordinary channel checks, the endpoint selects only `active`, non-hidden
+`cli-binary` releases whose build succeeded and whose full-release scope and
+rollout include the client. Exact pinned versions may also select a
+`superseded` release across channels, but the same rollout inclusion check still
+applies. Identical artifact identity prefers `main`, while divergent
+size/SHA-256 identity fails with `UPDATE_IDENTITY_CONFLICT`.
 
 ## Failure boundary
 

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -223,11 +223,14 @@ Installers should not care which arm served an entry: select by
 GET /public/v2/apps/:appSlug/versions?channel=alpha&platform=linux&arch=x64&limit=20
 ```
 
-Lists exact `cli-binary` versions that remain installable for one channel and
-machine target. Active and superseded full-scope releases are included;
-draft, cancelled, hidden, future, and target-incompatible releases are
-excluded. Superseded versions remain downloadable through their immutable
-release-bound `/dl` route and can therefore be used for an explicit rollback.
+Lists exact `cli-binary` versions that remain universally installable for one
+channel and machine target. Active and superseded full-scope releases are
+included only when their rollout is complete (`rollout_cohort_count` is null or
+100); partial-rollout, draft, cancelled, hidden, future, and target-incompatible
+releases are excluded. Partial-rollout rows remain governed by the device-aware
+update resolver. Superseded universal versions remain downloadable through
+their immutable release-bound `/dl` route and can therefore be used for an
+explicit rollback.
 
 ```json
 {

--- a/docs/public/public-api-reference.md
+++ b/docs/public/public-api-reference.md
@@ -217,6 +217,45 @@ Two storage arms feed it:
 Installers should not care which arm served an entry: select by
 `platform`/`arch`, download, verify, install.
 
+## CLI Version Index
+
+```http
+GET /public/v2/apps/:appSlug/versions?channel=alpha&platform=linux&arch=x64&limit=20
+```
+
+Lists exact `cli-binary` versions that remain installable for one channel and
+machine target. Active and superseded full-scope releases are included;
+draft, cancelled, hidden, future, and target-incompatible releases are
+excluded. Superseded versions remain downloadable through their immutable
+release-bound `/dl` route and can therefore be used for an explicit rollback.
+
+```json
+{
+  "schema_version": 1,
+  "app": { "id": "…", "slug": "raft-computer-cli", "platform": "desktop" },
+  "channel": "alpha",
+  "target": { "platform": "linux", "arch": "x64" },
+  "truncated": false,
+  "versions": [
+    {
+      "version": "1.0.22",
+      "version_code": 1000022,
+      "status": "active",
+      "published_at": 1788136459536,
+      "release_id": "…",
+      "sha256": "0f72382c…",
+      "size_bytes": 156503232
+    }
+  ]
+}
+```
+
+The endpoint validates every returned target identity. If two releases claim
+the same version with different bytes, or if integrity metadata is malformed,
+the request fails closed instead of returning a partial index. `limit`
+defaults to 20 and is bounded to 100; `truncated: true` tells the caller the
+bounded response omitted older versions.
+
 ### Verifying downloads with `sha256`
 
 Every asset entry carries the lowercase hex SHA-256 of the artifact bytes as

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -76,6 +76,7 @@ import {
 import {
   handlePublicR2Download,
   handleInternalR2Download,
+  handlePublicCliBinaryVersions,
   handlePublicV2Latest,
   handlePublicV2UpdateCheck,
 } from "./routes/public_v2";
@@ -600,6 +601,7 @@ app.get("/public/apps/:slug/channels", handlePublicListChannels);
 // v2 endpoints with scope resolution (publish-architecture §5.4).
 app.get("/public/v2/apps/:slug/latest", handlePublicV2Latest);
 app.get("/public/v2/apps/:slug/updates/check", handlePublicV2UpdateCheck);
+app.get("/public/v2/apps/:slug/versions", handlePublicCliBinaryVersions);
 app.get("/public/v2/apps/:slug/release-notes", handlePublicReleaseNotesJson);
 app.get("/public/r2/:key", handlePublicR2Download);
 // Internal signed R2 fetch (delta-patch container pulls source APKs by key).

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -294,8 +294,9 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
     tags: ["Public update"],
     summary: "List installable CLI-binary versions for a channel and target",
     description:
-      "Returns active and superseded full-scope CLI releases whose exact target remains installable. " +
+      "Returns universally rolled out active and superseded full-scope CLI releases whose exact target remains installable. " +
       "Draft, cancelled, hidden, future, incompatible, or malformed releases are never represented as available. " +
+      "Partial-rollout releases remain available only through the device-aware update resolver and are excluded here. " +
       "Duplicate version identities must agree or the endpoint fails closed.",
     request: {
       params: SlugParam,

--- a/worker/src/openapi/public.ts
+++ b/worker/src/openapi/public.ts
@@ -115,6 +115,29 @@ const PublicUpdateCheckResponse = z
   .union([PublicUpdateAvailableResponse, PublicNoUpdateResponse])
   .openapi("PublicUpdateCheckResponse");
 
+const PublicCliVersionsResponse = z
+  .object({
+    schema_version: z.literal(1),
+    app: z.object({
+      id: z.string(),
+      slug: z.string(),
+      platform: z.string(),
+    }),
+    channel: z.string(),
+    target: z.object({ platform: z.string(), arch: z.string() }),
+    truncated: z.boolean(),
+    versions: z.array(z.object({
+      version: z.string(),
+      version_code: z.number().int(),
+      status: z.enum(["active", "superseded"]),
+      published_at: z.number().int(),
+      release_id: z.string(),
+      sha256: z.string(),
+      size_bytes: z.number().int(),
+    })),
+  })
+  .openapi("PublicCliVersionsResponse");
+
 const PublicChannelsResponse = z
   .object({
     app: PublicApp,
@@ -262,6 +285,32 @@ export function registerPublicRoutes(registry: OpenApiRegistry) {
       400: error("current_version_code is missing or invalid."),
       404: error("No matching app, channel, release, or compatible asset was found."),
       500: error("Matched release data is inconsistent or signing failed."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/public/v2/apps/{slug}/versions",
+    tags: ["Public update"],
+    summary: "List installable CLI-binary versions for a channel and target",
+    description:
+      "Returns active and superseded full-scope CLI releases whose exact target remains installable. " +
+      "Draft, cancelled, hidden, future, incompatible, or malformed releases are never represented as available. " +
+      "Duplicate version identities must agree or the endpoint fails closed.",
+    request: {
+      params: SlugParam,
+      query: z.object({
+        channel: z.string().default("main").optional(),
+        platform: z.string(),
+        arch: z.string(),
+        limit: z.coerce.number().int().min(1).max(100).default(20).optional(),
+      }),
+    },
+    responses: {
+      200: success("Installable version index for the requested target.", PublicCliVersionsResponse),
+      400: error("Target or limit is invalid."),
+      404: error("App or channel was not found."),
+      409: error("The release ledger is too large or carries malformed/divergent exact-version identity."),
     },
   });
 

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -667,7 +667,8 @@ const CLI_VERSION_INDEX_MAX_LIMIT = 100;
  * List exact CLI-binary versions that remain installable for one public
  * channel and machine target. This is the authoritative counterpart to the
  * single-result `/updates/check` selector: active and superseded releases are
- * admitted, while draft/cancelled/hidden/future rows stay invisible.
+ * admitted only at universal rollout, while partial-rollout and
+ * draft/cancelled/hidden/future rows stay invisible.
  *
  * The response is intentionally release-metadata only. Exact downloads still
  * resolve through `/updates/check?...&version=<semver>`, which applies the same
@@ -729,6 +730,7 @@ export async function handlePublicCliBinaryVersions(c: Context<{ Bindings: Env }
        AND r.product_type = 'cli-binary'
        AND r.status IN ('active', 'superseded')
        AND r.hidden = 0
+       AND (r.rollout_cohort_count IS NULL OR r.rollout_cohort_count >= 100)
      JOIN builds b ON b.id = r.build_id AND b.status = 'succeeded'
      JOIN external_build_targets e ON e.build_id = b.id AND e.target = ?3
      WHERE a.id = ?1 AND ch.id = ?2

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -587,7 +587,9 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
      FROM apps a
      JOIN channels ch ON ch.app_id = a.id
      JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
-       AND r.product_type = 'cli-binary' AND r.status = 'active' AND r.hidden = 0
+       AND r.product_type = 'cli-binary' AND r.hidden = 0
+       AND ((?5 IS NULL AND r.status = 'active')
+        OR (?5 IS NOT NULL AND r.status IN ('active', 'superseded')))
      JOIN release_scopes s ON s.release_id = r.id
        AND s.scope_type = 'full' AND s.scope_value = 'all'
      JOIN builds b ON b.id = r.build_id AND b.status = 'succeeded'
@@ -597,6 +599,7 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
        AND ((?5 IS NULL AND ch.slug = ?2) OR ?5 IS NOT NULL)
        AND (?5 IS NULL OR b.version_name = ?5)
      ORDER BY CASE WHEN ch.slug = 'main' THEN 0 ELSE 1 END,
+              CASE WHEN r.status = 'active' THEN 0 ELSE 1 END,
               r.activated_at DESC, r.id ASC`,
   ).bind(slug, channel, target, Date.now(), requestedVersion).all<{
     app_id: string; slug: string; channel: string;
@@ -640,6 +643,173 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
       size_bytes: row.raw_size_bytes, sha256: row.raw_sha256,
       download_url: `${origin}/dl/${encodeURIComponent(slug)}/releases/${encodeURIComponent(row.release_id)}/${encodeURIComponent(target)}`,
     },
+  });
+}
+
+type PublicCliVersionRow = {
+  app_id: string;
+  slug: string;
+  app_platform: string;
+  release_id: string;
+  release_status: "active" | "superseded";
+  activated_at: number;
+  version_name: string;
+  version_code: number;
+  raw_sha256: string;
+  raw_size_bytes: number;
+};
+
+const CLI_VERSION_INDEX_ROW_CAP = 1000;
+const CLI_VERSION_INDEX_DEFAULT_LIMIT = 20;
+const CLI_VERSION_INDEX_MAX_LIMIT = 100;
+
+/**
+ * List exact CLI-binary versions that remain installable for one public
+ * channel and machine target. This is the authoritative counterpart to the
+ * single-result `/updates/check` selector: active and superseded releases are
+ * admitted, while draft/cancelled/hidden/future rows stay invisible.
+ *
+ * The response is intentionally release-metadata only. Exact downloads still
+ * resolve through `/updates/check?...&version=<semver>`, which applies the same
+ * status and artifact-identity gates before returning a release-bound URL.
+ */
+export async function handlePublicCliBinaryVersions(c: Context<{ Bindings: Env }>) {
+  const slug = c.req.param("slug") ?? "";
+  const channel = c.req.query("channel") ?? "main";
+  const platform = c.req.query("platform") ?? "";
+  const arch = c.req.query("arch") ?? "";
+  const target = `${platform}-${arch}`;
+  const rawLimit = c.req.query("limit");
+  const limit = rawLimit === undefined ? CLI_VERSION_INDEX_DEFAULT_LIMIT : Number(rawLimit);
+
+  if (!slug) {
+    return c.json({ error: "slug required", code: "slug_required" }, 400);
+  }
+  if (!/^[a-z0-9]+$/u.test(platform) || !/^[a-z0-9_]+$/u.test(arch)) {
+    return c.json(
+      { error: "platform and arch are required", code: "VERSIONS_TARGET_INVALID" },
+      400,
+    );
+  }
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > CLI_VERSION_INDEX_MAX_LIMIT) {
+    return c.json(
+      {
+        error: `limit must be an integer from 1 to ${CLI_VERSION_INDEX_MAX_LIMIT}`,
+        code: "VERSIONS_LIMIT_INVALID",
+      },
+      400,
+    );
+  }
+
+  const app = await c.env.DB.prepare(
+    "SELECT id, slug, platform FROM apps WHERE slug = ?1",
+  ).bind(slug).first<{ id: string; slug: string; platform: string }>();
+  if (!app) {
+    return c.json({ error: `app '${slug}' not found`, code: "app_not_found" }, 404);
+  }
+  const channelRow = await c.env.DB.prepare(
+    "SELECT id FROM channels WHERE app_id = ?1 AND slug = ?2 LIMIT 1",
+  ).bind(app.id, channel).first<{ id: string }>();
+  if (!channelRow) {
+    return c.json(
+      { error: `channel '${channel}' not found for app '${slug}'`, code: "channel_not_found" },
+      404,
+    );
+  }
+
+  const { results: rows } = await c.env.DB.prepare(
+    `SELECT a.id AS app_id, a.slug, a.platform AS app_platform,
+            r.id AS release_id, r.status AS release_status,
+            r.activated_at,
+            b.version_name, b.version_code,
+            e.raw_sha256, e.raw_size_bytes
+     FROM apps a
+     JOIN channels ch ON ch.app_id = a.id
+     JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
+       AND r.product_type = 'cli-binary'
+       AND r.status IN ('active', 'superseded')
+       AND r.hidden = 0
+     JOIN builds b ON b.id = r.build_id AND b.status = 'succeeded'
+     JOIN external_build_targets e ON e.build_id = b.id AND e.target = ?3
+     WHERE a.id = ?1 AND ch.id = ?2
+       AND (r.availability_at IS NULL OR r.availability_at <= ?4)
+       AND EXISTS (
+         SELECT 1 FROM release_scopes s
+         WHERE s.release_id = r.id
+           AND s.scope_type = 'full' AND s.scope_value = 'all'
+       )
+     ORDER BY r.activated_at DESC, r.id ASC
+     LIMIT ?5`,
+  ).bind(app.id, channelRow.id, target, Date.now(), CLI_VERSION_INDEX_ROW_CAP + 1)
+    .all<PublicCliVersionRow>();
+
+  if (rows.length > CLI_VERSION_INDEX_ROW_CAP) {
+    return c.json(
+      { error: "version index exceeds the bounded public read", code: "VERSION_INDEX_TOO_LARGE" },
+      409,
+    );
+  }
+
+  const byVersion = new Map<string, PublicCliVersionRow>();
+  for (const row of rows) {
+    if (
+      !parseStrictSemver(row.version_name)
+      || !Number.isSafeInteger(row.version_code)
+      || row.version_code < 0
+      || !/^[a-f0-9]{64}$/u.test(row.raw_sha256)
+      || !Number.isSafeInteger(row.raw_size_bytes)
+      || row.raw_size_bytes < 0
+      || !Number.isSafeInteger(row.activated_at)
+      || row.activated_at < 0
+      || !Number.isFinite(new Date(row.activated_at).valueOf())
+    ) {
+      return c.json(
+        { error: `published ${row.version_name} has invalid release identity`, code: "VERSION_IDENTITY_DRIFT" },
+        409,
+      );
+    }
+    const prior = byVersion.get(row.version_name);
+    if (prior) {
+      if (
+        prior.raw_sha256 !== row.raw_sha256
+        || prior.raw_size_bytes !== row.raw_size_bytes
+        || prior.version_code !== row.version_code
+      ) {
+        return c.json(
+          { error: `published ${row.version_name} has divergent target identities`, code: "VERSION_IDENTITY_CONFLICT" },
+          409,
+        );
+      }
+      if (prior.release_status === "superseded" && row.release_status === "active") {
+        byVersion.set(row.version_name, row);
+      }
+      continue;
+    }
+    byVersion.set(row.version_name, row);
+  }
+
+  const versions = [...byVersion.values()]
+    .sort((left, right) => {
+      if (left.activated_at !== right.activated_at) return right.activated_at - left.activated_at;
+      return left.release_id.localeCompare(right.release_id);
+    });
+  const selected = versions.slice(0, limit);
+
+  return c.json({
+    schema_version: 1,
+    app: { id: app.id, slug: app.slug, platform: app.platform },
+    channel,
+    target: { platform, arch },
+    truncated: versions.length > selected.length,
+    versions: selected.map((row) => ({
+      version: row.version_name,
+      version_code: row.version_code,
+      status: row.release_status,
+      published_at: row.activated_at,
+      release_id: row.release_id,
+      sha256: row.raw_sha256,
+      size_bytes: row.raw_size_bytes,
+    })),
   });
 }
 

--- a/worker/test/public_cli_updates.test.ts
+++ b/worker/test/public_cli_updates.test.ts
@@ -2,7 +2,10 @@ import Database from "better-sqlite3";
 import { createHash } from "node:crypto";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it } from "vitest";
-import { handlePublicCliBinaryUpdateCheck } from "../src/routes/public_v2";
+import {
+  handlePublicCliBinaryUpdateCheck,
+  handlePublicCliBinaryVersions,
+} from "../src/routes/public_v2";
 
 function d1(sqlite: Database.Database) {
   return { prepare(sql: string) {
@@ -41,6 +44,7 @@ describe("public cli-binary selection", () => {
     env = { DB: d1(sqlite), BUSINESS_ORIGIN: "https://hands.example" };
     app = new Hono<{ Bindings: typeof env }>();
     app.get("/public/v2/apps/:slug/updates/check", handlePublicCliBinaryUpdateCheck as never);
+    app.get("/public/v2/apps/:slug/versions", handlePublicCliBinaryVersions as never);
   });
 
   function seedRelease(id: string, version: string, status: string, activatedAt: number, options: { channel?: "main" | "alpha"; sha256?: string; reuseArtifactFrom?: string } = {}) {
@@ -62,12 +66,29 @@ describe("public cli-binary selection", () => {
     return app.request(`https://hands.example/public/v2/apps/computer/updates/check?current_version=0.5.0&channel=main&platform=linux&arch=x64${extra}`, {}, env);
   }
 
+  function versions(extra = "") {
+    return app.request(`https://hands.example/public/v2/apps/computer/versions?channel=alpha&platform=linux&arch=x64${extra}`, {}, env);
+  }
+
   it("selects an exact pinned active version", async () => {
     seedRelease("r1", "1.0.0", "active", 100);
     seedRelease("r2", "2.0.0", "active", 200);
     const response = await check("&version=1.0.0");
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ release: { id: "r1", version: "1.0.0" } });
+  });
+
+  it("selects an exact pinned superseded version while cancelled remains unavailable", async () => {
+    seedRelease("old", "1.0.0", "superseded", 100, { channel: "alpha" });
+    seedRelease("cancelled", "0.9.0", "cancelled", 90, { channel: "alpha" });
+
+    const old = await check("&version=1.0.0");
+    expect(old.status).toBe(200);
+    await expect(old.json()).resolves.toMatchObject({ release: { id: "old", version: "1.0.0" } });
+
+    const cancelled = await check("&version=0.9.0");
+    expect(cancelled.status).toBe(404);
+    await expect(cancelled.json()).resolves.toMatchObject({ code: "UPDATE_NO_COMPATIBLE_ARTIFACT" });
   });
 
   it("never exposes a draft through a pinned request", async () => {
@@ -107,5 +128,71 @@ describe("public cli-binary selection", () => {
     const response = await check("&version=6.0.0");
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({ code: "UPDATE_IDENTITY_CONFLICT" });
+  });
+
+  it("lists active and superseded target-compatible versions newest first", async () => {
+    seedRelease("old", "1.0.0", "superseded", 100, { channel: "alpha" });
+    seedRelease("latest", "2.0.0", "active", 200, { channel: "alpha" });
+    seedRelease("cancelled", "0.9.0", "cancelled", 90, { channel: "alpha" });
+    seedRelease("draft", "3.0.0", "draft", 300, { channel: "alpha" });
+
+    const response = await versions();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      app: { slug: "computer" },
+      channel: "alpha",
+      target: { platform: "linux", arch: "x64" },
+      truncated: false,
+      versions: [
+        { version: "2.0.0", status: "active", release_id: "latest", published_at: 200 },
+        { version: "1.0.0", status: "superseded", release_id: "old", published_at: 100 },
+      ],
+    });
+  });
+
+  it("returns an empty complete list for a real channel with no public versions", async () => {
+    const response = await versions();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      schema_version: 1,
+      channel: "alpha",
+      truncated: false,
+      versions: [],
+    });
+  });
+
+  it("fails closed on malformed limits and malformed listed integrity", async () => {
+    const invalidLimit = await versions("&limit=0");
+    expect(invalidLimit.status).toBe(400);
+    await expect(invalidLimit.json()).resolves.toMatchObject({ code: "VERSIONS_LIMIT_INVALID" });
+
+    seedRelease("drift", "1.0.0", "active", 100, { channel: "alpha" });
+    sqlite.prepare("UPDATE external_build_targets SET raw_sha256 = 'bad' WHERE id = 'artifact-drift'").run();
+    const drift = await versions();
+    expect(drift.status).toBe(409);
+    await expect(drift.json()).resolves.toMatchObject({ code: "VERSION_IDENTITY_DRIFT" });
+  });
+
+  it("fails closed when duplicate channel versions have divergent target identities", async () => {
+    seedRelease("first", "1.0.0", "superseded", 100, { channel: "alpha", sha256: "a".repeat(64) });
+    seedRelease("second", "1.0.0", "active", 200, { channel: "alpha", sha256: "b".repeat(64) });
+
+    const response = await versions();
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ code: "VERSION_IDENTITY_CONFLICT" });
+  });
+
+  it("reports truncation after deduplicating exact version identities", async () => {
+    seedRelease("old-a", "1.0.0", "superseded", 100, { channel: "alpha", sha256: "a".repeat(64) });
+    seedRelease("old-b", "1.0.0", "superseded", 101, { channel: "alpha", reuseArtifactFrom: "old-a" });
+    seedRelease("latest", "2.0.0", "active", 200, { channel: "alpha" });
+
+    const response = await versions("&limit=1");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      truncated: true,
+      versions: [{ version: "2.0.0" }],
+    });
   });
 });

--- a/worker/test/public_cli_updates.test.ts
+++ b/worker/test/public_cli_updates.test.ts
@@ -47,7 +47,7 @@ describe("public cli-binary selection", () => {
     app.get("/public/v2/apps/:slug/versions", handlePublicCliBinaryVersions as never);
   });
 
-  function seedRelease(id: string, version: string, status: string, activatedAt: number, options: { channel?: "main" | "alpha"; sha256?: string; reuseArtifactFrom?: string } = {}) {
+  function seedRelease(id: string, version: string, status: string, activatedAt: number, options: { channel?: "main" | "alpha"; sha256?: string; reuseArtifactFrom?: string; rolloutCohortCount?: number | null } = {}) {
     const source = options.reuseArtifactFrom ?? id;
     const buildId = `build-${source}`;
     const artifactId = `artifact-${source}`;
@@ -57,8 +57,8 @@ describe("public cli-binary selection", () => {
       sqlite.prepare("INSERT INTO builds VALUES (?, 'app', 'succeeded', ?, ?)").run(buildId, version, activatedAt);
       sqlite.prepare("INSERT INTO external_build_targets VALUES (?, ?, 'linux-x64', ?, 8)").run(artifactId, buildId, sha256);
     }
-    sqlite.prepare("INSERT INTO releases VALUES (?, 'app', ?, ?, 'cli-binary', 'stable', ?, 0, 1, NULL, ?, NULL)")
-      .run(id, buildId, `channel-${channel}`, status, activatedAt);
+    sqlite.prepare("INSERT INTO releases VALUES (?, 'app', ?, ?, 'cli-binary', 'stable', ?, 0, 1, ?, ?, NULL)")
+      .run(id, buildId, `channel-${channel}`, status, options.rolloutCohortCount ?? null, activatedAt);
     sqlite.prepare("INSERT INTO release_scopes VALUES (?, ?, 'full', 'all')").run(`scope-${id}`, id);
   }
 
@@ -148,6 +148,35 @@ describe("public cli-binary selection", () => {
         { version: "2.0.0", status: "active", release_id: "latest", published_at: 200 },
         { version: "1.0.0", status: "superseded", release_id: "old", published_at: 100 },
       ],
+    });
+  });
+
+  it("excludes partial-rollout rows that are not universally installable", async () => {
+    seedRelease("partial-active", "3.0.0", "active", 300, {
+      channel: "alpha",
+      rolloutCohortCount: 50,
+    });
+    seedRelease("partial-superseded", "2.0.0", "superseded", 200, {
+      channel: "alpha",
+      rolloutCohortCount: 25,
+    });
+    seedRelease("universal", "1.0.0", "superseded", 100, {
+      channel: "alpha",
+      rolloutCohortCount: 100,
+    });
+
+    const response = await versions();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      truncated: false,
+      versions: [{ version: "1.0.0", release_id: "universal" }],
+    });
+
+    const pinnedPartial = await check("&version=3.0.0");
+    expect(pinnedPartial.status).toBe(200);
+    await expect(pinnedPartial.json()).resolves.toMatchObject({
+      update_available: false,
+      current_version: "0.5.0",
     });
   });
 

--- a/worker/test/routes.test.ts
+++ b/worker/test/routes.test.ts
@@ -94,6 +94,7 @@ describe("quiver OpenAPI document", () => {
 
     for (const path of [
       "/public/v2/apps/{slug}/updates/check",
+      "/public/v2/apps/{slug}/versions",
       "/electron/{slug}/{channel}/{file}",
       "/public/v2/apps/{slug}/feedback",
       "/public/v2/apps/{slug}/metrics",


### PR DESCRIPTION
## Summary

- add an authoritative public version index for installable CLI-binary releases
- include active and superseded exact versions while excluding draft, cancelled, hidden, future, incomplete, and incompatible rows
- keep duplicate or malformed immutable target identities fail-closed
- allow the existing exact-version resolver to select superseded releases for explicit rollback
- publish the route in OpenAPI and the public API reference

## Verification

- Node 24.15.0 focused public CLI updater/index contract: 12/12
- Node 24.15.0 full Hands worker suite: 522/522
- `wrangler types --config wrangler.hands.jsonc`
- worker TypeScript build
- `git diff --check`
- right-cause mutations: active-only exact resolver, active-only index, and disabled duplicate-identity conflict each produced the expected RED and were restored

## Boundary

Source-only. No Hands deployment, release activation, CDN mutation, or publication action is included.
