### PR TITLE
feat(play): add private Google Play adapter and Hands binding

### DIFF
--- a/.github/workflows/deploy-hands-play-adapter.yml
+++ b/.github/workflows/deploy-hands-play-adapter.yml
@@ -1,0 +1,78 @@
+name: Deploy Hands Google Play Adapter
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hands-google-play-adapter-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    # This environment must keep a main-only deployment policy. The workflow
+    # writes a production secret and publishes a Worker; a job-level branch
+    # condition inside this file is not an equivalent external control.
+    environment: hands-play-production
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+      HANDS_PLAY_ADAPTER_WORKER_NAME: ${{ vars.HANDS_PLAY_ADAPTER_WORKER_NAME }}
+      HANDS_PLAY_ALLOWED_PACKAGE_NAMES: ${{ vars.HANDS_PLAY_ALLOWED_PACKAGE_NAMES }}
+      HANDS_PLAY_CLOSED_TRACK_NAME: ${{ vars.HANDS_PLAY_CLOSED_TRACK_NAME }}
+      HANDS_PLAY_MAX_AAB_SIZE_BYTES: ${{ vars.HANDS_PLAY_MAX_AAB_SIZE_BYTES }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.12.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Render production config
+        working-directory: play-adapter
+        run: node scripts/render-production-config.mjs --output wrangler.generated.jsonc
+
+      - name: Run checks
+        run: |
+          pnpm --filter @botiverse/hands-play-adapter test
+          pnpm --filter @botiverse/hands-play-adapter build
+          pnpm --filter @botiverse/hands-play-adapter exec wrangler deploy --dry-run --config wrangler.generated.jsonc
+
+      - name: Validate production credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+            echo "Missing Cloudflare deployment credential." >&2
+            exit 1
+          fi
+          if [[ -z "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]]; then
+            echo "Missing Google Play service-account credential." >&2
+            exit 1
+          fi
+
+      - name: Deploy private adapter with its service-account secret
+        working-directory: play-adapter
+        shell: bash
+        run: |
+          set -euo pipefail
+          secret_file="$(mktemp)"
+          trap 'rm -f "${secret_file}"' EXIT
+          chmod 600 "${secret_file}"
+          jq -n --arg value "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON}" \
+            '{GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: $value}' > "${secret_file}"
+          pnpm exec wrangler deploy --strict --config wrangler.generated.jsonc \
+            --secrets-file "${secret_file}"

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -67,6 +67,10 @@ jobs:
       HANDS_RAFT_CLIENT_ID: ${{ vars.HANDS_RAFT_CLIENT_ID }}
       HANDS_ADMIN_ALLOWED_SERVER_IDS: ${{ vars.HANDS_ADMIN_ALLOWED_SERVER_IDS }}
       HANDS_FLAGSHIP_APP_ID: ${{ vars.HANDS_FLAGSHIP_APP_ID }}
+      # Optional until the independently deployed adapter is ready. When set,
+      # the renderer adds only the service binding; Google credentials remain
+      # in the adapter's own secret store and never enter this Worker.
+      HANDS_PLAY_RELEASE_SERVICE_NAME: ${{ vars.HANDS_PLAY_RELEASE_SERVICE_NAME }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/notify-hands-workflow-failures.yml
+++ b/.github/workflows/notify-hands-workflow-failures.yml
@@ -9,6 +9,7 @@ on:
       - Publish Hands Node SDK
       - Publish OHOS SDK
       - Deploy Hands Server
+      - Deploy Hands Google Play Adapter
       - Deploy Quiver Server
     types: [completed]
 

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     paths:
       - "worker/**"
+      - "play-adapter/**"
       - "migrations/**"
       - "packages/**"
       - ".github/workflows/worker-tests.yml"
@@ -87,6 +88,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  play-adapter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Test, typecheck, and bundle the private Play adapter
+        env:
+          HANDS_PLAY_ADAPTER_WORKER_NAME: hands-google-play-adapter-ci
+          HANDS_PLAY_ALLOWED_PACKAGE_NAMES: build.raft.app
+          HANDS_PLAY_CLOSED_TRACK_NAME: closed-ci
+          HANDS_PLAY_MAX_AAB_SIZE_BYTES: "209715200"
+        run: |
+          pnpm --filter @botiverse/hands-play-adapter test
+          pnpm --filter @botiverse/hands-play-adapter build
+          node play-adapter/scripts/render-production-config.mjs \
+            --output play-adapter/wrangler.generated.jsonc
+          pnpm --filter @botiverse/hands-play-adapter exec wrangler deploy \
+            --dry-run --strict --config wrangler.generated.jsonc
+
   windows-device-id:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -108,7 +108,7 @@ jobs:
           pnpm --filter @botiverse/hands-play-adapter test
           pnpm --filter @botiverse/hands-play-adapter build
           node play-adapter/scripts/render-production-config.mjs \
-            --output play-adapter/wrangler.generated.jsonc
+            --output wrangler.generated.jsonc
           pnpm --filter @botiverse/hands-play-adapter exec wrangler deploy \
             --dry-run --strict --config wrangler.generated.jsonc
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ coverage/
 *.tsbuildinfo
 worker-configuration.d.ts
 worker/wrangler.*.generated.jsonc
+play-adapter/wrangler.generated.jsonc
 admin/public/docs/
 admin/public/docs.md

--- a/docs/google-play-distribution-design.md
+++ b/docs/google-play-distribution-design.md
@@ -113,9 +113,27 @@ requests and never sends credentials in headers or payloads:
 No call is retried automatically. Adapter absence, non-2xx, or malformed/mismatched
 readback is a typed `play_api_error` and never becomes success.
 
+The adapter is the `play-adapter/` Worker. It has no public route, `workers.dev`
+hostname, or preview URL. Its Google service-account JSON exists only as the
+adapter secret `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`; Hands receives only the
+`PLAY_RELEASE_SERVICE` service binding. `ALLOWED_PACKAGE_NAMES` restricts the
+package surface, `internal` maps to Play's `qa` track, `production` maps to
+`production`, and `closed` maps to the existing custom track named by
+`GOOGLE_PLAY_CLOSED_TRACK_NAME`.
+
+Each mutation creates one Google edit, streams the AAB without buffering it,
+compares both the local SHA-256 and Google's bundle SHA-256/versionCode, reads
+the live track again inside that edit, preserves its active releases, updates
+the requested release, and commits once with
+`changesInReviewBehavior=ERROR_IF_IN_REVIEW`. A fresh edit verifies the committed
+track before the adapter returns success. Pre-commit failures delete the edit;
+an ambiguous commit outcome is not retried or deleted. Partial rollout is
+allowed only for `production`; internal and closed-test promotion is 100%.
+
 ## Non-goals
 
-- no Play credentials, signing, or production promotion in this change;
+- no credential values in source, signing, deployment, or production Play write
+  performed by this source change;
 - no store listing automation, review replies, or crash/ANR threshold gate;
 - no Play distribution-certificate storage or gating;
 - no inclusion of Play artifacts in Hands alpha/delta updates.

--- a/play-adapter/package.json
+++ b/play-adapter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@botiverse/hands-play-adapter",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.8.0",
+    "jose": "^5.9.6"
+  },
+  "devDependencies": {
+    "jsonc-parser": "^3.3.1",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.8",
+    "wrangler": "^4.88.0"
+  }
+}

--- a/play-adapter/scripts/render-production-config.mjs
+++ b/play-adapter/scripts/render-production-config.mjs
@@ -1,0 +1,75 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse, printParseErrorCode } from "jsonc-parser";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const adapterDir = resolve(scriptDir, "..");
+const sourcePath = resolve(adapterDir, "wrangler.jsonc");
+const outputArgIndex = process.argv.indexOf("--output");
+const outputPath = resolve(
+  adapterDir,
+  outputArgIndex >= 0 && process.argv[outputArgIndex + 1]
+    ? process.argv[outputArgIndex + 1]
+    : "wrangler.generated.jsonc",
+);
+
+function required(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment value ${name}`);
+  return value;
+}
+
+function workerName(name) {
+  const value = required(name);
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(value)) {
+    throw new Error(`${name} must be a valid Cloudflare Worker service name`);
+  }
+  return value;
+}
+
+function packageNames(name) {
+  const value = required(name);
+  const packages = value.split(",").map((item) => item.trim()).filter(Boolean);
+  if (packages.length === 0 || packages.some((item) => !/^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/.test(item))) {
+    throw new Error(`${name} must be a comma-separated package-name allowlist`);
+  }
+  return packages.join(",");
+}
+
+function trackName(name) {
+  const value = required(name);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value) || value === "qa" || value === "production") {
+    throw new Error(`${name} must name a custom closed-testing track`);
+  }
+  return value;
+}
+
+function positiveInteger(name) {
+  const value = required(name);
+  if (!/^\d+$/.test(value) || !Number.isSafeInteger(Number(value)) || Number(value) <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+const errors = [];
+const config = parse(readFileSync(sourcePath, "utf8"), errors, {
+  allowTrailingComma: true,
+  disallowComments: false,
+});
+if (errors.length > 0 || !config || typeof config !== "object") {
+  const detail = errors.map((error) => printParseErrorCode(error.error)).join(", ");
+  throw new Error(`Unable to parse ${sourcePath}: ${detail || "invalid JSONC"}`);
+}
+
+config.name = workerName("HANDS_PLAY_ADAPTER_WORKER_NAME");
+config.vars = {
+  ALLOWED_PACKAGE_NAMES: packageNames("HANDS_PLAY_ALLOWED_PACKAGE_NAMES"),
+  GOOGLE_PLAY_CLOSED_TRACK_NAME: trackName("HANDS_PLAY_CLOSED_TRACK_NAME"),
+  MAX_AAB_SIZE_BYTES: positiveInteger("HANDS_PLAY_MAX_AAB_SIZE_BYTES"),
+};
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+console.log(`Rendered Google Play adapter config: ${outputPath}`);

--- a/play-adapter/src/auth.ts
+++ b/play-adapter/src/auth.ts
@@ -1,0 +1,84 @@
+import { importPKCS8, SignJWT } from "jose";
+import { PlayAdapterError } from "./errors";
+import type { ServiceAccountCredential } from "./types";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+
+export function parseServiceAccount(raw: string | undefined): ServiceAccountCredential {
+  if (!raw) {
+    throw new PlayAdapterError(503, "play_credentials_missing", "Google Play credentials are not configured");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new PlayAdapterError(503, "play_credentials_invalid", "Google Play credentials are invalid");
+  }
+  const object = value as Record<string, unknown> | null;
+  const clientEmail = object?.client_email;
+  const privateKey = object?.private_key;
+  const privateKeyId = object?.private_key_id;
+  if (
+    object?.type !== "service_account"
+    || typeof clientEmail !== "string"
+    || !/^[^@\s]+@[^@\s]+$/.test(clientEmail)
+    || typeof privateKey !== "string"
+    || !privateKey.includes("BEGIN PRIVATE KEY")
+    || (privateKeyId !== undefined && typeof privateKeyId !== "string")
+  ) {
+    throw new PlayAdapterError(503, "play_credentials_invalid", "Google Play credentials are invalid");
+  }
+  return {
+    client_email: clientEmail,
+    private_key: privateKey,
+    ...(privateKeyId ? { private_key_id: privateKeyId } : {}),
+  };
+}
+
+export async function createAccessToken(
+  credential: ServiceAccountCredential,
+  fetchImpl: typeof fetch,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  let privateKey: CryptoKey;
+  try {
+    privateKey = await importPKCS8(credential.private_key, "RS256");
+  } catch {
+    throw new PlayAdapterError(503, "play_credentials_invalid", "Google Play credentials are invalid");
+  }
+  const assertion = await new SignJWT({ scope: ANDROID_PUBLISHER_SCOPE })
+    .setProtectedHeader({
+      alg: "RS256",
+      typ: "JWT",
+      ...(credential.private_key_id ? { kid: credential.private_key_id } : {}),
+    })
+    .setIssuer(credential.client_email)
+    .setAudience(TOKEN_URL)
+    .setIssuedAt(nowSeconds)
+    .setExpirationTime(nowSeconds + 3600)
+    .sign(privateKey);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      }),
+      redirect: "error",
+    });
+  } catch {
+    throw new PlayAdapterError(502, "play_token_unavailable", "Google OAuth token request failed");
+  }
+  const body = await response.json().catch(() => null) as Record<string, unknown> | null;
+  if (!response.ok) {
+    throw new PlayAdapterError(502, "play_token_rejected", `Google OAuth token request failed with ${response.status}`);
+  }
+  if (!body || typeof body.access_token !== "string" || !body.access_token) {
+    throw new PlayAdapterError(502, "play_token_malformed", "Google OAuth returned a malformed token response");
+  }
+  return body.access_token;
+}

--- a/play-adapter/src/errors.ts
+++ b/play-adapter/src/errors.ts
@@ -1,0 +1,23 @@
+export class PlayAdapterError extends Error {
+  constructor(
+    public readonly status: 400 | 403 | 409 | 413 | 502 | 503,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function safeErrorResponse(error: unknown, operationId: string | null): Response {
+  const known = error instanceof PlayAdapterError;
+  const status = known ? error.status : 502;
+  const code = known ? error.code : "play_adapter_error";
+  const message = known ? error.message : "Google Play adapter request failed";
+  console.error(JSON.stringify({
+    event: "google_play_adapter_error",
+    operation_id: operationId,
+    code,
+    status,
+  }));
+  return Response.json({ error: { code, message } }, { status });
+}

--- a/play-adapter/src/google_play.ts
+++ b/play-adapter/src/google_play.ts
@@ -1,0 +1,312 @@
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import { PlayAdapterError } from "./errors";
+import type { PromotionRequest, TrackRelease, TrackResource } from "./types";
+
+const API_ROOT = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+const UPLOAD_ROOT = "https://androidpublisher.googleapis.com/upload/androidpublisher/v3";
+
+interface GoogleBundle {
+  versionCode?: number;
+  sha256?: string;
+}
+
+function exactVersionCode(value: unknown): number | null {
+  const parsed = typeof value === "string" && /^\d+$/.test(value) ? Number(value) : value;
+  return typeof parsed === "number" && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function maxTrackVersionCode(track: TrackResource): number {
+  let max = 0;
+  for (const release of track.releases ?? []) {
+    for (const value of release.versionCodes ?? []) {
+      const versionCode = exactVersionCode(value);
+      if (versionCode === null) {
+        throw new PlayAdapterError(502, "play_track_malformed", "Google Play returned an invalid track versionCode");
+      }
+      max = Math.max(max, versionCode);
+    }
+  }
+  return max;
+}
+
+function cleanRelease(value: TrackRelease): TrackRelease {
+  const release: TrackRelease = {};
+  if (typeof value.name === "string") release.name = value.name;
+  if (Array.isArray(value.versionCodes)) release.versionCodes = value.versionCodes.map((item) => String(item));
+  if (Array.isArray(value.releaseNotes)) {
+    release.releaseNotes = value.releaseNotes
+      .filter((item) => typeof item?.language === "string" && typeof item?.text === "string")
+      .map((item) => ({ language: item.language, text: item.text }));
+  }
+  const status = value.status;
+  if (status && ["statusUnspecified", "draft", "inProgress", "halted", "completed"].includes(status)) {
+    release.status = status;
+  }
+  if (typeof value.userFraction === "number" && Number.isFinite(value.userFraction)) {
+    release.userFraction = value.userFraction;
+  }
+  if (value.countryTargeting && typeof value.countryTargeting === "object") {
+    release.countryTargeting = {
+      ...(Array.isArray(value.countryTargeting.countries)
+        ? { countries: value.countryTargeting.countries.map((country) => String(country)) }
+        : {}),
+      ...(typeof value.countryTargeting.includeRestOfWorld === "boolean"
+        ? { includeRestOfWorld: value.countryTargeting.includeRestOfWorld }
+        : {}),
+    };
+  }
+  const priority = value.inAppUpdatePriority;
+  if (typeof priority === "number" && Number.isInteger(priority)) release.inAppUpdatePriority = priority;
+  return release;
+}
+
+function requestedRelease(request: PromotionRequest): TrackRelease {
+  if (request.rolloutPercent < 100) {
+    if (request.handsTrack !== "production") {
+      throw new PlayAdapterError(400, "rollout_track_invalid", "Partial rollout is supported only on the production track");
+    }
+    return {
+      versionCodes: [String(request.versionCode)],
+      status: "inProgress",
+      userFraction: request.rolloutPercent / 100,
+    };
+  }
+  return { versionCodes: [String(request.versionCode)], status: "completed" };
+}
+
+function hashingBody(body: ReadableStream<Uint8Array>, maxBytes: number) {
+  const hasher = sha256.create();
+  let size = 0;
+  let finished = false;
+  const stream = body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      size += chunk.byteLength;
+      if (size > maxBytes) {
+        throw new PlayAdapterError(413, "aab_too_large", "AAB exceeds the configured maximum size");
+      }
+      hasher.update(chunk);
+      controller.enqueue(chunk);
+    },
+    flush() {
+      finished = true;
+    },
+  }));
+  return {
+    stream,
+    digest() {
+      if (!finished) {
+        throw new PlayAdapterError(409, "aab_integrity_mismatch", "Google Play did not consume the complete AAB stream");
+      }
+      return { size, sha256: bytesToHex(hasher.digest()) };
+    },
+  };
+}
+
+export class GooglePlayClient {
+  constructor(
+    private readonly accessToken: string,
+    private readonly fetchImpl: typeof fetch,
+    private readonly maxAabSize: number,
+  ) {}
+
+  private async requestJson<T>(url: string, init: RequestInit = {}): Promise<T> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${this.accessToken}`,
+          ...(init.body === undefined ? {} : { "content-type": "application/json" }),
+          ...(init.headers ?? {}),
+        },
+        redirect: "error",
+      });
+    } catch {
+      throw new PlayAdapterError(502, "play_api_unavailable", "Google Play API request failed");
+    }
+    const body = await response.json().catch(() => null) as T | null;
+    if (!response.ok) {
+      throw new PlayAdapterError(502, "play_api_rejected", `Google Play API request failed with ${response.status}`);
+    }
+    if (!body || typeof body !== "object") {
+      throw new PlayAdapterError(502, "play_api_malformed", "Google Play API returned malformed JSON");
+    }
+    return body;
+  }
+
+  private async requestEmpty(url: string, init: RequestInit): Promise<void> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        ...init,
+        headers: { authorization: `Bearer ${this.accessToken}`, ...(init.headers ?? {}) },
+        redirect: "error",
+      });
+    } catch {
+      throw new PlayAdapterError(502, "play_api_unavailable", "Google Play API request failed");
+    }
+    if (!response.ok) {
+      throw new PlayAdapterError(502, "play_api_rejected", `Google Play API request failed with ${response.status}`);
+    }
+  }
+
+  private editRoot(packageName: string, editId?: string): string {
+    const root = `${API_ROOT}/applications/${encodeURIComponent(packageName)}/edits`;
+    return editId ? `${root}/${encodeURIComponent(editId)}` : root;
+  }
+
+  async createEdit(packageName: string): Promise<string> {
+    const body = await this.requestJson<{ id?: string }>(this.editRoot(packageName), {
+      method: "POST",
+      body: "{}",
+    });
+    if (typeof body.id !== "string" || !body.id) {
+      throw new PlayAdapterError(502, "play_edit_malformed", "Google Play did not return an edit id");
+    }
+    return body.id;
+  }
+
+  async deleteEdit(packageName: string, editId: string): Promise<void> {
+    await this.requestEmpty(this.editRoot(packageName, editId), { method: "DELETE" });
+  }
+
+  async getTrack(packageName: string, editId: string, track: string): Promise<TrackResource> {
+    return this.requestJson<TrackResource>(
+      `${this.editRoot(packageName, editId)}/tracks/${encodeURIComponent(track)}`,
+    );
+  }
+
+  async readTrackMaximum(packageName: string, track: string): Promise<number> {
+    const editId = await this.createEdit(packageName);
+    let value: number;
+    try {
+      value = maxTrackVersionCode(await this.getTrack(packageName, editId, track));
+    } catch (error) {
+      await this.cleanupOrThrow(packageName, editId, error);
+      throw error;
+    }
+    await this.deleteEdit(packageName, editId);
+    return value;
+  }
+
+  private async uploadBundle(request: PromotionRequest, editId: string): Promise<GoogleBundle> {
+    const local = hashingBody(request.body, this.maxAabSize);
+    let response: Response;
+    try {
+      response = await this.fetchImpl(
+        `${UPLOAD_ROOT}/applications/${encodeURIComponent(request.packageName)}/edits/${encodeURIComponent(editId)}/bundles?uploadType=media`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${this.accessToken}`,
+            "content-type": "application/octet-stream",
+          },
+          body: local.stream,
+          redirect: "error",
+        },
+      );
+    } catch (error) {
+      if (error instanceof PlayAdapterError) throw error;
+      throw new PlayAdapterError(502, "play_upload_unavailable", "Google Play AAB upload failed");
+    }
+    const body = await response.json().catch(() => null) as GoogleBundle | null;
+    if (!response.ok) {
+      throw new PlayAdapterError(502, "play_upload_rejected", `Google Play AAB upload failed with ${response.status}`);
+    }
+    if (!body || typeof body !== "object") {
+      throw new PlayAdapterError(502, "play_upload_malformed", "Google Play returned malformed AAB metadata");
+    }
+    const hashResult = local.digest();
+    if (hashResult.size !== request.expectedSize || hashResult.sha256 !== request.expectedSha256) {
+      throw new PlayAdapterError(409, "aab_integrity_mismatch", "Streamed AAB did not match the Hands identity");
+    }
+    if (exactVersionCode(body.versionCode) !== request.versionCode || body.sha256?.toLowerCase() !== request.expectedSha256) {
+      throw new PlayAdapterError(409, "play_bundle_mismatch", "Google Play AAB readback did not match Hands");
+    }
+    return body;
+  }
+
+  private async updateTrack(request: PromotionRequest, editId: string, current: TrackResource): Promise<void> {
+    const currentMax = maxTrackVersionCode(current);
+    if (request.versionCode !== currentMax + 1) {
+      throw new PlayAdapterError(409, "play_version_conflict", "AAB versionCode is no longer the live track maximum plus one");
+    }
+    if ((current.releases ?? []).some((release) => release.status === "inProgress" || release.status === "halted")) {
+      throw new PlayAdapterError(409, "play_rollout_conflict", "The track already has a staged or halted release");
+    }
+    await this.requestJson<TrackResource>(
+      `${this.editRoot(request.packageName, editId)}/tracks/${encodeURIComponent(request.playTrack)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          track: request.playTrack,
+          releases: [...(current.releases ?? []).map(cleanRelease), requestedRelease(request)],
+        }),
+      },
+    );
+  }
+
+  private async commitEdit(packageName: string, editId: string): Promise<void> {
+    await this.requestJson<{ id?: string }>(
+      `${this.editRoot(packageName, editId)}:commit?changesInReviewBehavior=ERROR_IF_IN_REVIEW`,
+      { method: "POST", body: "{}" },
+    );
+  }
+
+  private async cleanupOrThrow(packageName: string, editId: string, original: unknown): Promise<never> {
+    try {
+      await this.deleteEdit(packageName, editId);
+    } catch {
+      throw new PlayAdapterError(502, "play_edit_cleanup_failed", "Google Play edit cleanup failed");
+    }
+    throw original;
+  }
+
+  private async readback(request: PromotionRequest): Promise<void> {
+    const editId = await this.createEdit(request.packageName);
+    let track: TrackResource;
+    try {
+      track = await this.getTrack(request.packageName, editId, request.playTrack);
+    } catch (error) {
+      await this.cleanupOrThrow(request.packageName, editId, error);
+    }
+    await this.deleteEdit(request.packageName, editId);
+    const release = (track!.releases ?? []).find((candidate) =>
+      candidate.versionCodes?.some((value) => exactVersionCode(value) === request.versionCode));
+    const expectedStatus = request.rolloutPercent < 100 ? "inProgress" : "completed";
+    const fractionMatches = request.rolloutPercent === 100
+      ? release?.userFraction === undefined
+      : release?.userFraction === request.rolloutPercent / 100;
+    if (!release || release.status !== expectedStatus || !fractionMatches) {
+      throw new PlayAdapterError(502, "play_readback_mismatch", "Google Play track readback did not match the requested release");
+    }
+  }
+
+  async promote(request: PromotionRequest) {
+    if (request.expectedSize > this.maxAabSize) {
+      throw new PlayAdapterError(413, "aab_too_large", "AAB exceeds the configured maximum size");
+    }
+    const editId = await this.createEdit(request.packageName);
+    let commitAttempted = false;
+    try {
+      await this.uploadBundle(request, editId);
+      const current = await this.getTrack(request.packageName, editId, request.playTrack);
+      await this.updateTrack(request, editId, current);
+      commitAttempted = true;
+      await this.commitEdit(request.packageName, editId);
+    } catch (error) {
+      if (commitAttempted) throw error;
+      await this.cleanupOrThrow(request.packageName, editId, error);
+    }
+    await this.readback(request);
+    return {
+      edit_id: editId,
+      package_name: request.packageName,
+      version_code: request.versionCode,
+      track: request.handsTrack,
+      sha256: request.expectedSha256,
+      rollout_percent: request.rolloutPercent,
+    };
+  }
+}

