### PR TITLE
feat(play): add app-scoped self-service Google Play bindings

### DIFF
--- a/.github/workflows/deploy-hands-play-adapter.yml
+++ b/.github/workflows/deploy-hands-play-adapter.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy:
     # This environment must keep a main-only deployment policy. The workflow
-    # writes a production secret and publishes a Worker; a job-level branch
+    # publishes a private Worker; a job-level branch
     # condition inside this file is not an equivalent external control.
     environment: hands-play-production
     if: github.ref == 'refs/heads/main'
@@ -21,10 +21,7 @@ jobs:
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
-      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
       HANDS_PLAY_ADAPTER_WORKER_NAME: ${{ vars.HANDS_PLAY_ADAPTER_WORKER_NAME }}
-      HANDS_PLAY_ALLOWED_PACKAGE_NAMES: ${{ vars.HANDS_PLAY_ALLOWED_PACKAGE_NAMES }}
-      HANDS_PLAY_CLOSED_TRACK_NAME: ${{ vars.HANDS_PLAY_CLOSED_TRACK_NAME }}
       HANDS_PLAY_MAX_AAB_SIZE_BYTES: ${{ vars.HANDS_PLAY_MAX_AAB_SIZE_BYTES }}
     steps:
       - uses: actions/checkout@v6
@@ -51,7 +48,7 @@ jobs:
           pnpm --filter @botiverse/hands-play-adapter build
           pnpm --filter @botiverse/hands-play-adapter exec wrangler deploy --dry-run --config wrangler.generated.jsonc
 
-      - name: Validate production credentials
+      - name: Validate deployment credentials
         shell: bash
         run: |
           set -euo pipefail
@@ -59,20 +56,10 @@ jobs:
             echo "Missing Cloudflare deployment credential." >&2
             exit 1
           fi
-          if [[ -z "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]]; then
-            echo "Missing Google Play service-account credential." >&2
-            exit 1
-          fi
 
-      - name: Deploy private adapter with its service-account secret
+      - name: Deploy private stateless adapter
         working-directory: play-adapter
         shell: bash
         run: |
           set -euo pipefail
-          secret_file="$(mktemp)"
-          trap 'rm -f "${secret_file}"' EXIT
-          chmod 600 "${secret_file}"
-          jq -n --arg value "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON}" \
-            '{GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: $value}' > "${secret_file}"
-          pnpm exec wrangler deploy --strict --config wrangler.generated.jsonc \
-            --secrets-file "${secret_file}"
+          pnpm exec wrangler deploy --strict --config wrangler.generated.jsonc

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -68,9 +68,10 @@ jobs:
       HANDS_ADMIN_ALLOWED_SERVER_IDS: ${{ vars.HANDS_ADMIN_ALLOWED_SERVER_IDS }}
       HANDS_FLAGSHIP_APP_ID: ${{ vars.HANDS_FLAGSHIP_APP_ID }}
       # Optional until the independently deployed adapter is ready. When set,
-      # the renderer adds only the service binding; Google credentials remain
-      # in the adapter's own secret store and never enter this Worker.
+      # the renderer adds the private service binding and requires an active
+      # key version for app-scoped credential encryption in this Worker.
       HANDS_PLAY_RELEASE_SERVICE_NAME: ${{ vars.HANDS_PLAY_RELEASE_SERVICE_NAME }}
+      HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION: ${{ vars.HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION }}
     steps:
       - uses: actions/checkout@v6
 
@@ -762,6 +763,7 @@ jobs:
           RAFT_CLIENT_SECRET: ${{ secrets.HANDS_RAFT_CLIENT_SECRET }}
           ASC_CRED_ENC_KEY: ${{ secrets.HANDS_ASC_CRED_ENC_KEY }}
           AGC_CRED_ENC_KEY: ${{ secrets.HANDS_AGC_CRED_ENC_KEY }}
+          PLAY_CRED_ENC_KEYS: ${{ secrets.HANDS_PLAY_CRED_ENC_KEYS }}
           FEEDBACK_AUDIT_HMAC_KEY: ${{ secrets.HANDS_FEEDBACK_AUDIT_HMAC_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_BOTIVERSE_ACCOUNT_ID }}
           # Optional: R2 S3-API credentials enable direct-to-R2 presigned downloads
@@ -788,6 +790,10 @@ jobs:
             echo "Missing GitHub secret HANDS_AGC_CRED_ENC_KEY." >&2
             exit 1
           fi
+          if [[ -n "${HANDS_PLAY_RELEASE_SERVICE_NAME:-}" && -z "${PLAY_CRED_ENC_KEYS:-}" ]]; then
+            echo "Missing GitHub secret HANDS_PLAY_CRED_ENC_KEYS while the Play adapter is configured." >&2
+            exit 1
+          fi
           if [[ -z "${FEEDBACK_AUDIT_HMAC_KEY:-}" ]]; then
             echo "Missing GitHub secret HANDS_FEEDBACK_AUDIT_HMAC_KEY." >&2
             exit 1
@@ -801,6 +807,9 @@ jobs:
           printf '%s' "${RAFT_CLIENT_SECRET}" | pnpm exec wrangler secret put RAFT_CLIENT_SECRET --config "${config}"
           printf '%s' "${ASC_CRED_ENC_KEY}" | pnpm exec wrangler secret put ASC_CRED_ENC_KEY --config "${config}"
           printf '%s' "${AGC_CRED_ENC_KEY}" | pnpm exec wrangler secret put AGC_CRED_ENC_KEY --config "${config}"
+          if [[ -n "${PLAY_CRED_ENC_KEYS:-}" ]]; then
+            printf '%s' "${PLAY_CRED_ENC_KEYS}" | pnpm exec wrangler secret put PLAY_CRED_ENC_KEYS --config "${config}"
+          fi
           printf '%s' "${FEEDBACK_AUDIT_HMAC_KEY}" | pnpm exec wrangler secret put FEEDBACK_AUDIT_HMAC_KEY --config "${config}"
           printf '%s' "${R2_ACCOUNT_ID}" | pnpm exec wrangler secret put R2_ACCOUNT_ID --config "${config}"
           # Optional R2 S3-API credentials (only put when configured).

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -871,6 +871,54 @@ export const verifyAgcCredentials = (appId: string) =>
     `/api/apps/${appId}/agc-credentials/verify`, { method: "POST", admin: true },
   );
 
+// ---------- Google Play app binding (Android) ----------
+
+export interface GooglePlayBindingMeta {
+  id: string;
+  app_id: string;
+  enabled: boolean;
+  package_name: string;
+  internal_track: string;
+  closed_track: string;
+  production_track: string;
+  service_account_email: string;
+  service_account_project_id: string | null;
+  private_key_id: string | null;
+  credential_fingerprint: string;
+  credential_key_version: string;
+  verification_state: "verified" | "stale";
+  verified_at: number | null;
+  updated_at: number;
+}
+
+export const getGooglePlayBinding = (appId: string) =>
+  request<{ google_play: GooglePlayBindingMeta | null }>(`/api/apps/${appId}/google-play-binding`, { admin: true });
+
+export const setGooglePlayBinding = (
+  appId: string,
+  input: {
+    service_account_json: string;
+    package_name: string;
+    tracks: { internal: string; closed: string; production: string };
+  },
+) => request<{ google_play: GooglePlayBindingMeta }>(`/api/apps/${appId}/google-play-binding`, {
+  method: "PUT",
+  admin: true,
+  body: JSON.stringify(input),
+});
+
+export const verifyGooglePlayBinding = (appId: string) =>
+  request<{ ok: boolean }>(`/api/apps/${appId}/google-play-binding/verify`, { method: "POST", admin: true });
+
+export const setGooglePlayBindingEnabled = (appId: string, enabled: boolean) =>
+  request<{ ok: boolean; enabled: boolean }>(`/api/apps/${appId}/google-play-binding/${enabled ? "enable" : "disable"}`, {
+    method: "POST",
+    admin: true,
+  });
+
+export const deleteGooglePlayBinding = (appId: string) =>
+  request<{ ok: boolean }>(`/api/apps/${appId}/google-play-binding`, { method: "DELETE", admin: true });
+
 export interface AgcSubmission {
   id: string;
   app_id: string;

--- a/admin/src/lib/googlePlayMessages.test.ts
+++ b/admin/src/lib/googlePlayMessages.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { GOOGLE_PLAY_MESSAGES, GOOGLE_PLAY_MESSAGE_KEYS, googlePlayMessage } from "./googlePlayMessages";
+
+describe("Google Play app binding messages", () => {
+  it("keeps English and Simplified Chinese keys complete", () => {
+    for (const locale of ["en", "zh-CN"] as const) {
+      expect(Object.keys(GOOGLE_PLAY_MESSAGES[locale]).sort()).toEqual([...GOOGLE_PLAY_MESSAGE_KEYS].sort());
+    }
+  });
+
+  it("selects Chinese aliases and falls back to English", () => {
+    expect(googlePlayMessage("enable", ["zh-Hans-CN"])).toBe("启用");
+    expect(googlePlayMessage("enable", ["fr-FR"])).toBe("Enable");
+  });
+});

--- a/admin/src/lib/googlePlayMessages.ts
+++ b/admin/src/lib/googlePlayMessages.ts
@@ -1,0 +1,52 @@
+export const GOOGLE_PLAY_MESSAGE_KEYS = [
+  "title", "description", "configured", "enabled", "disabled", "verified", "stale", "serviceAccount",
+  "packageName", "internalTrack", "closedTrack", "productionTrack", "credentialJson", "chooseFile",
+  "saveEnable", "replace", "cancel", "test", "testing", "enable", "disable", "unbind",
+  "saveSuccess", "verifySuccess", "enableSuccess", "disableSuccess", "unbindSuccess", "actionFailed",
+  "confirmDisable", "confirmUnbind", "noPublish", "formHelp", "invalidJson",
+] as const;
+
+export type GooglePlayMessageKey = typeof GOOGLE_PLAY_MESSAGE_KEYS[number];
+
+export const GOOGLE_PLAY_MESSAGES: Record<"en" | "zh-CN", Record<GooglePlayMessageKey, string>> = {
+  en: {
+    title: "Google Play",
+    description: "Bind this app to its own Google Play service account. Credentials are encrypted and never shown again.",
+    configured: "Configured", enabled: "Enabled", disabled: "Disabled", verified: "Verified", stale: "Needs verification",
+    serviceAccount: "Service account", packageName: "Android package name", internalTrack: "Internal track",
+    closedTrack: "Closed testing track", productionTrack: "Production track", credentialJson: "Service account JSON",
+    chooseFile: "Choose JSON file", saveEnable: "Validate, save & enable", replace: "Replace credential", cancel: "Cancel",
+    test: "Test connection", testing: "Testing…", enable: "Enable", disable: "Disable", unbind: "Unbind",
+    saveSuccess: "Google Play binding saved", verifySuccess: "Google Play connection verified",
+    enableSuccess: "Google Play enabled", disableSuccess: "Google Play disabled", unbindSuccess: "Google Play unbound",
+    actionFailed: "Google Play action failed", confirmDisable: "Disable Google Play promotion for this app?",
+    confirmUnbind: "Remove this app's encrypted Google Play credential and binding?",
+    noPublish: "Connection testing creates and deletes a temporary Play edit; it never publishes a release.",
+    formHelp: "Use a service account that can access this exact package and all three configured tracks.",
+    invalidJson: "Choose the complete service-account JSON file downloaded from Google Cloud.",
+  },
+  "zh-CN": {
+    title: "Google Play",
+    description: "将此应用绑定到它自己的 Google Play 服务账号。凭据会加密保存，保存后不会再次显示。",
+    configured: "已配置", enabled: "已启用", disabled: "已停用", verified: "已验证", stale: "需要重新验证",
+    serviceAccount: "服务账号", packageName: "Android 包名", internalTrack: "内部测试轨道",
+    closedTrack: "封闭测试轨道", productionTrack: "正式发布轨道", credentialJson: "服务账号 JSON",
+    chooseFile: "选择 JSON 文件", saveEnable: "验证、保存并启用", replace: "更换凭据", cancel: "取消",
+    test: "测试连接", testing: "测试中…", enable: "启用", disable: "停用", unbind: "解除绑定",
+    saveSuccess: "Google Play 绑定已保存", verifySuccess: "Google Play 连接验证成功",
+    enableSuccess: "Google Play 已启用", disableSuccess: "Google Play 已停用", unbindSuccess: "Google Play 已解除绑定",
+    actionFailed: "Google Play 操作失败", confirmDisable: "停用此应用的 Google Play 发布功能？",
+    confirmUnbind: "删除此应用加密保存的 Google Play 凭据并解除绑定？",
+    noPublish: "连接测试只会创建并删除一个临时 Play edit，不会发布任何版本。",
+    formHelp: "请使用能访问这个确切包名和下列三个轨道的服务账号。",
+    invalidJson: "请选择从 Google Cloud 下载的完整服务账号 JSON 文件。",
+  },
+};
+
+export function googlePlayMessage(
+  key: GooglePlayMessageKey,
+  languages: readonly string[] = typeof navigator === "undefined" ? ["en"] : navigator.languages,
+) {
+  const locale = languages.some((language) => language.toLowerCase().startsWith("zh")) ? "zh-CN" : "en";
+  return GOOGLE_PLAY_MESSAGES[locale][key] ?? GOOGLE_PLAY_MESSAGES.en[key];
+}

--- a/admin/src/pages/AppDetail.tsx
+++ b/admin/src/pages/AppDetail.tsx
@@ -57,6 +57,11 @@ import {
   setAgcCredentials,
   deleteAgcCredentials,
   verifyAgcCredentials,
+  deleteGooglePlayBinding,
+  getGooglePlayBinding,
+  setGooglePlayBinding,
+  setGooglePlayBindingEnabled,
+  verifyGooglePlayBinding,
   getAppStoreReview,
   addDeviceGroupMember,
   createDeviceGroup,
@@ -69,6 +74,7 @@ import {
 import { useToast } from "../components/Toast";
 import { Operations } from "./Operations";
 import { deviceGroupUpdatePayload } from "../lib/deviceGroupForm";
+import { googlePlayMessage as gp } from "../lib/googlePlayMessages";
 
 export function AppDetail({ appId }: { appId: string }) {
   const apps = useQuery({ queryKey: ["apps"], queryFn: listApps });
@@ -886,6 +892,153 @@ function AppGalleryConnectPanel({ appId }: { appId: string }) {
   );
 }
 
+export function GooglePlayPanel({ appId }: { appId: string }) {
+  const toast = useToast();
+  const qc = useQueryClient();
+  const query = useQuery({ queryKey: ["google-play-binding", appId], queryFn: () => getGooglePlayBinding(appId) });
+  const meta = query.data?.google_play ?? null;
+  const [editing, setEditing] = useState(false);
+  const [credentialJson, setCredentialJson] = useState("");
+  const [packageName, setPackageName] = useState("");
+  const [internalTrack, setInternalTrack] = useState("internal");
+  const [closedTrack, setClosedTrack] = useState("closed");
+  const [productionTrack, setProductionTrack] = useState("production");
+
+  useEffect(() => {
+    if (!meta || editing) return;
+    setPackageName(meta.package_name);
+    setInternalTrack(meta.internal_track);
+    setClosedTrack(meta.closed_track);
+    setProductionTrack(meta.production_track);
+  }, [meta, editing]);
+
+  const refresh = () => qc.invalidateQueries({ queryKey: ["google-play-binding", appId] });
+  const fail = (error: unknown) => toast.show({ kind: "error", title: gp("actionFailed"), description: (error as Error).message });
+  const save = useMutation({
+    mutationFn: () => setGooglePlayBinding(appId, {
+      service_account_json: credentialJson,
+      package_name: packageName.trim(),
+      tracks: { internal: internalTrack.trim(), closed: closedTrack.trim(), production: productionTrack.trim() },
+    }),
+    onSuccess: () => {
+      setCredentialJson("");
+      setEditing(false);
+      refresh();
+      toast.show({ kind: "success", title: gp("saveSuccess") });
+    },
+    onError: fail,
+  });
+  const verify = useMutation({
+    mutationFn: () => verifyGooglePlayBinding(appId),
+    onSuccess: () => { toast.show({ kind: "success", title: gp("verifySuccess") }); },
+    onError: fail,
+    onSettled: refresh,
+  });
+  const toggle = useMutation({
+    mutationFn: (enabled: boolean) => setGooglePlayBindingEnabled(appId, enabled),
+    onSuccess: (_, enabled) => {
+      toast.show({ kind: "success", title: gp(enabled ? "enableSuccess" : "disableSuccess") });
+    },
+    onError: fail,
+    onSettled: refresh,
+  });
+  const remove = useMutation({
+    mutationFn: () => deleteGooglePlayBinding(appId),
+    onSuccess: () => {
+      setEditing(false);
+      setCredentialJson("");
+      setPackageName("");
+      refresh();
+      toast.show({ kind: "success", title: gp("unbindSuccess") });
+    },
+    onError: fail,
+  });
+
+  let credentialLooksValid = false;
+  try {
+    const parsed = JSON.parse(credentialJson) as Record<string, unknown>;
+    credentialLooksValid = parsed.type === "service_account" && typeof parsed.client_email === "string" && typeof parsed.private_key === "string";
+  } catch {
+    credentialLooksValid = false;
+  }
+  const formValid = Boolean(
+    credentialLooksValid
+    && packageName.trim()
+    && internalTrack.trim()
+    && closedTrack.trim()
+    && productionTrack.trim(),
+  );
+  const showForm = editing || (!meta && !query.isLoading);
+
+  return (
+    <div className="border-t border-slate-100 pt-3" data-testid="google-play-binding-panel">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium">{gp("title")}</div>
+          <div className="text-xs text-slate-500">{gp("description")}</div>
+          {meta && <div className="mt-1 text-xs space-y-0.5">
+            <div>
+              <span className={meta.enabled ? "text-green-700 font-medium" : "text-slate-600 font-medium"}>
+                {gp(meta.enabled ? "enabled" : "disabled")}
+              </span>
+              {" · "}{gp(meta.verification_state === "verified" ? "verified" : "stale")}{" · "}<span className="font-mono">{meta.package_name}</span>
+            </div>
+            <div className="font-mono break-all">{gp("serviceAccount")}: {meta.service_account_email}</div>
+            <div className="font-mono">{meta.internal_track} · {meta.closed_track} · {meta.production_track}</div>
+          </div>}
+        </div>
+        {meta && !editing && <div className="flex flex-wrap gap-2">
+          <Button variant="outline" disabled={verify.isPending} onClick={() => verify.mutate()}>
+            {verify.isPending ? gp("testing") : gp("test")}
+          </Button>
+          <Button variant="outline" onClick={() => setEditing(true)}>{gp("replace")}</Button>
+          <Button
+            variant="outline"
+            disabled={toggle.isPending}
+            onClick={() => {
+              if (meta.enabled && !window.confirm(gp("confirmDisable"))) return;
+              toggle.mutate(!meta.enabled);
+            }}
+          >
+            {gp(meta.enabled ? "disable" : "enable")}
+          </Button>
+          <Button variant="danger" disabled={remove.isPending} onClick={() => {
+            if (window.confirm(gp("confirmUnbind"))) remove.mutate();
+          }}>{gp("unbind")}</Button>
+        </div>}
+      </div>
+      {showForm && <div className="mt-3 p-3 border border-slate-200 rounded-md space-y-3">
+        <p className="text-xs text-slate-600">{gp("formHelp")}</p>
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="text-xs text-slate-600">{gp("packageName")}
+            <Input className="mt-1 font-mono" value={packageName} onChange={(event) => setPackageName(event.target.value)} placeholder="com.example.app" />
+          </label>
+          <label className="text-xs text-slate-600">{gp("internalTrack")}
+            <Input className="mt-1 font-mono" value={internalTrack} onChange={(event) => setInternalTrack(event.target.value)} />
+          </label>
+          <label className="text-xs text-slate-600">{gp("closedTrack")}
+            <Input className="mt-1 font-mono" value={closedTrack} onChange={(event) => setClosedTrack(event.target.value)} />
+          </label>
+          <label className="text-xs text-slate-600">{gp("productionTrack")}
+            <Input className="mt-1 font-mono" value={productionTrack} onChange={(event) => setProductionTrack(event.target.value)} />
+          </label>
+        </div>
+        <label className="block text-xs font-medium">{gp("credentialJson")}</label>
+        <input type="file" accept=".json,application/json" aria-label={gp("chooseFile")} onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) file.text().then(setCredentialJson, fail);
+        }} />
+        {credentialJson && !credentialLooksValid && <p className="text-xs text-amber-700">{gp("invalidJson")}</p>}
+        <p className="text-xs text-slate-500">{gp("noPublish")}</p>
+        <div className="flex gap-2 justify-end">
+          {meta && <Button variant="outline" onClick={() => { setCredentialJson(""); setEditing(false); }}>{gp("cancel")}</Button>}
+          <Button variant="primary" disabled={!formValid || save.isPending} onClick={() => save.mutate()}>{gp("saveEnable")}</Button>
+        </div>
+      </div>}
+    </div>
+  );
+}
+
 // --- App Store review status (read-only) ---------------------------------
 
 type BadgeVariant = NonNullable<BadgeProps["variant"]>;
@@ -1323,6 +1476,7 @@ export function AppSettings({ appId }: { appId: string }) {
 
         {/* Delta/differential updates — Android apps only */}
         {app.platform === "android" && <DeltaUpdatesToggle appId={appId} app={app} />}
+        {app.platform === "android" && <GooglePlayPanel appId={appId} />}
 
         {/* Client key (feedback/crash reporting auth) */}
         <ClientKeyPanel appId={appId} />

--- a/admin/src/pages/GooglePlayPanel.dom.test.tsx
+++ b/admin/src/pages/GooglePlayPanel.dom.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  save: vi.fn(),
+  verify: vi.fn(),
+  toggle: vi.fn(),
+  remove: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("../components/Toast", () => ({
+  useToast: () => ({ show: mocks.toast }),
+}));
+
+vi.mock("../lib/api", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../lib/api")>(),
+  getGooglePlayBinding: mocks.get,
+  setGooglePlayBinding: mocks.save,
+  verifyGooglePlayBinding: mocks.verify,
+  setGooglePlayBindingEnabled: mocks.toggle,
+  deleteGooglePlayBinding: mocks.remove,
+}));
+
+import { GooglePlayPanel } from "./AppDetail";
+
+afterEach(cleanup);
+
+function renderPanel() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <GooglePlayPanel appId="app-a" />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.save.mockResolvedValue({ google_play: {} });
+  mocks.verify.mockResolvedValue({ ok: true });
+  mocks.toggle.mockResolvedValue({ ok: true });
+  mocks.remove.mockResolvedValue({ ok: true });
+});
+
+describe("GooglePlayPanel", () => {
+  it("shows app-scoped binding metadata and enables only through the explicit action", async () => {
+    mocks.get.mockResolvedValue({
+      google_play: {
+        enabled: false,
+        verification_state: "stale",
+        package_name: "build.raft.app",
+        service_account_email: "app@tenant.example",
+        internal_track: "qa",
+        closed_track: "closed",
+        production_track: "production",
+      },
+    });
+    renderPanel();
+
+    expect(await screen.findByText("build.raft.app")).toBeTruthy();
+    expect(screen.getByText("Disabled")).toBeTruthy();
+    expect(screen.getByTestId("google-play-binding-panel").textContent).toContain("Needs verification");
+    fireEvent.click(screen.getByRole("button", { name: "Enable" }));
+    await waitFor(() => expect(mocks.toggle).toHaveBeenCalledWith("app-a", true));
+  });
+
+  it("requires a complete service-account file and package before save", async () => {
+    mocks.get.mockResolvedValue({ google_play: null });
+    renderPanel();
+
+    const save = await screen.findByRole("button", { name: "Validate, save & enable" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    fireEvent.change(screen.getByLabelText("Android package name"), { target: { value: "build.raft.app" } });
+    const file = new File(["fixture"], "service-account.json", { type: "application/json" });
+    Object.defineProperty(file, "text", {
+      value: async () => JSON.stringify({
+        type: "service_account",
+        client_email: "app@tenant.example",
+        private_key: "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+      }),
+    });
+    fireEvent.change(screen.getByLabelText("Choose JSON file"), { target: { files: [file] } });
+
+    await waitFor(() => expect(save.hasAttribute("disabled")).toBe(false));
+    fireEvent.click(save);
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledWith("app-a", expect.objectContaining({
+      package_name: "build.raft.app",
+      tracks: { internal: "internal", closed: "closed", production: "production" },
+    })));
+    expect(JSON.stringify(mocks.save.mock.calls[0]?.[1])).toContain("service_account");
+  });
+
+  it("refreshes binding state after a rejected verification disables it", async () => {
+    mocks.get
+      .mockResolvedValueOnce({
+        google_play: {
+          enabled: true,
+          verification_state: "verified",
+          package_name: "build.raft.app",
+          service_account_email: "app@tenant.example",
+          internal_track: "internal",
+          closed_track: "closed",
+          production_track: "production",
+        },
+      })
+      .mockResolvedValue({
+        google_play: {
+          enabled: false,
+          verification_state: "stale",
+          package_name: "build.raft.app",
+          service_account_email: "app@tenant.example",
+          internal_track: "internal",
+          closed_track: "closed",
+          production_track: "production",
+        },
+      });
+    mocks.verify.mockRejectedValue(new Error("permission denied"));
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Test connection" }));
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId("google-play-binding-panel").textContent).toContain("Needs verification"));
+    expect(mocks.toast).toHaveBeenCalledWith(expect.objectContaining({ kind: "error" }));
+  });
+});

--- a/docs/google-play-distribution-design.md
+++ b/docs/google-play-distribution-design.md
@@ -102,24 +102,29 @@ fail-closed until the server-side Play adapter explicitly implements them.
 
 ## Server-side Play adapter protocol
 
-`PLAY_RELEASE_SERVICE` owns Google credentials. Hands makes two service-binding
-requests and never sends credentials in headers or payloads:
+Each Android app has an owner-managed Google Play binding. Hands encrypts the
+service-account JSON with an app-bound AES-GCM keyring, stores only ciphertext,
+and exposes only non-secret metadata to the admin UI. Binding or re-enabling an
+app first validates OAuth, package access, and all configured tracks with a
+temporary edit that is deleted without commit.
 
-- `GET /v1/apps/:package/tracks/:track` → `{ "max_version_code": 122 }`
-- `POST /v1/apps/:package/edits` with the AAB byte stream and only public
-  `x-hands-*` identity headers → exact readback `{edit_id, package_name,
-  version_code, track, sha256, rollout_percent}`.
+`PLAY_RELEASE_SERVICE` is a private, stateless RPC Worker. Hands decrypts only
+the selected app binding and transfers it directly through the private service
+binding together with typed operation input:
+
+- `verifyBinding({credential, packageName, tracks})` validates the app binding;
+- `readTrackMaximum({credential, packageName, tracks, handsTrack})` returns the
+  live maximum versionCode;
+- `promote(input, aabStream)` transfers the AAB stream and returns exact
+  `{edit_id, package_name, version_code, track, sha256, rollout_percent}`.
 
 No call is retried automatically. Adapter absence, non-2xx, or malformed/mismatched
 readback is a typed `play_api_error` and never becomes success.
 
 The adapter is the `play-adapter/` Worker. It has no public route, `workers.dev`
-hostname, or preview URL. Its Google service-account JSON exists only as the
-adapter secret `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`; Hands receives only the
-`PLAY_RELEASE_SERVICE` service binding. `ALLOWED_PACKAGE_NAMES` restricts the
-package surface, `internal` maps to Play's `qa` track, `production` maps to
-`production`, and `closed` maps to the existing custom track named by
-`GOOGLE_PLAY_CLOSED_TRACK_NAME`.
+hostname, preview URL, global Google credential, package allowlist, or global
+track mapping. Package and track scope comes only from the authenticated app's
+encrypted binding. Neither Worker returns or logs private credential material.
 
 Each mutation creates one Google edit, streams the AAB without buffering it,
 compares both the local SHA-256 and Google's bundle SHA-256/versionCode, reads

--- a/migrations/sql/0071_app_google_play_bindings.sql
+++ b/migrations/sql/0071_app_google_play_bindings.sql
@@ -1,0 +1,31 @@
+-- Migration 0071: one encrypted, app-scoped Google Play binding per Android app.
+--
+-- Private service-account material is encrypted by the Hands Worker with an
+-- application-bound AES-GCM additional-data value. Only non-secret identity,
+-- configuration, validation state, and audit metadata are stored in plaintext.
+
+CREATE TABLE IF NOT EXISTS app_google_play_bindings (
+  id                         TEXT PRIMARY KEY,
+  app_id                     TEXT NOT NULL UNIQUE REFERENCES apps(id) ON DELETE CASCADE,
+  enabled                    INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+  package_name               TEXT NOT NULL,
+  internal_track             TEXT NOT NULL,
+  closed_track               TEXT NOT NULL,
+  production_track           TEXT NOT NULL,
+  service_account_email      TEXT NOT NULL,
+  service_account_project_id TEXT,
+  private_key_id             TEXT,
+  credential_fingerprint     TEXT NOT NULL,
+  credential_ciphertext_b64  TEXT NOT NULL,
+  credential_iv_b64          TEXT NOT NULL,
+  credential_key_version     TEXT NOT NULL,
+  verification_state         TEXT NOT NULL CHECK (verification_state IN ('verified', 'stale')),
+  verified_at                INTEGER,
+  created_by_actor           TEXT NOT NULL,
+  updated_by_actor           TEXT NOT NULL,
+  created_at                 INTEGER NOT NULL,
+  updated_at                 INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_google_play_bindings_enabled
+  ON app_google_play_bindings(enabled, app_id);

--- a/play-adapter/package.json
+++ b/play-adapter/package.json
@@ -14,9 +14,10 @@
     "jose": "^5.9.6"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "4.20260626.1",
     "jsonc-parser": "^3.3.1",
     "typescript": "^5.9.3",
     "vitest": "^2.1.8",
-    "wrangler": "^4.88.0"
+    "wrangler": "4.105.0"
   }
 }

