### PR TITLE
feat(worker): add Google Play distribution receipts

### DIFF
--- a/docs/google-play-distribution-design.md
+++ b/docs/google-play-distribution-design.md
@@ -62,7 +62,7 @@ Parent states are `uploading`, `ready`, or `failed`.
 Typed errors are `INVALID_RELEASE_ARTIFACTS`,
 `ARTIFACT_UPLOAD_UNAVAILABLE`, `ARTIFACT_NOT_FOUND`, `INTEGRITY_MISMATCH`,
 `IMMUTABLE_CONFLICT`, and `STATE_CONFLICT`, plus the existing authorization
-errors.
+error `INSUFFICIENT_APP_ROLE`.
 
 ## Acceptance and distribution API
 
@@ -73,6 +73,11 @@ errors.
 - `POST /api/apps/:appId/releases/:releaseId/distributions/play/promote`
 - `POST /api/apps/:appId/releases/:releaseId/distributions/play/halt`
 - `POST /api/apps/:appId/releases/:releaseId/distributions/play/rollback`
+
+Rollback input includes `expected_revision`, human `approval.note`, and a
+positive `to_version_code`. P0 validates that public request shape and then
+returns the typed fail-closed adapter-not-implemented result without a Play
+write.
 
 Reads require `viewer`; writes require `publisher`. Acceptance binds a verdict
 to the exact sealed AAB and advances the release revision with compare-and-set.

--- a/docs/google-play-distribution-design.md
+++ b/docs/google-play-distribution-design.md
@@ -1,0 +1,116 @@
+# Google Play distribution P0
+
+Status: source contract. It does not authorize a deployment or a Google Play write.
+
+## Model
+
+Mobile CI builds once and declares exactly one signed AAB plus one signed APK
+under one source commit, package, version name, and versionCode. Both objects go
+to Hands first. Hands seals each object by streaming one R2 snapshot through
+SHA-256 verification and an immutable final key. The parent build becomes
+`ready` only after both assets are sealed.
+
+The APK remains the Hands install carrier. Google Play promotion consumes only
+the accepted AAB. CI, the CLI, and devices never receive Play credentials.
+Hands calls a server-side `PLAY_RELEASE_SERVICE` binding; without that binding,
+all Play writes fail closed.
+
+P0 deliberately has no Play distribution-certificate field or gate. The only
+certificate fingerprint in this contract is the CI upload-key certificate.
+
+## Mobile artifact API
+
+All routes use the existing Hands bearer/session authentication and app roles.
+
+### Declare
+
+`POST /api/apps/:appId/android-release-artifacts` requires `publisher`.
+
+```json
+{
+  "source": {
+    "repository": "botiverse/mobile",
+    "commit_sha": "40 lowercase hex characters",
+    "ci_run_id": "123456"
+  },
+  "package_name": "build.raft.app",
+  "version_name": "1.2.3",
+  "version_code": 123,
+  "upload_key_cert_sha256": "64 lowercase hex characters",
+  "artifacts": [
+    { "kind": "aab", "filename": "raft.aab", "size_bytes": 1, "sha256": "64 lowercase hex characters" },
+    { "kind": "apk", "filename": "raft.apk", "size_bytes": 1, "sha256": "64 lowercase hex characters" }
+  ]
+}
+```
+
+The response contains one `build_id`, two asset declarations, and one
+presigned `PUT` plus `complete_url` per asset. Upload URLs and headers are
+ephemeral secrets and must not be logged.
+
+### Complete and read
+
+- `POST /api/apps/:appId/android-release-artifacts/:buildId/assets/:assetId/complete`
+  (`publisher`) hashes and seals the exact R2 stream. The caller does not
+  resubmit identity fields.
+- `GET /api/apps/:appId/android-release-artifacts/:buildId` (`viewer`) returns
+  the shared identity and the two declarations/readbacks.
+
+Per-asset states are `pending_upload`, `verifying`, `sealed`, or `failed`.
+Parent states are `uploading`, `ready`, or `failed`.
+
+Typed errors are `INVALID_RELEASE_ARTIFACTS`,
+`ARTIFACT_UPLOAD_UNAVAILABLE`, `ARTIFACT_NOT_FOUND`, `INTEGRITY_MISMATCH`,
+`IMMUTABLE_CONFLICT`, and `STATE_CONFLICT`, plus the existing authorization
+errors.
+
+## Acceptance and distribution API
+
+- `POST /api/apps/:appId/releases/:releaseId/receipts/acceptance`
+- `GET /api/apps/:appId/releases/:releaseId/receipts`
+- `GET /api/apps/:appId/releases/:releaseId/distributions`
+- `GET /api/apps/:appId/releases/:releaseId/distributions/play`
+- `POST /api/apps/:appId/releases/:releaseId/distributions/play/promote`
+- `POST /api/apps/:appId/releases/:releaseId/distributions/play/halt`
+- `POST /api/apps/:appId/releases/:releaseId/distributions/play/rollback`
+
+Reads require `viewer`; writes require `publisher`. Acceptance binds a verdict
+to the exact sealed AAB and advances the release revision with compare-and-set.
+Receipts are append-only at the database layer.
+
+Promotion requires:
+
+1. an AAB sealed to its declared SHA-256 and size;
+2. the latest acceptance receipt for that exact asset is `pass` and matches
+   package, source, versionCode, hash, and size;
+3. requested track is `internal`, `closed`, or `production`;
+4. artifact versionCode equals the live Play track maximum plus one;
+5. no other edit lock exists for the app/package; there is no automatic retry;
+6. no open release distribution hold;
+7. an authenticated human publisher and a nonblank approval note.
+
+The server reads track state once, reserves the release revision, streams the
+exact AAB once, and compares the adapter readback package/version/track/SHA.
+Only an exact match records a successful immutable receipt. Any post-reserve
+error records `failed-closed` where possible. Halt and rollback remain typed
+fail-closed until the server-side Play adapter explicitly implements them.
+
+## Server-side Play adapter protocol
+
+`PLAY_RELEASE_SERVICE` owns Google credentials. Hands makes two service-binding
+requests and never sends credentials in headers or payloads:
+
+- `GET /v1/apps/:package/tracks/:track` → `{ "max_version_code": 122 }`
+- `POST /v1/apps/:package/edits` with the AAB byte stream and only public
+  `x-hands-*` identity headers → exact readback `{edit_id, package_name,
+  version_code, track, sha256, rollout_percent}`.
+
+No call is retried automatically. Adapter absence, non-2xx, or malformed/mismatched
+readback is a typed `play_api_error` and never becomes success.
+
+## Non-goals
+
+- no Play credentials, signing, or production promotion in this change;
+- no store listing automation, review replies, or crash/ANR threshold gate;
+- no Play distribution-certificate storage or gating;
+- no inclusion of Play artifacts in Hands alpha/delta updates.