--- a/play-adapter/src/index.ts
+++ b/play-adapter/src/index.ts
@@ -1,0 +1,160 @@
+import { createAccessToken, parseServiceAccount } from "./auth";
+import { PlayAdapterError, safeErrorResponse } from "./errors";
+import { GooglePlayClient } from "./google_play";
+import type { HandsTrack, PlayAdapterEnv, PromotionRequest } from "./types";
+
+const PACKAGE_NAME = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const OPERATION_ID = /^[A-Za-z0-9._:-]{1,128}$/;
+const TRACK_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function positiveInteger(value: string | null): number | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function handsTrack(value: string): HandsTrack | null {
+  return value === "internal" || value === "closed" || value === "production" ? value : null;
+}
+
+function configuredPackages(env: PlayAdapterEnv): Set<string> {
+  const packages = (env.ALLOWED_PACKAGE_NAMES ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (packages.length === 0 || packages.some((value) => !PACKAGE_NAME.test(value))) {
+    throw new PlayAdapterError(503, "package_allowlist_invalid", "Google Play package allowlist is not configured");
+  }
+  return new Set(packages);
+}
+
+function maxAabSize(env: PlayAdapterEnv): number {
+  const value = positiveInteger(env.MAX_AAB_SIZE_BYTES ?? null);
+  if (value === null) {
+    throw new PlayAdapterError(503, "aab_limit_invalid", "Google Play AAB size limit is not configured");
+  }
+  return value;
+}
+
+function playTrack(env: PlayAdapterEnv, track: HandsTrack): string {
+  if (track === "internal") return "qa";
+  if (track === "production") return "production";
+  const value = env.GOOGLE_PLAY_CLOSED_TRACK_NAME?.trim() ?? "";
+  if (!TRACK_NAME.test(value) || value === "qa" || value === "production") {
+    throw new PlayAdapterError(503, "closed_track_invalid", "Google Play closed-testing track is not configured");
+  }
+  return value;
+}
+
+function route(request: Request): { packageName: string; track?: HandsTrack; operation: "track" | "promote" } | null {
+  const parts = new URL(request.url).pathname.split("/").filter(Boolean);
+  if (parts.length === 5 && parts[0] === "v1" && parts[1] === "apps" && parts[3] === "tracks") {
+    const track = handsTrack(parts[4] ?? "");
+    if (!track) return null;
+    try {
+      return { packageName: decodeURIComponent(parts[2] ?? ""), track, operation: "track" };
+    } catch {
+      return null;
+    }
+  }
+  if (parts.length === 4 && parts[0] === "v1" && parts[1] === "apps" && parts[3] === "edits") {
+    try {
+      return { packageName: decodeURIComponent(parts[2] ?? ""), operation: "promote" };
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function promotionRequest(
+  request: Request,
+  packageName: string,
+  env: PlayAdapterEnv,
+): PromotionRequest {
+  const track = handsTrack(request.headers.get("x-hands-track") ?? "");
+  const versionCode = positiveInteger(request.headers.get("x-hands-version-code"));
+  const expectedSize = positiveInteger(request.headers.get("x-hands-size-bytes"));
+  const expectedSha256 = request.headers.get("x-hands-sha256")?.toLowerCase() ?? "";
+  const rolloutPercent = positiveInteger(request.headers.get("x-hands-rollout-percent"));
+  const operationId = request.headers.get("x-hands-operation-id") ?? "";
+  if (
+    !track
+    || versionCode === null
+    || expectedSize === null
+    || !SHA256.test(expectedSha256)
+    || rolloutPercent === null
+    || rolloutPercent > 100
+    || !OPERATION_ID.test(operationId)
+    || !request.body
+  ) {
+    throw new PlayAdapterError(400, "promotion_request_invalid", "Hands promotion request is invalid");
+  }
+  if (track !== "production" && rolloutPercent !== 100) {
+    throw new PlayAdapterError(400, "rollout_track_invalid", "Partial rollout is supported only on the production track");
+  }
+  return {
+    packageName,
+    handsTrack: track,
+    playTrack: playTrack(env, track),
+    versionCode,
+    expectedSha256,
+    expectedSize,
+    rolloutPercent,
+    operationId,
+    body: request.body,
+  };
+}
+
+export interface AdapterOptions {
+  fetchImpl?: typeof fetch;
+  nowSeconds?: () => number;
+}
+
+export function createPlayAdapter(options: AdapterOptions = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  return {
+    async fetch(request: Request, env: PlayAdapterEnv): Promise<Response> {
+      let operationId: string | null = request.headers.get("x-hands-operation-id");
+      try {
+        const matched = route(request);
+        if (!matched || (matched.operation === "track" ? request.method !== "GET" : request.method !== "POST")) {
+          return new Response("Not found", { status: 404 });
+        }
+        if (!PACKAGE_NAME.test(matched.packageName) || !configuredPackages(env).has(matched.packageName)) {
+          throw new PlayAdapterError(403, "package_not_allowed", "Google Play package is not allowed");
+        }
+        let promotion: PromotionRequest | null = null;
+        if (matched.operation === "promote") {
+          promotion = promotionRequest(request, matched.packageName, env);
+          operationId = promotion.operationId;
+          const contentLength = request.headers.get("content-length");
+          if (contentLength !== null && positiveInteger(contentLength) !== promotion.expectedSize) {
+            throw new PlayAdapterError(409, "aab_size_mismatch", "AAB content length did not match Hands");
+          }
+          if (promotion.expectedSize > maxAabSize(env)) {
+            throw new PlayAdapterError(413, "aab_too_large", "AAB exceeds the configured maximum size");
+          }
+        }
+        const credential = parseServiceAccount(env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+        const accessToken = await createAccessToken(
+          credential,
+          fetchImpl,
+          options.nowSeconds?.() ?? Math.floor(Date.now() / 1000),
+        );
+        const client = new GooglePlayClient(accessToken, fetchImpl, maxAabSize(env));
+        if (matched.operation === "track") {
+          const mappedTrack = playTrack(env, matched.track!);
+          const maximum = await client.readTrackMaximum(matched.packageName, mappedTrack);
+          return Response.json({ max_version_code: maximum });
+        }
+        return Response.json(await client.promote(promotion!));
+      } catch (error) {
+        return safeErrorResponse(error, OPERATION_ID.test(operationId ?? "") ? operationId : null);
+      }
+    },
+  };
+}
+
+export default createPlayAdapter();

--- a/play-adapter/src/types.ts
+++ b/play-adapter/src/types.ts
@@ -1,0 +1,45 @@
+export type HandsTrack = "internal" | "closed" | "production";
+
+export interface PlayAdapterEnv {
+  /** Google service-account JSON; set only with `wrangler secret put`. */
+  GOOGLE_PLAY_SERVICE_ACCOUNT_JSON?: string;
+  /** Comma-separated package names accepted from the Hands service binding. */
+  ALLOWED_PACKAGE_NAMES?: string;
+  /** Existing Play Console closed-testing track identifier. */
+  GOOGLE_PLAY_CLOSED_TRACK_NAME?: string;
+  /** Maximum streamed AAB size accepted from Hands. */
+  MAX_AAB_SIZE_BYTES?: string;
+}
+
+export interface ServiceAccountCredential {
+  client_email: string;
+  private_key: string;
+  private_key_id?: string;
+}
+
+export interface TrackRelease {
+  name?: string;
+  versionCodes?: string[];
+  releaseNotes?: Array<{ language: string; text: string }>;
+  status?: "statusUnspecified" | "draft" | "inProgress" | "halted" | "completed";
+  userFraction?: number;
+  countryTargeting?: { countries?: string[]; includeRestOfWorld?: boolean };
+  inAppUpdatePriority?: number;
+}
+
+export interface TrackResource {
+  track?: string;
+  releases?: TrackRelease[];
+}
+
+export interface PromotionRequest {
+  packageName: string;
+  handsTrack: HandsTrack;
+  playTrack: string;
+  versionCode: number;
+  expectedSha256: string;
+  expectedSize: number;
+  rolloutPercent: number;
+  operationId: string;
+  body: ReadableStream<Uint8Array>;
+}

--- a/play-adapter/test/adapter.test.ts
+++ b/play-adapter/test/adapter.test.ts
@@ -1,0 +1,283 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import {
+  decodeProtectedHeader,
+  exportPKCS8,
+  generateKeyPair,
+  jwtVerify,
+} from "jose";
+import type { KeyLike } from "jose";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createPlayAdapter } from "../src/index";
+import type { PlayAdapterEnv, TrackResource } from "../src/types";
+
+const PACKAGE = "build.raft.app";
+const NOW = 1_780_000_000;
+const bytes = new TextEncoder().encode("exact-aab-bytes");
+const digest = bytesToHex(sha256(bytes));
+
+let credential = "";
+let publicKey: CryptoKey | KeyLike;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair("RS256", { extractable: true });
+  publicKey = pair.publicKey;
+  credential = JSON.stringify({
+    type: "service_account",
+    client_email: "hands-play@example.iam.gserviceaccount.com",
+    private_key: await exportPKCS8(pair.privateKey),
+    private_key_id: "key-1",
+  });
+});
+
+function environment(overrides: Partial<PlayAdapterEnv> = {}): PlayAdapterEnv {
+  return {
+    GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: credential,
+    ALLOWED_PACKAGE_NAMES: PACKAGE,
+    GOOGLE_PLAY_CLOSED_TRACK_NAME: "closed-alpha",
+    MAX_AAB_SIZE_BYTES: "209715200",
+    ...overrides,
+  };
+}
+
+function promotionRequest(overrides: Record<string, string> = {}, body: BodyInit = bytes): Request {
+  return new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/edits`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/octet-stream",
+      "x-hands-track": "internal",
+      "x-hands-version-code": "42",
+      "x-hands-sha256": digest,
+      "x-hands-size-bytes": String(bytes.byteLength),
+      "x-hands-rollout-percent": "100",
+      "x-hands-operation-id": "operation-1",
+      ...overrides,
+    },
+    body,
+  });
+}
+
+interface GoogleFixtureOptions {
+  uploadSha?: string;
+  trackMaximum?: number;
+  tokenStatus?: number;
+  commitThrows?: boolean;
+}
+
+function googleFixture(options: GoogleFixtureOptions = {}) {
+  let nextEdit = 1;
+  let track: TrackResource = {
+    track: "qa",
+    releases: [{ name: "existing", versionCodes: [String(options.trackMaximum ?? 41)], status: "completed" }],
+  };
+  const requests: Array<{ url: string; method: string; body: unknown }> = [];
+  let assertion = "";
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url = String(input);
+    const method = init.method ?? "GET";
+    if (url === "https://oauth2.googleapis.com/token") {
+      assertion = new URLSearchParams(String(init.body)).get("assertion") ?? "";
+      return Response.json(
+        options.tokenStatus && options.tokenStatus !== 200
+          ? { error: credential }
+          : { access_token: "access-token", expires_in: 3600 },
+        { status: options.tokenStatus ?? 200 },
+      );
+    }
+    let body: unknown = null;
+    if (typeof init.body === "string") body = JSON.parse(init.body);
+    requests.push({ url, method, body });
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer access-token");
+    if (method === "POST" && /\/applications\/[^/]+\/edits$/.test(url)) {
+      return Response.json({ id: `edit-${nextEdit++}` });
+    }
+    if (method === "DELETE") return new Response(null, { status: 204 });
+    if (method === "GET" && url.includes("/tracks/")) return Response.json(track);
+    if (url.includes("/bundles?uploadType=media")) {
+      const uploaded = new Uint8Array(await new Response(init.body).arrayBuffer());
+      return Response.json({
+        versionCode: 42,
+        sha256: options.uploadSha ?? bytesToHex(sha256(uploaded)),
+      });
+    }
+    if (method === "PUT" && url.includes("/tracks/")) {
+      track = body as TrackResource;
+      return Response.json(track);
+    }
+    if (method === "POST" && url.includes(":commit?")) {
+      if (options.commitThrows) throw new Error("ambiguous network failure");
+      return Response.json({ id: "edit-1" });
+    }
+    return Response.json({ error: "unexpected request" }, { status: 500 });
+  });
+  return {
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    requests,
+    assertion: () => assertion,
+    track: () => track,
+  };
+}
+
+describe("Google Play adapter", () => {
+  it("uses a one-hour RS256 service-account assertion without exposing credentials", async () => {
+    const fixture = googleFixture();
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const response = await adapter.fetch(
+      new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/tracks/internal`),
+      environment(),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ max_version_code: 41 });
+    expect(decodeProtectedHeader(fixture.assertion())).toMatchObject({ alg: "RS256", kid: "key-1" });
+    const verified = await jwtVerify(fixture.assertion(), publicKey, {
+      algorithms: ["RS256"],
+      issuer: "hands-play@example.iam.gserviceaccount.com",
+      audience: "https://oauth2.googleapis.com/token",
+      currentDate: new Date(NOW * 1000),
+    });
+    expect(verified.payload).toMatchObject({
+      iat: NOW,
+      exp: NOW + 3600,
+      scope: "https://www.googleapis.com/auth/androidpublisher",
+    });
+    expect(fixture.requests.map((request) => request.method)).toEqual(["POST", "GET", "DELETE"]);
+    expect(fixture.requests[1]!.url).toContain("/tracks/qa");
+  });
+
+  it("maps the contract closed track to the configured Play Console track", async () => {
+    const fixture = googleFixture();
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const response = await adapter.fetch(
+      new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/tracks/closed`),
+      environment(),
+    );
+    expect(response.status).toBe(200);
+    expect(fixture.requests[1]!.url).toContain("/tracks/closed-alpha");
+  });
+
+  it("streams once, preserves existing releases, commits once, and reads back exact identity", async () => {
+    const fixture = googleFixture();
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const response = await adapter.fetch(promotionRequest(), environment());
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      edit_id: "edit-1",
+      package_name: PACKAGE,
+      version_code: 42,
+      track: "internal",
+      sha256: digest,
+      rollout_percent: 100,
+    });
+    expect(fixture.track().releases).toEqual([
+      { name: "existing", versionCodes: ["41"], status: "completed" },
+      { versionCodes: ["42"], status: "completed" },
+    ]);
+    const commits = fixture.requests.filter((request) => request.url.includes(":commit?"));
+    expect(commits).toHaveLength(1);
+    expect(commits[0]!.url).toContain("changesInReviewBehavior=ERROR_IF_IN_REVIEW");
+    expect(fixture.requests.filter((request) => request.url.includes("/bundles?uploadType=media"))).toHaveLength(1);
+  });
+
+  it("deletes the uncommitted edit when Google reports a different AAB hash", async () => {
+    const fixture = googleFixture({ uploadSha: "f".repeat(64) });
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const response = await adapter.fetch(promotionRequest(), environment());
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: { code: "play_bundle_mismatch" } });
+    expect(fixture.requests.filter((request) => request.method === "PUT")).toHaveLength(0);
+    expect(fixture.requests.filter((request) => request.url.includes(":commit?"))).toHaveLength(0);
+    expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
+  });
+
+  it("rechecks the live track inside the edit and stops a version race", async () => {
+    const fixture = googleFixture({ trackMaximum: 42 });
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const response = await adapter.fetch(promotionRequest(), environment());
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: { code: "play_version_conflict" } });
+    expect(fixture.requests.filter((request) => request.method === "PUT")).toHaveLength(0);
+    expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
+  });
+
+  it("does not retry or delete an edit after an ambiguous commit attempt", async () => {
+    const fixture = googleFixture({ commitThrows: true });
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const response = await adapter.fetch(promotionRequest(), environment());
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ error: { code: "play_api_unavailable" } });
+    expect(fixture.requests.filter((request) => request.url.includes(":commit?"))).toHaveLength(1);
+    expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(0);
+  });
+
+  it("models a partial production rollout and rejects partial test-track rollout before OAuth", async () => {
+    const internalFixture = googleFixture();
+    const adapter = createPlayAdapter({ fetchImpl: internalFixture.fetchImpl, nowSeconds: () => NOW });
+    const rejected = await adapter.fetch(
+      promotionRequest({ "x-hands-rollout-percent": "25" }),
+      environment(),
+    );
+    expect(rejected.status).toBe(400);
+    expect(internalFixture.fetchImpl).not.toHaveBeenCalled();
+
+    const productionFixture = googleFixture();
+    const production = createPlayAdapter({ fetchImpl: productionFixture.fetchImpl, nowSeconds: () => NOW });
+    const accepted = await production.fetch(
+      promotionRequest({ "x-hands-track": "production", "x-hands-rollout-percent": "25" }),
+      environment(),
+    );
+    expect(accepted.status).toBe(200);
+    expect(productionFixture.track().releases?.at(-1)).toEqual({
+      versionCodes: ["42"],
+      status: "inProgress",
+      userFraction: 0.25,
+    });
+  });
+
+  it("rejects disallowed packages and oversized AABs before credential use", async () => {
+    const fixture = googleFixture();
+    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const disallowed = await adapter.fetch(
+      new Request("https://play-adapter.internal/v1/apps/other.example.app/tracks/internal"),
+      environment(),
+    );
+    expect(disallowed.status).toBe(403);
+    const oversized = await adapter.fetch(
+      promotionRequest({ "x-hands-size-bytes": "16" }),
+      environment({ MAX_AAB_SIZE_BYTES: "15" }),
+    );
+    expect(oversized.status).toBe(413);
+    expect(fixture.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("redacts provider response bodies and credentials from errors and logs", async () => {
+    const fixture = googleFixture({ tokenStatus: 401 });
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+      const response = await adapter.fetch(
+        new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/tracks/internal`),
+        environment(),
+      );
+      const body = JSON.stringify(await response.json());
+      expect(response.status).toBe(502);
+      expect(body).not.toContain("PRIVATE KEY");
+      expect(body).not.toContain("hands-play@example");
+      expect(log.mock.calls.flat().join(" ")).not.toContain("PRIVATE KEY");
+      expect(log.mock.calls.flat().join(" ")).not.toContain("hands-play@example");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("has no public route or preview URL in checked-in Wrangler config", () => {
+    const config = readFileSync(
+      fileURLToPath(new URL("../wrangler.jsonc", import.meta.url)),
+      "utf8",
+    );
+    expect(config).toMatch(/"workers_dev": false/);
+    expect(config).toMatch(/"preview_urls": false/);
+    expect(config).not.toMatch(/"routes"\s*:/);
+  });
+});

