### PR TITLE
feat: add controlled app transfer API and admin UI

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -550,6 +550,11 @@ export const updateApp = (
 export const listOrgs = () =>
   request<{ orgs: Org[] }>(`/api/orgs`, { admin: true });
 
+export const transferApp = (appId: string, input: { target_org_id: string; expected_source_org_id: string; idempotency_key: string }) =>
+  request<{ ok: true; app_id: string; from_org_id: string; target_org_id: string }>(`/api/apps/${appId}/transfer`, {
+    method: "POST", admin: true, body: JSON.stringify(input),
+  });
+
 export const listOrgMembers = (orgId: string) =>
   request<{ members: OrgMember[] }>(`/api/orgs/${orgId}/members`, { admin: true });
 

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -1468,8 +1468,9 @@ export function AppSettings({ appId }: { appId: string }) {
 function AppTransferPanel({ appId, app, orgs }: { appId: string; app: App; orgs: Array<{ id: string; name: string; slug: string; archived: number }> }) {
   const toast = useToast(); const qc = useQueryClient();
   const [target, setTarget] = useState(""); const [confirm, setConfirm] = useState("");
+  const [idempotencyKey] = useState(() => crypto.randomUUID());
   const transfer = useMutation({
-    mutationFn: () => transferApp(appId, { target_org_id: target, expected_source_org_id: app.org_id ?? "", idempotency_key: crypto.randomUUID() }),
+    mutationFn: () => transferApp(appId, { target_org_id: target, expected_source_org_id: app.org_id ?? "", idempotency_key: idempotencyKey }),
     onSuccess: () => { toast.show({ kind: "success", title: "App transferred" }); setConfirm(""); void qc.invalidateQueries({ queryKey: ["apps"] }); },
     onError: (e) => toast.show({ kind: "error", title: "Transfer failed", description: (e as Error).message }),
   });

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -47,6 +47,8 @@ import {
   getAppClientKey,
   rotateAppClientKey,
   purgeApp,
+  listOrgs,
+  transferApp,
   getAscCredentials,
   setAscCredentials,
   deleteAscCredentials,
@@ -1256,6 +1258,7 @@ export function AppSettings({ appId }: { appId: string }) {
   const me = useQuery({ queryKey: ["auth-me"], queryFn: () => getAuthMe() });
   const orgRole = me.data?.account.org_role ?? null;
   const isOrgAdmin = orgRole === "owner" || orgRole === "admin";
+  const orgs = useQuery({ queryKey: ["orgs"], queryFn: listOrgs });
 
   const [confirmArchive, setConfirmArchive] = useState(false);
 
@@ -1303,6 +1306,8 @@ export function AppSettings({ appId }: { appId: string }) {
 
       <div className="card p-4! text-sm space-y-3">
         <h2 className="text-base font-semibold">Settings</h2>
+
+        <AppTransferPanel appId={appId} app={app} orgs={orgs.data?.orgs ?? []} />
 
         {/* App name (slug is immutable) */}
         <AppNamePanel appId={appId} app={app} />
@@ -1458,6 +1463,18 @@ export function AppSettings({ appId }: { appId: string }) {
       </div>
     </div>
   );
+}
+
+function AppTransferPanel({ appId, app, orgs }: { appId: string; app: App; orgs: Array<{ id: string; name: string; slug: string; archived: number }> }) {
+  const toast = useToast(); const qc = useQueryClient();
+  const [target, setTarget] = useState(""); const [confirm, setConfirm] = useState("");
+  const transfer = useMutation({
+    mutationFn: () => transferApp(appId, { target_org_id: target, expected_source_org_id: app.org_id ?? "", idempotency_key: crypto.randomUUID() }),
+    onSuccess: () => { toast.show({ kind: "success", title: "App transferred" }); setConfirm(""); void qc.invalidateQueries({ queryKey: ["apps"] }); },
+    onError: (e) => toast.show({ kind: "error", title: "Transfer failed", description: (e as Error).message }),
+  });
+  const eligible = orgs.filter((o) => !o.archived && o.id !== app.org_id);
+  return <div className="border-t border-slate-100 pt-3"><h3 className="text-sm font-medium text-slate-700 mb-1">Transfer app</h3><p className="text-xs text-slate-500 mb-2">Preserves this app ID and all releases, builds, channels, and history. Owners of both organizations must authorize.</p><div className="flex flex-wrap gap-2"><select className="input text-sm" value={target} onChange={(e) => setTarget(e.target.value)} disabled={transfer.isPending}><option value="">Select target organization…</option>{eligible.map((o) => <option key={o.id} value={o.id}>{o.name} ({o.slug})</option>)}</select><input className="input text-sm" value={confirm} onChange={(e) => setConfirm(e.target.value)} placeholder={`Type ${app.slug} to confirm`} disabled={!target || transfer.isPending} /><button className="btn-secondary text-xs" disabled={!target || confirm !== app.slug || !app.org_id || transfer.isPending} onClick={() => transfer.mutate()}>{transfer.isPending ? "Transferring…" : "Transfer"}</button></div></div>;
 }
 
 function DefaultChannelPicker({

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -1468,10 +1468,10 @@ export function AppSettings({ appId }: { appId: string }) {
 function AppTransferPanel({ appId, app, orgs }: { appId: string; app: App; orgs: Array<{ id: string; name: string; slug: string; archived: number }> }) {
   const toast = useToast(); const qc = useQueryClient();
   const [target, setTarget] = useState(""); const [confirm, setConfirm] = useState("");
-  const [idempotencyKey] = useState(() => crypto.randomUUID());
+  const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
   const transfer = useMutation({
     mutationFn: () => transferApp(appId, { target_org_id: target, expected_source_org_id: app.org_id ?? "", idempotency_key: idempotencyKey }),
-    onSuccess: () => { toast.show({ kind: "success", title: "App transferred" }); setConfirm(""); void qc.invalidateQueries({ queryKey: ["apps"] }); },
+    onSuccess: () => { toast.show({ kind: "success", title: "App transferred" }); setConfirm(""); setIdempotencyKey(crypto.randomUUID()); void qc.invalidateQueries({ queryKey: ["apps"] }); },
     onError: (e) => toast.show({ kind: "error", title: "Transfer failed", description: (e as Error).message }),
   });
   const eligible = orgs.filter((o) => !o.archived && o.id !== app.org_id);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -59,6 +59,7 @@ import { handleAppGalleryReview, handleGetAgcBuildSubmission, handleGetAgcSubmis
 import {
   handleListApps,
   handleCreateApp,
+  handleTransferApp,
   handleGetApp,
   handleArchiveApp,
   handlePurgeApp,
@@ -798,6 +799,7 @@ admin.post("/api/invites/:token/accept", handleAcceptInvite);
 
 admin.get("/api/apps", requireCurrentOrgRole("viewer"), handleListApps);
 admin.post("/api/apps", requireCurrentOrgRole("member"), handleCreateApp);
+admin.post("/api/apps/:appId/transfer", handleTransferApp);
 admin.get("/api/apps/:appId", requireAppRole("viewer"), handleGetApp);
 admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -799,7 +799,7 @@ admin.post("/api/invites/:token/accept", handleAcceptInvite);
 
 admin.get("/api/apps", requireCurrentOrgRole("viewer"), handleListApps);
 admin.post("/api/apps", requireCurrentOrgRole("member"), handleCreateApp);
-admin.post("/api/apps/:appId/transfer", handleTransferApp);
+admin.post("/api/apps/:appId/transfer", requireAppRole("admin"), handleTransferApp);
 admin.get("/api/apps/:appId", requireAppRole("viewer"), handleGetApp);
 admin.patch("/api/apps/:appId", requireAppRole("admin"), handleUpdateApp);
 admin.post("/api/apps/:appId/archive", requireAppRole("admin"), handleArchiveApp);

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -254,9 +254,10 @@ export async function handleTransferApp(c: AdminContext) {
   for (const row of prior.results) {
     try {
       const p = JSON.parse(row.payload) as { idempotency_key?: string; target_org_id?: string; from_org_id?: string };
-      if (p.idempotency_key === body.idempotency_key) {
+      if (p.idempotency_key === body.idempotency_key && p.target_org_id === body.target_org_id) {
         return c.json({ ok: true, idempotent: true, app_id: appId, from_org_id: p.from_org_id ?? body.expected_source_org_id, target_org_id: p.target_org_id });
       }
+      if (p.idempotency_key === body.idempotency_key) return c.json({ error: "idempotency key is bound to a different target organization", code: "IDEMPOTENCY_CONFLICT" }, 409);
     } catch { /* ignore malformed historical payloads */ }
   }
   if (app.org_id !== body.expected_source_org_id) return c.json({ error: "source org changed", code: "TRANSFER_CONFLICT" }, 409);

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -7,7 +7,7 @@
 
 import type { Context } from "hono";
 import { APP_PLATFORMS, isAppPlatform } from "../lib/app_platform";
-import { currentActor, type AdminEnv } from "../middleware/auth";
+import { currentActor, currentActorInfo, type AdminEnv } from "../middleware/auth";
 import { currentAccount, currentDeployToken, getOrgMemberRole, isOrgAtLeast } from "../lib/permissions";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
@@ -248,31 +248,31 @@ export async function handleTransferApp(c: AdminContext) {
     getOrgMemberRole(c.env.DB, body.target_org_id, account.id),
   ]);
   if (!app) return c.json({ error: "not found" }, 404);
-  if (app.org_id !== body.expected_source_org_id) {
-    return c.json({ error: "source org changed", code: "TRANSFER_CONFLICT" }, 409);
-  }
-  if (!targetOrg || targetOrg.archived) return c.json({ error: "target organization not found or archived" }, 400);
-  if (!isOrgAtLeast(sourceRole, "owner") || !isOrgAtLeast(targetRole, "owner")) {
-    return c.json({ error: "source and target organization owner role required" }, 403);
-  }
   const prior = await c.env.DB.prepare(
     "SELECT payload FROM audit_logs WHERE app_id = ?1 AND action = 'app.transfer' ORDER BY created_at DESC LIMIT 20",
   ).bind(appId).all<{ payload: string }>();
   for (const row of prior.results) {
     try {
-      const p = JSON.parse(row.payload) as { idempotency_key?: string; target_org_id?: string };
+      const p = JSON.parse(row.payload) as { idempotency_key?: string; target_org_id?: string; from_org_id?: string };
       if (p.idempotency_key === body.idempotency_key) {
-        return c.json({ ok: true, idempotent: true, app_id: appId, from_org_id: app.org_id, target_org_id: p.target_org_id });
+        return c.json({ ok: true, idempotent: true, app_id: appId, from_org_id: p.from_org_id ?? body.expected_source_org_id, target_org_id: p.target_org_id });
       }
     } catch { /* ignore malformed historical payloads */ }
   }
+  if (app.org_id !== body.expected_source_org_id) return c.json({ error: "source org changed", code: "TRANSFER_CONFLICT" }, 409);
+  if (!targetOrg || targetOrg.archived) return c.json({ error: "target organization not found or archived" }, 400);
+  if (!isOrgAtLeast(sourceRole, "owner") || !isOrgAtLeast(targetRole, "owner")) return c.json({ error: "source and target organization owner role required" }, 403);
   const now = Date.now();
   const payload = { idempotency_key: body.idempotency_key, from_org_id: app.org_id, target_org_id: body.target_org_id, slug: app.slug };
   await c.env.DB.batch([
     c.env.DB.prepare("UPDATE apps SET org_id = ?1 WHERE id = ?2 AND org_id = ?3")
       .bind(body.target_org_id, appId, body.expected_source_org_id),
+    c.env.DB.prepare("UPDATE webhooks SET org_id = ?1 WHERE app_id = ?2 AND org_id = ?3")
+      .bind(body.target_org_id, appId, body.expected_source_org_id),
+    c.env.DB.prepare("UPDATE invites SET org_id = ?1 WHERE app_id = ?2 AND org_id = ?3")
+      .bind(body.target_org_id, appId, body.expected_source_org_id),
     c.env.DB.prepare("INSERT INTO audit_logs (id, app_id, action, actor, actor_id, actor_type, payload, created_at) SELECT ?1, ?2, 'app.transfer', ?3, ?4, ?5, ?6, ?7 FROM apps WHERE id = ?2 AND org_id = ?8")
-      .bind(crypto.randomUUID(), appId, account.display_name, account.id, account.principal_type, JSON.stringify(payload), now, body.target_org_id),
+      .bind(crypto.randomUUID(), appId, currentActorInfo(c).display_name, account.id, account.principal_type, JSON.stringify(payload), now, body.target_org_id),
   ]);
   const moved = await c.env.DB.prepare("SELECT org_id FROM apps WHERE id = ?1").bind(appId).first<{ org_id: string }>();
   if (moved?.org_id !== body.target_org_id) return c.json({ error: "transfer commit could not be verified", code: "TRANSFER_UNVERIFIED" }, 500);

--- a/worker/src/routes/apps.ts
+++ b/worker/src/routes/apps.ts
@@ -8,7 +8,7 @@
 import type { Context } from "hono";
 import { APP_PLATFORMS, isAppPlatform } from "../lib/app_platform";
 import { currentActor, type AdminEnv } from "../middleware/auth";
-import { currentAccount, currentDeployToken } from "../lib/permissions";
+import { currentAccount, currentDeployToken, getOrgMemberRole, isOrgAtLeast } from "../lib/permissions";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 
@@ -216,6 +216,67 @@ export async function handleCreateApp(c: AdminContext) {
   }
 
   return c.json({ id, org_id: orgId, slug: body.slug, name: body.name, platform: body.platform }, 201);
+}
+
+/** POST /api/apps/:appId/transfer — move an app identity between orgs.
+ *
+ * This is deliberately owner-only on both sides and uses an expected source
+ * org plus idempotency key so a stale UI cannot move a concurrently changed
+ * app. The app id and all child resources remain unchanged.
+ */
+export async function handleTransferApp(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const body = (await c.req.json().catch(() => ({}))) as {
+    target_org_id?: string;
+    expected_source_org_id?: string;
+    idempotency_key?: string;
+  };
+  if (!body.target_org_id || !body.expected_source_org_id || !body.idempotency_key) {
+    return c.json({ error: "target_org_id, expected_source_org_id, and idempotency_key are required" }, 400);
+  }
+  if (body.target_org_id === body.expected_source_org_id) {
+    return c.json({ error: "target_org_id must differ from source org" }, 400);
+  }
+  const account = currentAccount(c);
+  if (!account) return c.json({ error: "authenticated account required" }, 403);
+  const [app, targetOrg, sourceRole, targetRole] = await Promise.all([
+    c.env.DB.prepare("SELECT id, org_id, slug, name FROM apps WHERE id = ?1 LIMIT 1").bind(appId)
+      .first<{ id: string; org_id: string | null; slug: string; name: string }>(),
+    c.env.DB.prepare("SELECT id, archived FROM organizations WHERE id = ?1 LIMIT 1").bind(body.target_org_id)
+      .first<{ id: string; archived: number }>(),
+    getOrgMemberRole(c.env.DB, body.expected_source_org_id, account.id),
+    getOrgMemberRole(c.env.DB, body.target_org_id, account.id),
+  ]);
+  if (!app) return c.json({ error: "not found" }, 404);
+  if (app.org_id !== body.expected_source_org_id) {
+    return c.json({ error: "source org changed", code: "TRANSFER_CONFLICT" }, 409);
+  }
+  if (!targetOrg || targetOrg.archived) return c.json({ error: "target organization not found or archived" }, 400);
+  if (!isOrgAtLeast(sourceRole, "owner") || !isOrgAtLeast(targetRole, "owner")) {
+    return c.json({ error: "source and target organization owner role required" }, 403);
+  }
+  const prior = await c.env.DB.prepare(
+    "SELECT payload FROM audit_logs WHERE app_id = ?1 AND action = 'app.transfer' ORDER BY created_at DESC LIMIT 20",
+  ).bind(appId).all<{ payload: string }>();
+  for (const row of prior.results) {
+    try {
+      const p = JSON.parse(row.payload) as { idempotency_key?: string; target_org_id?: string };
+      if (p.idempotency_key === body.idempotency_key) {
+        return c.json({ ok: true, idempotent: true, app_id: appId, from_org_id: app.org_id, target_org_id: p.target_org_id });
+      }
+    } catch { /* ignore malformed historical payloads */ }
+  }
+  const now = Date.now();
+  const payload = { idempotency_key: body.idempotency_key, from_org_id: app.org_id, target_org_id: body.target_org_id, slug: app.slug };
+  await c.env.DB.batch([
+    c.env.DB.prepare("UPDATE apps SET org_id = ?1 WHERE id = ?2 AND org_id = ?3")
+      .bind(body.target_org_id, appId, body.expected_source_org_id),
+    c.env.DB.prepare("INSERT INTO audit_logs (id, app_id, action, actor, actor_id, actor_type, payload, created_at) SELECT ?1, ?2, 'app.transfer', ?3, ?4, ?5, ?6, ?7 FROM apps WHERE id = ?2 AND org_id = ?8")
+      .bind(crypto.randomUUID(), appId, account.display_name, account.id, account.principal_type, JSON.stringify(payload), now, body.target_org_id),
+  ]);
+  const moved = await c.env.DB.prepare("SELECT org_id FROM apps WHERE id = ?1").bind(appId).first<{ org_id: string }>();
+  if (moved?.org_id !== body.target_org_id) return c.json({ error: "transfer commit could not be verified", code: "TRANSFER_UNVERIFIED" }, 500);
+  return c.json({ ok: true, idempotent: false, app_id: appId, from_org_id: app.org_id, target_org_id: moved.org_id });
 }
 
 export async function handleArchiveApp(c: Context<{ Bindings: Env }>) {


### PR DESCRIPTION
Implements task #184 controlled app transfer.

- Owner-gated POST /api/apps/:appId/transfer with target validation, CAS/idempotency, audit, readback.
- Admin App Settings target-org selector and explicit slug confirmation.
- App-linked webhook/invite rows retain status/configuration; org_id follows app. Organization-level rows (app_id null) untouched.
- No migration/deploy performed.

Signed-off-by: 曜衡@mail.build