--- a/docs/schemas/release-receipt-v1.json
+++ b/docs/schemas/release-receipt-v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hands.build/schemas/release-receipt-v1.json",
+  "title": "Hands Release Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "kind", "receipt_id", "artifact", "source", "signing", "actor", "action", "result", "created_at"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "enum": ["acceptance", "play-promotion"] },
+    "receipt_id": { "type": "string", "format": "uuid" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "sha256", "size_bytes", "package", "version_name", "version_code"],
+      "properties": {
+        "type": { "enum": ["aab", "apk"] },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "size_bytes": { "type": "integer", "minimum": 1 },
+        "package": { "type": "string", "minLength": 1 },
+        "version_name": { "type": "string", "minLength": 1 },
+        "version_code": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "sha", "ci_run_id"],
+      "properties": {
+        "repo": { "type": "string", "minLength": 1 },
+        "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "ci_run_id": { "type": "string", "minLength": 1 },
+        "builder": { "type": "string" },
+        "sbom_ref": { "type": "string" }
+      }
+    },
+    "signing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upload_key_cert_sha256"],
+      "properties": {
+        "upload_key_cert_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "hands_acceptance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "matrix_ref"],
+      "properties": {
+        "verdict": { "enum": ["pass", "fail"] },
+        "matrix_ref": { "type": "string", "minLength": 1 },
+        "verifier": { "type": "string" }
+      }
+    },
+    "play": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["edit_id", "track", "api_readback"],
+      "properties": {
+        "edit_id": { "type": "string", "minLength": 1 },
+        "track": { "enum": ["internal", "closed", "production"] },
+        "rollout_percent": { "type": "number", "minimum": 0, "maximum": 100 },
+        "play_version_code": { "type": "integer", "minimum": 1 },
+        "api_readback": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["package", "version_code", "track", "sha256_match"],
+          "properties": {
+            "package": { "type": "string", "minLength": 1 },
+            "version_code": { "type": "integer", "minimum": 1 },
+            "track": { "enum": ["internal", "closed", "production"] },
+            "sha256_match": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "actor": { "type": "string", "minLength": 1 },
+    "action": { "enum": ["accept", "promote", "halt", "resume", "rollback-republish"] },
+    "approvals": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["approver", "at"],
+        "properties": {
+          "approver": { "type": "string", "minLength": 1 },
+          "at": { "type": "string", "format": "date-time" },
+          "scope": { "type": "string" }
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["success", "failed-closed"] },
+        "failure_reason": { "type": "string" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "kind": { "const": "acceptance" } }, "required": ["kind"] },
+      "then": { "required": ["hands_acceptance"] }
+    },
+    {
+      "if": { "properties": { "kind": { "const": "play-promotion" } }, "required": ["kind"] },
+      "then": {
+        "required": ["play", "approvals"],
+        "properties": { "artifact": { "properties": { "type": { "const": "aab" } } } }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": { "const": "play-promotion" },
+          "result": { "properties": { "status": { "const": "success" } }, "required": ["status"] }
+        },
+        "required": ["kind", "result"]
+      },
+      "then": {
+        "properties": {
+          "play": {
+            "properties": {
+              "api_readback": { "properties": { "sha256_match": { "const": true } } }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/migrations/sql/0070_google_play_distribution.sql
+++ b/migrations/sql/0070_google_play_distribution.sql
@@ -23,8 +23,7 @@ CREATE TABLE android_release_artifact_bundles (
   created_by                  TEXT NOT NULL,
   created_at                  INTEGER NOT NULL,
   completed_at                INTEGER,
-  UNIQUE (app_id, package_name, version_code),
-  UNIQUE (app_id, build_id)
+  UNIQUE (app_id, package_name, version_code)
 );
 
 CREATE INDEX idx_android_release_bundles_source

--- a/migrations/sql/0070_google_play_distribution.sql
+++ b/migrations/sql/0070_google_play_distribution.sql
@@ -1,0 +1,128 @@
+-- Google Play distribution P0.
+--
+-- The mobile producer declares one immutable Android build identity with exactly
+-- one AAB and one APK. build_assets holds the byte objects; this table holds the
+-- shared identity that must never drift between them.
+CREATE TABLE android_release_artifact_bundles (
+  build_id                    TEXT PRIMARY KEY REFERENCES builds(id) ON DELETE CASCADE,
+  app_id                      TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  package_name                TEXT NOT NULL,
+  version_name                TEXT NOT NULL,
+  version_code                INTEGER NOT NULL CHECK (version_code > 0),
+  source_repository           TEXT NOT NULL,
+  source_commit               TEXT NOT NULL CHECK (
+    length(source_commit) = 40 AND source_commit NOT GLOB '*[^0-9a-f]*'
+  ),
+  ci_run_id                   TEXT NOT NULL,
+  upload_key_cert_sha256      TEXT NOT NULL CHECK (
+    length(upload_key_cert_sha256) = 64
+    AND upload_key_cert_sha256 NOT GLOB '*[^0-9a-f]*'
+  ),
+  state                       TEXT NOT NULL DEFAULT 'uploading'
+                               CHECK (state IN ('uploading', 'ready', 'failed')),
+  created_by                  TEXT NOT NULL,
+  created_at                  INTEGER NOT NULL,
+  completed_at                INTEGER,
+  UNIQUE (app_id, package_name, version_code),
+  UNIQUE (app_id, build_id)
+);
+
+CREATE INDEX idx_android_release_bundles_source
+  ON android_release_artifact_bundles(app_id, source_commit, ci_run_id);
+
+-- Only the lifecycle projection may change. Artifact identity is append-only.
+CREATE TRIGGER trg_android_release_bundle_identity_immutable
+BEFORE UPDATE OF app_id, package_name, version_name, version_code,
+  source_repository, source_commit, ci_run_id, upload_key_cert_sha256,
+  created_by, created_at
+ON android_release_artifact_bundles
+BEGIN
+  SELECT RAISE(ABORT, 'android release artifact identity is immutable');
+END;
+
+-- Receipts are the immutable evidence chain. They intentionally contain only
+-- public metadata and never credentials or private key material.
+CREATE TABLE release_receipts (
+  id                TEXT PRIMARY KEY,
+  app_id            TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  release_id        TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  kind              TEXT NOT NULL CHECK (kind IN ('acceptance', 'play-promotion')),
+  verdict           TEXT NOT NULL CHECK (verdict IN ('pass', 'fail', 'success', 'failed-closed')),
+  artifact_id       TEXT REFERENCES build_assets(id) ON DELETE RESTRICT,
+  artifact_sha256   TEXT CHECK (
+    artifact_sha256 IS NULL OR (
+      length(artifact_sha256) = 64 AND artifact_sha256 NOT GLOB '*[^0-9a-f]*'
+    )
+  ),
+  artifact_size     INTEGER,
+  package_name      TEXT NOT NULL,
+  source_commit     TEXT NOT NULL,
+  version_code      INTEGER NOT NULL,
+  action            TEXT,
+  track             TEXT,
+  play_edit_id      TEXT,
+  payload_json      TEXT NOT NULL CHECK (json_valid(payload_json)),
+  created_by        TEXT NOT NULL,
+  created_at        INTEGER NOT NULL
+);
+
+CREATE INDEX idx_release_receipts_chain
+  ON release_receipts(app_id, release_id, created_at, id);
+CREATE INDEX idx_release_receipts_artifact
+  ON release_receipts(app_id, release_id, artifact_id, created_at DESC);
+
+CREATE TRIGGER trg_release_receipts_no_update
+BEFORE UPDATE ON release_receipts
+BEGIN
+  SELECT RAISE(ABORT, 'release receipts are immutable');
+END;
+
+CREATE TRIGGER trg_release_receipts_no_delete
+BEFORE DELETE ON release_receipts
+BEGIN
+  SELECT RAISE(ABORT, 'release receipts are immutable');
+END;
+
+CREATE TABLE play_distribution_state (
+  app_id              TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  release_id          TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  package_name        TEXT NOT NULL,
+  track               TEXT NOT NULL CHECK (track IN ('internal', 'closed', 'production')),
+  version_code        INTEGER NOT NULL,
+  rollout_percent     INTEGER CHECK (rollout_percent BETWEEN 0 AND 100),
+  state               TEXT NOT NULL CHECK (state IN ('active', 'halted', 'failed-closed')),
+  last_edit_id        TEXT,
+  last_receipt_id     TEXT NOT NULL REFERENCES release_receipts(id) ON DELETE RESTRICT,
+  revision            INTEGER NOT NULL DEFAULT 1,
+  updated_at          INTEGER NOT NULL,
+  PRIMARY KEY (app_id, release_id)
+);
+
+-- A primary-key row is the lock. Acquisition is one INSERT; conflicts are
+-- surfaced to the caller and are never retried automatically.
+CREATE TABLE play_edit_locks (
+  app_id          TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  package_name    TEXT NOT NULL,
+  release_id      TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  operation_id    TEXT NOT NULL UNIQUE,
+  acquired_by     TEXT NOT NULL,
+  acquired_at     INTEGER NOT NULL,
+  PRIMARY KEY (app_id, package_name)
+);
+
+-- Holds are an explicit operator surface. P0 only consumes this table as a
+-- fail-closed gate; hold administration is deliberately a separate concern.
+CREATE TABLE release_distribution_holds (
+  id            TEXT PRIMARY KEY,
+  app_id        TEXT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  release_id    TEXT NOT NULL REFERENCES releases(id) ON DELETE CASCADE,
+  reason        TEXT NOT NULL,
+  opened_by     TEXT NOT NULL,
+  opened_at     INTEGER NOT NULL,
+  closed_by     TEXT,
+  closed_at     INTEGER
+);
+
+CREATE INDEX idx_release_distribution_holds_open
+  ON release_distribution_holds(app_id, release_id)
+  WHERE closed_at IS NULL;

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -41,6 +41,11 @@ declare global {
     FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION?: string;
     /** Secret JSON object containing one or two base64url HMAC keys by version. */
     FEEDBACK_REPORTER_SESSION_KEYS?: string;
+    /**
+     * Server-side Google Play adapter. The adapter owns Play credentials; this
+     * Worker and every CI/CLI/device caller only see the service binding.
+     */
+    PLAY_RELEASE_SERVICE?: Fetcher;
   }
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -197,6 +197,20 @@ import {
   handleListIosSimulatorArtifacts,
 } from "./routes/qa_artifacts";
 import {
+  handleCompleteAndroidReleaseArtifact,
+  handleCreateAndroidReleaseArtifacts,
+  handleGetAndroidReleaseArtifacts,
+} from "./routes/android_release_artifacts";
+import {
+  handleCreateAcceptanceReceipt,
+  handleGetPlayDistribution,
+  handleHaltPlayDistribution,
+  handleListDistributions,
+  handleListReleaseReceipts,
+  handlePromotePlayDistribution,
+  handleRollbackPlayDistribution,
+} from "./routes/play_distribution";
+import {
   handleBumpRollout,
   handleCreateRelease,
   handleCreateReleaseDraft,
@@ -855,6 +869,24 @@ admin.get(
   handleDownloadIosSimulatorArtifact,
 );
 
+// Mobile CI declares one Android release build with exactly one AAB and one
+// APK. The pair is sealed independently but becomes ready only as one bundle.
+admin.post(
+  "/api/apps/:appId/android-release-artifacts",
+  requireAppRole("publisher"),
+  handleCreateAndroidReleaseArtifacts,
+);
+admin.get(
+  "/api/apps/:appId/android-release-artifacts/:buildId",
+  requireAppRole("viewer"),
+  handleGetAndroidReleaseArtifacts,
+);
+admin.post(
+  "/api/apps/:appId/android-release-artifacts/:buildId/assets/:assetId/complete",
+  requireAppRole("publisher"),
+  handleCompleteAndroidReleaseArtifact,
+);
+
 admin.get("/api/apps/:appId/releases", requireAppRole("viewer"), handleListReleases);
 admin.post("/api/apps/:appId/releases", requireAppRole("publisher"), handleCreateRelease);
 admin.post("/api/apps/:appId/releases/draft", requireAppRole("publisher"), handleCreateReleaseDraft);
@@ -867,6 +899,41 @@ admin.post("/api/apps/:appId/releases/:releaseId/bump-rollout", requireAppRole("
 admin.post("/api/apps/:appId/releases/:releaseId/force-update", requireAppRole("publisher"), handleForceUpdate);
 admin.get("/api/apps/:appId/releases/:releaseId/checks", requireAppRole("viewer"), handleListReleaseChecks);
 admin.post("/api/apps/:appId/releases/:releaseId/checks", requireAppRole("publisher"), handleUpsertReleaseCheck);
+admin.get(
+  "/api/apps/:appId/releases/:releaseId/distributions",
+  requireAppRole("viewer"),
+  handleListDistributions,
+);
+admin.get(
+  "/api/apps/:appId/releases/:releaseId/distributions/play",
+  requireAppRole("viewer"),
+  handleGetPlayDistribution,
+);
+admin.post(
+  "/api/apps/:appId/releases/:releaseId/distributions/play/promote",
+  requireAppRole("publisher"),
+  handlePromotePlayDistribution,
+);
+admin.post(
+  "/api/apps/:appId/releases/:releaseId/distributions/play/halt",
+  requireAppRole("publisher"),
+  handleHaltPlayDistribution,
+);
+admin.post(
+  "/api/apps/:appId/releases/:releaseId/distributions/play/rollback",
+  requireAppRole("publisher"),
+  handleRollbackPlayDistribution,
+);
+admin.get(
+  "/api/apps/:appId/releases/:releaseId/receipts",
+  requireAppRole("viewer"),
+  handleListReleaseReceipts,
+);
+admin.post(
+  "/api/apps/:appId/releases/:releaseId/receipts/acceptance",
+  requireAppRole("publisher"),
+  handleCreateAcceptanceReceipt,
+);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
 admin.post("/api/apps/:appId/shares/:shareId/rebind", requireAppRole("publisher"), handleRebindReleaseShare);
 admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { registerAppRoutes } from "./openapi/apps";
+import { registerAndroidDistributionRoutes } from "./openapi/android_distribution";
 import { registerAuthRoutes } from "./openapi/auth";
 import { registerBuildRoutes } from "./openapi/builds";
 import { registerFeedbackRoutes } from "./openapi/feedback";
@@ -13,6 +14,7 @@ const docs = new OpenAPIHono();
 registerAuthRoutes(docs.openAPIRegistry);
 registerPublicRoutes(docs.openAPIRegistry);
 registerAppRoutes(docs.openAPIRegistry);
+registerAndroidDistributionRoutes(docs.openAPIRegistry);
 registerBuildRoutes(docs.openAPIRegistry);
 registerReleaseRoutes(docs.openAPIRegistry);
 registerFeedbackRoutes(docs.openAPIRegistry);
@@ -73,6 +75,10 @@ export const openApiDocument = docs.getOpenAPI31Document({
     {
       name: "Builds",
       description: "Create, inspect, and download build artifacts.",
+    },
+    {
+      name: "Android distribution",
+      description: "Immutable AAB/APK bundles, acceptance receipts, and server-side Google Play promotion.",
     },
     {
       name: "TestFlight",

--- a/worker/src/openapi/android_distribution.ts
+++ b/worker/src/openapi/android_distribution.ts
@@ -1,0 +1,217 @@
+import { z } from "@hono/zod-openapi";
+import {
+  AppIdParam,
+  AssetIdParam,
+  BuildIdParam,
+  GenericObject,
+  ReleaseIdParam,
+  auth,
+  error,
+  json,
+  register,
+  success,
+  type OpenApiRegistry,
+} from "./common";
+
+const AppBuildParams = AppIdParam.merge(BuildIdParam);
+const AppBuildAssetParams = AppBuildParams.merge(AssetIdParam);
+const AppReleaseParams = AppIdParam.merge(ReleaseIdParam);
+
+const Sha256 = z.string().regex(/^[0-9a-f]{64}$/);
+const SourceCommit = z.string().regex(/^[0-9a-f]{40}$/);
+const AndroidArtifactDeclaration = z.object({
+  kind: z.enum(["aab", "apk"]),
+  filename: z.string().min(1).max(255),
+  size_bytes: z.number().int().positive().max(4 * 1024 * 1024 * 1024),
+  sha256: Sha256,
+}).strict();
+
+const AndroidReleaseArtifactInput = z.object({
+  channel_id: z.string().min(1).max(128).optional(),
+  source: z.object({
+    repository: z.string().min(1).max(255),
+    commit_sha: SourceCommit,
+    ci_run_id: z.union([z.string().min(1).max(128), z.number().int().nonnegative()]),
+  }).strict(),
+  package_name: z.string().min(3).max(255),
+  version_name: z.string().min(1).max(128),
+  version_code: z.number().int().positive(),
+  upload_key_cert_sha256: Sha256,
+  artifacts: z.array(AndroidArtifactDeclaration).length(2).openapi({
+    description: "Exactly one AAB and one APK; duplicate or missing kinds are rejected.",
+  }),
+}).strict().openapi("AndroidReleaseArtifactInput");
+
+const AcceptanceReceiptInput = z.object({
+  artifact_id: z.string().min(1),
+  verdict: z.enum(["pass", "fail"]),
+  matrix_ref: z.string().min(1),
+  note: z.string().optional(),
+  expected_revision: z.number().int().nonnegative(),
+}).strict().openapi("AcceptanceReceiptInput");
+
+const PlayApprovalInput = z.object({
+  expected_revision: z.number().int().nonnegative(),
+  approval: z.object({ note: z.string().min(1) }).strict(),
+}).strict();
+
+const PlayPromotionInput = PlayApprovalInput.extend({
+  track: z.enum(["internal", "closed", "production"]),
+  rollout_percent: z.number().int().min(0).max(100).optional(),
+}).strict().openapi("PlayPromotionInput");
+
+export function registerAndroidDistributionRoutes(registry: OpenApiRegistry) {
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/android-release-artifacts",
+    tags: ["Android distribution"],
+    summary: "Declare one immutable Android AAB and APK bundle",
+    description:
+      "Creates one build identity and two direct-upload declarations. The parent becomes ready only after both exact objects are verified and sealed by Hands.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      body: { content: json(AndroidReleaseArtifactInput), required: true },
+    },
+    responses: {
+      201: success("Created immutable AAB/APK upload bundle.", GenericObject),
+      400: error("Declaration is invalid."),
+      403: error("App publisher role is required."),
+      404: error("App was not found."),
+      409: error("An immutable identity conflicts."),
+      503: error("Direct artifact upload is unavailable."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/android-release-artifacts/{buildId}",
+    tags: ["Android distribution"],
+    summary: "Read an Android release artifact bundle",
+    security: auth,
+    request: { params: AppBuildParams },
+    responses: {
+      200: success("Shared build identity and exact per-asset seal state.", GenericObject),
+      403: error("App viewer role is required."),
+      404: error("Artifact bundle was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/android-release-artifacts/{buildId}/assets/{assetId}/complete",
+    tags: ["Android distribution"],
+    summary: "Verify and seal one uploaded Android artifact",
+    description:
+      "Streams one uploaded object through SHA-256 verification into an immutable final key. The caller cannot resubmit identity fields.",
+    security: auth,
+    request: { params: AppBuildAssetParams },
+    responses: {
+      200: success("Artifact sealed; returns the current two-asset bundle.", GenericObject),
+      403: error("App publisher role is required."),
+      404: error("Artifact or uploaded object was not found."),
+      409: error("Artifact state or immutable key conflicts."),
+      422: error("Uploaded size or SHA-256 does not match."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/releases/{releaseId}/receipts",
+    tags: ["Android distribution"],
+    summary: "List append-only release receipts",
+    security: auth,
+    request: { params: AppReleaseParams },
+    responses: {
+      200: success("Acceptance and Google Play receipt chain.", GenericObject),
+      403: error("App viewer role is required."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/releases/{releaseId}/receipts/acceptance",
+    tags: ["Android distribution"],
+    summary: "Append a Hands acceptance receipt",
+    description:
+      "Binds the verdict to one exact sealed AAB or APK and advances the release revision with compare-and-set.",
+    security: auth,
+    request: {
+      params: AppReleaseParams,
+      body: { content: json(AcceptanceReceiptInput), required: true },
+    },
+    responses: {
+      201: success("Acceptance receipt appended.", GenericObject),
+      400: error("Receipt input is invalid."),
+      403: error("App publisher role is required."),
+      404: error("Release artifact was not found."),
+      409: error("Artifact state or release revision conflicts."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/releases/{releaseId}/distributions",
+    tags: ["Android distribution"],
+    summary: "List Hands and Google Play distribution state",
+    security: auth,
+    request: { params: AppReleaseParams },
+    responses: {
+      200: success("Distribution states.", GenericObject),
+      403: error("App viewer role is required."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/releases/{releaseId}/distributions/play",
+    tags: ["Android distribution"],
+    summary: "Read Google Play distribution state",
+    security: auth,
+    request: { params: AppReleaseParams },
+    responses: {
+      200: success("Google Play state or null.", GenericObject),
+      403: error("App viewer role is required."),
+    },
+  });
+
+  register(registry, {
+    method: "post",
+    path: "/api/apps/{appId}/releases/{releaseId}/distributions/play/promote",
+    tags: ["Android distribution"],
+    summary: "Promote the accepted exact AAB through the server-side Play adapter",
+    description:
+      "Requires immutable binding, latest passing AAB acceptance, track max + 1 versionCode, one edit lock, no live hold, and explicit human approval. No Play credential reaches this API caller.",
+    security: auth,
+    request: {
+      params: AppReleaseParams,
+      body: { content: json(PlayPromotionInput), required: true },
+    },
+    responses: {
+      200: success("Play readback matched and immutable receipt was appended.", GenericObject),
+      400: error("A promotion gate failed."),
+      403: error("Human approval, publisher role, or live-hold gate failed."),
+      409: error("Release revision, versionCode, or edit lock conflicts."),
+      502: error("Server-side Play adapter failed or returned mismatched readback."),
+    },
+  });
+
+  for (const action of ["halt", "rollback"] as const) {
+    register(registry, {
+      method: "post",
+      path: `/api/apps/{appId}/releases/{releaseId}/distributions/play/${action}`,
+      tags: ["Android distribution"],
+      summary: action === "halt" ? "Halt a Play distribution" : "Rollback by republishing a prior accepted AAB",
+      description: "P0 validates human approval and then fails closed until the server-side Play adapter implements this operation.",
+      security: auth,
+      request: {
+        params: AppReleaseParams,
+        body: { content: json(PlayApprovalInput), required: true },
+      },
+      responses: {
+        403: error("Human approval or publisher role is missing."),
+        502: error("Operation is not implemented by the server-side Play adapter."),
+      },
+    });
+  }
+}

--- a/worker/src/openapi/android_distribution.ts
+++ b/worker/src/openapi/android_distribution.ts
@@ -60,6 +60,10 @@ const PlayPromotionInput = PlayApprovalInput.extend({
   rollout_percent: z.number().int().min(0).max(100).optional(),
 }).strict().openapi("PlayPromotionInput");
 
+const PlayRollbackInput = PlayApprovalInput.extend({
+  to_version_code: z.number().int().positive(),
+}).strict().openapi("PlayRollbackInput");
+
 export function registerAndroidDistributionRoutes(registry: OpenApiRegistry) {
   register(registry, {
     method: "post",
@@ -206,7 +210,10 @@ export function registerAndroidDistributionRoutes(registry: OpenApiRegistry) {
       security: auth,
       request: {
         params: AppReleaseParams,
-        body: { content: json(PlayApprovalInput), required: true },
+        body: {
+          content: json(action === "rollback" ? PlayRollbackInput : PlayApprovalInput),
+          required: true,
+        },
       },
       responses: {
         403: error("Human approval or publisher role is missing."),

--- a/worker/src/routes/android_release_artifacts.ts
+++ b/worker/src/routes/android_release_artifacts.ts
@@ -1,0 +1,517 @@
+import type { Context } from "hono";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import { currentActor, type AdminEnv } from "../middleware/auth";
+import { requestOrigin } from "../lib/origin";
+import { presignR2UploadUrl } from "../lib/r2_presign";
+import { autoParseInstallableAsset, createBuild, createBuildAsset, resolveChannelId } from "./builds";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+type JsonObject = Record<string, unknown>;
+type ArtifactKind = "aab" | "apk";
+type UploadState = "pending_upload" | "verifying" | "ready" | "failed";
+
+const SCHEMA = "hands.android-release-artifacts.v1";
+const MAX_ARTIFACT_BYTES = 4 * 1024 * 1024 * 1024;
+const UPLOAD_TTL_SECONDS = 3600;
+
+export interface AndroidReleaseArtifactInput {
+  channel_id?: string;
+  source: {
+    repository: string;
+    commit_sha: string;
+    ci_run_id: string | number;
+  };
+  package_name: string;
+  version_name: string;
+  version_code: number;
+  upload_key_cert_sha256: string;
+  artifacts: Array<{
+    kind: ArtifactKind;
+    filename: string;
+    size_bytes: number;
+    sha256: string;
+  }>;
+}
+
+interface NormalizedArtifact {
+  kind: ArtifactKind;
+  filename: string;
+  sizeBytes: number;
+  sha256: string;
+  contentType: string;
+}
+
+export interface NormalizedAndroidReleaseArtifactInput {
+  channel: string | null;
+  source: { repository: string; commitSha: string; ciRunId: string };
+  packageName: string;
+  versionName: string;
+  versionCode: number;
+  uploadKeyCertSha256: string;
+  artifacts: [NormalizedArtifact, NormalizedArtifact];
+}
+
+interface AndroidAssetRow {
+  app_id: string;
+  build_id: string;
+  asset_id: string;
+  package_name: string;
+  version_name: string;
+  version_code: number;
+  source_repository: string;
+  source_commit: string;
+  ci_run_id: string;
+  upload_key_cert_sha256: string;
+  bundle_state: "uploading" | "ready" | "failed";
+  bundle_created_at: number;
+  bundle_completed_at: number | null;
+  filetype: ArtifactKind;
+  r2_key: string;
+  file_hash: string;
+  size_bytes: number;
+  metadata_json: string;
+  asset_created_at: number;
+}
+
+function requiredString(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== "string") throw new Error(`${field} required`);
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${field} required`);
+  if (normalized.length > maxLength) throw new Error(`${field} is too long`);
+  return normalized;
+}
+
+function digest(value: unknown, field: string): string {
+  const normalized = requiredString(value, field, 64);
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    throw new Error(`${field} must be a 64-character lowercase hex digest`);
+  }
+  return normalized;
+}
+
+function filename(value: unknown, kind: ArtifactKind): string {
+  const normalized = requiredString(value, `artifacts.${kind}.filename`, 255);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._ -]*$/.test(normalized) || !normalized.toLowerCase().endsWith(`.${kind}`)) {
+    throw new Error(`artifacts.${kind}.filename must be a safe basename ending with .${kind}`);
+  }
+  return normalized;
+}
+
+function size(value: unknown, kind: ArtifactKind): number {
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized <= 0 || normalized > MAX_ARTIFACT_BYTES) {
+    throw new Error(`artifacts.${kind}.size_bytes must be a positive integer no larger than 4 GiB`);
+  }
+  return normalized;
+}
+
+export function normalizeAndroidReleaseArtifactInput(
+  input: AndroidReleaseArtifactInput,
+): NormalizedAndroidReleaseArtifactInput {
+  if (!input || typeof input !== "object") throw new Error("request body required");
+  if (!input.source || typeof input.source !== "object") throw new Error("source required");
+  const commitSha = requiredString(input.source.commit_sha, "source.commit_sha", 40);
+  if (!/^[0-9a-f]{40}$/.test(commitSha)) {
+    throw new Error("source.commit_sha must be a full 40-character git object id");
+  }
+  const versionCode = Number(input.version_code);
+  if (!Number.isSafeInteger(versionCode) || versionCode <= 0) {
+    throw new Error("version_code must be a positive integer");
+  }
+  const packageName = requiredString(input.package_name, "package_name", 255);
+  if (!/^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/.test(packageName)) {
+    throw new Error("package_name must be a reverse-DNS Android application id");
+  }
+  if (!Array.isArray(input.artifacts) || input.artifacts.length !== 2) {
+    throw new Error("artifacts must contain exactly one AAB and one APK");
+  }
+  const byKind = new Map<ArtifactKind, AndroidReleaseArtifactInput["artifacts"][number]>();
+  for (const artifact of input.artifacts) {
+    if (!artifact || (artifact.kind !== "aab" && artifact.kind !== "apk")) {
+      throw new Error("artifact kind must be aab or apk");
+    }
+    if (byKind.has(artifact.kind)) throw new Error(`duplicate ${artifact.kind} artifact`);
+    byKind.set(artifact.kind, artifact);
+  }
+  if (!byKind.has("aab") || !byKind.has("apk")) {
+    throw new Error("artifacts must contain exactly one AAB and one APK");
+  }
+  const artifacts = (["aab", "apk"] as const).map((kind) => {
+    const artifact = byKind.get(kind)!;
+    return {
+      kind,
+      filename: filename(artifact.filename, kind),
+      sizeBytes: size(artifact.size_bytes, kind),
+      sha256: digest(artifact.sha256, `artifacts.${kind}.sha256`),
+      contentType: kind === "apk" ? "application/vnd.android.package-archive" : "application/octet-stream",
+    };
+  }) as [NormalizedArtifact, NormalizedArtifact];
+  return {
+    channel: input.channel_id ? requiredString(input.channel_id, "channel_id", 128) : null,
+    source: {
+      repository: requiredString(input.source.repository, "source.repository", 255),
+      commitSha,
+      ciRunId: requiredString(String(input.source.ci_run_id ?? ""), "source.ci_run_id", 128),
+    },
+    packageName,
+    versionName: requiredString(input.version_name, "version_name", 128),
+    versionCode,
+    uploadKeyCertSha256: digest(input.upload_key_cert_sha256, "upload_key_cert_sha256"),
+    artifacts,
+  };
+}
+
+function parseObject(value: string): JsonObject {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function uploadState(row: AndroidAssetRow): UploadState {
+  const state = parseObject(row.metadata_json).upload_state;
+  return state === "verifying" || state === "ready" || state === "failed" ? state : "pending_upload";
+}
+
+function safeFilename(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-");
+}
+
+async function resolveChannel(db: D1Database, appId: string, requested: string | null): Promise<string | null> {
+  if (requested) return resolveChannelId(db, appId, requested);
+  const row = await db.prepare(
+    `SELECT id FROM channels WHERE app_id = ?1
+     ORDER BY CASE slug WHEN 'main' THEN 0 ELSE 1 END, created_at ASC LIMIT 1`,
+  ).bind(appId).first<{ id: string }>();
+  return row?.id ?? null;
+}
+
+async function rowsForBuild(db: D1Database, appId: string, buildId: string): Promise<AndroidAssetRow[]> {
+  const result = await db.prepare(
+    `SELECT arb.app_id, arb.build_id, ba.id AS asset_id,
+            arb.package_name, arb.version_name, arb.version_code,
+            arb.source_repository, arb.source_commit, arb.ci_run_id,
+            arb.upload_key_cert_sha256, arb.state AS bundle_state,
+            arb.created_at AS bundle_created_at, arb.completed_at AS bundle_completed_at,
+            ba.filetype, ba.r2_key, ba.file_hash, ba.size_bytes,
+            ba.metadata_json, ba.created_at AS asset_created_at
+     FROM android_release_artifact_bundles arb
+     JOIN build_assets ba ON ba.build_id = arb.build_id
+     WHERE arb.app_id = ?1 AND arb.build_id = ?2
+       AND ba.artifact_kind = 'installable' AND ba.platform = 'android'
+       AND ba.filetype IN ('aab', 'apk')
+     ORDER BY CASE ba.filetype WHEN 'aab' THEN 0 ELSE 1 END`,
+  ).bind(appId, buildId).all<AndroidAssetRow>();
+  return result.results;
+}
+
+function bundleResponse(c: Context<any>, rows: AndroidAssetRow[]) {
+  const first = rows[0]!;
+  const origin = requestOrigin(c);
+  return {
+    schema: SCHEMA,
+    build_id: first.build_id,
+    status: first.bundle_state,
+    source: {
+      repository: first.source_repository,
+      commit_sha: first.source_commit,
+      ci_run_id: first.ci_run_id,
+    },
+    package_name: first.package_name,
+    version_name: first.version_name,
+    version_code: first.version_code,
+    upload_key_cert_sha256: first.upload_key_cert_sha256,
+    artifacts: rows.map((row) => {
+      const metadata = parseObject(row.metadata_json);
+      return {
+        asset_id: row.asset_id,
+        kind: row.filetype,
+        filename: metadata.filename,
+        status: uploadState(row) === "ready" ? "sealed" : uploadState(row),
+        size_bytes: row.size_bytes,
+        sha256: row.file_hash,
+        verified_size_bytes: metadata.verified_size_bytes ?? null,
+        verified_sha256: metadata.verified_sha256 ?? null,
+        verified_at: metadata.verified_at ?? null,
+        complete_url: `${origin}/api/apps/${row.app_id}/android-release-artifacts/${row.build_id}/assets/${row.asset_id}/complete`,
+      };
+    }),
+    created_at: first.bundle_created_at,
+    completed_at: first.bundle_completed_at,
+  };
+}
+
+async function insertAudit(db: D1Database, appId: string, action: string, actor: string, payload: unknown) {
+  await db.prepare(
+    "INSERT INTO audit_logs (id, app_id, action, actor, payload, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+  ).bind(crypto.randomUUID(), appId, action, actor, JSON.stringify(payload), Date.now()).run();
+}
+
+export async function handleCreateAndroidReleaseArtifacts(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  let input: NormalizedAndroidReleaseArtifactInput;
+  try {
+    input = normalizeAndroidReleaseArtifactInput((await c.req.json()) as AndroidReleaseArtifactInput);
+  } catch (error) {
+    return c.json({ error: (error as Error).message, code: "INVALID_RELEASE_ARTIFACTS" }, 400);
+  }
+  const app = await c.env.DB.prepare("SELECT id FROM apps WHERE id = ?1").bind(appId).first();
+  if (!app) return c.json({ error: "app not found", code: "ARTIFACT_NOT_FOUND" }, 404);
+  const channelId = await resolveChannel(c.env.DB, appId, input.channel);
+  if (!channelId) {
+    return c.json({ error: "app has no matching channel", code: "INVALID_RELEASE_ARTIFACTS" }, 400);
+  }
+
+  const buildId = crypto.randomUUID();
+  const declared = input.artifacts.map((artifact) => {
+    const assetId = crypto.randomUUID();
+    const stagingKey = `apps/${appId}/android-release/pending/${buildId}/${assetId}/${safeFilename(artifact.filename)}`;
+    const finalKey = `apps/${appId}/android-release/verified/${buildId}/${assetId}/${safeFilename(artifact.filename)}`;
+    return { ...artifact, assetId, stagingKey, finalKey };
+  });
+  const uploadUrls = await Promise.all(
+    declared.map((artifact) => presignR2UploadUrl(c.env, artifact.stagingKey, artifact.contentType, UPLOAD_TTL_SECONDS)),
+  );
+  if (uploadUrls.some((url) => !url)) {
+    return c.json({ error: "direct artifact uploads are unavailable", code: "ARTIFACT_UPLOAD_UNAVAILABLE" }, 503);
+  }
+
+  const actor = currentActor(c);
+  try {
+    await createBuild(c.env.DB, appId, {
+      channel_id: channelId,
+      product_type: "android-apk",
+      release_type: "stable",
+      version_name: input.versionName,
+      version_code: input.versionCode,
+      source: "mobile-ci",
+      status: "pending",
+      build_metadata_json: {
+        schema: SCHEMA,
+        package_name: input.packageName,
+        upload_key_cert_sha256: input.uploadKeyCertSha256,
+        required_artifacts: ["aab", "apk"],
+      },
+      provenance_json: {
+        schema: SCHEMA,
+        source_repository: input.source.repository,
+        source_commit: input.source.commitSha,
+        ci_run_id: input.source.ciRunId,
+      },
+    }, actor, buildId);
+    await c.env.DB.prepare(
+      `INSERT INTO android_release_artifact_bundles
+       (build_id, app_id, package_name, version_name, version_code,
+        source_repository, source_commit, ci_run_id, upload_key_cert_sha256,
+        state, created_by, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'uploading', ?10, ?11)`,
+    ).bind(
+      buildId, appId, input.packageName, input.versionName, input.versionCode,
+      input.source.repository, input.source.commitSha, input.source.ciRunId,
+      input.uploadKeyCertSha256, actor, Date.now(),
+    ).run();
+    for (const artifact of declared) {
+      await createBuildAsset(c.env.DB, appId, buildId, {
+        artifact_kind: "installable",
+        platform: "android",
+        arch: null,
+        variant: "release",
+        filetype: artifact.kind,
+        r2_key: artifact.stagingKey,
+        file_hash: artifact.sha256,
+        size_bytes: artifact.sizeBytes,
+        metadata_json: {
+          schema: SCHEMA,
+          upload_state: "pending_upload",
+          filename: artifact.filename,
+          content_type: artifact.contentType,
+          final_r2_key: artifact.finalKey,
+        },
+      }, actor, artifact.assetId);
+    }
+  } catch (error) {
+    await c.env.DB.prepare("DELETE FROM builds WHERE id = ?1 AND app_id = ?2").bind(buildId, appId).run();
+    const message = (error as Error).message;
+    const immutable = /UNIQUE constraint|immutable/i.test(message);
+    return c.json(
+      { error: message, code: immutable ? "IMMUTABLE_CONFLICT" : "INVALID_RELEASE_ARTIFACTS" },
+      immutable ? 409 : 400,
+    );
+  }
+
+  const rows = await rowsForBuild(c.env.DB, appId, buildId);
+  const response = bundleResponse(c, rows);
+  return c.json({
+    ...response,
+    artifacts: response.artifacts.map((artifact, index) => ({
+      ...artifact,
+      upload: {
+        method: "PUT",
+        url: uploadUrls[index],
+        headers: { "content-type": declared[index]!.contentType },
+        expires_at: Date.now() + UPLOAD_TTL_SECONDS * 1000,
+      },
+    })),
+  }, 201);
+}
+
+async function hashBody(body: ReadableStream<Uint8Array>): Promise<{ sha256: string; size: number }> {
+  const hasher = sha256.create();
+  let total = 0;
+  const reader = body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > MAX_ARTIFACT_BYTES) throw new Error("artifact exceeds maximum size");
+    hasher.update(value);
+  }
+  return { sha256: bytesToHex(hasher.digest()), size: total };
+}
+
+function fixedLengthBody(body: ReadableStream<Uint8Array>, length: number) {
+  if (typeof FixedLengthStream === "undefined") return { readable: body, pump: Promise.resolve() };
+  const fixed = new FixedLengthStream(length);
+  return { readable: fixed.readable, pump: body.pipeTo(fixed.writable) };
+}
+
+async function setFailed(c: AdminContext, row: AndroidAssetRow, reason: string, keys: string[]) {
+  await Promise.all(keys.map((key) => c.env.APK_BUCKET.delete(key).catch(() => {})));
+  const metadata = { ...parseObject(row.metadata_json), upload_state: "failed", verification_error: reason, verified_at: Date.now() };
+  await c.env.DB.batch([
+    c.env.DB.prepare("UPDATE build_assets SET metadata_json = ?1 WHERE id = ?2").bind(JSON.stringify(metadata), row.asset_id),
+    c.env.DB.prepare("UPDATE android_release_artifact_bundles SET state = 'failed', completed_at = ?1 WHERE build_id = ?2").bind(Date.now(), row.build_id),
+    c.env.DB.prepare("UPDATE builds SET status = 'failed', completed_at = ?1, updated_at = ?1 WHERE id = ?2").bind(Date.now(), row.build_id),
+  ]);
+}
+
+export async function handleCompleteAndroidReleaseArtifact(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const buildId = c.req.param("buildId") ?? "";
+  const assetId = c.req.param("assetId") ?? "";
+  const rows = await rowsForBuild(c.env.DB, appId, buildId);
+  const row = rows.find((candidate) => candidate.asset_id === assetId);
+  if (!row) return c.json({ error: "artifact not found", code: "ARTIFACT_NOT_FOUND" }, 404);
+  if (row.bundle_state === "failed" || uploadState(row) !== "pending_upload") {
+    return c.json({ error: "artifact state does not allow completion", code: "STATE_CONFLICT" }, 409);
+  }
+  const verifying = { ...parseObject(row.metadata_json), upload_state: "verifying", verifying_started_at: Date.now() };
+  const claimed = await c.env.DB.prepare(
+    `UPDATE build_assets SET metadata_json = ?1
+     WHERE id = ?2 AND build_id = ?3
+       AND json_extract(metadata_json, '$.upload_state') = 'pending_upload'`,
+  ).bind(JSON.stringify(verifying), assetId, buildId).run();
+  if (Number(claimed.meta?.changes ?? 0) !== 1) {
+    return c.json({ error: "artifact completion is already in progress", code: "STATE_CONFLICT" }, 409);
+  }
+  const head = await c.env.APK_BUCKET.head(row.r2_key);
+  if (!head) {
+    await setFailed(c, row, "upload_not_found", []);
+    return c.json({ error: "uploaded object not found", code: "ARTIFACT_NOT_FOUND" }, 409);
+  }
+  if (head.size !== row.size_bytes) {
+    await setFailed(c, row, "size_mismatch", [row.r2_key]);
+    return c.json({ error: "uploaded size does not match declaration", code: "INTEGRITY_MISMATCH" }, 422);
+  }
+  const object = await c.env.APK_BUCKET.get(row.r2_key);
+  if (!object || object.size !== row.size_bytes) {
+    await setFailed(c, row, "upload_changed_before_verification", [row.r2_key]);
+    return c.json({ error: "uploaded object changed before verification", code: "INTEGRITY_MISMATCH" }, 422);
+  }
+  const metadata = parseObject(row.metadata_json);
+  const finalKey = typeof metadata.final_r2_key === "string" ? metadata.final_r2_key : "";
+  const expectedPrefix = `apps/${appId}/android-release/verified/${buildId}/${assetId}/`;
+  if (!finalKey.startsWith(expectedPrefix)) {
+    await setFailed(c, row, "invalid_final_storage_key", [row.r2_key]);
+    return c.json({ error: "final storage key is invalid", code: "STATE_CONFLICT" }, 500);
+  }
+  if (await c.env.APK_BUCKET.head(finalKey)) {
+    await setFailed(c, row, "immutable_key_conflict", [row.r2_key]);
+    return c.json({ error: "immutable artifact key already exists", code: "IMMUTABLE_CONFLICT" }, 409);
+  }
+  const [hashStream, sealStream] = object.body.tee();
+  const fixed = fixedLengthBody(sealStream, row.size_bytes);
+  const [hashResult, pumpResult, putResult] = await Promise.allSettled([
+    hashBody(hashStream),
+    fixed.pump,
+    c.env.APK_BUCKET.put(finalKey, fixed.readable, {
+      httpMetadata: { contentType: String(metadata.content_type ?? "application/octet-stream") },
+      customMetadata: { sha256: row.file_hash, build_id: buildId, asset_id: assetId },
+    }),
+  ]);
+  if (hashResult.status !== "fulfilled" || pumpResult.status !== "fulfilled" || putResult.status !== "fulfilled") {
+    await setFailed(c, row, "stream_or_seal_failed", [row.r2_key, finalKey]);
+    return c.json({ error: "failed to verify and seal artifact", code: "INTEGRITY_MISMATCH" }, 422);
+  }
+  const actual = hashResult.value;
+  if (actual.size !== row.size_bytes || actual.sha256 !== row.file_hash) {
+    await setFailed(c, row, "sha256_or_size_mismatch", [row.r2_key, finalKey]);
+    return c.json({
+      error: "uploaded artifact does not match declared exact bytes",
+      code: "INTEGRITY_MISMATCH",
+      expected: { sha256: row.file_hash, size_bytes: row.size_bytes },
+      actual: { sha256: actual.sha256, size_bytes: actual.size },
+    }, 422);
+  }
+  const readyMetadata = {
+    ...metadata,
+    upload_state: "ready",
+    verified_sha256: actual.sha256,
+    verified_size_bytes: actual.size,
+    verified_at: Date.now(),
+  };
+  const updated = await c.env.DB.prepare(
+    `UPDATE build_assets SET r2_key = ?1, metadata_json = ?2
+     WHERE id = ?3 AND build_id = ?4
+       AND json_extract(metadata_json, '$.upload_state') = 'verifying'`,
+  ).bind(finalKey, JSON.stringify(readyMetadata), assetId, buildId).run();
+  if (Number(updated.meta?.changes ?? 0) !== 1) {
+    await c.env.APK_BUCKET.delete(finalKey);
+    return c.json({ error: "artifact state changed during verification", code: "STATE_CONFLICT" }, 409);
+  }
+  await c.env.APK_BUCKET.delete(row.r2_key);
+  const remaining = await c.env.DB.prepare(
+    `SELECT COUNT(*) AS count FROM build_assets
+     WHERE build_id = ?1 AND artifact_kind = 'installable' AND platform = 'android'
+       AND filetype IN ('aab','apk')
+       AND json_extract(metadata_json, '$.upload_state') <> 'ready'`,
+  ).bind(buildId).first<{ count: number }>();
+  if (Number(remaining?.count ?? 1) === 0) {
+    const now = Date.now();
+    await c.env.DB.batch([
+      c.env.DB.prepare("UPDATE android_release_artifact_bundles SET state = 'ready', completed_at = ?1 WHERE build_id = ?2 AND state = 'uploading'").bind(now, buildId),
+      c.env.DB.prepare("UPDATE builds SET status = 'succeeded', completed_at = ?1, updated_at = ?1 WHERE id = ?2 AND status = 'pending'").bind(now, buildId),
+    ]);
+  }
+  await insertAudit(c.env.DB, appId, "android_release_artifact.complete", currentActor(c), {
+    build_id: buildId,
+    asset_id: assetId,
+    kind: row.filetype,
+    sha256: actual.sha256,
+    size_bytes: actual.size,
+  });
+  if (row.filetype === "apk" && c.env.APK_PARSER) {
+    try {
+      c.executionCtx.waitUntil(autoParseInstallableAsset(c.env, appId, buildId, finalKey, "apk-aapt"));
+    } catch {
+      // Some unit or direct-handler callers have no execution context. Parsing
+      // remains best-effort and never weakens the exact-byte seal.
+      void autoParseInstallableAsset(c.env, appId, buildId, finalKey, "apk-aapt");
+    }
+  }
+  return c.json(bundleResponse(c, await rowsForBuild(c.env.DB, appId, buildId)));
+}
+
+export async function handleGetAndroidReleaseArtifacts(c: Context<{ Bindings: Env }>) {
+  const rows = await rowsForBuild(
+    c.env.DB,
+    c.req.param("appId") ?? "",
+    c.req.param("buildId") ?? "",
+  );
+  if (rows.length !== 2) return c.json({ error: "artifact bundle not found", code: "ARTIFACT_NOT_FOUND" }, 404);
+  return c.json(bundleResponse(c, rows));
+}

--- a/worker/src/routes/play_distribution.ts
+++ b/worker/src/routes/play_distribution.ts
@@ -1,0 +1,578 @@
+import type { Context } from "hono";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import { currentActor, currentActorInfo, type AdminEnv } from "../middleware/auth";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+type PlayTrack = "internal" | "closed" | "production";
+
+export interface PlayPromotionInput {
+  track: PlayTrack;
+  rollout_percent?: number;
+  expected_revision: number;
+  approval: { note: string };
+}
+
+interface ReleaseArtifactRow {
+  release_id: string;
+  release_revision: number;
+  release_status: string;
+  build_id: string;
+  package_name: string;
+  version_name: string;
+  version_code: number;
+  source_repository: string;
+  source_commit: string;
+  ci_run_id: string;
+  upload_key_cert_sha256: string;
+  bundle_state: string;
+  asset_id: string;
+  filetype: string;
+  r2_key: string;
+  file_hash: string;
+  size_bytes: number;
+  metadata_json: string;
+}
+
+interface PlayReadback {
+  edit_id: string;
+  package_name: string;
+  version_code: number;
+  track: PlayTrack;
+  sha256: string;
+  rollout_percent?: number | null;
+}
+
+interface GateFailure {
+  code: "gate_failed" | "edit_conflict" | "version_conflict" | "play_api_error" | "hold_active" | "forbidden";
+  gate: "immutable_binding" | "acceptance_receipt" | "channel" | "version_code" | "edit_lock" | "live_hold" | "permission" | null;
+  message: string;
+  receipt_id?: string | null;
+}
+
+function fail(c: Context<any>, status: 400 | 403 | 409 | 502, failure: GateFailure) {
+  return c.json({ error: { receipt_id: null, ...failure } }, status);
+}
+
+function jsonObject(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function positiveRevision(value: unknown): number | null {
+  const revision = Number(value);
+  return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
+}
+
+export function normalizePlayPromotionInput(input: PlayPromotionInput): PlayPromotionInput {
+  if (!input || typeof input !== "object") throw new Error("request body required");
+  if (input.track !== "internal" && input.track !== "closed" && input.track !== "production") {
+    throw new Error("track must be internal, closed, or production");
+  }
+  const expectedRevision = positiveRevision(input.expected_revision);
+  if (expectedRevision === null) throw new Error("expected_revision must be a non-negative integer");
+  const note = typeof input.approval?.note === "string" ? input.approval.note.trim() : "";
+  if (!note) throw new Error("approval.note required");
+  const rollout = input.rollout_percent;
+  if (rollout !== undefined && (!Number.isInteger(rollout) || rollout < 0 || rollout > 100)) {
+    throw new Error("rollout_percent must be an integer from 0 to 100");
+  }
+  return { track: input.track, expected_revision: expectedRevision, approval: { note }, ...(rollout === undefined ? {} : { rollout_percent: rollout }) };
+}
+
+export function playReadbackMatches(
+  artifact: Pick<ReleaseArtifactRow, "package_name" | "version_code" | "file_hash">,
+  requestedTrack: PlayTrack,
+  readback: PlayReadback,
+): boolean {
+  return typeof readback?.sha256 === "string"
+    && readback.package_name === artifact.package_name
+    && readback.version_code === artifact.version_code
+    && readback.track === requestedTrack
+    && readback.sha256.toLowerCase() === artifact.file_hash.toLowerCase();
+}
+
+async function getReleaseArtifact(db: D1Database, appId: string, releaseId: string): Promise<ReleaseArtifactRow | null> {
+  return db.prepare(
+    `SELECT r.id AS release_id, r.revision AS release_revision, r.status AS release_status,
+            b.id AS build_id, arb.package_name, arb.version_name, arb.version_code,
+            arb.source_repository, arb.source_commit, arb.ci_run_id,
+            arb.upload_key_cert_sha256,
+            arb.state AS bundle_state, ba.id AS asset_id, ba.filetype,
+            ba.r2_key, ba.file_hash, ba.size_bytes, ba.metadata_json
+     FROM releases r
+     JOIN builds b ON b.id = r.build_id AND b.app_id = r.app_id
+     JOIN android_release_artifact_bundles arb ON arb.build_id = b.id AND arb.app_id = r.app_id
+     JOIN build_assets ba ON ba.build_id = b.id
+     WHERE r.app_id = ?1 AND r.id = ?2
+       AND ba.artifact_kind = 'installable' AND ba.platform = 'android' AND ba.filetype = 'aab'
+     LIMIT 1`,
+  ).bind(appId, releaseId).first<ReleaseArtifactRow>();
+}
+
+async function getReleaseArtifactById(
+  db: D1Database,
+  appId: string,
+  releaseId: string,
+  assetId: string,
+): Promise<ReleaseArtifactRow | null> {
+  return db.prepare(
+    `SELECT r.id AS release_id, r.revision AS release_revision, r.status AS release_status,
+            b.id AS build_id, arb.package_name, arb.version_name, arb.version_code,
+            arb.source_repository, arb.source_commit, arb.ci_run_id,
+            arb.upload_key_cert_sha256, arb.state AS bundle_state,
+            ba.id AS asset_id, ba.filetype, ba.r2_key, ba.file_hash,
+            ba.size_bytes, ba.metadata_json
+     FROM releases r
+     JOIN builds b ON b.id = r.build_id AND b.app_id = r.app_id
+     JOIN android_release_artifact_bundles arb ON arb.build_id = b.id AND arb.app_id = r.app_id
+     JOIN build_assets ba ON ba.build_id = b.id
+     WHERE r.app_id = ?1 AND r.id = ?2 AND ba.id = ?3
+       AND ba.artifact_kind = 'installable' AND ba.platform = 'android'
+       AND ba.filetype IN ('aab', 'apk')
+     LIMIT 1`,
+  ).bind(appId, releaseId, assetId).first<ReleaseArtifactRow>();
+}
+
+function receiptArtifact(artifact: ReleaseArtifactRow) {
+  return {
+    type: artifact.filetype,
+    sha256: artifact.file_hash,
+    size_bytes: artifact.size_bytes,
+    package: artifact.package_name,
+    version_name: artifact.version_name,
+    version_code: artifact.version_code,
+  };
+}
+
+function receiptSource(artifact: ReleaseArtifactRow) {
+  return {
+    repo: artifact.source_repository,
+    sha: artifact.source_commit,
+    ci_run_id: artifact.ci_run_id,
+  };
+}
+
+async function latestAcceptance(db: D1Database, appId: string, releaseId: string, assetId: string) {
+  return db.prepare(
+    `SELECT id, verdict, artifact_sha256, artifact_size, package_name, source_commit, version_code
+     FROM release_receipts
+     WHERE app_id = ?1 AND release_id = ?2 AND kind = 'acceptance' AND artifact_id = ?3
+     ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+  ).bind(appId, releaseId, assetId).first<{
+    id: string;
+    verdict: string;
+    artifact_sha256: string;
+    artifact_size: number;
+    package_name: string;
+    source_commit: string;
+    version_code: number;
+  }>();
+}
+
+function acceptanceMatches(row: ReleaseArtifactRow, receipt: Awaited<ReturnType<typeof latestAcceptance>>): boolean {
+  return Boolean(receipt
+    && receipt.verdict === "pass"
+    && receipt.artifact_sha256 === row.file_hash
+    && receipt.artifact_size === row.size_bytes
+    && receipt.package_name === row.package_name
+    && receipt.source_commit === row.source_commit
+    && receipt.version_code === row.version_code);
+}
+
+async function insertReceipt(
+  db: D1Database,
+  args: {
+    id: string;
+    appId: string;
+    releaseId: string;
+    kind: "acceptance" | "play-promotion";
+    verdict: "pass" | "fail" | "success" | "failed-closed";
+    artifact: ReleaseArtifactRow;
+    action?: string | null;
+    track?: PlayTrack | null;
+    editId?: string | null;
+    payload: unknown;
+    actor: string;
+  },
+) {
+  await db.prepare(
+    `INSERT INTO release_receipts
+     (id, app_id, release_id, kind, verdict, artifact_id, artifact_sha256,
+      artifact_size, package_name, source_commit, version_code, action, track,
+      play_edit_id, payload_json, created_by, created_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)`,
+  ).bind(
+    args.id, args.appId, args.releaseId, args.kind, args.verdict,
+    args.artifact.asset_id, args.artifact.file_hash, args.artifact.size_bytes,
+    args.artifact.package_name, args.artifact.source_commit, args.artifact.version_code,
+    args.action ?? null, args.track ?? null, args.editId ?? null,
+    JSON.stringify(args.payload), args.actor, Date.now(),
+  ).run();
+}
+
+export async function handleCreateAcceptanceReceipt(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  let body: {
+    artifact_id: string;
+    verdict: "pass" | "fail";
+    matrix_ref: string;
+    note?: string;
+    expected_revision: number;
+  };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "valid JSON body required", code: "INVALID_ACCEPTANCE_RECEIPT" }, 400);
+  }
+  const expectedRevision = positiveRevision(body.expected_revision);
+  if (!body.artifact_id || (body.verdict !== "pass" && body.verdict !== "fail") || !body.matrix_ref?.trim() || expectedRevision === null) {
+    return c.json({ error: "artifact_id, verdict, matrix_ref, expected_revision required", code: "INVALID_ACCEPTANCE_RECEIPT" }, 400);
+  }
+  const artifact = await getReleaseArtifactById(c.env.DB, appId, releaseId, body.artifact_id);
+  if (!artifact) {
+    return c.json({ error: "release artifact not found", code: "ARTIFACT_NOT_FOUND" }, 404);
+  }
+  const metadata = jsonObject(artifact.metadata_json);
+  if (artifact.bundle_state !== "ready" || metadata.upload_state !== "ready") {
+    return c.json({ error: "artifact is not sealed and ready", code: "STATE_CONFLICT" }, 409);
+  }
+  if (artifact.release_revision !== expectedRevision) {
+    return c.json({ error: "release revision conflict", code: "VERSION_CONFLICT", current_revision: artifact.release_revision }, 409);
+  }
+  const receiptId = crypto.randomUUID();
+  const actor = currentActor(c);
+  const createdAt = Date.now();
+  const receipt = {
+    schema_version: 1,
+    kind: "acceptance",
+    receipt_id: receiptId,
+    created_at: new Date(createdAt).toISOString(),
+    artifact: receiptArtifact(artifact),
+    source: receiptSource(artifact),
+    signing: { upload_key_cert_sha256: artifact.upload_key_cert_sha256 },
+    hands_acceptance: {
+      verdict: body.verdict,
+      matrix_ref: body.matrix_ref.trim(),
+      verifier: actor,
+    },
+    actor,
+    action: "accept",
+    result: {
+      status: body.verdict === "pass" ? "success" : "failed-closed",
+      ...(body.verdict === "fail" ? { failure_reason: body.note?.trim() || "acceptance failed" } : {}),
+    },
+  };
+  const inserted = await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO release_receipts
+       (id, app_id, release_id, kind, verdict, artifact_id, artifact_sha256,
+        artifact_size, package_name, source_commit, version_code, payload_json,
+        created_by, created_at)
+       SELECT ?1, ?2, ?3, 'acceptance', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13
+       FROM releases WHERE app_id = ?2 AND id = ?3 AND revision = ?14`,
+    ).bind(
+      receiptId, appId, releaseId, body.verdict, artifact.asset_id, artifact.file_hash,
+      artifact.size_bytes, artifact.package_name, artifact.source_commit, artifact.version_code,
+      JSON.stringify(receipt), actor, createdAt, expectedRevision,
+    ),
+    c.env.DB.prepare(
+      `UPDATE releases SET revision = revision + 1, updated_at = ?1
+       WHERE app_id = ?2 AND id = ?3 AND revision = ?4
+         AND EXISTS (SELECT 1 FROM release_receipts WHERE id = ?5)`,
+    ).bind(Date.now(), appId, releaseId, expectedRevision, receiptId),
+  ]);
+  if (Number(inserted[0]?.meta?.changes ?? 0) !== 1 || Number(inserted[1]?.meta?.changes ?? 0) !== 1) {
+    return c.json({ error: "release revision conflict", code: "VERSION_CONFLICT" }, 409);
+  }
+  return c.json({ receipt_id: receiptId, kind: "acceptance", verdict: body.verdict, release_id: releaseId, artifact_id: artifact.asset_id }, 201);
+}
+
+export async function handleListReleaseReceipts(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  const result = await c.env.DB.prepare(
+    `SELECT id, kind, verdict, artifact_id, artifact_sha256, artifact_size,
+            package_name, source_commit, version_code, action, track,
+            play_edit_id, payload_json, created_by, created_at
+     FROM release_receipts WHERE app_id = ?1 AND release_id = ?2
+     ORDER BY created_at ASC, rowid ASC`,
+  ).bind(appId, releaseId).all();
+  return c.json({ receipts: result.results.map((row) => ({ ...row, payload: jsonObject(String(row.payload_json)), payload_json: undefined })) });
+}
+
+async function hashStream(body: ReadableStream<Uint8Array>) {
+  const hasher = sha256.create();
+  let size = 0;
+  const reader = body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    size += value.byteLength;
+    hasher.update(value);
+  }
+  return { size, sha256: bytesToHex(hasher.digest()) };
+}
+
+async function takeLock(db: D1Database, appId: string, row: ReleaseArtifactRow, operationId: string, actor: string) {
+  try {
+    await db.prepare(
+      `INSERT INTO play_edit_locks
+       (app_id, package_name, release_id, operation_id, acquired_by, acquired_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    ).bind(appId, row.package_name, row.release_id, operationId, actor, Date.now()).run();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function releaseLock(db: D1Database, operationId: string) {
+  await db.prepare("DELETE FROM play_edit_locks WHERE operation_id = ?1").bind(operationId).run();
+}
+
+async function failedPromotionReceipt(
+  c: AdminContext,
+  artifact: ReleaseArtifactRow,
+  actor: string,
+  track: PlayTrack,
+  approvalNote: string,
+  reason: string,
+  details: unknown,
+) {
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  await insertReceipt(c.env.DB, {
+    id, appId: c.req.param("appId") ?? "", releaseId: artifact.release_id,
+    kind: "play-promotion", verdict: "failed-closed", artifact,
+    action: "promote", track, payload: {
+      schema_version: 1,
+      kind: "play-promotion",
+      receipt_id: id,
+      created_at: createdAt,
+      artifact: receiptArtifact(artifact),
+      source: receiptSource(artifact),
+      signing: { upload_key_cert_sha256: artifact.upload_key_cert_sha256 },
+      actor,
+      action: "promote",
+      approvals: [{ approver: actor, at: createdAt, scope: `${track}: ${approvalNote}` }],
+      play: {
+        edit_id: "failed-closed",
+        track,
+        play_version_code: artifact.version_code,
+        api_readback: {
+          package: artifact.package_name,
+          version_code: artifact.version_code,
+          track,
+          sha256_match: false,
+        },
+      },
+      result: {
+        status: "failed-closed",
+        failure_reason: `${reason}: ${JSON.stringify(details)}`,
+      },
+    }, actor,
+  });
+  return id;
+}
+
+export async function handlePromotePlayDistribution(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  let input: PlayPromotionInput;
+  try {
+    input = normalizePlayPromotionInput(await c.req.json<PlayPromotionInput>());
+  } catch (error) {
+    return fail(c, 400, { code: "gate_failed", gate: "permission", message: (error as Error).message });
+  }
+  if (currentActorInfo(c).type !== "human") {
+    return fail(c, 403, { code: "forbidden", gate: "permission", message: "Play promotion requires approval by an authenticated human publisher" });
+  }
+  const artifact = await getReleaseArtifact(c.env.DB, appId, releaseId);
+  if (!artifact) return fail(c, 400, { code: "gate_failed", gate: "channel", message: "release does not contain an Android AAB" });
+  if (artifact.release_revision !== input.expected_revision) {
+    return fail(c, 409, { code: "version_conflict", gate: null, message: `release revision is ${artifact.release_revision}, not ${input.expected_revision}` });
+  }
+  const metadata = jsonObject(artifact.metadata_json);
+  if (artifact.filetype !== "aab") return fail(c, 400, { code: "gate_failed", gate: "channel", message: "Google Play promotion accepts AAB only" });
+  if (artifact.bundle_state !== "ready" || metadata.upload_state !== "ready" || metadata.verified_sha256 !== artifact.file_hash || metadata.verified_size_bytes !== artifact.size_bytes) {
+    return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "AAB is not sealed to its declared exact bytes" });
+  }
+  const acceptance = await latestAcceptance(c.env.DB, appId, releaseId, artifact.asset_id);
+  if (!acceptanceMatches(artifact, acceptance)) {
+    return fail(c, 400, { code: "gate_failed", gate: "acceptance_receipt", message: "latest Hands acceptance receipt does not pass for the exact AAB" });
+  }
+  const hold = await c.env.DB.prepare(
+    "SELECT id FROM release_distribution_holds WHERE app_id = ?1 AND release_id = ?2 AND closed_at IS NULL LIMIT 1",
+  ).bind(appId, releaseId).first();
+  if (hold) return fail(c, 403, { code: "hold_active", gate: "live_hold", message: "release has an active distribution hold" });
+  if (!c.env.PLAY_RELEASE_SERVICE) {
+    return fail(c, 502, { code: "play_api_error", gate: null, message: "Google Play release service is not configured" });
+  }
+
+  const actor = currentActor(c);
+  const operationId = crypto.randomUUID();
+  if (!(await takeLock(c.env.DB, appId, artifact, operationId, actor))) {
+    return fail(c, 409, { code: "edit_conflict", gate: "edit_lock", message: "another Play edit is active for this package" });
+  }
+  try {
+    const trackUrl = `https://play-release.service/v1/apps/${encodeURIComponent(artifact.package_name)}/tracks/${input.track}`;
+    const trackResponse = await c.env.PLAY_RELEASE_SERVICE.fetch(trackUrl, { method: "GET" });
+    if (!trackResponse.ok) {
+      return fail(c, 502, { code: "play_api_error", gate: null, message: `Play track read failed with ${trackResponse.status}` });
+    }
+    const trackState = await trackResponse.json<{ max_version_code: number }>();
+    const requiredVersionCode = Number(trackState.max_version_code) + 1;
+    if (!Number.isSafeInteger(requiredVersionCode) || artifact.version_code !== requiredVersionCode) {
+      return fail(c, 409, { code: "version_conflict", gate: "version_code", message: `artifact versionCode ${artifact.version_code} must equal Play ${input.track} max + 1 (${requiredVersionCode})` });
+    }
+    const reserved = await c.env.DB.prepare(
+      `UPDATE releases SET revision = revision + 1, updated_at = ?1
+       WHERE app_id = ?2 AND id = ?3 AND revision = ?4`,
+    ).bind(Date.now(), appId, releaseId, input.expected_revision).run();
+    if (Number(reserved.meta?.changes ?? 0) !== 1) {
+      return fail(c, 409, { code: "version_conflict", gate: null, message: "release changed before the Play edit was reserved" });
+    }
+    const object = await c.env.APK_BUCKET.get(artifact.r2_key);
+    if (!object || object.size !== artifact.size_bytes) {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { object_size: object?.size ?? null });
+      return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "stored AAB size changed", receipt_id: receiptId });
+    }
+    const [hashBranch, uploadBranch] = object.body.tee();
+    const uploadResponsePromise = c.env.PLAY_RELEASE_SERVICE.fetch(
+      `https://play-release.service/v1/apps/${encodeURIComponent(artifact.package_name)}/edits`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-hands-track": input.track,
+          "x-hands-version-code": String(artifact.version_code),
+          "x-hands-sha256": artifact.file_hash,
+          "x-hands-size-bytes": String(artifact.size_bytes),
+          "x-hands-rollout-percent": String(input.rollout_percent ?? 100),
+          "x-hands-operation-id": operationId,
+        },
+        body: uploadBranch,
+      },
+    );
+    const [local, uploadResponse] = await Promise.all([hashStream(hashBranch), uploadResponsePromise]);
+    if (local.sha256 !== artifact.file_hash || local.size !== artifact.size_bytes) {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { actual: local });
+      return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "streamed AAB did not match the accepted artifact", receipt_id: receiptId });
+    }
+    if (!uploadResponse.ok) {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_api_error", { status: uploadResponse.status });
+      return fail(c, 502, { code: "play_api_error", gate: null, message: `Play edit failed with ${uploadResponse.status}`, receipt_id: receiptId });
+    }
+    const readback = await uploadResponse.json<PlayReadback>();
+    if (!playReadbackMatches(artifact, input.track, readback)) {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_readback_mismatch", { readback });
+      return fail(c, 502, { code: "play_api_error", gate: "immutable_binding", message: "Play readback did not match package/version/track/SHA-256", receipt_id: receiptId });
+    }
+    const receiptId = crypto.randomUUID();
+    await insertReceipt(c.env.DB, {
+      id: receiptId, appId, releaseId, kind: "play-promotion", verdict: "success",
+      artifact, action: "promote", track: input.track, editId: readback.edit_id,
+      payload: {
+        schema_version: 1,
+        kind: "play-promotion",
+        receipt_id: receiptId,
+        created_at: new Date().toISOString(),
+        artifact: receiptArtifact(artifact),
+        source: receiptSource(artifact),
+        signing: { upload_key_cert_sha256: artifact.upload_key_cert_sha256 },
+        actor,
+        action: "promote",
+        approvals: [{ approver: actor, at: new Date().toISOString(), scope: input.track }],
+        play: {
+          edit_id: readback.edit_id,
+          track: input.track,
+          rollout_percent: input.rollout_percent ?? 100,
+          play_version_code: artifact.version_code,
+          api_readback: {
+            package: readback.package_name,
+            version_code: readback.version_code,
+            track: readback.track,
+            sha256_match: true,
+          },
+        },
+        result: { status: "success" },
+      },
+      actor,
+    });
+    await c.env.DB.prepare(
+      `INSERT INTO play_distribution_state
+       (app_id, release_id, package_name, track, version_code, rollout_percent,
+        state, last_edit_id, last_receipt_id, revision, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', ?7, ?8, 1, ?9)
+       ON CONFLICT(app_id, release_id) DO UPDATE SET
+         package_name = excluded.package_name, track = excluded.track,
+         version_code = excluded.version_code, rollout_percent = excluded.rollout_percent,
+         state = excluded.state, last_edit_id = excluded.last_edit_id,
+         last_receipt_id = excluded.last_receipt_id,
+         revision = play_distribution_state.revision + 1, updated_at = excluded.updated_at`,
+    ).bind(
+      appId, releaseId, artifact.package_name, input.track, artifact.version_code,
+      input.rollout_percent ?? 100, readback.edit_id, receiptId, Date.now(),
+    ).run();
+    return c.json({ receipt_id: receiptId, edit_id: readback.edit_id, track: input.track, version_code: artifact.version_code, revision: input.expected_revision + 1 });
+  } finally {
+    await releaseLock(c.env.DB, operationId);
+  }
+}
+
+export async function handleGetPlayDistribution(c: Context<{ Bindings: Env }>) {
+  const row = await c.env.DB.prepare(
+    `SELECT package_name, track, version_code, rollout_percent, state,
+            last_edit_id, last_receipt_id, revision, updated_at
+     FROM play_distribution_state WHERE app_id = ?1 AND release_id = ?2`,
+  ).bind(c.req.param("appId") ?? "", c.req.param("releaseId") ?? "").first();
+  return c.json({ play: row ?? null });
+}
+
+export async function handleListDistributions(c: Context<{ Bindings: Env }>) {
+  const appId = c.req.param("appId") ?? "";
+  const releaseId = c.req.param("releaseId") ?? "";
+  const play = await c.env.DB.prepare(
+    "SELECT track, version_code, rollout_percent, state, last_receipt_id, updated_at FROM play_distribution_state WHERE app_id = ?1 AND release_id = ?2",
+  ).bind(appId, releaseId).first();
+  const accepted = await c.env.DB.prepare(
+    `SELECT verdict FROM release_receipts
+     WHERE app_id = ?1 AND release_id = ?2 AND kind = 'acceptance'
+     ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+  ).bind(appId, releaseId).first<{ verdict: string }>();
+  return c.json({
+    distributions: [
+      { provider: "hands", state: accepted?.verdict === "pass" ? "accepted" : "not-accepted" },
+      { provider: "google-play", ...(play ?? { state: "not-promoted" }) },
+    ],
+  });
+}
+
+async function unsupportedPlayMutation(c: AdminContext, action: "halt" | "rollback-republish") {
+  const actor = currentActorInfo(c);
+  let body: { expected_revision?: number; approval?: { note?: string } };
+  try {
+    body = await c.req.json();
+  } catch {
+    return fail(c, 403, { code: "forbidden", gate: "permission", message: `${action} requires a valid JSON approval body` });
+  }
+  if (actor.type !== "human" || positiveRevision(body.expected_revision) === null || !body.approval?.note?.trim()) {
+    return fail(c, 403, { code: "forbidden", gate: "permission", message: `${action} requires expected_revision and authenticated human approval` });
+  }
+  return fail(c, 502, { code: "play_api_error", gate: null, message: `${action} is fail-closed until the Google Play release service implements this operation` });
+}
+
+export async function handleHaltPlayDistribution(c: AdminContext) {
+  return unsupportedPlayMutation(c, "halt");
+}
+
+export async function handleRollbackPlayDistribution(c: AdminContext) {
+  return unsupportedPlayMutation(c, "rollback-republish");
+}

--- a/worker/src/routes/play_distribution.ts
+++ b/worker/src/routes/play_distribution.ts
@@ -423,13 +423,27 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
   }
   try {
     const trackUrl = `https://play-release.service/v1/apps/${encodeURIComponent(artifact.package_name)}/tracks/${input.track}`;
-    const trackResponse = await c.env.PLAY_RELEASE_SERVICE.fetch(trackUrl, { method: "GET" });
+    let trackResponse: Response;
+    try {
+      trackResponse = await c.env.PLAY_RELEASE_SERVICE.fetch(trackUrl, { method: "GET" });
+    } catch {
+      return fail(c, 502, { code: "play_api_error", gate: null, message: "Play track read request failed" });
+    }
     if (!trackResponse.ok) {
       return fail(c, 502, { code: "play_api_error", gate: null, message: `Play track read failed with ${trackResponse.status}` });
     }
-    const trackState = await trackResponse.json<{ max_version_code: number }>();
-    const requiredVersionCode = Number(trackState.max_version_code) + 1;
-    if (!Number.isSafeInteger(requiredVersionCode) || artifact.version_code !== requiredVersionCode) {
+    let trackState: { max_version_code: number };
+    try {
+      trackState = await trackResponse.json();
+    } catch {
+      return fail(c, 502, { code: "play_api_error", gate: null, message: "Play track read returned malformed JSON" });
+    }
+    const maxVersionCode = Number(trackState?.max_version_code);
+    if (!Number.isSafeInteger(maxVersionCode) || maxVersionCode < 0) {
+      return fail(c, 502, { code: "play_api_error", gate: null, message: "Play track read returned an invalid max_version_code" });
+    }
+    const requiredVersionCode = maxVersionCode + 1;
+    if (artifact.version_code !== requiredVersionCode) {
       return fail(c, 409, { code: "version_conflict", gate: "version_code", message: `artifact versionCode ${artifact.version_code} must equal Play ${input.track} max + 1 (${requiredVersionCode})` });
     }
     const reserved = await c.env.DB.prepare(
@@ -439,13 +453,19 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
     if (Number(reserved.meta?.changes ?? 0) !== 1) {
       return fail(c, 409, { code: "version_conflict", gate: null, message: "release changed before the Play edit was reserved" });
     }
-    const object = await c.env.APK_BUCKET.get(artifact.r2_key);
+    let object: R2ObjectBody | null;
+    try {
+      object = await c.env.APK_BUCKET.get(artifact.r2_key);
+    } catch {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { object_read: "failed" });
+      return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "stored AAB could not be read", receipt_id: receiptId });
+    }
     if (!object || object.size !== artifact.size_bytes) {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { object_size: object?.size ?? null });
       return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "stored AAB size changed", receipt_id: receiptId });
     }
     const [hashBranch, uploadBranch] = object.body.tee();
-    const uploadResponsePromise = c.env.PLAY_RELEASE_SERVICE.fetch(
+    const uploadResponsePromise = Promise.resolve().then(() => c.env.PLAY_RELEASE_SERVICE!.fetch(
       `https://play-release.service/v1/apps/${encodeURIComponent(artifact.package_name)}/edits`,
       {
         method: "POST",
@@ -460,8 +480,18 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
         },
         body: uploadBranch,
       },
-    );
-    const [local, uploadResponse] = await Promise.all([hashStream(hashBranch), uploadResponsePromise]);
+    ));
+    const [localResult, uploadResult] = await Promise.allSettled([hashStream(hashBranch), uploadResponsePromise]);
+    if (localResult.status === "rejected") {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { stream_read: "failed" });
+      return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "stored AAB stream could not be verified", receipt_id: receiptId });
+    }
+    if (uploadResult.status === "rejected") {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_api_error", { request: "failed" });
+      return fail(c, 502, { code: "play_api_error", gate: null, message: "Play edit request failed", receipt_id: receiptId });
+    }
+    const local = localResult.value;
+    const uploadResponse = uploadResult.value;
     if (local.sha256 !== artifact.file_hash || local.size !== artifact.size_bytes) {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { actual: local });
       return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "streamed AAB did not match the accepted artifact", receipt_id: receiptId });
@@ -470,7 +500,21 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_api_error", { status: uploadResponse.status });
       return fail(c, 502, { code: "play_api_error", gate: null, message: `Play edit failed with ${uploadResponse.status}`, receipt_id: receiptId });
     }
-    const readback = await uploadResponse.json<PlayReadback>();
+    let readback: PlayReadback;
+    try {
+      readback = await uploadResponse.json();
+    } catch {
+      const receiptId = await failedPromotionReceipt(
+        c,
+        artifact,
+        actor,
+        input.track,
+        input.approval.note,
+        "play_readback_malformed",
+        { status: uploadResponse.status },
+      );
+      return fail(c, 502, { code: "play_api_error", gate: "immutable_binding", message: "Play edit returned malformed JSON", receipt_id: receiptId });
+    }
     if (!playReadbackMatches(artifact, input.track, readback)) {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_readback_mismatch", { readback });
       return fail(c, 502, { code: "play_api_error", gate: "immutable_binding", message: "Play readback did not match package/version/track/SHA-256", receipt_id: receiptId });
@@ -557,7 +601,11 @@ export async function handleListDistributions(c: Context<{ Bindings: Env }>) {
 
 async function unsupportedPlayMutation(c: AdminContext, action: "halt" | "rollback-republish") {
   const actor = currentActorInfo(c);
-  let body: { expected_revision?: number; approval?: { note?: string } };
+  let body: {
+    expected_revision?: number;
+    approval?: { note?: string };
+    to_version_code?: number;
+  };
   try {
     body = await c.req.json();
   } catch {
@@ -565,6 +613,12 @@ async function unsupportedPlayMutation(c: AdminContext, action: "halt" | "rollba
   }
   if (actor.type !== "human" || positiveRevision(body.expected_revision) === null || !body.approval?.note?.trim()) {
     return fail(c, 403, { code: "forbidden", gate: "permission", message: `${action} requires expected_revision and authenticated human approval` });
+  }
+  if (action === "rollback-republish") {
+    const toVersionCode = Number(body.to_version_code);
+    if (!Number.isSafeInteger(toVersionCode) || toVersionCode <= 0) {
+      return fail(c, 400, { code: "gate_failed", gate: "version_code", message: "rollback-republish requires a positive to_version_code" });
+    }
   }
   return fail(c, 502, { code: "play_api_error", gate: null, message: `${action} is fail-closed until the Google Play release service implements this operation` });
 }

--- a/worker/test/google_play_distribution.test.ts
+++ b/worker/test/google_play_distribution.test.ts
@@ -1,0 +1,622 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+import { Hono } from "hono";
+import {
+  normalizeAndroidReleaseArtifactInput,
+  handleCompleteAndroidReleaseArtifact,
+  handleCreateAndroidReleaseArtifacts,
+  handleGetAndroidReleaseArtifacts,
+  type AndroidReleaseArtifactInput,
+} from "../src/routes/android_release_artifacts";
+import {
+  normalizePlayPromotionInput,
+  playReadbackMatches,
+  handleCreateAcceptanceReceipt,
+  handleListDistributions,
+  handleListReleaseReceipts,
+  handlePromotePlayDistribution,
+} from "../src/routes/play_distribution";
+import { createRelease } from "../src/routes/releases";
+import { openApiDocument } from "../src/openapi";
+
+const A = "a".repeat(64);
+const B = "b".repeat(64);
+const COMMIT = "c".repeat(40);
+const migrationDir = fileURLToPath(new URL("../../migrations/sql/", import.meta.url));
+
+function validBundle(): AndroidReleaseArtifactInput {
+  return {
+    source: { repository: "botiverse/mobile", commit_sha: COMMIT, ci_run_id: "123" },
+    package_name: "build.raft.app",
+    version_name: "1.2.3",
+    version_code: 42,
+    upload_key_cert_sha256: A,
+    artifacts: [
+      { kind: "aab", filename: "raft-1.2.3.aab", size_bytes: 100, sha256: A },
+      { kind: "apk", filename: "raft-1.2.3.apk", size_bytes: 200, sha256: B },
+    ],
+  };
+}
+
+describe("Android release artifact declaration", () => {
+  it("binds exactly one AAB and one APK to one source/version identity", () => {
+    const normalized = normalizeAndroidReleaseArtifactInput(validBundle());
+    expect(normalized.source.commitSha).toBe(COMMIT);
+    expect(normalized.versionCode).toBe(42);
+    expect(normalized.artifacts.map((artifact) => artifact.kind)).toEqual(["aab", "apk"]);
+    expect(normalized.artifacts[0].contentType).toBe("application/octet-stream");
+    expect(normalized.artifacts[1].contentType).toBe("application/vnd.android.package-archive");
+  });
+
+  it("fails closed when either carrier is missing or duplicated", () => {
+    const missing = validBundle();
+    missing.artifacts = [missing.artifacts[0]!];
+    expect(() => normalizeAndroidReleaseArtifactInput(missing)).toThrow(/exactly one AAB and one APK/);
+
+    const duplicate = validBundle();
+    duplicate.artifacts = [duplicate.artifacts[0]!, { ...duplicate.artifacts[0]!, filename: "second.aab" }];
+    expect(() => normalizeAndroidReleaseArtifactInput(duplicate)).toThrow(/duplicate aab/);
+  });
+
+  it("rejects non-canonical hashes, commits, version codes, and filenames", () => {
+    const uppercase = validBundle();
+    uppercase.upload_key_cert_sha256 = "A".repeat(64);
+    expect(() => normalizeAndroidReleaseArtifactInput(uppercase)).toThrow(/lowercase hex/);
+
+    const shortCommit = validBundle();
+    shortCommit.source.commit_sha = "c".repeat(39);
+    expect(() => normalizeAndroidReleaseArtifactInput(shortCommit)).toThrow(/40-character/);
+
+    const zeroVersion = validBundle();
+    zeroVersion.version_code = 0;
+    expect(() => normalizeAndroidReleaseArtifactInput(zeroVersion)).toThrow(/positive integer/);
+
+    const path = validBundle();
+    path.artifacts[0]!.filename = "../escape.aab";
+    expect(() => normalizeAndroidReleaseArtifactInput(path)).toThrow(/safe basename/);
+  });
+});
+
+describe("Play promotion gates", () => {
+  it("requires an explicit supported track, revision, and approval", () => {
+    expect(normalizePlayPromotionInput({
+      track: "internal",
+      expected_revision: 3,
+      approval: { note: "ship exact accepted bytes" },
+    })).toEqual({
+      track: "internal",
+      expected_revision: 3,
+      approval: { note: "ship exact accepted bytes" },
+    });
+    expect(() => normalizePlayPromotionInput({
+      track: "internal",
+      expected_revision: 3,
+      approval: { note: " " },
+    })).toThrow(/approval.note/);
+  });
+
+  it("accepts readback only when package, version, track, and SHA all match", () => {
+    const artifact = { package_name: "build.raft.app", version_code: 42, file_hash: A };
+    expect(playReadbackMatches(artifact, "internal", {
+      edit_id: "edit-1",
+      package_name: "build.raft.app",
+      version_code: 42,
+      track: "internal",
+      sha256: A,
+    })).toBe(true);
+    for (const mismatch of [
+      { package_name: "wrong.app" },
+      { version_code: 43 },
+      { track: "closed" as const },
+      { sha256: B },
+    ]) {
+      expect(playReadbackMatches(artifact, "internal", {
+        edit_id: "edit-1",
+        package_name: "build.raft.app",
+        version_code: 42,
+        track: "internal",
+        sha256: A,
+        ...mismatch,
+      })).toBe(false);
+    }
+  });
+});
+
+describe("0070 durable constraints", () => {
+  function migratedDb() {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec(`
+      CREATE TABLE apps (id TEXT PRIMARY KEY);
+      CREATE TABLE builds (id TEXT PRIMARY KEY, app_id TEXT NOT NULL REFERENCES apps(id), version_code INTEGER, revision INTEGER);
+      CREATE TABLE releases (id TEXT PRIMARY KEY, app_id TEXT NOT NULL REFERENCES apps(id), build_id TEXT NOT NULL REFERENCES builds(id));
+      CREATE TABLE build_assets (id TEXT PRIMARY KEY, build_id TEXT NOT NULL REFERENCES builds(id));
+    `);
+    const migration = readFileSync(
+      fileURLToPath(new URL("../../migrations/sql/0070_google_play_distribution.sql", import.meta.url)),
+      "utf8",
+    );
+    db.exec(migration);
+    db.prepare("INSERT INTO apps(id) VALUES ('app')").run();
+    db.prepare("INSERT INTO builds(id, app_id, version_code, revision) VALUES ('build', 'app', 42, 0)").run();
+    db.prepare("INSERT INTO releases(id, app_id, build_id) VALUES ('release', 'app', 'build')").run();
+    db.prepare("INSERT INTO build_assets(id, build_id) VALUES ('aab', 'build')").run();
+    return db;
+  }
+
+  it("makes receipts append-only", () => {
+    const db = migratedDb();
+    db.prepare(`INSERT INTO release_receipts
+      (id, app_id, release_id, kind, verdict, artifact_id, artifact_sha256,
+       artifact_size, package_name, source_commit, version_code, payload_json,
+       created_by, created_at)
+      VALUES ('receipt', 'app', 'release', 'acceptance', 'pass', 'aab', ?, 100,
+              'build.raft.app', ?, 42, '{}', 'tester', 1)`).run(A, COMMIT);
+    expect(() => db.prepare("UPDATE release_receipts SET verdict='fail' WHERE id='receipt'").run()).toThrow(/immutable/);
+    expect(() => db.prepare("DELETE FROM release_receipts WHERE id='receipt'").run()).toThrow(/immutable/);
+  });
+
+  it("allows exactly one active Play edit per app/package", () => {
+    const db = migratedDb();
+    db.prepare(`INSERT INTO play_edit_locks
+      (app_id, package_name, release_id, operation_id, acquired_by, acquired_at)
+      VALUES ('app', 'build.raft.app', 'release', 'one', 'human', 1)`).run();
+    expect(() => db.prepare(`INSERT INTO play_edit_locks
+      (app_id, package_name, release_id, operation_id, acquired_by, acquired_at)
+      VALUES ('app', 'build.raft.app', 'release', 'two', 'human', 2)`).run()).toThrow(/UNIQUE/);
+  });
+
+  it("contains no Play distribution-certificate schema or gate", () => {
+    const migration = readFileSync(
+      fileURLToPath(new URL("../../migrations/sql/0070_google_play_distribution.sql", import.meta.url)),
+      "utf8",
+    );
+    expect(migration).not.toMatch(/play_distribution_cert|distribution_cert/i);
+    const schema = readFileSync(
+      fileURLToPath(new URL("../../docs/schemas/release-receipt-v1.json", import.meta.url)),
+      "utf8",
+    );
+    expect(schema).not.toMatch(/play_distribution_cert|distribution_cert/i);
+  });
+});
+
+describe("Android distribution OpenAPI", () => {
+  it("publishes every P0 artifact, receipt, and Play route", () => {
+    const paths = openApiDocument.paths ?? {};
+    for (const path of [
+      "/api/apps/{appId}/android-release-artifacts",
+      "/api/apps/{appId}/android-release-artifacts/{buildId}",
+      "/api/apps/{appId}/android-release-artifacts/{buildId}/assets/{assetId}/complete",
+      "/api/apps/{appId}/releases/{releaseId}/receipts",
+      "/api/apps/{appId}/releases/{releaseId}/receipts/acceptance",
+      "/api/apps/{appId}/releases/{releaseId}/distributions",
+      "/api/apps/{appId}/releases/{releaseId}/distributions/play",
+      "/api/apps/{appId}/releases/{releaseId}/distributions/play/promote",
+      "/api/apps/{appId}/releases/{releaseId}/distributions/play/halt",
+      "/api/apps/{appId}/releases/{releaseId}/distributions/play/rollback",
+    ]) {
+      expect(paths[path]).toBeDefined();
+    }
+  });
+});
+
+function d1(sqlite: Database.Database): D1Database {
+  const prepare = (sql: string) => {
+    const indexes: number[] = [];
+    const statement = sqlite.prepare(sql.replace(/\?(\d+)/g, (_match, index) => {
+      indexes.push(Number(index));
+      return "?";
+    }));
+    const bind = (...parameters: unknown[]) => {
+      const expanded = indexes.length ? indexes.map((index) => parameters[index - 1]) : parameters;
+      const runSync = () => {
+        const info = statement.run(...expanded);
+        return { success: true, meta: { changes: info.changes } };
+      };
+      const allSync = () => statement.reader
+        ? { success: true, results: statement.all(...expanded) }
+        : runSync();
+      return {
+        _batchSync: allSync,
+        run: async () => runSync(),
+        all: async () => ({ success: true, results: statement.all(...expanded) }),
+        first: async (column?: string) => {
+          const row = statement.get(...expanded) as Record<string, unknown> | undefined;
+          return column ? row?.[column] ?? null : row ?? null;
+        },
+      };
+    };
+    return { bind, run: () => bind().run(), all: () => bind().all(), first: () => bind().first() };
+  };
+  return {
+    prepare,
+    batch: async (statements: Array<{ _batchSync: () => unknown }>) =>
+      sqlite.transaction(() => statements.map((statement) => statement._batchSync()))(),
+  } as unknown as D1Database;
+}
+
+function fullDatabase() {
+  const sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  for (const name of readdirSync(migrationDir).sort()) {
+    if (name.endsWith(".sql")) sqlite.exec(readFileSync(`${migrationDir}${name}`, "utf8"));
+  }
+  const now = Date.now();
+  sqlite.prepare("INSERT INTO apps (id, slug, name, platform, created_at) VALUES (?, ?, ?, ?, ?)")
+    .run("app", "raft-android", "Raft Android", "android", now);
+  sqlite.prepare(`INSERT INTO channels
+    (id, app_id, slug, name, enabled_product_types_json, metadata_json, created_at)
+    VALUES (?, ?, ?, ?, ?, '{}', ?)`)
+    .run("main", "app", "main", "Main", '["android-apk"]', now);
+  return sqlite;
+}
+
+class MemoryBucket {
+  readonly objects = new Map<string, Uint8Array>();
+
+  async head(key: string) {
+    const bytes = this.objects.get(key);
+    return bytes ? { key, size: bytes.byteLength } : null;
+  }
+
+  async get(key: string) {
+    const bytes = this.objects.get(key);
+    if (!bytes) return null;
+    return { key, size: bytes.byteLength, body: new Response(bytes).body! };
+  }
+
+  async put(key: string, value: ReadableStream<Uint8Array> | Uint8Array) {
+    const bytes = value instanceof Uint8Array
+      ? value
+      : new Uint8Array(await new Response(value).arrayBuffer());
+    this.objects.set(key, bytes);
+    return { key, size: bytes.byteLength };
+  }
+
+  async delete(key: string) {
+    this.objects.delete(key);
+  }
+}
+
+const executionContext = {
+  waitUntil() {},
+  passThroughOnException() {},
+  props: {},
+} as unknown as ExecutionContext;
+
+function routeHarness() {
+  const sqlite = fullDatabase();
+  const bucket = new MemoryBucket();
+  const env = {
+    DB: d1(sqlite),
+    APK_BUCKET: bucket,
+    ENVIRONMENT: "development",
+    BUSINESS_ORIGIN: "https://hands.test",
+    R2_S3_ENDPOINT: "https://r2.test",
+    R2_BUCKET_NAME: "artifacts",
+    R2_S3_ACCESS_KEY_ID: "access",
+    R2_S3_SECRET_ACCESS_KEY: "secret",
+  } as unknown as Env;
+  const app = new Hono<{ Bindings: Env; Variables: { admin_account: any; admin_actor: string } }>();
+  app.use("*", async (c, next) => {
+    c.set("admin_account", {
+      id: "human",
+      provider: "raft",
+      provider_subject: "human",
+      server_id: "server",
+      server_slug: "test",
+      principal_type: "human",
+      server_role: "member",
+      username: "human",
+      display_name: "Human",
+      avatar_url: null,
+      raw_profile: "{}",
+      created_at: 1,
+      updated_at: 1,
+      last_login_at: 1,
+    });
+    c.set("admin_actor", "raft:human@test");
+    await next();
+  });
+  app.post("/api/apps/:appId/android-release-artifacts", handleCreateAndroidReleaseArtifacts);
+  app.post(
+    "/api/apps/:appId/android-release-artifacts/:buildId/assets/:assetId/complete",
+    handleCompleteAndroidReleaseArtifact,
+  );
+  app.get("/api/apps/:appId/android-release-artifacts/:buildId", handleGetAndroidReleaseArtifacts);
+  app.post("/api/apps/:appId/releases/:releaseId/receipts/acceptance", handleCreateAcceptanceReceipt);
+  app.get("/api/apps/:appId/releases/:releaseId/receipts", handleListReleaseReceipts);
+  app.get("/api/apps/:appId/releases/:releaseId/distributions", handleListDistributions);
+  app.post("/api/apps/:appId/releases/:releaseId/distributions/play/promote", handlePromotePlayDistribution);
+  const request = (path: string, init?: RequestInit) =>
+    app.fetch(new Request(`https://hands.test${path}`, init), env, executionContext);
+  return { sqlite, bucket, env, request };
+}
+
+function sha(bytes: Uint8Array) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+describe("Android artifact routes", () => {
+  it("seals both exact objects before the parent build becomes ready", async () => {
+    const { sqlite, bucket, request } = routeHarness();
+    const aab = new TextEncoder().encode("exact-aab");
+    const apk = new TextEncoder().encode("exact-apk");
+    const body = validBundle();
+    body.artifacts = [
+      { kind: "aab", filename: "raft.aab", size_bytes: aab.byteLength, sha256: sha(aab) },
+      { kind: "apk", filename: "raft.apk", size_bytes: apk.byteLength, sha256: sha(apk) },
+    ];
+    const declaredResponse = await request("/api/apps/app/android-release-artifacts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(declaredResponse.status).toBe(201);
+    const declared = await declaredResponse.json() as {
+      build_id: string;
+      status: string;
+      artifacts: Array<{
+        asset_id: string;
+        kind: "aab" | "apk";
+        status: string;
+        complete_url: string;
+        upload: { url: string };
+      }>;
+    };
+    expect(declared.status).toBe("uploading");
+    expect(declared.artifacts.map((artifact) => artifact.kind)).toEqual(["aab", "apk"]);
+    expect(declared.artifacts.every((artifact) => artifact.upload.url.startsWith("https://r2.test/"))).toBe(true);
+    expect(declared.artifacts.every((artifact) => artifact.complete_url.endsWith(`/assets/${artifact.asset_id}/complete`))).toBe(true);
+
+    for (const artifact of declared.artifacts) {
+      const row = sqlite.prepare("SELECT r2_key FROM build_assets WHERE id = ?").get(artifact.asset_id) as { r2_key: string };
+      bucket.objects.set(row.r2_key, artifact.kind === "aab" ? aab : apk);
+      const completedResponse = await request(
+        `/api/apps/app/android-release-artifacts/${declared.build_id}/assets/${artifact.asset_id}/complete`,
+        { method: "POST" },
+      );
+      expect(completedResponse.status).toBe(200);
+      const completed = await completedResponse.json() as { status: string; artifacts: Array<{ status: string }> };
+      expect(completed.artifacts.some((item) => item.status === "sealed")).toBe(true);
+      expect(completed.status).toBe(artifact.kind === "aab" ? "uploading" : "ready");
+    }
+
+    const readbackResponse = await request(`/api/apps/app/android-release-artifacts/${declared.build_id}`);
+    expect(readbackResponse.status).toBe(200);
+    const readback = await readbackResponse.json() as { status: string; artifacts: Array<{ status: string; verified_sha256: string }> };
+    expect(readback.status).toBe("ready");
+    expect(readback.artifacts.every((artifact) => artifact.status === "sealed")).toBe(true);
+    expect(readback.artifacts.map((artifact) => artifact.verified_sha256)).toEqual([sha(aab), sha(apk)]);
+  });
+
+  it("fails the whole bundle when uploaded bytes do not match the declaration", async () => {
+    const { sqlite, bucket, request } = routeHarness();
+    const body = validBundle();
+    body.artifacts[0] = { kind: "aab", filename: "raft.aab", size_bytes: 5, sha256: A };
+    body.artifacts[1] = { kind: "apk", filename: "raft.apk", size_bytes: 5, sha256: B };
+    const declared = await (await request("/api/apps/app/android-release-artifacts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })).json() as { build_id: string; artifacts: Array<{ asset_id: string; kind: string }> };
+    const aabAsset = declared.artifacts.find((artifact) => artifact.kind === "aab")!;
+    const row = sqlite.prepare("SELECT r2_key FROM build_assets WHERE id = ?").get(aabAsset.asset_id) as { r2_key: string };
+    bucket.objects.set(row.r2_key, new TextEncoder().encode("wrong"));
+    const completed = await request(
+      `/api/apps/app/android-release-artifacts/${declared.build_id}/assets/${aabAsset.asset_id}/complete`,
+      { method: "POST" },
+    );
+    expect(completed.status).toBe(422);
+    expect(await completed.json()).toMatchObject({ code: "INTEGRITY_MISMATCH" });
+    const bundle = await (await request(`/api/apps/app/android-release-artifacts/${declared.build_id}`)).json() as { status: string };
+    expect(bundle.status).toBe("failed");
+  });
+});
+
+async function readyRelease() {
+  const harness = routeHarness();
+  const aab = new TextEncoder().encode("exact-aab");
+  const apk = new TextEncoder().encode("exact-apk");
+  const body = validBundle();
+  body.artifacts = [
+    { kind: "aab", filename: "raft.aab", size_bytes: aab.byteLength, sha256: sha(aab) },
+    { kind: "apk", filename: "raft.apk", size_bytes: apk.byteLength, sha256: sha(apk) },
+  ];
+  const declared = await (await harness.request("/api/apps/app/android-release-artifacts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })).json() as { build_id: string; artifacts: Array<{ asset_id: string; kind: "aab" | "apk" }> };
+  for (const artifact of declared.artifacts) {
+    const row = harness.sqlite.prepare("SELECT r2_key FROM build_assets WHERE id = ?").get(artifact.asset_id) as { r2_key: string };
+    harness.bucket.objects.set(row.r2_key, artifact.kind === "aab" ? aab : apk);
+    const completed = await harness.request(
+      `/api/apps/app/android-release-artifacts/${declared.build_id}/assets/${artifact.asset_id}/complete`,
+      { method: "POST" },
+    );
+    expect(completed.status).toBe(200);
+  }
+  await createRelease(
+    harness.env.DB,
+    "app",
+    { build_id: declared.build_id, status: "draft" },
+    "raft:human@test",
+    "release",
+  );
+  const aabAsset = declared.artifacts.find((artifact) => artifact.kind === "aab")!;
+  const acceptance = await harness.request("/api/apps/app/releases/release/receipts/acceptance", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      artifact_id: aabAsset.asset_id,
+      verdict: "pass",
+      matrix_ref: "matrix://android/p0/1",
+      expected_revision: 0,
+    }),
+  });
+  expect(acceptance.status).toBe(201);
+  return { ...harness, aab, aabAsset, declared };
+}
+
+describe("Play promotion route", () => {
+  it("streams the accepted exact AAB once and records matching readback", async () => {
+    const harness = await readyRelease();
+    let trackReads = 0;
+    let edits = 0;
+    harness.env.PLAY_RELEASE_SERVICE = {
+      fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "GET") {
+          trackReads += 1;
+          return Response.json({ max_version_code: 41 });
+        }
+        edits += 1;
+        const bytes = new Uint8Array(await new Response(init?.body).arrayBuffer());
+        return Response.json({
+          edit_id: "edit-1",
+          package_name: "build.raft.app",
+          version_code: 42,
+          track: "internal",
+          sha256: sha(bytes),
+          rollout_percent: 100,
+          adapter_url: url,
+        });
+      },
+    } as unknown as Fetcher;
+
+    const promoted = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        track: "internal",
+        expected_revision: 1,
+        approval: { note: "promote accepted exact AAB" },
+      }),
+    });
+    expect(promoted.status).toBe(200);
+    expect(await promoted.json()).toMatchObject({ edit_id: "edit-1", track: "internal", version_code: 42 });
+    expect(trackReads).toBe(1);
+    expect(edits).toBe(1);
+    expect(harness.sqlite.prepare("SELECT COUNT(*) AS count FROM play_edit_locks").get()).toEqual({ count: 0 });
+    expect(harness.sqlite.prepare("SELECT verdict, artifact_id, track FROM release_receipts WHERE kind='play-promotion'").get())
+      .toEqual({ verdict: "success", artifact_id: harness.aabAsset.asset_id, track: "internal" });
+    const payload = JSON.parse(String((harness.sqlite.prepare(
+      "SELECT payload_json FROM release_receipts WHERE kind='play-promotion'",
+    ).get() as { payload_json: string }).payload_json));
+    expect(payload).toMatchObject({
+      schema_version: 1,
+      kind: "play-promotion",
+      artifact: { type: "aab", sha256: sha(harness.aab), package: "build.raft.app", version_code: 42 },
+      source: { repo: "botiverse/mobile", sha: COMMIT, ci_run_id: "123" },
+      signing: { upload_key_cert_sha256: A },
+      play: { edit_id: "edit-1", track: "internal", api_readback: { sha256_match: true } },
+      result: { status: "success" },
+    });
+    expect(JSON.stringify(payload)).not.toMatch(/distribution[_-]?cert/i);
+  });
+
+  it("returns edit_conflict without calling Play and never retries", async () => {
+    const harness = await readyRelease();
+    let calls = 0;
+    harness.env.PLAY_RELEASE_SERVICE = {
+      fetch: async () => {
+        calls += 1;
+        return Response.json({ max_version_code: 41 });
+      },
+    } as unknown as Fetcher;
+    harness.sqlite.prepare(`INSERT INTO play_edit_locks
+      (app_id, package_name, release_id, operation_id, acquired_by, acquired_at)
+      VALUES ('app', 'build.raft.app', 'release', 'other', 'other', 1)`).run();
+    const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ track: "internal", expected_revision: 1, approval: { note: "approved" } }),
+    });
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: { code: "edit_conflict", gate: "edit_lock" } });
+    expect(calls).toBe(0);
+  });
+
+  it("fails before Play when the latest acceptance does not pass", async () => {
+    const harness = await readyRelease();
+    harness.sqlite.prepare("UPDATE releases SET revision = 2 WHERE id = 'release'").run();
+    harness.sqlite.prepare(`INSERT INTO release_receipts
+      (id, app_id, release_id, kind, verdict, artifact_id, artifact_sha256,
+       artifact_size, package_name, source_commit, version_code, payload_json,
+       created_by, created_at)
+      SELECT '!later-fail', app_id, release_id, kind, 'fail', artifact_id,
+             artifact_sha256, artifact_size, package_name, source_commit,
+             version_code, '{}', 'human', created_at
+      FROM release_receipts WHERE kind = 'acceptance'`).run();
+    const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ track: "internal", expected_revision: 2, approval: { note: "approved" } }),
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { gate: "acceptance_receipt" } });
+  });
+
+  it("derives Hands distribution state from the latest appended acceptance", async () => {
+    const harness = await readyRelease();
+    let distributions = await (await harness.request(
+      "/api/apps/app/releases/release/distributions",
+    )).json() as { distributions: Array<{ provider: string; state: string }> };
+    expect(distributions.distributions).toContainEqual({ provider: "hands", state: "accepted" });
+
+    const existing = harness.sqlite.prepare(
+      "SELECT * FROM release_receipts WHERE kind = 'acceptance'",
+    ).get() as Record<string, unknown>;
+    harness.sqlite.prepare(`INSERT INTO release_receipts
+      (id, app_id, release_id, kind, verdict, artifact_id, artifact_sha256,
+       artifact_size, package_name, source_commit, version_code, payload_json,
+       created_by, created_at)
+      VALUES ('!later-fail', ?, ?, 'acceptance', 'fail', ?, ?, ?, ?, ?, ?, '{}', 'human', ?)`)
+      .run(
+        existing.app_id, existing.release_id, existing.artifact_id,
+        existing.artifact_sha256, existing.artifact_size, existing.package_name,
+        existing.source_commit, existing.version_code, existing.created_at,
+      );
+    distributions = await (await harness.request(
+      "/api/apps/app/releases/release/distributions",
+    )).json() as { distributions: Array<{ provider: string; state: string }> };
+    expect(distributions.distributions).toContainEqual({ provider: "hands", state: "not-accepted" });
+  });
+
+  it("records complete acceptance provenance for either sealed Android asset", async () => {
+    const harness = await readyRelease();
+    const acceptancePayload = JSON.parse(String((harness.sqlite.prepare(
+      "SELECT payload_json FROM release_receipts WHERE kind='acceptance' ORDER BY rowid LIMIT 1",
+    ).get() as { payload_json: string }).payload_json));
+    expect(acceptancePayload).toMatchObject({
+      schema_version: 1,
+      kind: "acceptance",
+      artifact: { type: "aab", sha256: sha(harness.aab), version_name: "1.2.3", version_code: 42 },
+      source: { repo: "botiverse/mobile", sha: COMMIT, ci_run_id: "123" },
+      signing: { upload_key_cert_sha256: A },
+      hands_acceptance: { verdict: "pass", matrix_ref: "matrix://android/p0/1" },
+      result: { status: "success" },
+    });
+
+    const apkAsset = harness.declared.artifacts.find((artifact) => artifact.kind === "apk")!;
+    const response = await harness.request("/api/apps/app/releases/release/receipts/acceptance", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        artifact_id: apkAsset.asset_id,
+        verdict: "pass",
+        matrix_ref: "matrix://android/apk/1",
+        expected_revision: 1,
+      }),
+    });
+    expect(response.status).toBe(201);
+    const apkPayload = JSON.parse(String((harness.sqlite.prepare(
+      "SELECT payload_json FROM release_receipts WHERE artifact_id = ? ORDER BY rowid DESC LIMIT 1",
+    ).get(apkAsset.asset_id) as { payload_json: string }).payload_json));
+    expect(apkPayload.artifact.type).toBe("apk");
+  });
+});