--- a/play-adapter/test/production_config.test.ts
+++ b/play-adapter/test/production_config.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "vitest";
+
+const adapterDir = resolve(import.meta.dirname, "..");
+const repositoryDir = resolve(adapterDir, "..");
+const renderScript = resolve(adapterDir, "scripts/render-production-config.mjs");
+const BASE_ENV = {
+  HANDS_PLAY_ADAPTER_WORKER_NAME: "hands-google-play-adapter",
+  HANDS_PLAY_ALLOWED_PACKAGE_NAMES: "build.raft.app",
+  HANDS_PLAY_CLOSED_TRACK_NAME: "closed-alpha",
+  HANDS_PLAY_MAX_AAB_SIZE_BYTES: "209715200",
+};
+
+function render(extraEnv: Record<string, string> = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "hands-play-config-"));
+  const output = join(directory, "wrangler.json");
+  const result = spawnSync(process.execPath, [renderScript, "--output", output], {
+    cwd: adapterDir,
+    encoding: "utf8",
+    env: { ...process.env, ...BASE_ENV, ...extraEnv },
+  });
+  return { result, output, cleanup: () => rmSync(directory, { recursive: true, force: true }) };
+}
+
+test("production config keeps the adapter private and renders the exact bounded surface", () => {
+  const fixture = render();
+  try {
+    assert.equal(fixture.result.status, 0, fixture.result.stderr);
+    const config = JSON.parse(readFileSync(fixture.output, "utf8"));
+    assert.equal(config.name, BASE_ENV.HANDS_PLAY_ADAPTER_WORKER_NAME);
+    assert.equal(config.workers_dev, false);
+    assert.equal(config.preview_urls, false);
+    assert.equal("routes" in config, false);
+    assert.deepEqual(config.vars, {
+      ALLOWED_PACKAGE_NAMES: "build.raft.app",
+      GOOGLE_PLAY_CLOSED_TRACK_NAME: "closed-alpha",
+      MAX_AAB_SIZE_BYTES: "209715200",
+    });
+    assert.equal(JSON.stringify(config).includes("SERVICE_ACCOUNT"), false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("production config rejects malformed service, package, track, and size inputs", () => {
+  const cases = [
+    [{ HANDS_PLAY_ADAPTER_WORKER_NAME: "https://bad.example" }, /valid Cloudflare Worker/],
+    [{ HANDS_PLAY_ALLOWED_PACKAGE_NAMES: "../bad" }, /package-name allowlist/],
+    [{ HANDS_PLAY_CLOSED_TRACK_NAME: "production" }, /custom closed-testing track/],
+    [{ HANDS_PLAY_MAX_AAB_SIZE_BYTES: "0" }, /positive safe integer/],
+  ] as const;
+  for (const [environment, pattern] of cases) {
+    const fixture = render(environment);
+    try {
+      assert.notEqual(fixture.result.status, 0);
+      assert.match(fixture.result.stderr, pattern);
+    } finally {
+      fixture.cleanup();
+    }
+  }
+});
+
+test("adapter deployment is manual, environment-gated, and injects the credential only as a deploy secret", () => {
+  const workflow = readFileSync(
+    resolve(repositoryDir, ".github/workflows/deploy-hands-play-adapter.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /^  workflow_dispatch:$/m);
+  assert.doesNotMatch(workflow, /^  (push|pull_request):$/m);
+  assert.match(workflow, /^    environment: hands-play-production$/m);
+  assert.match(workflow, /^    if: github\.ref == 'refs\/heads\/main'$/m);
+  assert.doesNotMatch(workflow, /run_checks/);
+  assert.match(workflow, /--secrets-file "\$\{secret_file\}"/);
+  assert.doesNotMatch(workflow, /wrangler secret put/);
+});

--- a/play-adapter/tsconfig.json
+++ b/play-adapter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/play-adapter/vitest.config.ts
+++ b/play-adapter/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/play-adapter/wrangler.jsonc
+++ b/play-adapter/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "hands-google-play-adapter",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-09-03",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": false,
+  "preview_urls": false,
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+      "head_sampling_rate": 1
+    }
+  },
+  "vars": {
+    "ALLOWED_PACKAGE_NAMES": "build.raft.app",
+    "GOOGLE_PLAY_CLOSED_TRACK_NAME": "closed",
+    "MAX_AAB_SIZE_BYTES": "209715200"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,28 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.20.0)(jsdom@26.1.0)(lightningcss@1.32.0)
 
+  play-adapter:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+    devDependencies:
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
+      wrangler:
+        specifier: ^4.88.0
+        version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
+
   worker:
     dependencies:
       '@cloudflare/containers':
@@ -1935,6 +1957,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "worker"
+  - "play-adapter"
   - "container"
   - "admin"
   - "migrations"

--- a/worker/scripts/render-production-config.mjs
+++ b/worker/scripts/render-production-config.mjs
@@ -60,6 +60,15 @@ function optionalKeyVersion(name) {
   return value;
 }
 
+function optionalWorkerName(name) {
+  const value = process.env[name]?.trim();
+  if (!value) return null;
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(value)) {
+    throw new Error(`${name} must be a valid Cloudflare Worker service name`);
+  }
+  return value;
+}
+
 const errors = [];
 const config = parse(readFileSync(sourcePath, "utf8"), errors, {
   allowTrailingComma: true,
@@ -76,6 +85,7 @@ const reporterSessionEnabled = booleanString("HANDS_FEEDBACK_REPORTER_SESSION_EN
 const reporterSessionActiveKeyVersion = optionalKeyVersion(
   "HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION",
 );
+const playReleaseServiceName = optionalWorkerName("HANDS_PLAY_RELEASE_SERVICE_NAME");
 if (reporterSessionEnabled === "true" && !reporterSessionActiveKeyVersion) {
   throw new Error(
     "HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION is required when reporter sessions are enabled",
@@ -120,6 +130,15 @@ if (reporterSessionActiveKeyVersion) {
   config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION = reporterSessionActiveKeyVersion;
 } else {
   delete config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION;
+}
+if (playReleaseServiceName) {
+  config.services = [
+    ...(config.services ?? []).filter((binding) => binding.binding !== "PLAY_RELEASE_SERVICE"),
+      { binding: "PLAY_RELEASE_SERVICE", service: playReleaseServiceName },
+  ];
+} else if (Array.isArray(config.services)) {
+  config.services = config.services.filter((binding) => binding.binding !== "PLAY_RELEASE_SERVICE");
+  if (config.services.length === 0) delete config.services;
 }
 
 // Build stamp for the container image, so a rollout can be verified by reading the

--- a/worker/src/routes/play_distribution.ts
+++ b/worker/src/routes/play_distribution.ts
@@ -78,8 +78,11 @@ export function normalizePlayPromotionInput(input: PlayPromotionInput): PlayProm
   const note = typeof input.approval?.note === "string" ? input.approval.note.trim() : "";
   if (!note) throw new Error("approval.note required");
   const rollout = input.rollout_percent;
-  if (rollout !== undefined && (!Number.isInteger(rollout) || rollout < 0 || rollout > 100)) {
-    throw new Error("rollout_percent must be an integer from 0 to 100");
+  if (rollout !== undefined && (!Number.isInteger(rollout) || rollout < 1 || rollout > 100)) {
+    throw new Error("rollout_percent must be an integer from 1 to 100");
+  }
+  if (input.track !== "production" && rollout !== undefined && rollout !== 100) {
+    throw new Error("partial rollout is supported only for production");
   }
   return { track: input.track, expected_revision: expectedRevision, approval: { note }, ...(rollout === undefined ? {} : { rollout_percent: rollout }) };
 }

--- a/worker/test/google_play_distribution.test.ts
+++ b/worker/test/google_play_distribution.test.ts
@@ -97,6 +97,24 @@ describe("Play promotion gates", () => {
       expected_revision: 3,
       approval: { note: " " },
     })).toThrow(/approval.note/);
+    expect(() => normalizePlayPromotionInput({
+      track: "internal",
+      rollout_percent: 25,
+      expected_revision: 3,
+      approval: { note: "ship" },
+    })).toThrow(/partial rollout.*production/);
+    expect(() => normalizePlayPromotionInput({
+      track: "production",
+      rollout_percent: 0,
+      expected_revision: 3,
+      approval: { note: "ship" },
+    })).toThrow(/1 to 100/);
+    expect(normalizePlayPromotionInput({
+      track: "production",
+      rollout_percent: 25,
+      expected_revision: 3,
+      approval: { note: "ship" },
+    })).toMatchObject({ track: "production", rollout_percent: 25 });
   });
 
   it("accepts readback only when package, version, track, and SHA all match", () => {

--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -31,6 +31,7 @@ function render(extraEnv: Record<string, string> = {}) {
   for (const key of Object.keys(inheritedEnv)) {
     if (key.startsWith("HANDS_FEEDBACK_REPORTER_SESSION_")) delete inheritedEnv[key];
   }
+  delete inheritedEnv.HANDS_PLAY_RELEASE_SERVICE_NAME;
   const result = spawnSync(process.execPath, [renderScript, "--output", output], {
     cwd: workerDir,
     encoding: "utf8",
@@ -81,6 +82,36 @@ test("production config requires a valid Flagship app id", () => {
   try {
     assert.notEqual(invalid.result.status, 0);
     assert.match(invalid.result.stderr, /HANDS_FLAGSHIP_APP_ID must be a UUID/);
+  } finally {
+    invalid.cleanup();
+  }
+});
+
+test("production config binds the Play adapter only when its exact service name is configured", () => {
+  const absent = render();
+  try {
+    assert.equal(absent.result.status, 0, absent.result.stderr);
+    const config = JSON.parse(readFileSync(absent.output, "utf8"));
+    assert.equal("services" in config, false);
+  } finally {
+    absent.cleanup();
+  }
+
+  const configured = render({ HANDS_PLAY_RELEASE_SERVICE_NAME: "hands-google-play-adapter" });
+  try {
+    assert.equal(configured.result.status, 0, configured.result.stderr);
+    const config = JSON.parse(readFileSync(configured.output, "utf8"));
+    assert.deepEqual(config.services, [
+      { binding: "PLAY_RELEASE_SERVICE", service: "hands-google-play-adapter" },
+    ]);
+  } finally {
+    configured.cleanup();
+  }
+
+  const invalid = render({ HANDS_PLAY_RELEASE_SERVICE_NAME: "https://not-a-worker.example/path" });
+  try {
+    assert.notEqual(invalid.result.status, 0);
+    assert.match(invalid.result.stderr, /must be a valid Cloudflare Worker service name/);
   } finally {
     invalid.cleanup();
   }


### PR DESCRIPTION
Raft author: @XX. Shared GitHub carrier: stdrc.

## What this adds

- a private Cloudflare Worker adapter for Google Play Android Publisher edits, reachable only through a Hands service binding
- service-account JWT/OAuth contained in the adapter secret store; Hands and Mobile never receive the Google credential
- AAB streaming with local and Google SHA-256/versionCode readback, live track race protection, one commit attempt, and post-commit readback
- explicit `internal → qa`, configurable closed-test track, and production rollout semantics
- production render/deploy packages for the adapter and the Hands `PLAY_RELEASE_SERVICE` binding

## Safety properties

- package allowlist and maximum AAB size checked before OAuth
- partial rollout allowed only on production
- pre-commit failures clean up the edit; an ambiguous commit is neither retried nor deleted
- commit uses `changesInReviewBehavior=ERROR_IF_IN_REVIEW`
- deployment remains manual, main-only, environment-gated, private, and uses an ephemeral `--secrets-file`

## Verification

- adapter: 13 tests
- Hands Worker: 545 tests
- focused Hands Play/config: 27 tests
- adapter TypeScript build and Wrangler strict dry run
- CLI/admin builds and workflow lint
- reverse mutations: removing the commit guard and breaking the service-binding name each made the intended tooth fail; both were restored and rerun green

This PR is source and deployment-package preparation only. It does not deploy production, configure credentials, upload an AAB, write Google Play state, or submit a release for review.
