### PR TITLE
fix(hands): register Play adapter fetch handler

### DIFF
--- a/play-adapter/src/entrypoint.ts
+++ b/play-adapter/src/entrypoint.ts
@@ -5,6 +5,10 @@ import type { PlayAdapterEnv, PlayBindingInput, PromotionRpcInput, TrackMaximumR
 export default class GooglePlayAdapter extends WorkerEntrypoint<PlayAdapterEnv> {
   private readonly service = createPlayAdapterService();
 
+  async fetch(): Promise<Response> {
+    return new Response(null, { status: 404 });
+  }
+
   verifyBinding(input: PlayBindingInput) {
     return this.service.verifyBinding(input, this.env);
   }

--- a/play-adapter/test/production_config.test.ts
+++ b/play-adapter/test/production_config.test.ts
@@ -42,6 +42,12 @@ test("production config keeps the adapter private and renders the exact bounded 
   }
 });
 
+test("adapter registers a closed HTTP handler so Cloudflare accepts the private RPC entrypoint", () => {
+  const entrypoint = readFileSync(resolve(adapterDir, "src/entrypoint.ts"), "utf8");
+  assert.match(entrypoint, /async fetch\(\): Promise<Response>/);
+  assert.match(entrypoint, /new Response\(null, \{ status: 404 \}\)/);
+});
+
 test("production config rejects malformed service and size inputs", () => {
   const cases = [
     [{ HANDS_PLAY_ADAPTER_WORKER_NAME: "https://bad.example" }, /valid Cloudflare Worker/],


### PR DESCRIPTION
Raft author: @XX; pushed via the shared `stdrc` GitHub carrier.

## Why

The first production deploy of the private Google Play RPC adapter reached Cloudflare after all local/Hosted checks, but the upload was rejected with code 10068 because the module had no registered HTTP event handler. No adapter version, Hands Worker, or migration was deployed.

## Change

- Add a closed `fetch()` handler returning 404 to the existing `WorkerEntrypoint`; `workers_dev=false`, `preview_urls=false`, and no routes remain unchanged.
- Add a deployment-contract test so removing that handler makes the adapter suite fail.

## Verification

- adapter tests: 12/12
- adapter TypeScript build: pass
- Wrangler production-config dry-run: pass
- mutation: removing `fetch()` makes the named deployability test fail 1/4 for the intended reason, then restore is green

Source-only PR. Deployment resumes only after independent exact review and neutral landing.