--- a/play-adapter/scripts/render-production-config.mjs
+++ b/play-adapter/scripts/render-production-config.mjs
@@ -28,23 +28,6 @@ function workerName(name) {
   return value;
 }
 
-function packageNames(name) {
-  const value = required(name);
-  const packages = value.split(",").map((item) => item.trim()).filter(Boolean);
-  if (packages.length === 0 || packages.some((item) => !/^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/.test(item))) {
-    throw new Error(`${name} must be a comma-separated package-name allowlist`);
-  }
-  return packages.join(",");
-}
-
-function trackName(name) {
-  const value = required(name);
-  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value) || value === "qa" || value === "production") {
-    throw new Error(`${name} must name a custom closed-testing track`);
-  }
-  return value;
-}
-
 function positiveInteger(name) {
   const value = required(name);
   if (!/^\d+$/.test(value) || !Number.isSafeInteger(Number(value)) || Number(value) <= 0) {
@@ -65,8 +48,6 @@ if (errors.length > 0 || !config || typeof config !== "object") {
 
 config.name = workerName("HANDS_PLAY_ADAPTER_WORKER_NAME");
 config.vars = {
-  ALLOWED_PACKAGE_NAMES: packageNames("HANDS_PLAY_ALLOWED_PACKAGE_NAMES"),
-  GOOGLE_PLAY_CLOSED_TRACK_NAME: trackName("HANDS_PLAY_CLOSED_TRACK_NAME"),
   MAX_AAB_SIZE_BYTES: positiveInteger("HANDS_PLAY_MAX_AAB_SIZE_BYTES"),
 };
 

--- a/play-adapter/src/auth.ts
+++ b/play-adapter/src/auth.ts
@@ -5,31 +5,35 @@ import type { ServiceAccountCredential } from "./types";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
 
-export function parseServiceAccount(raw: string | undefined): ServiceAccountCredential {
-  if (!raw) {
-    throw new PlayAdapterError(503, "play_credentials_missing", "Google Play credentials are not configured");
-  }
+export function parseServiceAccount(raw: unknown): ServiceAccountCredential {
   let value: unknown;
-  try {
-    value = JSON.parse(raw);
-  } catch {
-    throw new PlayAdapterError(503, "play_credentials_invalid", "Google Play credentials are invalid");
+  if (typeof raw === "string") {
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      throw new PlayAdapterError(400, "play_credentials_invalid", "Google Play credentials are invalid");
+    }
+  } else {
+    value = raw;
   }
   const object = value as Record<string, unknown> | null;
   const clientEmail = object?.client_email;
   const privateKey = object?.private_key;
   const privateKeyId = object?.private_key_id;
   if (
-    object?.type !== "service_account"
+    !object
+    || object.type !== "service_account"
     || typeof clientEmail !== "string"
     || !/^[^@\s]+@[^@\s]+$/.test(clientEmail)
     || typeof privateKey !== "string"
     || !privateKey.includes("BEGIN PRIVATE KEY")
     || (privateKeyId !== undefined && typeof privateKeyId !== "string")
   ) {
-    throw new PlayAdapterError(503, "play_credentials_invalid", "Google Play credentials are invalid");
+    throw new PlayAdapterError(400, "play_credentials_invalid", "Google Play credentials are invalid");
   }
   return {
+    type: "service_account",
+    ...(typeof object.project_id === "string" && object.project_id ? { project_id: object.project_id } : {}),
     client_email: clientEmail,
     private_key: privateKey,
     ...(privateKeyId ? { private_key_id: privateKeyId } : {}),
@@ -45,7 +49,7 @@ export async function createAccessToken(
   try {
     privateKey = await importPKCS8(credential.private_key, "RS256");
   } catch {
-    throw new PlayAdapterError(503, "play_credentials_invalid", "Google Play credentials are invalid");
+    throw new PlayAdapterError(400, "play_credentials_invalid", "Google Play credentials are invalid");
   }
   const assertion = await new SignJWT({ scope: ANDROID_PUBLISHER_SCOPE })
     .setProtectedHeader({
@@ -75,7 +79,8 @@ export async function createAccessToken(
   }
   const body = await response.json().catch(() => null) as Record<string, unknown> | null;
   if (!response.ok) {
-    throw new PlayAdapterError(502, "play_token_rejected", `Google OAuth token request failed with ${response.status}`);
+    const status = [400, 401, 403, 404].includes(response.status) ? 403 : 502;
+    throw new PlayAdapterError(status, "play_token_rejected", `Google OAuth token request failed with ${response.status}`);
   }
   if (!body || typeof body.access_token !== "string" || !body.access_token) {
     throw new PlayAdapterError(502, "play_token_malformed", "Google OAuth returned a malformed token response");

--- a/play-adapter/src/entrypoint.ts
+++ b/play-adapter/src/entrypoint.ts
@@ -1,0 +1,19 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { createPlayAdapterService } from "./index";
+import type { PlayAdapterEnv, PlayBindingInput, PromotionRpcInput, TrackMaximumRpcInput } from "./types";
+
+export default class GooglePlayAdapter extends WorkerEntrypoint<PlayAdapterEnv> {
+  private readonly service = createPlayAdapterService();
+
+  verifyBinding(input: PlayBindingInput) {
+    return this.service.verifyBinding(input, this.env);
+  }
+
+  readTrackMaximum(input: TrackMaximumRpcInput) {
+    return this.service.readTrackMaximum(input, this.env);
+  }
+
+  promote(input: PromotionRpcInput, body: ReadableStream<Uint8Array>) {
+    return this.service.promote(input, body, this.env);
+  }
+}

--- a/play-adapter/src/google_play.ts
+++ b/play-adapter/src/google_play.ts
@@ -127,7 +127,8 @@ export class GooglePlayClient {
     }
     const body = await response.json().catch(() => null) as T | null;
     if (!response.ok) {
-      throw new PlayAdapterError(502, "play_api_rejected", `Google Play API request failed with ${response.status}`);
+      const status = [400, 401, 403, 404].includes(response.status) ? 403 : 502;
+      throw new PlayAdapterError(status, "play_api_rejected", `Google Play API request failed with ${response.status}`);
     }
     if (!body || typeof body !== "object") {
       throw new PlayAdapterError(502, "play_api_malformed", "Google Play API returned malformed JSON");
@@ -147,7 +148,8 @@ export class GooglePlayClient {
       throw new PlayAdapterError(502, "play_api_unavailable", "Google Play API request failed");
     }
     if (!response.ok) {
-      throw new PlayAdapterError(502, "play_api_rejected", `Google Play API request failed with ${response.status}`);
+      const status = [400, 401, 403, 404].includes(response.status) ? 403 : 502;
+      throw new PlayAdapterError(status, "play_api_rejected", `Google Play API request failed with ${response.status}`);
     }
   }
 
@@ -188,6 +190,18 @@ export class GooglePlayClient {
     }
     await this.deleteEdit(packageName, editId);
     return value;
+  }
+
+  async verifyBinding(packageName: string, tracks: string[]): Promise<void> {
+    const editId = await this.createEdit(packageName);
+    try {
+      for (const track of [...new Set(tracks)]) {
+        await this.getTrack(packageName, editId, track);
+      }
+    } catch (error) {
+      await this.cleanupOrThrow(packageName, editId, error);
+    }
+    await this.deleteEdit(packageName, editId);
   }
 
   private async uploadBundle(request: PromotionRequest, editId: string): Promise<GoogleBundle> {

--- a/play-adapter/src/index.ts
+++ b/play-adapter/src/index.ts
@@ -1,110 +1,107 @@
 import { createAccessToken, parseServiceAccount } from "./auth";
-import { PlayAdapterError, safeErrorResponse } from "./errors";
+import { PlayAdapterError } from "./errors";
 import { GooglePlayClient } from "./google_play";
-import type { HandsTrack, PlayAdapterEnv, PromotionRequest } from "./types";
+import type {
+  AdapterResult,
+  HandsTrack,
+  PlayAdapterEnv,
+  PlayBindingInput,
+  PlayTracks,
+  PromotionRequest,
+  PromotionRpcInput,
+  TrackMaximumRpcInput,
+} from "./types";
 
 const PACKAGE_NAME = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;
 const SHA256 = /^[a-f0-9]{64}$/;
 const OPERATION_ID = /^[A-Za-z0-9._:-]{1,128}$/;
 const TRACK_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 
-function positiveInteger(value: string | null): number | null {
-  if (!value || !/^\d+$/.test(value)) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function handsTrack(value: string): HandsTrack | null {
-  return value === "internal" || value === "closed" || value === "production" ? value : null;
-}
-
-function configuredPackages(env: PlayAdapterEnv): Set<string> {
-  const packages = (env.ALLOWED_PACKAGE_NAMES ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-  if (packages.length === 0 || packages.some((value) => !PACKAGE_NAME.test(value))) {
-    throw new PlayAdapterError(503, "package_allowlist_invalid", "Google Play package allowlist is not configured");
-  }
-  return new Set(packages);
+function positiveInteger(value: unknown): number | null {
+  const parsed = typeof value === "string" && /^\d+$/.test(value) ? Number(value) : value;
+  return typeof parsed === "number" && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function maxAabSize(env: PlayAdapterEnv): number {
-  const value = positiveInteger(env.MAX_AAB_SIZE_BYTES ?? null);
+  const value = positiveInteger(env.MAX_AAB_SIZE_BYTES);
   if (value === null) {
     throw new PlayAdapterError(503, "aab_limit_invalid", "Google Play AAB size limit is not configured");
   }
   return value;
 }
 
-function playTrack(env: PlayAdapterEnv, track: HandsTrack): string {
-  if (track === "internal") return "qa";
-  if (track === "production") return "production";
-  const value = env.GOOGLE_PLAY_CLOSED_TRACK_NAME?.trim() ?? "";
-  if (!TRACK_NAME.test(value) || value === "qa" || value === "production") {
-    throw new PlayAdapterError(503, "closed_track_invalid", "Google Play closed-testing track is not configured");
+function bindingInput(input: PlayBindingInput): PlayBindingInput {
+  if (!input || typeof input !== "object") {
+    throw new PlayAdapterError(400, "play_binding_invalid", "Google Play binding is invalid");
   }
-  return value;
+  const packageName = typeof input.packageName === "string" ? input.packageName.trim() : "";
+  if (!PACKAGE_NAME.test(packageName)) {
+    throw new PlayAdapterError(400, "package_name_invalid", "Google Play package name is invalid");
+  }
+  const source = input.tracks as Partial<PlayTracks> | undefined;
+  const tracks = {
+    internal: typeof source?.internal === "string" ? source.internal.trim() : "",
+    closed: typeof source?.closed === "string" ? source.closed.trim() : "",
+    production: typeof source?.production === "string" ? source.production.trim() : "",
+  };
+  if (Object.values(tracks).some((track) => !TRACK_NAME.test(track))) {
+    throw new PlayAdapterError(400, "track_name_invalid", "Google Play track name is invalid");
+  }
+  return { credential: parseServiceAccount(input.credential), packageName, tracks };
 }
 
-function route(request: Request): { packageName: string; track?: HandsTrack; operation: "track" | "promote" } | null {
-  const parts = new URL(request.url).pathname.split("/").filter(Boolean);
-  if (parts.length === 5 && parts[0] === "v1" && parts[1] === "apps" && parts[3] === "tracks") {
-    const track = handsTrack(parts[4] ?? "");
-    if (!track) return null;
-    try {
-      return { packageName: decodeURIComponent(parts[2] ?? ""), track, operation: "track" };
-    } catch {
-      return null;
-    }
+function trackInput(input: TrackMaximumRpcInput) {
+  const binding = bindingInput(input);
+  const handsTrack = input?.handsTrack;
+  if (handsTrack !== "internal" && handsTrack !== "closed" && handsTrack !== "production") {
+    throw new PlayAdapterError(400, "hands_track_invalid", "Hands track is invalid");
   }
-  if (parts.length === 4 && parts[0] === "v1" && parts[1] === "apps" && parts[3] === "edits") {
-    try {
-      return { packageName: decodeURIComponent(parts[2] ?? ""), operation: "promote" };
-    } catch {
-      return null;
-    }
-  }
-  return null;
+  return { ...binding, handsTrack, playTrack: binding.tracks[handsTrack] };
 }
 
-function promotionRequest(
-  request: Request,
-  packageName: string,
-  env: PlayAdapterEnv,
-): PromotionRequest {
-  const track = handsTrack(request.headers.get("x-hands-track") ?? "");
-  const versionCode = positiveInteger(request.headers.get("x-hands-version-code"));
-  const expectedSize = positiveInteger(request.headers.get("x-hands-size-bytes"));
-  const expectedSha256 = request.headers.get("x-hands-sha256")?.toLowerCase() ?? "";
-  const rolloutPercent = positiveInteger(request.headers.get("x-hands-rollout-percent"));
-  const operationId = request.headers.get("x-hands-operation-id") ?? "";
+function promotionInput(input: PromotionRpcInput, body: ReadableStream<Uint8Array>, env: PlayAdapterEnv): PromotionRequest {
+  const track = trackInput(input);
+  const versionCode = positiveInteger(input.versionCode);
+  const expectedSize = positiveInteger(input.expectedSize);
+  const rolloutPercent = positiveInteger(input.rolloutPercent);
+  const expectedSha256 = typeof input.expectedSha256 === "string" ? input.expectedSha256.toLowerCase() : "";
+  const operationId = typeof input.operationId === "string" ? input.operationId : "";
   if (
-    !track
-    || versionCode === null
+    versionCode === null
     || expectedSize === null
     || !SHA256.test(expectedSha256)
     || rolloutPercent === null
     || rolloutPercent > 100
     || !OPERATION_ID.test(operationId)
-    || !request.body
+    || !(body instanceof ReadableStream)
   ) {
     throw new PlayAdapterError(400, "promotion_request_invalid", "Hands promotion request is invalid");
   }
-  if (track !== "production" && rolloutPercent !== 100) {
+  if (track.handsTrack !== "production" && rolloutPercent !== 100) {
     throw new PlayAdapterError(400, "rollout_track_invalid", "Partial rollout is supported only on the production track");
   }
+  if (expectedSize > maxAabSize(env)) {
+    throw new PlayAdapterError(413, "aab_too_large", "AAB exceeds the configured maximum size");
+  }
   return {
-    packageName,
-    handsTrack: track,
-    playTrack: playTrack(env, track),
+    packageName: track.packageName,
+    handsTrack: track.handsTrack,
+    playTrack: track.playTrack,
     versionCode,
     expectedSha256,
     expectedSize,
     rolloutPercent,
     operationId,
-    body: request.body,
+    body,
   };
+}
+function failure(error: unknown, operationId: string | null): AdapterResult<never> {
+  const known = error instanceof PlayAdapterError;
+  const status = known ? error.status : 502;
+  const code = known ? error.code : "play_adapter_error";
+  const message = known ? error.message : "Google Play adapter request failed";
+  console.error(JSON.stringify({ event: "google_play_adapter_error", operation_id: operationId, code, status }));
+  return { ok: false, error: { status, code, message } };
 }
 
 export interface AdapterOptions {
@@ -112,49 +109,67 @@ export interface AdapterOptions {
   nowSeconds?: () => number;
 }
 
-export function createPlayAdapter(options: AdapterOptions = {}) {
+export function createPlayAdapterService(options: AdapterOptions = {}) {
   const fetchImpl = options.fetchImpl ?? fetch;
+
+  async function client(input: PlayBindingInput, env: PlayAdapterEnv) {
+    const binding = bindingInput(input);
+    const accessToken = await createAccessToken(
+      binding.credential,
+      fetchImpl,
+      options.nowSeconds?.() ?? Math.floor(Date.now() / 1000),
+    );
+    return { binding, client: new GooglePlayClient(accessToken, fetchImpl, maxAabSize(env)) };
+  }
+
   return {
-    async fetch(request: Request, env: PlayAdapterEnv): Promise<Response> {
-      let operationId: string | null = request.headers.get("x-hands-operation-id");
+    async verifyBinding(input: PlayBindingInput, env: PlayAdapterEnv): Promise<AdapterResult<{
+      client_email: string;
+      package_name: string;
+      tracks: PlayTracks;
+    }>> {
       try {
-        const matched = route(request);
-        if (!matched || (matched.operation === "track" ? request.method !== "GET" : request.method !== "POST")) {
-          return new Response("Not found", { status: 404 });
-        }
-        if (!PACKAGE_NAME.test(matched.packageName) || !configuredPackages(env).has(matched.packageName)) {
-          throw new PlayAdapterError(403, "package_not_allowed", "Google Play package is not allowed");
-        }
-        let promotion: PromotionRequest | null = null;
-        if (matched.operation === "promote") {
-          promotion = promotionRequest(request, matched.packageName, env);
-          operationId = promotion.operationId;
-          const contentLength = request.headers.get("content-length");
-          if (contentLength !== null && positiveInteger(contentLength) !== promotion.expectedSize) {
-            throw new PlayAdapterError(409, "aab_size_mismatch", "AAB content length did not match Hands");
-          }
-          if (promotion.expectedSize > maxAabSize(env)) {
-            throw new PlayAdapterError(413, "aab_too_large", "AAB exceeds the configured maximum size");
-          }
-        }
-        const credential = parseServiceAccount(env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
-        const accessToken = await createAccessToken(
-          credential,
-          fetchImpl,
-          options.nowSeconds?.() ?? Math.floor(Date.now() / 1000),
-        );
-        const client = new GooglePlayClient(accessToken, fetchImpl, maxAabSize(env));
-        if (matched.operation === "track") {
-          const mappedTrack = playTrack(env, matched.track!);
-          const maximum = await client.readTrackMaximum(matched.packageName, mappedTrack);
-          return Response.json({ max_version_code: maximum });
-        }
-        return Response.json(await client.promote(promotion!));
+        const resolved = await client(input, env);
+        await resolved.client.verifyBinding(resolved.binding.packageName, Object.values(resolved.binding.tracks));
+        return {
+          ok: true,
+          value: {
+            client_email: resolved.binding.credential.client_email,
+            package_name: resolved.binding.packageName,
+            tracks: resolved.binding.tracks,
+          },
+        };
       } catch (error) {
-        return safeErrorResponse(error, OPERATION_ID.test(operationId ?? "") ? operationId : null);
+        return failure(error, null);
+      }
+    },
+
+    async readTrackMaximum(input: TrackMaximumRpcInput, env: PlayAdapterEnv): Promise<AdapterResult<{
+      max_version_code: number;
+    }>> {
+      try {
+        const resolvedInput = trackInput(input);
+        const resolved = await client(resolvedInput, env);
+        const maximum = await resolved.client.readTrackMaximum(resolvedInput.packageName, resolvedInput.playTrack);
+        return { ok: true, value: { max_version_code: maximum } };
+      } catch (error) {
+        return failure(error, null);
+      }
+    },
+
+    async promote(
+      input: PromotionRpcInput,
+      body: ReadableStream<Uint8Array>,
+      env: PlayAdapterEnv,
+    ): Promise<AdapterResult<Awaited<ReturnType<GooglePlayClient["promote"]>>>> {
+      const operationId = OPERATION_ID.test(input?.operationId ?? "") ? input.operationId : null;
+      try {
+        const promotion = promotionInput(input, body, env);
+        const resolved = await client(input, env);
+        return { ok: true, value: await resolved.client.promote(promotion) };
+      } catch (error) {
+        return failure(error, operationId);
       }
     },
   };
 }
-
-export default createPlayAdapter();

--- a/play-adapter/src/types.ts
+++ b/play-adapter/src/types.ts
@@ -1,21 +1,41 @@
 export type HandsTrack = "internal" | "closed" | "production";
 
 export interface PlayAdapterEnv {
-  /** Google service-account JSON; set only with `wrangler secret put`. */
-  GOOGLE_PLAY_SERVICE_ACCOUNT_JSON?: string;
-  /** Comma-separated package names accepted from the Hands service binding. */
-  ALLOWED_PACKAGE_NAMES?: string;
-  /** Existing Play Console closed-testing track identifier. */
-  GOOGLE_PLAY_CLOSED_TRACK_NAME?: string;
   /** Maximum streamed AAB size accepted from Hands. */
   MAX_AAB_SIZE_BYTES?: string;
 }
 
 export interface ServiceAccountCredential {
+  type: "service_account";
+  project_id?: string;
   client_email: string;
   private_key: string;
   private_key_id?: string;
 }
+
+export type PlayTracks = Record<HandsTrack, string>;
+
+export interface PlayBindingInput {
+  credential: ServiceAccountCredential;
+  packageName: string;
+  tracks: PlayTracks;
+}
+
+export interface TrackMaximumRpcInput extends PlayBindingInput {
+  handsTrack: HandsTrack;
+}
+
+export interface PromotionRpcInput extends TrackMaximumRpcInput {
+  versionCode: number;
+  expectedSha256: string;
+  expectedSize: number;
+  rolloutPercent: number;
+  operationId: string;
+}
+
+export type AdapterResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: { status: number; code: string; message: string } };
 
 export interface TrackRelease {
   name?: string;

--- a/play-adapter/test/adapter.test.ts
+++ b/play-adapter/test/adapter.test.ts
@@ -2,61 +2,55 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
-import {
-  decodeProtectedHeader,
-  exportPKCS8,
-  generateKeyPair,
-  jwtVerify,
-} from "jose";
+import { decodeProtectedHeader, exportPKCS8, generateKeyPair, jwtVerify } from "jose";
 import type { KeyLike } from "jose";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { createPlayAdapter } from "../src/index";
-import type { PlayAdapterEnv, TrackResource } from "../src/types";
+import { createPlayAdapterService } from "../src/index";
+import type { PlayAdapterEnv, PlayBindingInput, PromotionRpcInput, TrackResource } from "../src/types";
 
 const PACKAGE = "build.raft.app";
 const NOW = 1_780_000_000;
 const bytes = new TextEncoder().encode("exact-aab-bytes");
 const digest = bytesToHex(sha256(bytes));
 
-let credential = "";
+let binding: PlayBindingInput;
 let publicKey: CryptoKey | KeyLike;
 
 beforeAll(async () => {
   const pair = await generateKeyPair("RS256", { extractable: true });
   publicKey = pair.publicKey;
-  credential = JSON.stringify({
-    type: "service_account",
-    client_email: "hands-play@example.iam.gserviceaccount.com",
-    private_key: await exportPKCS8(pair.privateKey),
-    private_key_id: "key-1",
-  });
+  binding = {
+    credential: {
+      type: "service_account",
+      project_id: "tenant-project",
+      client_email: "tenant-app@example.iam.gserviceaccount.com",
+      private_key: await exportPKCS8(pair.privateKey),
+      private_key_id: "key-1",
+    },
+    packageName: PACKAGE,
+    tracks: { internal: "qa", closed: "closed-alpha", production: "production" },
+  };
 });
 
 function environment(overrides: Partial<PlayAdapterEnv> = {}): PlayAdapterEnv {
-  return {
-    GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: credential,
-    ALLOWED_PACKAGE_NAMES: PACKAGE,
-    GOOGLE_PLAY_CLOSED_TRACK_NAME: "closed-alpha",
-    MAX_AAB_SIZE_BYTES: "209715200",
-    ...overrides,
-  };
+  return { MAX_AAB_SIZE_BYTES: "209715200", ...overrides };
 }
 
-function promotionRequest(overrides: Record<string, string> = {}, body: BodyInit = bytes): Request {
-  return new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/edits`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/octet-stream",
-      "x-hands-track": "internal",
-      "x-hands-version-code": "42",
-      "x-hands-sha256": digest,
-      "x-hands-size-bytes": String(bytes.byteLength),
-      "x-hands-rollout-percent": "100",
-      "x-hands-operation-id": "operation-1",
-      ...overrides,
-    },
-    body,
-  });
+function body() {
+  return new Blob([bytes]).stream();
+}
+
+function promotion(overrides: Partial<PromotionRpcInput> = {}): PromotionRpcInput {
+  return {
+    ...binding,
+    handsTrack: "internal",
+    versionCode: 42,
+    expectedSha256: digest,
+    expectedSize: bytes.byteLength,
+    rolloutPercent: 100,
+    operationId: "operation-1",
+    ...overrides,
+  };
 }
 
 interface GoogleFixtureOptions {
@@ -81,14 +75,14 @@ function googleFixture(options: GoogleFixtureOptions = {}) {
       assertion = new URLSearchParams(String(init.body)).get("assertion") ?? "";
       return Response.json(
         options.tokenStatus && options.tokenStatus !== 200
-          ? { error: credential }
+          ? { error: JSON.stringify(binding.credential) }
           : { access_token: "access-token", expires_in: 3600 },
         { status: options.tokenStatus ?? 200 },
       );
     }
-    let body: unknown = null;
-    if (typeof init.body === "string") body = JSON.parse(init.body);
-    requests.push({ url, method, body });
+    let requestBody: unknown = null;
+    if (typeof init.body === "string") requestBody = JSON.parse(init.body);
+    requests.push({ url, method, body: requestBody });
     expect(new Headers(init.headers).get("authorization")).toBe("Bearer access-token");
     if (method === "POST" && /\/applications\/[^/]+\/edits$/.test(url)) {
       return Response.json({ id: `edit-${nextEdit++}` });
@@ -97,13 +91,10 @@ function googleFixture(options: GoogleFixtureOptions = {}) {
     if (method === "GET" && url.includes("/tracks/")) return Response.json(track);
     if (url.includes("/bundles?uploadType=media")) {
       const uploaded = new Uint8Array(await new Response(init.body).arrayBuffer());
-      return Response.json({
-        versionCode: 42,
-        sha256: options.uploadSha ?? bytesToHex(sha256(uploaded)),
-      });
+      return Response.json({ versionCode: 42, sha256: options.uploadSha ?? bytesToHex(sha256(uploaded)) });
     }
     if (method === "PUT" && url.includes("/tracks/")) {
-      track = body as TrackResource;
+      track = requestBody as TrackResource;
       return Response.json(track);
     }
     if (method === "POST" && url.includes(":commit?")) {
@@ -120,164 +111,128 @@ function googleFixture(options: GoogleFixtureOptions = {}) {
   };
 }
 
-describe("Google Play adapter", () => {
-  it("uses a one-hour RS256 service-account assertion without exposing credentials", async () => {
+describe("Google Play adapter RPC service", () => {
+  it("validates the tenant package and every configured track without committing a release", async () => {
     const fixture = googleFixture();
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const response = await adapter.fetch(
-      new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/tracks/internal`),
-      environment(),
-    );
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ max_version_code: 41 });
+    const service = createPlayAdapterService({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const result = await service.verifyBinding(binding, environment());
+    expect(result).toEqual({
+      ok: true,
+      value: { client_email: binding.credential.client_email, package_name: PACKAGE, tracks: binding.tracks },
+    });
+    expect(fixture.requests.filter((request) => request.method === "GET").map((request) => request.url)).toEqual([
+      expect.stringContaining("/tracks/qa"),
+      expect.stringContaining("/tracks/closed-alpha"),
+      expect.stringContaining("/tracks/production"),
+    ]);
+    expect(fixture.requests.filter((request) => request.url.includes(":commit"))).toHaveLength(0);
+    expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
+  });
+
+  it("uses a one-hour RS256 assertion and reads the app-selected track", async () => {
+    const fixture = googleFixture();
+    const service = createPlayAdapterService({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const result = await service.readTrackMaximum({ ...binding, handsTrack: "closed" }, environment());
+    expect(result).toEqual({ ok: true, value: { max_version_code: 41 } });
     expect(decodeProtectedHeader(fixture.assertion())).toMatchObject({ alg: "RS256", kid: "key-1" });
     const verified = await jwtVerify(fixture.assertion(), publicKey, {
       algorithms: ["RS256"],
-      issuer: "hands-play@example.iam.gserviceaccount.com",
+      issuer: binding.credential.client_email,
       audience: "https://oauth2.googleapis.com/token",
       currentDate: new Date(NOW * 1000),
     });
-    expect(verified.payload).toMatchObject({
-      iat: NOW,
-      exp: NOW + 3600,
-      scope: "https://www.googleapis.com/auth/androidpublisher",
-    });
-    expect(fixture.requests.map((request) => request.method)).toEqual(["POST", "GET", "DELETE"]);
-    expect(fixture.requests[1]!.url).toContain("/tracks/qa");
-  });
-
-  it("maps the contract closed track to the configured Play Console track", async () => {
-    const fixture = googleFixture();
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const response = await adapter.fetch(
-      new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/tracks/closed`),
-      environment(),
-    );
-    expect(response.status).toBe(200);
+    expect(verified.payload).toMatchObject({ iat: NOW, exp: NOW + 3600 });
     expect(fixture.requests[1]!.url).toContain("/tracks/closed-alpha");
   });
 
-  it("streams once, preserves existing releases, commits once, and reads back exact identity", async () => {
+  it("streams once, preserves releases, commits once, and reads back exact identity", async () => {
     const fixture = googleFixture();
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const response = await adapter.fetch(promotionRequest(), environment());
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      edit_id: "edit-1",
-      package_name: PACKAGE,
-      version_code: 42,
-      track: "internal",
-      sha256: digest,
-      rollout_percent: 100,
+    const service = createPlayAdapterService({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const result = await service.promote(promotion(), body(), environment());
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        edit_id: "edit-1",
+        package_name: PACKAGE,
+        version_code: 42,
+        track: "internal",
+        sha256: digest,
+        rollout_percent: 100,
+      },
     });
     expect(fixture.track().releases).toEqual([
       { name: "existing", versionCodes: ["41"], status: "completed" },
       { versionCodes: ["42"], status: "completed" },
     ]);
-    const commits = fixture.requests.filter((request) => request.url.includes(":commit?"));
-    expect(commits).toHaveLength(1);
-    expect(commits[0]!.url).toContain("changesInReviewBehavior=ERROR_IF_IN_REVIEW");
+    expect(fixture.requests.filter((request) => request.url.includes(":commit?"))).toHaveLength(1);
     expect(fixture.requests.filter((request) => request.url.includes("/bundles?uploadType=media"))).toHaveLength(1);
   });
 
-  it("deletes the uncommitted edit when Google reports a different AAB hash", async () => {
+  it("deletes an uncommitted edit on exact-byte mismatch", async () => {
     const fixture = googleFixture({ uploadSha: "f".repeat(64) });
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const response = await adapter.fetch(promotionRequest(), environment());
-    expect(response.status).toBe(409);
-    expect(await response.json()).toMatchObject({ error: { code: "play_bundle_mismatch" } });
-    expect(fixture.requests.filter((request) => request.method === "PUT")).toHaveLength(0);
-    expect(fixture.requests.filter((request) => request.url.includes(":commit?"))).toHaveLength(0);
-    expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
-  });
-
-  it("rechecks the live track inside the edit and stops a version race", async () => {
-    const fixture = googleFixture({ trackMaximum: 42 });
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const response = await adapter.fetch(promotionRequest(), environment());
-    expect(response.status).toBe(409);
-    expect(await response.json()).toMatchObject({ error: { code: "play_version_conflict" } });
+    const service = createPlayAdapterService({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    const result = await service.promote(promotion(), body(), environment());
+    expect(result).toMatchObject({ ok: false, error: { code: "play_bundle_mismatch" } });
     expect(fixture.requests.filter((request) => request.method === "PUT")).toHaveLength(0);
     expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
   });
 
-  it("does not retry or delete an edit after an ambiguous commit attempt", async () => {
-    const fixture = googleFixture({ commitThrows: true });
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const response = await adapter.fetch(promotionRequest(), environment());
-    expect(response.status).toBe(502);
-    expect(await response.json()).toMatchObject({ error: { code: "play_api_unavailable" } });
-    expect(fixture.requests.filter((request) => request.url.includes(":commit?"))).toHaveLength(1);
-    expect(fixture.requests.filter((request) => request.method === "DELETE")).toHaveLength(0);
-  });
-
-  it("models a partial production rollout and rejects partial test-track rollout before OAuth", async () => {
-    const internalFixture = googleFixture();
-    const adapter = createPlayAdapter({ fetchImpl: internalFixture.fetchImpl, nowSeconds: () => NOW });
-    const rejected = await adapter.fetch(
-      promotionRequest({ "x-hands-rollout-percent": "25" }),
-      environment(),
-    );
-    expect(rejected.status).toBe(400);
-    expect(internalFixture.fetchImpl).not.toHaveBeenCalled();
-
-    const productionFixture = googleFixture();
-    const production = createPlayAdapter({ fetchImpl: productionFixture.fetchImpl, nowSeconds: () => NOW });
-    const accepted = await production.fetch(
-      promotionRequest({ "x-hands-track": "production", "x-hands-rollout-percent": "25" }),
-      environment(),
-    );
-    expect(accepted.status).toBe(200);
-    expect(productionFixture.track().releases?.at(-1)).toEqual({
-      versionCodes: ["42"],
-      status: "inProgress",
-      userFraction: 0.25,
+  it("stops a version race and does not undo an ambiguous commit", async () => {
+    const race = googleFixture({ trackMaximum: 42 });
+    const raceService = createPlayAdapterService({ fetchImpl: race.fetchImpl, nowSeconds: () => NOW });
+    expect(await raceService.promote(promotion(), body(), environment())).toMatchObject({
+      ok: false,
+      error: { code: "play_version_conflict" },
     });
+    expect(race.requests.filter((request) => request.method === "PUT")).toHaveLength(0);
+    expect(race.requests.filter((request) => request.method === "DELETE")).toHaveLength(1);
+
+    const ambiguous = googleFixture({ commitThrows: true });
+    const ambiguousService = createPlayAdapterService({ fetchImpl: ambiguous.fetchImpl, nowSeconds: () => NOW });
+    expect(await ambiguousService.promote(promotion(), body(), environment())).toMatchObject({
+      ok: false,
+      error: { code: "play_api_unavailable" },
+    });
+    expect(ambiguous.requests.filter((request) => request.url.includes(":commit?"))).toHaveLength(1);
+    expect(ambiguous.requests.filter((request) => request.method === "DELETE")).toHaveLength(0);
   });
 
-  it("rejects disallowed packages and oversized AABs before credential use", async () => {
+  it("rejects invalid tenant input and oversized bytes before OAuth", async () => {
     const fixture = googleFixture();
-    const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-    const disallowed = await adapter.fetch(
-      new Request("https://play-adapter.internal/v1/apps/other.example.app/tracks/internal"),
-      environment(),
-    );
-    expect(disallowed.status).toBe(403);
-    const oversized = await adapter.fetch(
-      promotionRequest({ "x-hands-size-bytes": "16" }),
-      environment({ MAX_AAB_SIZE_BYTES: "15" }),
-    );
-    expect(oversized.status).toBe(413);
+    const service = createPlayAdapterService({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+    expect(await service.readTrackMaximum({ ...binding, packageName: "../bad", handsTrack: "internal" }, environment())).toMatchObject({
+      ok: false,
+      error: { code: "package_name_invalid" },
+    });
+    expect(await service.promote(promotion({ expectedSize: 16 }), body(), environment({ MAX_AAB_SIZE_BYTES: "15" }))).toMatchObject({
+      ok: false,
+      error: { code: "aab_too_large" },
+    });
     expect(fixture.fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("redacts provider response bodies and credentials from errors and logs", async () => {
+  it("redacts provider bodies and per-app credentials from errors and logs", async () => {
     const fixture = googleFixture({ tokenStatus: 401 });
     const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
-      const adapter = createPlayAdapter({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
-      const response = await adapter.fetch(
-        new Request(`https://play-adapter.internal/v1/apps/${PACKAGE}/tracks/internal`),
-        environment(),
-      );
-      const body = JSON.stringify(await response.json());
-      expect(response.status).toBe(502);
-      expect(body).not.toContain("PRIVATE KEY");
-      expect(body).not.toContain("hands-play@example");
+      const service = createPlayAdapterService({ fetchImpl: fixture.fetchImpl, nowSeconds: () => NOW });
+      const result = await service.readTrackMaximum({ ...binding, handsTrack: "internal" }, environment());
+      const text = JSON.stringify(result);
+      expect(result).toMatchObject({ ok: false, error: { status: 403, code: "play_token_rejected" } });
+      expect(text).not.toContain("PRIVATE KEY");
+      expect(text).not.toContain("tenant-app@example");
       expect(log.mock.calls.flat().join(" ")).not.toContain("PRIVATE KEY");
-      expect(log.mock.calls.flat().join(" ")).not.toContain("hands-play@example");
+      expect(log.mock.calls.flat().join(" ")).not.toContain("tenant-app@example");
     } finally {
       log.mockRestore();
     }
   });
 
-  it("has no public route or preview URL in checked-in Wrangler config", () => {
-    const config = readFileSync(
-      fileURLToPath(new URL("../wrangler.jsonc", import.meta.url)),
-      "utf8",
-    );
+  it("has no public route, preview URL, or global tenant credential in Wrangler config", () => {
+    const config = readFileSync(fileURLToPath(new URL("../wrangler.jsonc", import.meta.url)), "utf8");
     expect(config).toMatch(/"workers_dev": false/);
     expect(config).toMatch(/"preview_urls": false/);
     expect(config).not.toMatch(/"routes"\s*:/);
+    expect(config).not.toMatch(/GOOGLE_PLAY_SERVICE_ACCOUNT_JSON|ALLOWED_PACKAGE_NAMES|CLOSED_TRACK_NAME/);
   });
 });

--- a/play-adapter/test/production_config.test.ts
+++ b/play-adapter/test/production_config.test.ts
@@ -10,8 +10,6 @@ const repositoryDir = resolve(adapterDir, "..");
 const renderScript = resolve(adapterDir, "scripts/render-production-config.mjs");
 const BASE_ENV = {
   HANDS_PLAY_ADAPTER_WORKER_NAME: "hands-google-play-adapter",
-  HANDS_PLAY_ALLOWED_PACKAGE_NAMES: "build.raft.app",
-  HANDS_PLAY_CLOSED_TRACK_NAME: "closed-alpha",
   HANDS_PLAY_MAX_AAB_SIZE_BYTES: "209715200",
 };
 
@@ -36,21 +34,17 @@ test("production config keeps the adapter private and renders the exact bounded 
     assert.equal(config.preview_urls, false);
     assert.equal("routes" in config, false);
     assert.deepEqual(config.vars, {
-      ALLOWED_PACKAGE_NAMES: "build.raft.app",
-      GOOGLE_PLAY_CLOSED_TRACK_NAME: "closed-alpha",
       MAX_AAB_SIZE_BYTES: "209715200",
     });
-    assert.equal(JSON.stringify(config).includes("SERVICE_ACCOUNT"), false);
+    assert.doesNotMatch(JSON.stringify(config), /SERVICE_ACCOUNT|ALLOWED_PACKAGE|CLOSED_TRACK/);
   } finally {
     fixture.cleanup();
   }
 });
 
-test("production config rejects malformed service, package, track, and size inputs", () => {
+test("production config rejects malformed service and size inputs", () => {
   const cases = [
     [{ HANDS_PLAY_ADAPTER_WORKER_NAME: "https://bad.example" }, /valid Cloudflare Worker/],
-    [{ HANDS_PLAY_ALLOWED_PACKAGE_NAMES: "../bad" }, /package-name allowlist/],
-    [{ HANDS_PLAY_CLOSED_TRACK_NAME: "production" }, /custom closed-testing track/],
     [{ HANDS_PLAY_MAX_AAB_SIZE_BYTES: "0" }, /positive safe integer/],
   ] as const;
   for (const [environment, pattern] of cases) {
@@ -64,7 +58,7 @@ test("production config rejects malformed service, package, track, and size inpu
   }
 });
 
-test("adapter deployment is manual, environment-gated, and injects the credential only as a deploy secret", () => {
+test("adapter deployment is manual, environment-gated, and has no global Play credential", () => {
   const workflow = readFileSync(
     resolve(repositoryDir, ".github/workflows/deploy-hands-play-adapter.yml"),
     "utf8",
@@ -74,6 +68,6 @@ test("adapter deployment is manual, environment-gated, and injects the credentia
   assert.match(workflow, /^    environment: hands-play-production$/m);
   assert.match(workflow, /^    if: github\.ref == 'refs\/heads\/main'$/m);
   assert.doesNotMatch(workflow, /run_checks/);
-  assert.match(workflow, /--secrets-file "\$\{secret_file\}"/);
-  assert.doesNotMatch(workflow, /wrangler secret put/);
+  assert.doesNotMatch(workflow, /GOOGLE_PLAY_SERVICE_ACCOUNT_JSON|HANDS_PLAY_ALLOWED_PACKAGE_NAMES|HANDS_PLAY_CLOSED_TRACK_NAME/);
+  assert.doesNotMatch(workflow, /--secrets-file|wrangler secret put/);
 });

--- a/play-adapter/tsconfig.json
+++ b/play-adapter/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["@cloudflare/workers-types", "vitest/globals"],
     "noEmit": true,
     "isolatedModules": true
   },

--- a/play-adapter/wrangler.jsonc
+++ b/play-adapter/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "hands-google-play-adapter",
-  "main": "src/index.ts",
+  "main": "src/entrypoint.ts",
   "compatibility_date": "2026-09-03",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
@@ -15,8 +15,6 @@
     }
   },
   "vars": {
-    "ALLOWED_PACKAGE_NAMES": "build.raft.app",
-    "GOOGLE_PLAY_CLOSED_TRACK_NAME": "closed",
     "MAX_AAB_SIZE_BYTES": "209715200"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
         specifier: ^5.9.6
         version: 5.10.0
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20260626.1
+        version: 4.20260626.1
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
@@ -209,7 +212,7 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.13.2)(jsdom@26.1.0)(lightningcss@1.32.0)
       wrangler:
-        specifier: ^4.88.0
+        specifier: 4.105.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
 
   worker:

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -5,6 +5,55 @@
 
 import "@cloudflare/workers-types";
 
+type GooglePlayCredential = {
+  type: "service_account";
+  project_id?: string;
+  private_key_id?: string;
+  private_key: string;
+  client_email: string;
+};
+
+type GooglePlayTracks = Record<"internal" | "closed" | "production", string>;
+
+type GooglePlayBindingInput = {
+  credential: GooglePlayCredential;
+  packageName: string;
+  tracks: GooglePlayTracks;
+};
+
+type GooglePlayAdapterResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: { status: number; code: string; message: string } };
+
+interface GooglePlayAdapterService {
+  verifyBinding(input: GooglePlayBindingInput): Promise<GooglePlayAdapterResult<{
+    client_email: string;
+    package_name: string;
+    tracks: GooglePlayTracks;
+  }>>;
+  readTrackMaximum(input: GooglePlayBindingInput & { handsTrack: keyof GooglePlayTracks }): Promise<
+    GooglePlayAdapterResult<{ max_version_code: number }>
+  >;
+  promote(
+    input: GooglePlayBindingInput & {
+      handsTrack: keyof GooglePlayTracks;
+      versionCode: number;
+      expectedSha256: string;
+      expectedSize: number;
+      rolloutPercent: number;
+      operationId: string;
+    },
+    body: ReadableStream<Uint8Array>,
+  ): Promise<GooglePlayAdapterResult<{
+    edit_id: string;
+    package_name: string;
+    version_code: number;
+    track: keyof GooglePlayTracks;
+    sha256: string;
+    rollout_percent: number;
+  }>>;
+}
+
 declare global {
   interface Env {
     ADMIN_API_TOKEN?: string;
@@ -28,6 +77,10 @@ declare global {
     ASC_CRED_ENC_KEY?: string;
     /** AES-GCM root secret for per-app AppGallery Connect credential JSON. */
     AGC_CRED_ENC_KEY?: string;
+    /** Secret JSON keyring used for app-scoped Google Play credentials. */
+    PLAY_CRED_ENC_KEYS?: string;
+    /** Active key version within PLAY_CRED_ENC_KEYS. */
+    PLAY_CRED_ENC_ACTIVE_KEY_VERSION?: string;
     RAFT_ALLOWED_SERVER_IDS?: string;
     RAFT_ALLOWED_SERVER_SLUGS?: string;
     /** Exact HTTPS app-link callbacks registered for Hands Installer. */
@@ -41,11 +94,8 @@ declare global {
     FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION?: string;
     /** Secret JSON object containing one or two base64url HMAC keys by version. */
     FEEDBACK_REPORTER_SESSION_KEYS?: string;
-    /**
-     * Server-side Google Play adapter. The adapter owns Play credentials; this
-     * Worker and every CI/CLI/device caller only see the service binding.
-     */
-    PLAY_RELEASE_SERVICE?: Fetcher;
+    /** Private stateless adapter; only Hands decrypts and supplies app-scoped credentials. */
+    PLAY_RELEASE_SERVICE?: GooglePlayAdapterService;
   }
 }
 

--- a/worker/scripts/render-production-config.mjs
+++ b/worker/scripts/render-production-config.mjs
@@ -86,6 +86,9 @@ const reporterSessionActiveKeyVersion = optionalKeyVersion(
   "HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION",
 );
 const playReleaseServiceName = optionalWorkerName("HANDS_PLAY_RELEASE_SERVICE_NAME");
+const playCredentialActiveKeyVersion = optionalKeyVersion(
+  "HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION",
+);
 if (reporterSessionEnabled === "true" && !reporterSessionActiveKeyVersion) {
   throw new Error(
     "HANDS_FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION is required when reporter sessions are enabled",
@@ -132,6 +135,12 @@ if (reporterSessionActiveKeyVersion) {
   delete config.vars.FEEDBACK_REPORTER_SESSION_ACTIVE_KEY_VERSION;
 }
 if (playReleaseServiceName) {
+  if (!playCredentialActiveKeyVersion) {
+    throw new Error(
+      "HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION is required when the Play adapter is configured",
+    );
+  }
+  config.vars.PLAY_CRED_ENC_ACTIVE_KEY_VERSION = playCredentialActiveKeyVersion;
   config.services = [
     ...(config.services ?? []).filter((binding) => binding.binding !== "PLAY_RELEASE_SERVICE"),
       { binding: "PLAY_RELEASE_SERVICE", service: playReleaseServiceName },
@@ -139,6 +148,9 @@ if (playReleaseServiceName) {
 } else if (Array.isArray(config.services)) {
   config.services = config.services.filter((binding) => binding.binding !== "PLAY_RELEASE_SERVICE");
   if (config.services.length === 0) delete config.services;
+}
+if (!playReleaseServiceName) {
+  delete config.vars.PLAY_CRED_ENC_ACTIVE_KEY_VERSION;
 }
 
 // Build stamp for the container image, so a rollout can be verified by reading the

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -212,6 +212,14 @@ import {
   handleRollbackPlayDistribution,
 } from "./routes/play_distribution";
 import {
+  handleDeleteGooglePlayBinding,
+  handleDisableGooglePlayBinding,
+  handleEnableGooglePlayBinding,
+  handleGetGooglePlayBinding,
+  handlePutGooglePlayBinding,
+  handleVerifyGooglePlayBinding,
+} from "./routes/google_play_bindings";
+import {
   handleBumpRollout,
   handleCreateRelease,
   handleCreateReleaseDraft,
@@ -936,6 +944,12 @@ admin.post(
   requireAppRole("publisher"),
   handleCreateAcceptanceReceipt,
 );
+admin.get("/api/apps/:appId/google-play-binding", requireAppRole("admin"), handleGetGooglePlayBinding);
+admin.put("/api/apps/:appId/google-play-binding", requireAppRole("admin"), handlePutGooglePlayBinding);
+admin.post("/api/apps/:appId/google-play-binding/verify", requireAppRole("admin"), handleVerifyGooglePlayBinding);
+admin.post("/api/apps/:appId/google-play-binding/enable", requireAppRole("admin"), handleEnableGooglePlayBinding);
+admin.post("/api/apps/:appId/google-play-binding/disable", requireAppRole("admin"), handleDisableGooglePlayBinding);
+admin.delete("/api/apps/:appId/google-play-binding", requireAppRole("admin"), handleDeleteGooglePlayBinding);
 admin.get("/api/apps/:appId/shares", requireAppRole("viewer"), handleListAppShares);
 admin.post("/api/apps/:appId/shares/:shareId/rebind", requireAppRole("publisher"), handleRebindReleaseShare);
 admin.put("/api/apps/:appId/icon", requireAppRole("publisher"), handleUploadAppIcon);

--- a/worker/src/lib/google_play_bindings.ts
+++ b/worker/src/lib/google_play_bindings.ts
@@ -1,0 +1,318 @@
+export type GoogleServiceAccountCredential = {
+  type: "service_account";
+  project_id?: string;
+  private_key_id?: string;
+  private_key: string;
+  client_email: string;
+};
+
+export type GooglePlayTracks = {
+  internal: string;
+  closed: string;
+  production: string;
+};
+
+export type GooglePlayBindingMeta = {
+  id: string;
+  app_id: string;
+  enabled: number;
+  package_name: string;
+  internal_track: string;
+  closed_track: string;
+  production_track: string;
+  service_account_email: string;
+  service_account_project_id: string | null;
+  private_key_id: string | null;
+  credential_fingerprint: string;
+  credential_key_version: string;
+  verification_state: "verified" | "stale";
+  verified_at: number | null;
+  created_by_actor: string;
+  updated_by_actor: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export type GooglePlayBinding = GooglePlayBindingMeta & {
+  credential: GoogleServiceAccountCredential;
+  tracks: GooglePlayTracks;
+};
+
+const PACKAGE_NAME = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;
+const TRACK_NAME = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const KEY_VERSION = /^[A-Za-z0-9._-]{1,64}$/;
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${name} is required`);
+  return value.trim();
+}
+
+export function normalizeGooglePlayPackage(value: unknown): string {
+  const packageName = requiredString(value, "package_name");
+  if (!PACKAGE_NAME.test(packageName)) throw new Error("package_name is invalid");
+  return packageName;
+}
+
+export function normalizeGooglePlayTracks(value: unknown): GooglePlayTracks {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("tracks is required");
+  }
+  const object = value as Record<string, unknown>;
+  const tracks = {
+    internal: requiredString(object.internal, "tracks.internal"),
+    closed: requiredString(object.closed, "tracks.closed"),
+    production: requiredString(object.production, "tracks.production"),
+  };
+  for (const [name, track] of Object.entries(tracks)) {
+    if (!TRACK_NAME.test(track)) throw new Error(`tracks.${name} is invalid`);
+  }
+  return tracks;
+}
+
+export function parseGoogleServiceAccount(input: unknown): GoogleServiceAccountCredential {
+  let value = input;
+  if (typeof input === "string") {
+    try {
+      value = JSON.parse(input);
+    } catch {
+      throw new Error("service_account_json must contain valid JSON");
+    }
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("service_account_json must be a JSON object");
+  }
+  const object = value as Record<string, unknown>;
+  if (object.type !== "service_account") throw new Error("credential type must be service_account");
+  const clientEmail = requiredString(object.client_email, "client_email");
+  if (!/^[^@\s]+@[^@\s]+$/.test(clientEmail)) throw new Error("client_email is invalid");
+  const privateKey = requiredString(object.private_key, "private_key");
+  if (!privateKey.includes("BEGIN PRIVATE KEY")) {
+    throw new Error("private_key must be a PKCS#8 PEM private key");
+  }
+  return {
+    type: "service_account",
+    client_email: clientEmail,
+    private_key: privateKey,
+    ...(typeof object.project_id === "string" && object.project_id.trim()
+      ? { project_id: object.project_id.trim() }
+      : {}),
+    ...(typeof object.private_key_id === "string" && object.private_key_id.trim()
+      ? { private_key_id: object.private_key_id.trim() }
+      : {}),
+  };
+}
+
+function b64Encode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function b64Decode(value: string): Uint8Array {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+function parseKeyring(raw: string | undefined): Record<string, string> {
+  if (!raw) throw new Error("PLAY_CRED_ENC_KEYS is not configured");
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error("PLAY_CRED_ENC_KEYS is invalid");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("PLAY_CRED_ENC_KEYS is invalid");
+  }
+  const result: Record<string, string> = {};
+  for (const [version, secret] of Object.entries(value as Record<string, unknown>)) {
+    if (!KEY_VERSION.test(version) || typeof secret !== "string" || secret.length < 32) {
+      throw new Error("PLAY_CRED_ENC_KEYS is invalid");
+    }
+    result[version] = secret;
+  }
+  if (Object.keys(result).length === 0) throw new Error("PLAY_CRED_ENC_KEYS is invalid");
+  return result;
+}
+
+export function assertGooglePlayCredentialKeyring(
+  keyringJson: string | undefined,
+  activeVersion: string | undefined,
+): { version: string; secret: string } {
+  const keyring = parseKeyring(keyringJson);
+  const version = activeVersion?.trim() ?? "";
+  const secret = keyring[version];
+  if (!KEY_VERSION.test(version) || !secret) {
+    throw new Error("PLAY_CRED_ENC_ACTIVE_KEY_VERSION is not configured");
+  }
+  return { version, secret };
+}
+
+async function aesKey(secret: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+function additionalData(appId: string, version: string): Uint8Array {
+  return new TextEncoder().encode(`hands-google-play:${appId}:${version}`);
+}
+
+export async function encryptGooglePlayCredential(
+  credential: GoogleServiceAccountCredential,
+  appId: string,
+  keyringJson: string | undefined,
+  activeVersion: string | undefined,
+) {
+  const { version, secret } = assertGooglePlayCredentialKeyring(keyringJson, activeVersion);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(JSON.stringify(credential));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv, additionalData: additionalData(appId, version) },
+    await aesKey(secret),
+    plaintext,
+  );
+  return {
+    ciphertext_b64: b64Encode(new Uint8Array(ciphertext)),
+    iv_b64: b64Encode(iv),
+    key_version: version,
+  };
+}
+
+export async function decryptGooglePlayCredential(
+  ciphertext: string,
+  iv: string,
+  appId: string,
+  keyVersion: string,
+  keyringJson: string | undefined,
+): Promise<GoogleServiceAccountCredential> {
+  const keyring = parseKeyring(keyringJson);
+  const secret = keyring[keyVersion];
+  if (!secret) throw new Error("Google Play credential key version is unavailable");
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: b64Decode(iv), additionalData: additionalData(appId, keyVersion) },
+    await aesKey(secret),
+    b64Decode(ciphertext),
+  );
+  return parseGoogleServiceAccount(new TextDecoder().decode(plaintext));
+}
+
+export async function fingerprintGooglePlayCredential(credential: GoogleServiceAccountCredential): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(JSON.stringify(credential))),
+  );
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+const META_COLUMNS = `id, app_id, enabled, package_name, internal_track, closed_track,
+  production_track, service_account_email, service_account_project_id, private_key_id,
+  credential_fingerprint, credential_key_version, verification_state, verified_at,
+  created_by_actor, updated_by_actor, created_at, updated_at`;
+
+export async function getGooglePlayBindingMeta(db: D1Database, appId: string) {
+  return (await db.prepare(`SELECT ${META_COLUMNS} FROM app_google_play_bindings WHERE app_id=?1`)
+    .bind(appId).first<GooglePlayBindingMeta>()) ?? null;
+}
+
+export async function getGooglePlayBinding(
+  db: D1Database,
+  appId: string,
+  keyringJson: string | undefined,
+): Promise<GooglePlayBinding | null> {
+  const row = await db.prepare(`SELECT ${META_COLUMNS}, credential_ciphertext_b64, credential_iv_b64
+    FROM app_google_play_bindings WHERE app_id=?1`).bind(appId).first<GooglePlayBindingMeta & {
+      credential_ciphertext_b64: string;
+      credential_iv_b64: string;
+    }>();
+  if (!row) return null;
+  const credential = await decryptGooglePlayCredential(
+    row.credential_ciphertext_b64,
+    row.credential_iv_b64,
+    appId,
+    row.credential_key_version,
+    keyringJson,
+  );
+  return {
+    ...row,
+    credential,
+    tracks: { internal: row.internal_track, closed: row.closed_track, production: row.production_track },
+  };
+}
+
+export async function storeGooglePlayBinding(
+  db: D1Database,
+  args: {
+    appId: string;
+    packageName: string;
+    tracks: GooglePlayTracks;
+    credential: GoogleServiceAccountCredential;
+    actor: string;
+    keyringJson: string | undefined;
+    activeKeyVersion: string | undefined;
+  },
+) {
+  const encrypted = await encryptGooglePlayCredential(
+    args.credential,
+    args.appId,
+    args.keyringJson,
+    args.activeKeyVersion,
+  );
+  const fingerprint = await fingerprintGooglePlayCredential(args.credential);
+  const now = Date.now();
+  await db.prepare(`INSERT INTO app_google_play_bindings
+    (id, app_id, enabled, package_name, internal_track, closed_track, production_track,
+     service_account_email, service_account_project_id, private_key_id, credential_fingerprint,
+     credential_ciphertext_b64, credential_iv_b64, credential_key_version, verification_state,
+     verified_at, created_by_actor, updated_by_actor, created_at, updated_at)
+    VALUES (?1, ?2, 1, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'verified', ?14, ?15, ?15, ?14, ?14)
+    ON CONFLICT(app_id) DO UPDATE SET enabled=1, package_name=excluded.package_name,
+      internal_track=excluded.internal_track, closed_track=excluded.closed_track,
+      production_track=excluded.production_track, service_account_email=excluded.service_account_email,
+      service_account_project_id=excluded.service_account_project_id, private_key_id=excluded.private_key_id,
+      credential_fingerprint=excluded.credential_fingerprint,
+      credential_ciphertext_b64=excluded.credential_ciphertext_b64,
+      credential_iv_b64=excluded.credential_iv_b64,
+      credential_key_version=excluded.credential_key_version,
+      verification_state='verified', verified_at=excluded.verified_at,
+      updated_by_actor=excluded.updated_by_actor, updated_at=excluded.updated_at`)
+    .bind(
+      crypto.randomUUID(), args.appId, args.packageName, args.tracks.internal, args.tracks.closed,
+      args.tracks.production, args.credential.client_email, args.credential.project_id ?? null,
+      args.credential.private_key_id ?? null, fingerprint, encrypted.ciphertext_b64,
+      encrypted.iv_b64, encrypted.key_version, now, args.actor,
+    ).run();
+  return (await getGooglePlayBindingMeta(db, args.appId))!;
+}
+
+export async function setGooglePlayBindingEnabled(
+  db: D1Database,
+  appId: string,
+  enabled: boolean,
+  actor: string,
+) {
+  const now = Date.now();
+  const result = await db.prepare(`UPDATE app_google_play_bindings
+    SET enabled=?1, updated_by_actor=?2, updated_at=?3 WHERE app_id=?4`)
+    .bind(enabled ? 1 : 0, actor, now, appId).run();
+  return Number(result.meta?.changes ?? 0) === 1;
+}
+
+export async function setGooglePlayBindingVerification(
+  db: D1Database,
+  appId: string,
+  verified: boolean,
+  actor: string,
+) {
+  const now = Date.now();
+  const result = await db.prepare(`UPDATE app_google_play_bindings
+    SET verification_state=?1, verified_at=?2,
+      enabled=CASE WHEN ?3=1 THEN enabled ELSE 0 END,
+      updated_by_actor=?4, updated_at=?5
+    WHERE app_id=?6`)
+    .bind(verified ? "verified" : "stale", verified ? now : null, verified ? 1 : 0, actor, now, appId)
+    .run();
+  return Number(result.meta?.changes ?? 0) === 1;
+}
+
+export async function deleteGooglePlayBinding(db: D1Database, appId: string) {
+  await db.prepare("DELETE FROM app_google_play_bindings WHERE app_id=?1").bind(appId).run();
+}

--- a/worker/src/openapi/android_distribution.ts
+++ b/worker/src/openapi/android_distribution.ts
@@ -64,6 +64,19 @@ const PlayRollbackInput = PlayApprovalInput.extend({
   to_version_code: z.number().int().positive(),
 }).strict().openapi("PlayRollbackInput");
 
+const GooglePlayBindingInput = z.object({
+  service_account_json: z.union([
+    z.string().min(1),
+    z.record(z.string(), z.unknown()),
+  ]).openapi({ description: "Complete Google service-account JSON; private material is never returned." }),
+  package_name: z.string().regex(/^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/),
+  tracks: z.object({
+    internal: z.string().min(1).max(128),
+    closed: z.string().min(1).max(128),
+    production: z.string().min(1).max(128),
+  }).strict(),
+}).strict().openapi("GooglePlayBindingInput");
+
 export function registerAndroidDistributionRoutes(registry: OpenApiRegistry) {
   register(registry, {
     method: "post",
@@ -84,6 +97,73 @@ export function registerAndroidDistributionRoutes(registry: OpenApiRegistry) {
       404: error("App was not found."),
       409: error("An immutable identity conflicts."),
       503: error("Direct artifact upload is unavailable."),
+    },
+  });
+
+  register(registry, {
+    method: "get",
+    path: "/api/apps/{appId}/google-play-binding",
+    tags: ["Android distribution"],
+    summary: "Read this app's Google Play binding metadata",
+    description: "Returns only non-secret app-scoped metadata. Stored service-account private material is never returned.",
+    security: auth,
+    request: { params: AppIdParam },
+    responses: {
+      200: success("Google Play binding metadata or null.", GenericObject),
+      403: error("App admin role is required."),
+      404: error("App was not found."),
+    },
+  });
+
+  register(registry, {
+    method: "put",
+    path: "/api/apps/{appId}/google-play-binding",
+    tags: ["Android distribution"],
+    summary: "Validate and replace this app's encrypted Google Play binding",
+    description: "Validates package and track access through the private adapter before encrypting the app-scoped credential and enabling the binding.",
+    security: auth,
+    request: {
+      params: AppIdParam,
+      body: { content: json(GooglePlayBindingInput), required: true },
+    },
+    responses: {
+      200: success("Binding validated, encrypted, and enabled.", GenericObject),
+      400: error("Credential, package, tracks, or platform is invalid."),
+      403: error("App admin role is required."),
+      502: error("Google Play rejected validation."),
+      503: error("The private Play adapter is unavailable."),
+    },
+  });
+
+  for (const action of ["verify", "enable", "disable"] as const) {
+    register(registry, {
+      method: "post",
+      path: `/api/apps/{appId}/google-play-binding/${action}`,
+      tags: ["Android distribution"],
+      summary: action === "verify"
+        ? "Revalidate this app's stored Google Play binding"
+        : `${action === "enable" ? "Enable" : "Disable"} Google Play promotion for this app`,
+      security: auth,
+      request: { params: AppIdParam },
+      responses: {
+        200: success("Binding state updated.", GenericObject),
+        403: error("App admin role is required."),
+        404: error("Binding was not found."),
+        502: error("Google Play validation failed."),
+      },
+    });
+  }
+
+  register(registry, {
+    method: "delete",
+    path: "/api/apps/{appId}/google-play-binding",
+    tags: ["Android distribution"],
+    summary: "Delete this app's encrypted Google Play binding",
+    security: auth,
+    request: { params: AppIdParam },
+    responses: {
+      200: success("Binding and encrypted credential deleted.", GenericObject),
+      403: error("App admin role is required."),
     },
   });
 

--- a/worker/src/routes/google_play_bindings.ts
+++ b/worker/src/routes/google_play_bindings.ts
@@ -1,0 +1,202 @@
+import type { Context } from "hono";
+import { currentActor, type AdminEnv } from "../middleware/auth";
+import { insertAuditLog } from "../lib/permissions";
+import {
+  assertGooglePlayCredentialKeyring,
+  deleteGooglePlayBinding,
+  getGooglePlayBinding,
+  getGooglePlayBindingMeta,
+  normalizeGooglePlayPackage,
+  normalizeGooglePlayTracks,
+  parseGoogleServiceAccount,
+  setGooglePlayBindingEnabled,
+  setGooglePlayBindingVerification,
+  storeGooglePlayBinding,
+  type GooglePlayBinding,
+} from "../lib/google_play_bindings";
+
+type AdminContext = Context<AdminEnv & { Bindings: Env }>;
+
+async function requireAndroidApp(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const app = await c.env.DB.prepare("SELECT platform FROM apps WHERE id=?1").bind(appId)
+    .first<{ platform: string }>();
+  if (!app) return c.json({ error: "app not found", code: "APP_NOT_FOUND" }, 404);
+  if (app.platform !== "android") {
+    return c.json({ error: "Google Play is only available for Android apps", code: "PLATFORM_MISMATCH" }, 400);
+  }
+  return null;
+}
+
+function safeMeta(meta: Awaited<ReturnType<typeof getGooglePlayBindingMeta>>) {
+  return meta ? { ...meta, enabled: meta.enabled === 1 } : null;
+}
+
+async function verifyBinding(c: AdminContext, binding: Pick<GooglePlayBinding, "credential" | "package_name" | "tracks">) {
+  if (!c.env.PLAY_RELEASE_SERVICE) {
+    return { ok: false as const, invalidate: false, status: 503 as const, code: "PLAY_SERVICE_UNAVAILABLE", error: "Google Play validation service is not configured" };
+  }
+  try {
+    const result = await c.env.PLAY_RELEASE_SERVICE.verifyBinding({
+      credential: binding.credential,
+      packageName: binding.package_name,
+      tracks: binding.tracks,
+    });
+    if (!result?.ok) {
+      return {
+        ok: false as const,
+        invalidate: result?.error?.status === 400 || result?.error?.status === 403,
+        status: 502 as const,
+        code: result?.error?.code ?? "PLAY_BINDING_REJECTED",
+        error: result?.error?.message ?? "Google Play rejected the binding",
+      };
+    }
+    if (
+      result.value.client_email !== binding.credential.client_email
+      || result.value.package_name !== binding.package_name
+    ) {
+      return { ok: false as const, invalidate: true, status: 502 as const, code: "PLAY_BINDING_MISMATCH", error: "Google Play validation returned a different binding identity" };
+    }
+    return { ok: true as const, result: result.value };
+  } catch {
+    return { ok: false as const, invalidate: false, status: 502 as const, code: "PLAY_SERVICE_UNAVAILABLE", error: "Google Play validation request failed" };
+  }
+}
+
+export async function handleGetGooglePlayBinding(c: AdminContext) {
+  const invalid = await requireAndroidApp(c);
+  if (invalid) return invalid;
+  return c.json({ google_play: safeMeta(await getGooglePlayBindingMeta(c.env.DB, c.req.param("appId") ?? "")) });
+}
+
+export async function handlePutGooglePlayBinding(c: AdminContext) {
+  const invalid = await requireAndroidApp(c);
+  if (invalid) return invalid;
+  let body: { service_account_json?: unknown; package_name?: unknown; tracks?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "valid JSON body required", code: "INVALID_PLAY_BINDING" }, 400);
+  }
+  let credential;
+  let packageName;
+  let tracks;
+  try {
+    credential = parseGoogleServiceAccount(body.service_account_json);
+    packageName = normalizeGooglePlayPackage(body.package_name);
+    tracks = normalizeGooglePlayTracks(body.tracks);
+  } catch (error) {
+    return c.json({ error: (error as Error).message, code: "INVALID_PLAY_BINDING" }, 400);
+  }
+  const appId = c.req.param("appId") ?? "";
+  try {
+    assertGooglePlayCredentialKeyring(
+      c.env.PLAY_CRED_ENC_KEYS,
+      c.env.PLAY_CRED_ENC_ACTIVE_KEY_VERSION,
+    );
+  } catch {
+    return c.json({
+      error: "Google Play credential encryption is not configured",
+      code: "PLAY_CREDENTIAL_STORAGE_UNAVAILABLE",
+    }, 500);
+  }
+  const verified = await verifyBinding(c, { credential, package_name: packageName, tracks });
+  if (!verified.ok) return c.json({ error: verified.error, code: verified.code }, verified.status);
+  let meta;
+  try {
+    meta = await storeGooglePlayBinding(c.env.DB, {
+      appId,
+      packageName,
+      tracks,
+      credential,
+      actor: currentActor(c),
+      keyringJson: c.env.PLAY_CRED_ENC_KEYS,
+      activeKeyVersion: c.env.PLAY_CRED_ENC_ACTIVE_KEY_VERSION,
+    });
+  } catch {
+    return c.json({ error: "Google Play credential encryption is not configured", code: "PLAY_CREDENTIAL_STORAGE_UNAVAILABLE" }, 500);
+  }
+  await insertAuditLog(c.env.DB, c, {
+    app_id: appId,
+    action: "google_play.binding.set",
+    payload: {
+      package_name: packageName,
+      tracks,
+      service_account_email: credential.client_email,
+      credential_fingerprint: meta.credential_fingerprint,
+    },
+    created_at: meta.updated_at,
+  });
+  return c.json({ google_play: safeMeta(meta), verification: verified.result });
+}
+
+export async function handleVerifyGooglePlayBinding(c: AdminContext) {
+  const invalid = await requireAndroidApp(c);
+  if (invalid) return invalid;
+  const appId = c.req.param("appId") ?? "";
+  let binding;
+  try {
+    binding = await getGooglePlayBinding(c.env.DB, appId, c.env.PLAY_CRED_ENC_KEYS);
+  } catch {
+    return c.json({ error: "Stored Google Play credential could not be decrypted", code: "PLAY_CREDENTIAL_UNAVAILABLE" }, 500);
+  }
+  if (!binding) return c.json({ error: "Google Play is not bound for this app", code: "PLAY_BINDING_MISSING" }, 404);
+  const verified = await verifyBinding(c, binding);
+  if (verified.ok || verified.invalidate) {
+    await setGooglePlayBindingVerification(c.env.DB, appId, verified.ok, currentActor(c));
+  }
+  await insertAuditLog(c.env.DB, c, {
+    app_id: appId,
+    action: "google_play.binding.verify",
+    payload: { package_name: binding.package_name, ok: verified.ok },
+  });
+  if (!verified.ok) return c.json({ error: verified.error, code: verified.code }, verified.status);
+  return c.json({ ok: true, verification: verified.result });
+}
+
+export async function handleDisableGooglePlayBinding(c: AdminContext) {
+  const invalid = await requireAndroidApp(c);
+  if (invalid) return invalid;
+  const appId = c.req.param("appId") ?? "";
+  const changed = await setGooglePlayBindingEnabled(c.env.DB, appId, false, currentActor(c));
+  if (!changed) return c.json({ error: "Google Play is not bound for this app", code: "PLAY_BINDING_MISSING" }, 404);
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "google_play.binding.disable", payload: {} });
+  return c.json({ ok: true, enabled: false });
+}
+
+export async function handleEnableGooglePlayBinding(c: AdminContext) {
+  const invalid = await requireAndroidApp(c);
+  if (invalid) return invalid;
+  const appId = c.req.param("appId") ?? "";
+  let binding;
+  try {
+    binding = await getGooglePlayBinding(c.env.DB, appId, c.env.PLAY_CRED_ENC_KEYS);
+  } catch {
+    return c.json({ error: "Stored Google Play credential could not be decrypted", code: "PLAY_CREDENTIAL_UNAVAILABLE" }, 500);
+  }
+  if (!binding) return c.json({ error: "Google Play is not bound for this app", code: "PLAY_BINDING_MISSING" }, 404);
+  const verified = await verifyBinding(c, binding);
+  if (verified.ok || verified.invalidate) {
+    await setGooglePlayBindingVerification(c.env.DB, appId, verified.ok, currentActor(c));
+  }
+  if (!verified.ok) {
+    await insertAuditLog(c.env.DB, c, {
+      app_id: appId,
+      action: "google_play.binding.enable",
+      payload: { package_name: binding.package_name, ok: false, code: verified.code },
+    });
+    return c.json({ error: verified.error, code: verified.code }, verified.status);
+  }
+  await setGooglePlayBindingEnabled(c.env.DB, appId, true, currentActor(c));
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "google_play.binding.enable", payload: { package_name: binding.package_name, ok: true } });
+  return c.json({ ok: true, enabled: true, verification: verified.result });
+}
+
+export async function handleDeleteGooglePlayBinding(c: AdminContext) {
+  const invalid = await requireAndroidApp(c);
+  if (invalid) return invalid;
+  const appId = c.req.param("appId") ?? "";
+  await deleteGooglePlayBinding(c.env.DB, appId);
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "google_play.binding.delete", payload: {} });
+  return c.json({ ok: true });
+}

--- a/worker/src/routes/play_distribution.ts
+++ b/worker/src/routes/play_distribution.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { currentActor, currentActorInfo, type AdminEnv } from "../middleware/auth";
+import { getGooglePlayBinding } from "../lib/google_play_bindings";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 type PlayTrack = "internal" | "closed" | "production";
@@ -418,6 +419,18 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
   if (!c.env.PLAY_RELEASE_SERVICE) {
     return fail(c, 502, { code: "play_api_error", gate: null, message: "Google Play release service is not configured" });
   }
+  let binding;
+  try {
+    binding = await getGooglePlayBinding(c.env.DB, appId, c.env.PLAY_CRED_ENC_KEYS);
+  } catch {
+    return fail(c, 502, { code: "play_api_error", gate: "permission", message: "Google Play credentials are unavailable for this app" });
+  }
+  if (!binding || binding.enabled !== 1 || binding.verification_state !== "verified") {
+    return fail(c, 403, { code: "forbidden", gate: "permission", message: "Google Play must be bound, verified, and enabled for this app" });
+  }
+  if (binding.package_name !== artifact.package_name) {
+    return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "AAB package does not match this app's Google Play binding" });
+  }
 
   const actor = currentActor(c);
   const operationId = crypto.randomUUID();
@@ -425,23 +438,21 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
     return fail(c, 409, { code: "edit_conflict", gate: "edit_lock", message: "another Play edit is active for this package" });
   }
   try {
-    const trackUrl = `https://play-release.service/v1/apps/${encodeURIComponent(artifact.package_name)}/tracks/${input.track}`;
-    let trackResponse: Response;
+    let trackResult;
     try {
-      trackResponse = await c.env.PLAY_RELEASE_SERVICE.fetch(trackUrl, { method: "GET" });
+      trackResult = await c.env.PLAY_RELEASE_SERVICE.readTrackMaximum({
+        credential: binding.credential,
+        packageName: binding.package_name,
+        tracks: binding.tracks,
+        handsTrack: input.track,
+      });
     } catch {
       return fail(c, 502, { code: "play_api_error", gate: null, message: "Play track read request failed" });
     }
-    if (!trackResponse.ok) {
-      return fail(c, 502, { code: "play_api_error", gate: null, message: `Play track read failed with ${trackResponse.status}` });
+    if (!trackResult?.ok) {
+      return fail(c, 502, { code: "play_api_error", gate: null, message: trackResult?.error?.message ?? "Play track read failed" });
     }
-    let trackState: { max_version_code: number };
-    try {
-      trackState = await trackResponse.json();
-    } catch {
-      return fail(c, 502, { code: "play_api_error", gate: null, message: "Play track read returned malformed JSON" });
-    }
-    const maxVersionCode = Number(trackState?.max_version_code);
+    const maxVersionCode = Number(trackResult.value.max_version_code);
     if (!Number.isSafeInteger(maxVersionCode) || maxVersionCode < 0) {
       return fail(c, 502, { code: "play_api_error", gate: null, message: "Play track read returned an invalid max_version_code" });
     }
@@ -468,22 +479,17 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
       return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "stored AAB size changed", receipt_id: receiptId });
     }
     const [hashBranch, uploadBranch] = object.body.tee();
-    const uploadResponsePromise = Promise.resolve().then(() => c.env.PLAY_RELEASE_SERVICE!.fetch(
-      `https://play-release.service/v1/apps/${encodeURIComponent(artifact.package_name)}/edits`,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/octet-stream",
-          "x-hands-track": input.track,
-          "x-hands-version-code": String(artifact.version_code),
-          "x-hands-sha256": artifact.file_hash,
-          "x-hands-size-bytes": String(artifact.size_bytes),
-          "x-hands-rollout-percent": String(input.rollout_percent ?? 100),
-          "x-hands-operation-id": operationId,
-        },
-        body: uploadBranch,
-      },
-    ));
+    const uploadResponsePromise = Promise.resolve().then(() => c.env.PLAY_RELEASE_SERVICE!.promote({
+      credential: binding.credential,
+      packageName: binding.package_name,
+      tracks: binding.tracks,
+      handsTrack: input.track,
+      versionCode: artifact.version_code,
+      expectedSha256: artifact.file_hash,
+      expectedSize: artifact.size_bytes,
+      rolloutPercent: input.rollout_percent ?? 100,
+      operationId,
+    }, uploadBranch));
     const [localResult, uploadResult] = await Promise.allSettled([hashStream(hashBranch), uploadResponsePromise]);
     if (localResult.status === "rejected") {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { stream_read: "failed" });
@@ -499,25 +505,11 @@ export async function handlePromotePlayDistribution(c: AdminContext) {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "immutable_binding", { actual: local });
       return fail(c, 400, { code: "gate_failed", gate: "immutable_binding", message: "streamed AAB did not match the accepted artifact", receipt_id: receiptId });
     }
-    if (!uploadResponse.ok) {
-      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_api_error", { status: uploadResponse.status });
-      return fail(c, 502, { code: "play_api_error", gate: null, message: `Play edit failed with ${uploadResponse.status}`, receipt_id: receiptId });
+    if (!uploadResponse?.ok) {
+      const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_api_error", { code: uploadResponse?.error?.code ?? "unknown" });
+      return fail(c, 502, { code: "play_api_error", gate: null, message: uploadResponse?.error?.message ?? "Play edit failed", receipt_id: receiptId });
     }
-    let readback: PlayReadback;
-    try {
-      readback = await uploadResponse.json();
-    } catch {
-      const receiptId = await failedPromotionReceipt(
-        c,
-        artifact,
-        actor,
-        input.track,
-        input.approval.note,
-        "play_readback_malformed",
-        { status: uploadResponse.status },
-      );
-      return fail(c, 502, { code: "play_api_error", gate: "immutable_binding", message: "Play edit returned malformed JSON", receipt_id: receiptId });
-    }
+    const readback: PlayReadback = uploadResponse.value;
     if (!playReadbackMatches(artifact, input.track, readback)) {
       const receiptId = await failedPromotionReceipt(c, artifact, actor, input.track, input.approval.note, "play_readback_mismatch", { readback });
       return fail(c, 502, { code: "play_api_error", gate: "immutable_binding", message: "Play readback did not match package/version/track/SHA-256", receipt_id: receiptId });

--- a/worker/test/google_play_bindings.test.ts
+++ b/worker/test/google_play_bindings.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import {
+  assertGooglePlayCredentialKeyring,
+  decryptGooglePlayCredential,
+  encryptGooglePlayCredential,
+  normalizeGooglePlayPackage,
+  normalizeGooglePlayTracks,
+  parseGoogleServiceAccount,
+} from "../src/lib/google_play_bindings";
+
+const credential = {
+  type: "service_account" as const,
+  project_id: "tenant-project",
+  private_key_id: "tenant-key",
+  client_email: "tenant@example.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nprivate-tenant-material\n-----END PRIVATE KEY-----",
+};
+const keyring = JSON.stringify({ v1: "first-test-key-material-with-32-bytes", v2: "second-test-key-material-with-32-bytes" });
+
+describe("app-scoped Google Play bindings", () => {
+  it("encrypts private material and binds ciphertext to the app identity", async () => {
+    const encrypted = await encryptGooglePlayCredential(credential, "app-a", keyring, "v1");
+    expect(JSON.stringify(encrypted)).not.toContain("private-tenant-material");
+    expect(await decryptGooglePlayCredential(
+      encrypted.ciphertext_b64,
+      encrypted.iv_b64,
+      "app-a",
+      encrypted.key_version,
+      keyring,
+    )).toEqual(credential);
+    await expect(decryptGooglePlayCredential(
+      encrypted.ciphertext_b64,
+      encrypted.iv_b64,
+      "app-b",
+      encrypted.key_version,
+      keyring,
+    )).rejects.toThrow();
+  });
+
+  it("keeps old ciphertext readable while new credentials rotate to the active key", async () => {
+    const old = await encryptGooglePlayCredential(credential, "app-a", keyring, "v1");
+    const next = await encryptGooglePlayCredential(credential, "app-a", keyring, "v2");
+    expect(old.key_version).toBe("v1");
+    expect(next.key_version).toBe("v2");
+    await expect(decryptGooglePlayCredential(old.ciphertext_b64, old.iv_b64, "app-a", "v1", keyring))
+      .resolves.toEqual(credential);
+    await expect(decryptGooglePlayCredential(old.ciphertext_b64, old.iv_b64, "app-a", "v1", JSON.stringify({ v2: "second-test-key-material-with-32-bytes" })))
+      .rejects.toThrow(/key version is unavailable/);
+  });
+
+  it("rejects invalid credentials, package names, and track mappings before storage", () => {
+    expect(() => parseGoogleServiceAccount({ ...credential, type: "authorized_user" })).toThrow(/service_account/);
+    expect(() => parseGoogleServiceAccount({ ...credential, private_key: "secret" })).toThrow(/PKCS#8/);
+    expect(() => normalizeGooglePlayPackage("../tenant" )).toThrow(/invalid/);
+    expect(() => normalizeGooglePlayTracks({ internal: "qa", closed: "bad track", production: "production" })).toThrow(/invalid/);
+  });
+
+  it("fails closed unless the active encryption key is present in the keyring", () => {
+    expect(() => assertGooglePlayCredentialKeyring(undefined, "v1")).toThrow(/not configured/);
+    expect(() => assertGooglePlayCredentialKeyring(keyring, "missing")).toThrow(/ACTIVE_KEY_VERSION/);
+    expect(() => assertGooglePlayCredentialKeyring(keyring, "v2")).not.toThrow();
+  });
+
+  it("keeps every credential-binding route at the app-admin tier", () => {
+    const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+    const routes = source.split("\n")
+      .filter((line) => line.includes('"/api/apps/:appId/google-play-binding'));
+    expect(routes).toHaveLength(6);
+    expect(routes.every((line) => line.includes('requireAppRole("admin")'))).toBe(true);
+    expect(source).toContain('requireAppRole("publisher")');
+  });
+
+  it("keeps migration 0071 additive, rerunnable, app-unique, and cascade-scoped", () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    db.exec("CREATE TABLE apps (id TEXT PRIMARY KEY)");
+    const migration = readFileSync(
+      new URL("../../migrations/sql/0071_app_google_play_bindings.sql", import.meta.url),
+      "utf8",
+    );
+    expect(() => db.exec(migration)).not.toThrow();
+    expect(() => db.exec(migration)).not.toThrow();
+    db.prepare("INSERT INTO apps(id) VALUES ('app-a')").run();
+    const insert = db.prepare(`INSERT INTO app_google_play_bindings
+      (id, app_id, enabled, package_name, internal_track, closed_track, production_track,
+       service_account_email, credential_fingerprint, credential_ciphertext_b64,
+       credential_iv_b64, credential_key_version, verification_state, verified_at,
+       created_by_actor, updated_by_actor, created_at, updated_at)
+      VALUES (?, 'app-a', 1, 'build.raft.app', 'qa', 'closed', 'production',
+              'app@example.iam.gserviceaccount.com', 'fingerprint', 'ciphertext',
+              'iv', 'v1', 'verified', 1, 'actor', 'actor', 1, 1)`);
+    insert.run("binding-a");
+    expect(() => insert.run("binding-b")).toThrow(/UNIQUE/);
+    db.prepare("DELETE FROM apps WHERE id='app-a'").run();
+    expect(db.prepare("SELECT COUNT(*) AS count FROM app_google_play_bindings").get())
+      .toEqual({ count: 0 });
+  });
+});

--- a/worker/test/google_play_distribution.test.ts
+++ b/worker/test/google_play_distribution.test.ts
@@ -22,6 +22,14 @@ import {
 } from "../src/routes/play_distribution";
 import { createRelease } from "../src/routes/releases";
 import { openApiDocument } from "../src/openapi";
+import { storeGooglePlayBinding } from "../src/lib/google_play_bindings";
+import { requireAppRole } from "../src/lib/permissions";
+import {
+  handleEnableGooglePlayBinding,
+  handleGetGooglePlayBinding,
+  handlePutGooglePlayBinding,
+  handleVerifyGooglePlayBinding,
+} from "../src/routes/google_play_bindings";
 
 const A = "a".repeat(64);
 const B = "b".repeat(64);
@@ -209,6 +217,10 @@ describe("Android distribution OpenAPI", () => {
       "/api/apps/{appId}/android-release-artifacts",
       "/api/apps/{appId}/android-release-artifacts/{buildId}",
       "/api/apps/{appId}/android-release-artifacts/{buildId}/assets/{assetId}/complete",
+      "/api/apps/{appId}/google-play-binding",
+      "/api/apps/{appId}/google-play-binding/verify",
+      "/api/apps/{appId}/google-play-binding/enable",
+      "/api/apps/{appId}/google-play-binding/disable",
       "/api/apps/{appId}/releases/{releaseId}/receipts",
       "/api/apps/{appId}/releases/{releaseId}/receipts/acceptance",
       "/api/apps/{appId}/releases/{releaseId}/distributions",
@@ -439,6 +451,21 @@ describe("Android artifact routes", () => {
 
 async function readyRelease() {
   const harness = routeHarness();
+  harness.env.PLAY_CRED_ENC_KEYS = JSON.stringify({ v1: "test-only-google-play-key-material-1234567890" });
+  harness.env.PLAY_CRED_ENC_ACTIVE_KEY_VERSION = "v1";
+  await storeGooglePlayBinding(harness.env.DB, {
+    appId: "app",
+    packageName: "build.raft.app",
+    tracks: { internal: "qa", closed: "closed", production: "production" },
+    credential: {
+      type: "service_account",
+      client_email: "app@example.iam.gserviceaccount.com",
+      private_key: "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+    },
+    actor: "raft:human@test",
+    keyringJson: harness.env.PLAY_CRED_ENC_KEYS,
+    activeKeyVersion: harness.env.PLAY_CRED_ENC_ACTIVE_KEY_VERSION,
+  });
   const aab = new TextEncoder().encode("exact-aab");
   const apk = new TextEncoder().encode("exact-apk");
   const body = validBundle();
@@ -482,31 +509,238 @@ async function readyRelease() {
   return { ...harness, aab, aabAsset, declared };
 }
 
+type PlayAdapter = NonNullable<Env["PLAY_RELEASE_SERVICE"]>;
+
+function playAdapterStub(overrides: Partial<PlayAdapter> = {}): PlayAdapter {
+  return {
+    verifyBinding: async (input) => ({
+      ok: true,
+      value: {
+        client_email: input.credential.client_email,
+        package_name: input.packageName,
+        tracks: input.tracks,
+      },
+    }),
+    readTrackMaximum: async () => ({ ok: true, value: { max_version_code: 41 } }),
+    promote: async () => {
+      throw new Error("unexpected promote call");
+    },
+    ...overrides,
+  };
+}
+
+function googlePlayBindingHarness(role: "admin" | "publisher", withKeyring = true) {
+  const sqlite = fullDatabase();
+  const now = Date.now();
+  sqlite.prepare(`INSERT INTO raft_accounts
+    (id, provider, provider_subject, server_id, server_slug, principal_type, server_role,
+     username, display_name, avatar_url, raw_profile, created_at, updated_at, last_login_at)
+    VALUES ('binding-user', 'raft', 'binding-user', 'server', 'test', 'human', NULL,
+            'binding-user', 'Binding User', NULL, '{}', ?, ?, ?)`)
+    .run(now, now, now);
+  sqlite.prepare(`INSERT INTO app_members
+    (id, app_id, account_id, app_role, joined_at)
+    VALUES ('binding-member', 'app', 'binding-user', ?, ?)`)
+    .run(role, now);
+  sqlite.prepare("INSERT INTO apps (id, slug, name, platform, created_at) VALUES ('other', 'other', 'Other', 'android', ?)")
+    .run(now);
+
+  const env = {
+    DB: d1(sqlite),
+    ENVIRONMENT: "development",
+    BUSINESS_ORIGIN: "https://hands.test",
+    DASHBOARD_ORIGIN: "https://app.hands.test",
+    ...(withKeyring
+      ? {
+          PLAY_CRED_ENC_KEYS: JSON.stringify({ v1: "test-only-google-play-key-material-1234567890" }),
+          PLAY_CRED_ENC_ACTIVE_KEY_VERSION: "v1",
+        }
+      : {}),
+    PLAY_RELEASE_SERVICE: playAdapterStub(),
+  } as unknown as Env;
+  const app = new Hono<{ Bindings: Env; Variables: { admin_account: any; admin_actor: string } }>();
+  app.use("*", async (c, next) => {
+    c.set("admin_account", {
+      id: "binding-user",
+      provider: "raft",
+      provider_subject: "binding-user",
+      server_id: "server",
+      server_slug: "test",
+      principal_type: "human",
+      server_role: null,
+      username: "binding-user",
+      display_name: "Binding User",
+      avatar_url: null,
+      raw_profile: "{}",
+      created_at: now,
+      updated_at: now,
+      last_login_at: now,
+    });
+    c.set("admin_actor", "raft:binding-user@test");
+    await next();
+  });
+  app.get("/api/apps/:appId/google-play-binding", requireAppRole("admin"), handleGetGooglePlayBinding);
+  app.put("/api/apps/:appId/google-play-binding", requireAppRole("admin"), handlePutGooglePlayBinding);
+  app.post("/api/apps/:appId/google-play-binding/verify", requireAppRole("admin"), handleVerifyGooglePlayBinding);
+  app.post("/api/apps/:appId/google-play-binding/enable", requireAppRole("admin"), handleEnableGooglePlayBinding);
+  const request = (path: string, init?: RequestInit) =>
+    app.fetch(new Request(`https://hands.test${path}`, init), env, executionContext);
+  return { sqlite, env, request };
+}
+
+function validBindingBody() {
+  return {
+    service_account_json: {
+      type: "service_account",
+      project_id: "tenant-project",
+      private_key_id: "tenant-key",
+      client_email: "tenant@example.iam.gserviceaccount.com",
+      private_key: "-----BEGIN PRIVATE KEY-----\nprivate-tenant-material\n-----END PRIVATE KEY-----",
+    },
+    package_name: "build.raft.app",
+    tracks: { internal: "qa", closed: "closed", production: "production" },
+  };
+}
+
+describe("Google Play binding routes", () => {
+  it("allows only the app admin, stores encrypted private material, and returns safe metadata", async () => {
+    const publisher = googlePlayBindingHarness("publisher");
+    const denied = await publisher.request("/api/apps/app/google-play-binding", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validBindingBody()),
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({ code: "INSUFFICIENT_APP_ROLE", required_role: "admin" });
+
+    const admin = googlePlayBindingHarness("admin");
+    const stored = await admin.request("/api/apps/app/google-play-binding", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validBindingBody()),
+    });
+    expect(stored.status).toBe(200);
+    const responseText = await stored.text();
+    expect(responseText).not.toContain("private-tenant-material");
+    expect(responseText).not.toContain("BEGIN PRIVATE KEY");
+    expect(JSON.parse(responseText)).toMatchObject({
+      google_play: { app_id: "app", enabled: true, package_name: "build.raft.app" },
+    });
+    const row = admin.sqlite.prepare(`SELECT credential_ciphertext_b64, credential_iv_b64,
+      credential_key_version FROM app_google_play_bindings WHERE app_id='app'`).get() as Record<string, string>;
+    expect(JSON.stringify(row)).not.toContain("private-tenant-material");
+    expect(row.credential_key_version).toBe("v1");
+    const audit = admin.sqlite.prepare("SELECT payload FROM audit_logs WHERE action='google_play.binding.set'").get() as { payload: string };
+    expect(audit.payload).not.toContain("private-tenant-material");
+
+    const readback = await admin.request("/api/apps/app/google-play-binding");
+    expect(readback.status).toBe(200);
+    expect(await readback.text()).not.toContain("credential_ciphertext_b64");
+
+    const crossApp = await admin.request("/api/apps/other/google-play-binding");
+    expect(crossApp.status).toBe(403);
+  });
+
+  it("fails before external validation when credential encryption is unavailable", async () => {
+    const harness = googlePlayBindingHarness("admin", false);
+    let adapterCalls = 0;
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      verifyBinding: async () => {
+        adapterCalls += 1;
+        return { ok: false, error: { status: 500, code: "UNEXPECTED", message: "unexpected" } };
+      },
+    });
+    const response = await harness.request("/api/apps/app/google-play-binding", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validBindingBody()),
+    });
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ code: "PLAY_CREDENTIAL_STORAGE_UNAVAILABLE" });
+    expect(adapterCalls).toBe(0);
+  });
+
+  it("marks a definitively rejected binding stale and disabled, then re-verifies before enable", async () => {
+    const harness = googlePlayBindingHarness("admin");
+    const stored = await harness.request("/api/apps/app/google-play-binding", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validBindingBody()),
+    });
+    expect(stored.status).toBe(200);
+
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      verifyBinding: async () => ({
+        ok: false,
+        error: { status: 502, code: "PLAY_UPSTREAM_UNAVAILABLE", message: "temporarily unavailable" },
+      }),
+    });
+    const transient = await harness.request("/api/apps/app/google-play-binding/verify", { method: "POST" });
+    expect(transient.status).toBe(502);
+    expect(harness.sqlite.prepare(`SELECT enabled, verification_state FROM app_google_play_bindings
+      WHERE app_id='app'`).get()).toEqual({ enabled: 1, verification_state: "verified" });
+
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      verifyBinding: async () => ({
+        ok: false,
+        error: { status: 403, code: "PLAY_PERMISSION_DENIED", message: "permission denied" },
+      }),
+    });
+    const rejected = await harness.request("/api/apps/app/google-play-binding/verify", { method: "POST" });
+    expect(rejected.status).toBe(502);
+    expect(harness.sqlite.prepare(`SELECT enabled, verification_state, verified_at
+      FROM app_google_play_bindings WHERE app_id='app'`).get()).toEqual({
+      enabled: 0,
+      verification_state: "stale",
+      verified_at: null,
+    });
+
+    const deniedEnable = await harness.request("/api/apps/app/google-play-binding/enable", { method: "POST" });
+    expect(deniedEnable.status).toBe(502);
+    const deniedAudit = harness.sqlite.prepare(`SELECT payload FROM audit_logs
+      WHERE action='google_play.binding.enable' ORDER BY created_at DESC LIMIT 1`).get() as { payload: string };
+    expect(JSON.parse(deniedAudit.payload)).toEqual({
+      package_name: "build.raft.app",
+      ok: false,
+      code: "PLAY_PERMISSION_DENIED",
+    });
+    expect(deniedAudit.payload).not.toContain("private-tenant-material");
+
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub();
+    const enabled = await harness.request("/api/apps/app/google-play-binding/enable", { method: "POST" });
+    expect(enabled.status).toBe(200);
+    expect(harness.sqlite.prepare(`SELECT enabled, verification_state, verified_at IS NOT NULL AS verified
+      FROM app_google_play_bindings WHERE app_id='app'`).get()).toEqual({
+      enabled: 1,
+      verification_state: "verified",
+      verified: 1,
+    });
+  });
+});
+
 describe("Play promotion route", () => {
   it("streams the accepted exact AAB once and records matching readback", async () => {
     const harness = await readyRelease();
     let trackReads = 0;
     let edits = 0;
-    harness.env.PLAY_RELEASE_SERVICE = {
-      fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = String(input);
-        if (init?.method === "GET") {
-          trackReads += 1;
-          return Response.json({ max_version_code: 41 });
-        }
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      readTrackMaximum: async () => {
+        trackReads += 1;
+        return { ok: true, value: { max_version_code: 41 } };
+      },
+      promote: async (_input, stream) => {
         edits += 1;
-        const bytes = new Uint8Array(await new Response(init?.body).arrayBuffer());
-        return Response.json({
+        const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+        return { ok: true, value: {
           edit_id: "edit-1",
           package_name: "build.raft.app",
           version_code: 42,
           track: "internal",
           sha256: sha(bytes),
           rollout_percent: 100,
-          adapter_url: url,
-        });
+        } };
       },
-    } as unknown as Fetcher;
+    });
 
     const promoted = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
       method: "POST",
@@ -539,15 +773,55 @@ describe("Play promotion route", () => {
     expect(JSON.stringify(payload)).not.toMatch(/distribution[_-]?cert/i);
   });
 
+  it("rejects missing, disabled, and package-mismatched app bindings before any adapter call", async () => {
+    const cases = [
+      {
+        mutate: (db: Database.Database) => db.prepare("DELETE FROM app_google_play_bindings WHERE app_id='app'").run(),
+        status: 403,
+        gate: "permission",
+      },
+      {
+        mutate: (db: Database.Database) => db.prepare("UPDATE app_google_play_bindings SET enabled=0 WHERE app_id='app'").run(),
+        status: 403,
+        gate: "permission",
+      },
+      {
+        mutate: (db: Database.Database) => db.prepare("UPDATE app_google_play_bindings SET package_name='other.package' WHERE app_id='app'").run(),
+        status: 400,
+        gate: "immutable_binding",
+      },
+    ];
+    for (const fixture of cases) {
+      const harness = await readyRelease();
+      let adapterCalls = 0;
+      harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+        readTrackMaximum: async () => {
+          adapterCalls += 1;
+          return { ok: true, value: { max_version_code: 41 } };
+        },
+      });
+      fixture.mutate(harness.sqlite);
+      const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ track: "internal", expected_revision: 1, approval: { note: "approved" } }),
+      });
+      expect(response.status).toBe(fixture.status);
+      expect(await response.json()).toMatchObject({ error: { gate: fixture.gate } });
+      expect(adapterCalls).toBe(0);
+      expect(harness.sqlite.prepare("SELECT revision FROM releases WHERE id='release'").get()).toEqual({ revision: 1 });
+    }
+  });
+
   it("returns edit_conflict without calling Play and never retries", async () => {
     const harness = await readyRelease();
     let calls = 0;
-    harness.env.PLAY_RELEASE_SERVICE = {
-      fetch: async () => {
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      readTrackMaximum: async () => {
         calls += 1;
-        return Response.json({ max_version_code: 41 });
+        return { ok: true, value: { max_version_code: 41 } };
       },
-    } as unknown as Fetcher;
+    });
     harness.sqlite.prepare(`INSERT INTO play_edit_locks
       (app_id, package_name, release_id, operation_id, acquired_by, acquired_at)
       VALUES ('app', 'build.raft.app', 'release', 'other', 'other', 1)`).run();
@@ -563,9 +837,9 @@ describe("Play promotion route", () => {
 
   it("returns typed play_api_error before revision reserve for malformed track JSON", async () => {
     const harness = await readyRelease();
-    harness.env.PLAY_RELEASE_SERVICE = {
-      fetch: async () => new Response("{", { status: 200, headers: { "content-type": "application/json" } }),
-    } as unknown as Fetcher;
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      readTrackMaximum: async () => ({ ok: true, value: { max_version_code: Number.NaN } }),
+    });
     const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -580,9 +854,9 @@ describe("Play promotion route", () => {
 
   it("returns typed play_api_error before reserve when the track request rejects", async () => {
     const harness = await readyRelease();
-    harness.env.PLAY_RELEASE_SERVICE = {
-      fetch: async () => { throw new Error("adapter unavailable"); },
-    } as unknown as Fetcher;
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      readTrackMaximum: async () => { throw new Error("adapter unavailable"); },
+    });
     const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -595,11 +869,10 @@ describe("Play promotion route", () => {
 
   it("records failed-closed after reserve when Play edit readback is malformed", async () => {
     const harness = await readyRelease();
-    harness.env.PLAY_RELEASE_SERVICE = {
-      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => init?.method === "GET"
-        ? Response.json({ max_version_code: 41 })
-        : new Response("not-json", { status: 200, headers: { "content-type": "application/json" } }),
-    } as unknown as Fetcher;
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      readTrackMaximum: async () => ({ ok: true, value: { max_version_code: 41 } }),
+      promote: async () => ({ ok: true, value: null }),
+    } as unknown as Partial<PlayAdapter>);
     const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -616,12 +889,10 @@ describe("Play promotion route", () => {
 
   it("records failed-closed after reserve when the Play edit request rejects", async () => {
     const harness = await readyRelease();
-    harness.env.PLAY_RELEASE_SERVICE = {
-      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
-        if (init?.method === "GET") return Response.json({ max_version_code: 41 });
-        throw new Error("adapter unavailable");
-      },
-    } as unknown as Fetcher;
+    harness.env.PLAY_RELEASE_SERVICE = playAdapterStub({
+      readTrackMaximum: async () => ({ ok: true, value: { max_version_code: 41 } }),
+      promote: async () => { throw new Error("adapter unavailable"); },
+    });
     const response = await harness.request("/api/apps/app/releases/release/distributions/play/promote", {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/worker/test/production_config.test.ts
+++ b/worker/test/production_config.test.ts
@@ -32,6 +32,7 @@ function render(extraEnv: Record<string, string> = {}) {
     if (key.startsWith("HANDS_FEEDBACK_REPORTER_SESSION_")) delete inheritedEnv[key];
   }
   delete inheritedEnv.HANDS_PLAY_RELEASE_SERVICE_NAME;
+  delete inheritedEnv.HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION;
   const result = spawnSync(process.execPath, [renderScript, "--output", output], {
     cwd: workerDir,
     encoding: "utf8",
@@ -97,13 +98,25 @@ test("production config binds the Play adapter only when its exact service name 
     absent.cleanup();
   }
 
-  const configured = render({ HANDS_PLAY_RELEASE_SERVICE_NAME: "hands-google-play-adapter" });
+  const missingKeyVersion = render({ HANDS_PLAY_RELEASE_SERVICE_NAME: "hands-google-play-adapter" });
+  try {
+    assert.notEqual(missingKeyVersion.result.status, 0);
+    assert.match(missingKeyVersion.result.stderr, /PLAY_CRED_ENC_ACTIVE_KEY_VERSION is required/);
+  } finally {
+    missingKeyVersion.cleanup();
+  }
+
+  const configured = render({
+    HANDS_PLAY_RELEASE_SERVICE_NAME: "hands-google-play-adapter",
+    HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION: "play-v1",
+  });
   try {
     assert.equal(configured.result.status, 0, configured.result.stderr);
     const config = JSON.parse(readFileSync(configured.output, "utf8"));
     assert.deepEqual(config.services, [
       { binding: "PLAY_RELEASE_SERVICE", service: "hands-google-play-adapter" },
     ]);
+    assert.equal(config.vars.PLAY_CRED_ENC_ACTIVE_KEY_VERSION, "play-v1");
   } finally {
     configured.cleanup();
   }
@@ -115,6 +128,14 @@ test("production config binds the Play adapter only when its exact service name 
   } finally {
     invalid.cleanup();
   }
+});
+
+test("the deploy workflow writes the app-scoped Play credential keyring as a secret", () => {
+  const workflow = readFileSync(resolve(repositoryDir, ".github/workflows/deploy-hands-server.yml"), "utf8");
+  assert.match(workflow, /PLAY_CRED_ENC_KEYS: \$\{\{ secrets\.HANDS_PLAY_CRED_ENC_KEYS \}\}/);
+  assert.match(workflow, /wrangler secret put PLAY_CRED_ENC_KEYS/);
+  assert.match(workflow, /HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION: \$\{\{ vars\.HANDS_PLAY_CRED_ENC_ACTIVE_KEY_VERSION \}\}/);
+  assert.doesNotMatch(workflow, /PLAY_CRED_ENC_KEYS: \$\{\{ vars\./);
 });
 
 test("production config requires a closed key version before enabling reporter sessions", () => {


### PR DESCRIPTION
Raft author: @XX; GitHub carrier: stdrc (shared).

## Summary
- move Google Play credentials, package, and track mapping from global adapter config to one encrypted binding per Android app
- add app-admin UI/API to validate, bind/replace, verify, enable/disable, and unbind the app's own service account
- keep the private adapter stateless; Hands decrypts only the selected app binding and passes it over a private service binding
- require exact package/track access before enable and fail closed on missing, stale, disabled, or cross-app bindings

## Security and behavior
- AES-GCM credential storage uses app-bound additional data and a versioned Worker-secret keyring
- only safe metadata is returned; private credential material is neither returned nor logged
- definitive Google credential/access rejection marks the binding stale and disabled; transient provider failures preserve current state
- promotion still requires a sealed exact AAB, acceptance receipt, human approval, no live hold, versionCode=max+1, a single edit, and exact post-commit readback

## Verification
- `pnpm test` (all workspaces; Worker 54 files / 556 tests, Admin 11 / 38, adapter 2 / 11)
- `pnpm build` (all workspaces)
- Hands Worker and private adapter `wrangler deploy --dry-run`
- credential-route admin-tier and keyring-preflight mutation teeth both observed RED before restore
- `git diff --check`

Draft only. No production deployment, migration apply, credential/config write, AAB upload, or Google Play mutation is included.