--- a/worker/test/google_play_distribution.test.ts
+++ b/worker/test/google_play_distribution.test.ts
@@ -17,6 +17,7 @@ import {
   handleCreateAcceptanceReceipt,
   handleListDistributions,
   handleListReleaseReceipts,
+  handleRollbackPlayDistribution,
   handlePromotePlayDistribution,
 } from "../src/routes/play_distribution";
 import { createRelease } from "../src/routes/releases";
@@ -331,6 +332,7 @@ function routeHarness() {
   app.get("/api/apps/:appId/releases/:releaseId/receipts", handleListReleaseReceipts);
   app.get("/api/apps/:appId/releases/:releaseId/distributions", handleListDistributions);
   app.post("/api/apps/:appId/releases/:releaseId/distributions/play/promote", handlePromotePlayDistribution);
+  app.post("/api/apps/:appId/releases/:releaseId/distributions/play/rollback", handleRollbackPlayDistribution);
   const request = (path: string, init?: RequestInit) =>
     app.fetch(new Request(`https://hands.test${path}`, init), env, executionContext);
   return { sqlite, bucket, env, request };
@@ -539,6 +541,100 @@ describe("Play promotion route", () => {
     expect(response.status).toBe(409);
     expect(await response.json()).toMatchObject({ error: { code: "edit_conflict", gate: "edit_lock" } });
     expect(calls).toBe(0);
+  });
+
+  it("returns typed play_api_error before revision reserve for malformed track JSON", async () => {
+    const harness = await readyRelease();
+    harness.env.PLAY_RELEASE_SERVICE = {
+      fetch: async () => new Response("{", { status: 200, headers: { "content-type": "application/json" } }),
+    } as unknown as Fetcher;
+    const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ track: "internal", expected_revision: 1, approval: { note: "approved" } }),
+    });
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ error: { code: "play_api_error", receipt_id: null } });
+    expect(harness.sqlite.prepare("SELECT revision FROM releases WHERE id='release'").get()).toEqual({ revision: 1 });
+    expect(harness.sqlite.prepare("SELECT COUNT(*) AS count FROM release_receipts WHERE kind='play-promotion'").get())
+      .toEqual({ count: 0 });
+  });
+
+  it("returns typed play_api_error before reserve when the track request rejects", async () => {
+    const harness = await readyRelease();
+    harness.env.PLAY_RELEASE_SERVICE = {
+      fetch: async () => { throw new Error("adapter unavailable"); },
+    } as unknown as Fetcher;
+    const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ track: "internal", expected_revision: 1, approval: { note: "approved" } }),
+    });
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ error: { code: "play_api_error", receipt_id: null } });
+    expect(harness.sqlite.prepare("SELECT revision FROM releases WHERE id='release'").get()).toEqual({ revision: 1 });
+  });
+
+  it("records failed-closed after reserve when Play edit readback is malformed", async () => {
+    const harness = await readyRelease();
+    harness.env.PLAY_RELEASE_SERVICE = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => init?.method === "GET"
+        ? Response.json({ max_version_code: 41 })
+        : new Response("not-json", { status: 200, headers: { "content-type": "application/json" } }),
+    } as unknown as Fetcher;
+    const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ track: "internal", expected_revision: 1, approval: { note: "approved" } }),
+    });
+    expect(response.status).toBe(502);
+    const failure = await response.json() as { error: { code: string; receipt_id: string } };
+    expect(failure.error).toMatchObject({ code: "play_api_error" });
+    expect(failure.error.receipt_id).toBeTruthy();
+    expect(harness.sqlite.prepare("SELECT revision FROM releases WHERE id='release'").get()).toEqual({ revision: 2 });
+    expect(harness.sqlite.prepare("SELECT verdict, id FROM release_receipts WHERE kind='play-promotion'").get())
+      .toEqual({ verdict: "failed-closed", id: failure.error.receipt_id });
+  });
+
+  it("records failed-closed after reserve when the Play edit request rejects", async () => {
+    const harness = await readyRelease();
+    harness.env.PLAY_RELEASE_SERVICE = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "GET") return Response.json({ max_version_code: 41 });
+        throw new Error("adapter unavailable");
+      },
+    } as unknown as Fetcher;
+    const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ track: "internal", expected_revision: 1, approval: { note: "approved" } }),
+    });
+    expect(response.status).toBe(502);
+    const failure = await response.json() as { error: { code: string; receipt_id: string } };
+    expect(failure.error).toMatchObject({ code: "play_api_error" });
+    expect(failure.error.receipt_id).toBeTruthy();
+    expect(harness.sqlite.prepare("SELECT revision FROM releases WHERE id='release'").get()).toEqual({ revision: 2 });
+    expect(harness.sqlite.prepare("SELECT verdict, id FROM release_receipts WHERE kind='play-promotion'").get())
+      .toEqual({ verdict: "failed-closed", id: failure.error.receipt_id });
+  });
+
+  it("validates rollback to_version_code before the fail-closed adapter boundary", async () => {
+    const harness = await readyRelease();
+    const missing = await harness.request("/api/apps/app/releases/release/distributions/play/rollback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ expected_revision: 1, approval: { note: "approved" } }),
+    });
+    expect(missing.status).toBe(400);
+    expect(await missing.json()).toMatchObject({ error: { gate: "version_code" } });
+
+    const valid = await harness.request("/api/apps/app/releases/release/distributions/play/rollback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ expected_revision: 1, approval: { note: "approved" }, to_version_code: 40 }),
+    });
+    expect(valid.status).toBe(502);
+    expect(await valid.json()).toMatchObject({ error: { code: "play_api_error" } });
   });
 
   it("fails before Play when the latest acceptance does not pass", async () => {


### PR DESCRIPTION
Raft author: @XX. GitHub actor `stdrc` is a shared transport carrier only.

## Outcome

Adds the source-only Hands server boundary for Android AAB+APK ingestion, immutable release receipts, and fail-closed Google Play promotion through a server-side service binding.

## Contract

- declares exactly one AAB and one APK under one source/package/version identity;
- seals each R2 object against declared size/SHA-256 and marks the parent ready only after both;
- records append-only acceptance and Play promotion receipts;
- gates promotion on exact AAB acceptance, package/versionCode/track, track max + 1, one edit lock, no live hold, human approval, and exact adapter readback;
- keeps Play credentials behind `PLAY_RELEASE_SERVICE` and never exposes them to CI, CLI, or devices;
- contains no Play distribution-certificate field or gate.

This PR does not configure a Play adapter, deploy Hands, migrate production D1, sign artifacts, or perform any Google Play write.

## Validation

- focused Google Play distribution contract: 16/16
- Worker suite: 53 files / 539 tests
- full workspace build: green
- full workspace test: green
- Worker typecheck: green
- `git diff --check`: green
- right-cause mutations: early one-asset ready, ID-based same-millisecond latest receipt, and omitted SHA readback each failed at the intended assertion and were restored
- lint: not obtained because the repository currently has ESLint 9 but no `eslint.config.*`; `pnpm -r lint` exits before source linting
