### PR TITLE
feat(cli): add Google Play distribution commands to hands releases

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1746,3 +1746,310 @@ describe("hands api command path (--api / --json wiring)", () => {
     expect(errs.join("\n")).not.toMatch(/\b200\b/);
   });
 });
+
+describe("play distribution commands", () => {
+  interface PlayRequest {
+    method: string;
+    url: string;
+    body?: unknown;
+  }
+
+  interface PlayHarness {
+    requests: PlayRequest[];
+    logs: string[];
+    run: (...args: string[]) => Promise<void>;
+    close: () => Promise<void>;
+  }
+
+  const originalEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ["HANDS_API", "HANDS_BEARER_TOKEN", "SLOCK_CLI_TRANSPORT_DIR", "SLOCK_HOME", "SLOCK_AGENT_ID"];
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      // Human/CI auth path: clear inherited agent markers so admission is `human`.
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+  });
+
+  async function startPlayHarness(
+    overrides: { writeError?: { status: number; error: Record<string, unknown> } } = {},
+  ): Promise<PlayHarness> {
+    const requests: PlayRequest[] = [];
+    const logs: string[] = [];
+    const server = createServer(async (req, res) => {
+      let body: unknown;
+      if (req.headers["content-type"]?.includes("application/json")) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      }
+      requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/apps") {
+        return res.end(JSON.stringify({ apps: [{ id: "app-1", slug: "raft-android" }] }));
+      }
+      if (req.url === "/api/apps/app-1/releases/release-1" && req.method === "GET") {
+        return res.end(JSON.stringify({
+          release: { id: "release-1", status: "active", revision: 7 },
+        }));
+      }
+      if (req.url === "/api/apps/app-1/releases/release-1/distributions") {
+        return res.end(JSON.stringify({
+          distributions: [
+            { channel: "hands", state: "active" },
+            { channel: "google-play", state: "staged", track: "internal", version_code: 42, rollout_percent: 25 },
+          ],
+        }));
+      }
+      if (req.url === "/api/apps/app-1/releases/release-1/distributions/play" && req.method === "GET") {
+        return res.end(JSON.stringify({
+          play: {
+            track: "internal",
+            version_code: 42,
+            rollout_percent: 25,
+            last_edit_id: "edit-1",
+            last_receipt_id: "rcpt-1",
+          },
+        }));
+      }
+      if (req.url?.startsWith("/api/apps/app-1/releases/release-1/distributions/play/") && req.method === "POST") {
+        if (overrides.writeError) {
+          res.statusCode = overrides.writeError.status;
+          return res.end(JSON.stringify({ error: overrides.writeError.error }));
+        }
+        const action = req.url.split("/").at(-1);
+        return res.end(JSON.stringify({
+          receipt: {
+            id: `rcpt-${action}`,
+            action: action === "rollback" ? "rollback-republish" : action,
+            result: "success",
+            track: "internal",
+            version_code: 42,
+            rollout_percent: 25,
+            play_edit_id: `edit-${action}`,
+          },
+        }));
+      }
+      if (req.url === "/api/apps/app-1/releases/release-1/receipts") {
+        return res.end(JSON.stringify({
+          receipts: [
+            { id: "rcpt-0", kind: "acceptance", verdict: "pass", created_at: 1700000000000 },
+            { id: "rcpt-1", kind: "play-promotion", action: "promote", result: "success", created_at: 1700000100000 },
+          ],
+        }));
+      }
+      res.statusCode = 404;
+      return res.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("bad address");
+    process.env.HANDS_API = `http://127.0.0.1:${address.port}`;
+    process.env.HANDS_BEARER_TOKEN = "test-token";
+    // api.ts caches a process-wide base once any test calls setApiBase (e.g. the
+    // `hands api` describe above), so pin the base explicitly instead of relying
+    // on HANDS_API env resolution alone.
+    const { setApiBase } = await import("../src/lib/api.js");
+    setApiBase(process.env.HANDS_API);
+    const logSpy = vi.spyOn(console, "log").mockImplementation((m?: unknown) => {
+      logs.push(String(m));
+    });
+    const { registerReleaseCommands } = await import("../src/commands/releases.js");
+    const run = async (...args: string[]) => {
+      const program = new Command().option("--json", "JSON output", false);
+      registerReleaseCommands(program);
+      await program.parseAsync(["node", "hands", ...args]);
+    };
+    return {
+      requests,
+      logs,
+      run,
+      close: async () => {
+        logSpy.mockRestore();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      },
+    };
+  }
+
+  it("lists distribution channels, in text and via --json at subcommand and root level", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await harness.run("releases", "distributions", "raft-android", "release-1");
+      const text = harness.logs.join("\n");
+      expect(text).toContain("hands  active");
+      expect(text).toContain("google-play  staged  track=internal  versionCode=42  rollout=25%");
+
+      harness.logs.length = 0;
+      await harness.run("releases", "distributions", "raft-android", "release-1", "--json");
+      expect(JSON.parse(harness.logs.join("\n"))).toEqual({
+        distributions: [
+          { channel: "hands", state: "active" },
+          { channel: "google-play", state: "staged", track: "internal", version_code: 42, rollout_percent: 25 },
+        ],
+      });
+
+      // Root-level --json must not be swallowed by the subcommand (task #140 contract).
+      harness.logs.length = 0;
+      await harness.run("--json", "releases", "distributions", "raft-android", "release-1");
+      expect(JSON.parse(harness.logs.join("\n")).distributions).toHaveLength(2);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("promotes with expected_revision, approval note, and prints receipt/edit/track/versionCode", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await harness.run(
+        "releases", "play-promote", "raft-android", "release-1",
+        "--track", "internal", "--rollout-percent", "25", "--note", "ship it",
+      );
+      const post = harness.requests.find((request) => request.method === "POST");
+      expect(post).toEqual({
+        method: "POST",
+        url: "/api/apps/app-1/releases/release-1/distributions/play/promote",
+        body: {
+          track: "internal",
+          expected_revision: 7,
+          approval: { note: "ship it" },
+          rollout_percent: 25,
+        },
+      });
+      const text = harness.logs.join("\n");
+      expect(text).toContain("rcpt-promote");
+      expect(text).toContain("edit-promote");
+      expect(text).toContain("track:       internal");
+      expect(text).toContain("versionCode: 42");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("halts and rolls back with expected_revision; rollback sends to_version_code", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await harness.run("releases", "play-halt", "raft-android", "release-1");
+      await harness.run(
+        "releases", "play-rollback", "raft-android", "release-1",
+        "--to-version-code", "41", "--note", "regression",
+      );
+      const posts = harness.requests.filter((request) => request.method === "POST");
+      expect(posts).toEqual([
+        {
+          method: "POST",
+          url: "/api/apps/app-1/releases/release-1/distributions/play/halt",
+          body: { expected_revision: 7, approval: { note: "" } },
+        },
+        {
+          method: "POST",
+          url: "/api/apps/app-1/releases/release-1/distributions/play/rollback",
+          body: { to_version_code: 41, expected_revision: 7, approval: { note: "regression" } },
+        },
+      ]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("maps gate_failed to a verbatim gate name with no partial output", async () => {
+    const harness = await startPlayHarness({
+      writeError: {
+        status: 400,
+        error: {
+          code: "gate_failed",
+          gate: "acceptance_receipt",
+          message: "no passing acceptance receipt for this AAB",
+          receipt_id: "rcpt-failed",
+        },
+      },
+    });
+    try {
+      await expect(harness.run(
+        "releases", "play-promote", "raft-android", "release-1", "--track", "internal",
+      )).rejects.toThrow("gate acceptance_receipt");
+      expect(harness.logs).toHaveLength(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("reports edit_conflict without auto-retry", async () => {
+    const harness = await startPlayHarness({
+      writeError: {
+        status: 409,
+        error: {
+          code: "edit_conflict",
+          gate: "edit_lock",
+          message: "another Play edit is active for this package",
+          receipt_id: null,
+        },
+      },
+    });
+    try {
+      await expect(harness.run(
+        "releases", "play-halt", "raft-android", "release-1",
+      )).rejects.toThrow(/edit_conflict.*Not retried automatically/);
+      expect(harness.requests.filter((request) => request.method === "POST")).toHaveLength(1);
+      expect(harness.logs).toHaveLength(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("rejects invalid --track, --rollout-percent, and --to-version-code before any request", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await expect(harness.run(
+        "releases", "play-promote", "raft-android", "release-1", "--track", "beta",
+      )).rejects.toThrow("--track must be one of: internal, closed, production");
+      await expect(harness.run(
+        "releases", "play-promote", "raft-android", "release-1", "--track", "closed", "--rollout-percent", "101",
+      )).rejects.toThrow("--rollout-percent must be an integer from 0 to 100");
+      await expect(harness.run(
+        "releases", "play-rollback", "raft-android", "release-1", "--to-version-code", "0",
+      )).rejects.toThrow("--to-version-code must be a positive integer");
+      expect(harness.requests).toHaveLength(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("prints the immutable receipt chain", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await harness.run("releases", "receipts", "raft-android", "release-1");
+      const text = harness.logs.join("\n");
+      expect(text).toContain("rcpt-0  acceptance  pass");
+      expect(text).toContain("rcpt-1  play-promotion/promote  success");
+
+      harness.logs.length = 0;
+      await harness.run("--json", "releases", "receipts", "raft-android", "release-1");
+      expect(JSON.parse(harness.logs.join("\n")).receipts).toHaveLength(2);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("shows current Play state", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await harness.run("releases", "play-status", "raft-android", "release-1");
+      const text = harness.logs.join("\n");
+      expect(text).toContain("track:        internal");
+      expect(text).toContain("versionCode:  42");
+      expect(text).toContain("rollout:      25%");
+      expect(text).toContain("last edit:    edit-1");
+      expect(text).toContain("last receipt: rcpt-1");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1864,7 +1864,9 @@ describe("play distribution commands", () => {
     });
     const { registerReleaseCommands } = await import("../src/commands/releases.js");
     const run = async (...args: string[]) => {
-      const program = new Command().option("--json", "JSON output", false);
+      // exitOverride turns parse-time errors (e.g. a missing required option)
+      // into rejections instead of process.exit, so tests can assert them.
+      const program = new Command().option("--json", "JSON output", false).exitOverride();
       registerReleaseCommands(program);
       await program.parseAsync(["node", "hands", ...args]);
     };
@@ -1937,7 +1939,7 @@ describe("play distribution commands", () => {
   it("halts and rolls back with expected_revision; rollback sends to_version_code", async () => {
     const harness = await startPlayHarness();
     try {
-      await harness.run("releases", "play-halt", "raft-android", "release-1");
+      await harness.run("releases", "play-halt", "raft-android", "release-1", "--note", "pause rollout");
       await harness.run(
         "releases", "play-rollback", "raft-android", "release-1",
         "--to-version-code", "41", "--note", "regression",
@@ -1947,7 +1949,7 @@ describe("play distribution commands", () => {
         {
           method: "POST",
           url: "/api/apps/app-1/releases/release-1/distributions/play/halt",
-          body: { expected_revision: 7, approval: { note: "" } },
+          body: { expected_revision: 7, approval: { note: "pause rollout" } },
         },
         {
           method: "POST",
@@ -1974,7 +1976,7 @@ describe("play distribution commands", () => {
     });
     try {
       await expect(harness.run(
-        "releases", "play-promote", "raft-android", "release-1", "--track", "internal",
+        "releases", "play-promote", "raft-android", "release-1", "--track", "internal", "--note", "ship",
       )).rejects.toThrow("gate acceptance_receipt");
       expect(harness.logs).toHaveLength(0);
     } finally {
@@ -1996,7 +1998,7 @@ describe("play distribution commands", () => {
     });
     try {
       await expect(harness.run(
-        "releases", "play-halt", "raft-android", "release-1",
+        "releases", "play-halt", "raft-android", "release-1", "--note", "hold",
       )).rejects.toThrow(/edit_conflict.*Not retried automatically/);
       expect(harness.requests.filter((request) => request.method === "POST")).toHaveLength(1);
       expect(harness.logs).toHaveLength(0);
@@ -2009,14 +2011,32 @@ describe("play distribution commands", () => {
     const harness = await startPlayHarness();
     try {
       await expect(harness.run(
-        "releases", "play-promote", "raft-android", "release-1", "--track", "beta",
+        "releases", "play-promote", "raft-android", "release-1", "--track", "beta", "--note", "n",
       )).rejects.toThrow("--track must be one of: internal, closed, production");
       await expect(harness.run(
-        "releases", "play-promote", "raft-android", "release-1", "--track", "closed", "--rollout-percent", "101",
+        "releases", "play-promote", "raft-android", "release-1", "--track", "closed", "--rollout-percent", "101", "--note", "n",
       )).rejects.toThrow("--rollout-percent must be an integer from 0 to 100");
       await expect(harness.run(
-        "releases", "play-rollback", "raft-android", "release-1", "--to-version-code", "0",
+        "releases", "play-rollback", "raft-android", "release-1", "--to-version-code", "0", "--note", "n",
       )).rejects.toThrow("--to-version-code must be a positive integer");
+      expect(harness.requests).toHaveLength(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("requires --note on Play writes; commander rejects before any request", async () => {
+    const harness = await startPlayHarness();
+    try {
+      await expect(harness.run(
+        "releases", "play-promote", "raft-android", "release-1", "--track", "internal",
+      )).rejects.toThrow("required option '--note <note>' not specified");
+      await expect(harness.run(
+        "releases", "play-halt", "raft-android", "release-1",
+      )).rejects.toThrow("required option '--note <note>' not specified");
+      await expect(harness.run(
+        "releases", "play-rollback", "raft-android", "release-1", "--to-version-code", "41",
+      )).rejects.toThrow("required option '--note <note>' not specified");
       expect(harness.requests).toHaveLength(0);
     } finally {
       await harness.close();

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1780,7 +1780,7 @@ describe("play distribution commands", () => {
   });
 
   async function startPlayHarness(
-    overrides: { writeError?: { status: number; error: Record<string, unknown> } } = {},
+    overrides: { writeError?: { status: number; error: Record<string, unknown> }; playNull?: boolean } = {},
   ): Promise<PlayHarness> {
     const requests: PlayRequest[] = [];
     const logs: string[] = [];
@@ -1804,12 +1804,15 @@ describe("play distribution commands", () => {
       if (req.url === "/api/apps/app-1/releases/release-1/distributions") {
         return res.end(JSON.stringify({
           distributions: [
-            { channel: "hands", state: "active" },
-            { channel: "google-play", state: "staged", track: "internal", version_code: 42, rollout_percent: 25 },
+            { provider: "hands", state: "active" },
+            { provider: "google-play", state: "staged", track: "internal", version_code: 42, rollout_percent: 25 },
           ],
         }));
       }
       if (req.url === "/api/apps/app-1/releases/release-1/distributions/play" && req.method === "GET") {
+        if (overrides.playNull) {
+          return res.end(JSON.stringify({ play: null }));
+        }
         return res.end(JSON.stringify({
           play: {
             track: "internal",
@@ -1827,15 +1830,12 @@ describe("play distribution commands", () => {
         }
         const action = req.url.split("/").at(-1);
         return res.end(JSON.stringify({
-          receipt: {
-            id: `rcpt-${action}`,
-            action: action === "rollback" ? "rollback-republish" : action,
-            result: "success",
-            track: "internal",
-            version_code: 42,
-            rollout_percent: 25,
-            play_edit_id: `edit-${action}`,
-          },
+          receipt_id: `rcpt-${action}`,
+          edit_id: `edit-${action}`,
+          track: "internal",
+          version_code: 42,
+          revision: 8,
+          rollout_percent: 25,
         }));
       }
       if (req.url === "/api/apps/app-1/releases/release-1/receipts") {
@@ -1891,8 +1891,8 @@ describe("play distribution commands", () => {
       await harness.run("releases", "distributions", "raft-android", "release-1", "--json");
       expect(JSON.parse(harness.logs.join("\n"))).toEqual({
         distributions: [
-          { channel: "hands", state: "active" },
-          { channel: "google-play", state: "staged", track: "internal", version_code: 42, rollout_percent: 25 },
+          { provider: "hands", state: "active" },
+          { provider: "google-play", state: "staged", track: "internal", version_code: 42, rollout_percent: 25 },
         ],
       });
 
@@ -1928,6 +1928,7 @@ describe("play distribution commands", () => {
       expect(text).toContain("edit-promote");
       expect(text).toContain("track:       internal");
       expect(text).toContain("versionCode: 42");
+      expect(text).toContain("rollout:     25%");
     } finally {
       await harness.close();
     }
@@ -2048,6 +2049,20 @@ describe("play distribution commands", () => {
       expect(text).toContain("rollout:      25%");
       expect(text).toContain("last edit:    edit-1");
       expect(text).toContain("last receipt: rcpt-1");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("handles the empty play-status state ({play: null}) in text and --json", async () => {
+    const harness = await startPlayHarness({ playNull: true });
+    try {
+      await harness.run("releases", "play-status", "raft-android", "release-1");
+      expect(harness.logs.join("\n")).toContain("No Play distribution yet.");
+
+      harness.logs.length = 0;
+      await harness.run("releases", "play-status", "raft-android", "release-1", "--json");
+      expect(JSON.parse(harness.logs.join("\n"))).toEqual({ play: null });
     } finally {
       await harness.close();
     }

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -629,12 +629,12 @@ export function registerReleaseCommands(program: Command): void {
     .description("Promote the release's accepted AAB to a Google Play track (publisher role; fail-closed gates, no auto-retry).")
     .requiredOption("--track <track>", "Play track: internal, closed, or production.")
     .option("--rollout-percent <percent>", "Staged rollout percentage (0-100).")
-    .option("--note <note>", "Approval note recorded in the play-promotion receipt.")
+    .requiredOption("--note <note>", "Approval note written into the promotion receipt's approvals (required, non-empty).")
     .option("--json", "Output JSON.", false)
     .action(async (
       appIdOrSlug: string,
       releaseId: string,
-      opts: { track: string; rolloutPercent?: string; note?: string; json?: boolean },
+      opts: { track: string; rolloutPercent?: string; note: string; json?: boolean },
       command: Command,
     ) => {
       const track = parsePlayTrack(opts.track);
@@ -645,7 +645,7 @@ export function registerReleaseCommands(program: Command): void {
       const body: Record<string, unknown> = {
         track,
         expected_revision: await fetchReleaseRevision(appId, releaseId),
-        approval: { note: opts.note ?? "" },
+        approval: { note: opts.note },
       };
       if (rolloutPercent !== undefined) body.rollout_percent = rolloutPercent;
       let res: PlayWriteResult;
@@ -672,18 +672,18 @@ export function registerReleaseCommands(program: Command): void {
   releases
     .command("play-halt <appIdOrSlug> <releaseId>")
     .description("Halt the staged Google Play rollout for a release (publisher role; no auto-retry).")
-    .option("--note <note>", "Approval note recorded in the play-promotion receipt.")
+    .requiredOption("--note <note>", "Approval note written into the promotion receipt's approvals (required, non-empty).")
     .option("--json", "Output JSON.", false)
     .action(async (
       appIdOrSlug: string,
       releaseId: string,
-      opts: { note?: string; json?: boolean },
+      opts: { note: string; json?: boolean },
       command: Command,
     ) => {
       const appId = await resolveAppId(appIdOrSlug);
       const body: Record<string, unknown> = {
         expected_revision: await fetchReleaseRevision(appId, releaseId),
-        approval: { note: opts.note ?? "" },
+        approval: { note: opts.note },
       };
       let res: PlayWriteResult;
       try {
@@ -710,12 +710,12 @@ export function registerReleaseCommands(program: Command): void {
     .command("play-rollback <appIdOrSlug> <releaseId>")
     .description("Republish a previous stable versionCode on Google Play (Play has no in-place downgrade; publisher role).")
     .requiredOption("--to-version-code <versionCode>", "Previous stable versionCode to republish at a higher versionCode.")
-    .option("--note <note>", "Approval note recorded in the play-promotion receipt.")
+    .requiredOption("--note <note>", "Approval note written into the promotion receipt's approvals (required, non-empty).")
     .option("--json", "Output JSON.", false)
     .action(async (
       appIdOrSlug: string,
       releaseId: string,
-      opts: { toVersionCode: string; note?: string; json?: boolean },
+      opts: { toVersionCode: string; note: string; json?: boolean },
       command: Command,
     ) => {
       const toVersionCode = parsePlayVersionCode(opts.toVersionCode);
@@ -723,7 +723,7 @@ export function registerReleaseCommands(program: Command): void {
       const body: Record<string, unknown> = {
         to_version_code: toVersionCode,
         expected_revision: await fetchReleaseRevision(appId, releaseId),
-        approval: { note: opts.note ?? "" },
+        approval: { note: opts.note },
       };
       let res: PlayWriteResult;
       try {

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -26,14 +26,14 @@ interface ReleaseScope {
   scope_value: string;
 }
 
-// Response shapes below follow docs/google-play-distribution-design.md. The
-// design pins endpoint paths, request bodies, and the error model but not the
-// exact success envelopes, so the CLI reads the repo's usual noun wrapper
-// (`{ distributions: [...] }`, `{ play: {...} }`, `{ receipt: {...} }`,
-// `{ receipts: [...] }`); keep the server implementation aligned with these.
+// Response shapes below follow docs/google-play-distribution-design.md plus the
+// server-frozen envelopes: distributions items key the channel as `provider`,
+// play-status returns `{ play: null }` before the first promotion, and Play
+// write commands return a flat `{ receipt_id, edit_id, track, version_code,
+// revision, rollout_percent? }`.
 
 interface DistributionChannel {
-  channel: string;
+  provider: string;
   state: string;
   track?: string | null;
   version_code?: number | null;
@@ -48,14 +48,13 @@ interface PlayDistributionState {
   last_receipt_id?: string | null;
 }
 
-interface PlayWriteReceipt {
-  id: string;
-  action?: string;
-  result?: string;
+interface PlayWriteResult {
+  receipt_id: string;
+  edit_id?: string | null;
   track?: string | null;
   version_code?: number | null;
+  revision?: number;
   rollout_percent?: number | null;
-  play_edit_id?: string | null;
 }
 
 interface ReleaseReceipt {
@@ -595,7 +594,7 @@ export function registerReleaseCommands(program: Command): void {
           channel.version_code != null ? `versionCode=${channel.version_code}` : "",
           channel.rollout_percent != null ? `rollout=${channel.rollout_percent}%` : "",
         ].filter(Boolean).join("  ");
-        console.log(`${channel.channel}  ${channel.state}${details ? `  ${details}` : ""}`);
+        console.log(`${channel.provider}  ${channel.state}${details ? `  ${details}` : ""}`);
       }
     });
 
@@ -605,7 +604,7 @@ export function registerReleaseCommands(program: Command): void {
     .option("--json", "Output JSON.", false)
     .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }, command: Command) => {
       const appId = await resolveAppId(appIdOrSlug);
-      const res = await apiRequest<{ play: PlayDistributionState }>(
+      const res = await apiRequest<{ play: PlayDistributionState | null }>(
         `/api/apps/${appId}/releases/${releaseId}/distributions/play`,
       );
       if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
@@ -613,6 +612,10 @@ export function registerReleaseCommands(program: Command): void {
         return;
       }
       const play = res.play;
+      if (!play) {
+        console.log("No Play distribution yet.");
+        return;
+      }
       console.log(`Google Play state for release ${releaseId}`);
       console.log(`  track:        ${play.track ?? "(none)"}`);
       console.log(`  versionCode:  ${play.version_code ?? "(none)"}`);
@@ -645,25 +648,25 @@ export function registerReleaseCommands(program: Command): void {
         approval: { note: opts.note ?? "" },
       };
       if (rolloutPercent !== undefined) body.rollout_percent = rolloutPercent;
-      let res: { receipt: PlayWriteReceipt };
+      let res: PlayWriteResult;
       try {
-        res = await apiRequest<{ receipt: PlayWriteReceipt }>(
+        res = await apiRequest<PlayWriteResult>(
           `/api/apps/${appId}/releases/${releaseId}/distributions/play/promote`,
           { method: "POST", body },
         );
       } catch (err) {
         throw playWriteError("promote", err);
       }
-      const receipt = res.receipt;
       if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
         console.log(JSON.stringify(res, null, 2));
         return;
       }
       console.log(`Promoted release ${releaseId} to Google Play.`);
-      console.log(`  receipt:     ${receipt.id}`);
-      console.log(`  play edit:   ${receipt.play_edit_id ?? "unavailable"}`);
-      console.log(`  track:       ${receipt.track ?? track}`);
-      console.log(`  versionCode: ${receipt.version_code ?? "unavailable"}`);
+      console.log(`  receipt:     ${res.receipt_id}`);
+      console.log(`  play edit:   ${res.edit_id ?? "unavailable"}`);
+      console.log(`  track:       ${res.track ?? track}`);
+      console.log(`  versionCode: ${res.version_code ?? "unavailable"}`);
+      if (res.rollout_percent != null) console.log(`  rollout:     ${res.rollout_percent}%`);
     });
 
   releases
@@ -682,25 +685,25 @@ export function registerReleaseCommands(program: Command): void {
         expected_revision: await fetchReleaseRevision(appId, releaseId),
         approval: { note: opts.note ?? "" },
       };
-      let res: { receipt: PlayWriteReceipt };
+      let res: PlayWriteResult;
       try {
-        res = await apiRequest<{ receipt: PlayWriteReceipt }>(
+        res = await apiRequest<PlayWriteResult>(
           `/api/apps/${appId}/releases/${releaseId}/distributions/play/halt`,
           { method: "POST", body },
         );
       } catch (err) {
         throw playWriteError("halt", err);
       }
-      const receipt = res.receipt;
       if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
         console.log(JSON.stringify(res, null, 2));
         return;
       }
       console.log(`Halted the Google Play rollout for release ${releaseId}.`);
-      console.log(`  receipt:     ${receipt.id}`);
-      console.log(`  play edit:   ${receipt.play_edit_id ?? "unavailable"}`);
-      console.log(`  track:       ${receipt.track ?? "(unknown)"}`);
-      console.log(`  versionCode: ${receipt.version_code ?? "unavailable"}`);
+      console.log(`  receipt:     ${res.receipt_id}`);
+      console.log(`  play edit:   ${res.edit_id ?? "unavailable"}`);
+      console.log(`  track:       ${res.track ?? "(unknown)"}`);
+      console.log(`  versionCode: ${res.version_code ?? "unavailable"}`);
+      if (res.rollout_percent != null) console.log(`  rollout:     ${res.rollout_percent}%`);
     });
 
   releases
@@ -722,25 +725,25 @@ export function registerReleaseCommands(program: Command): void {
         expected_revision: await fetchReleaseRevision(appId, releaseId),
         approval: { note: opts.note ?? "" },
       };
-      let res: { receipt: PlayWriteReceipt };
+      let res: PlayWriteResult;
       try {
-        res = await apiRequest<{ receipt: PlayWriteReceipt }>(
+        res = await apiRequest<PlayWriteResult>(
           `/api/apps/${appId}/releases/${releaseId}/distributions/play/rollback`,
           { method: "POST", body },
         );
       } catch (err) {
         throw playWriteError("rollback", err);
       }
-      const receipt = res.receipt;
       if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
         console.log(JSON.stringify(res, null, 2));
         return;
       }
       console.log(`Rolled back release ${releaseId} on Google Play to versionCode ${toVersionCode}.`);
-      console.log(`  receipt:     ${receipt.id}`);
-      console.log(`  play edit:   ${receipt.play_edit_id ?? "unavailable"}`);
-      console.log(`  track:       ${receipt.track ?? "(unknown)"}`);
-      console.log(`  versionCode: ${receipt.version_code ?? "unavailable"}`);
+      console.log(`  receipt:     ${res.receipt_id}`);
+      console.log(`  play edit:   ${res.edit_id ?? "unavailable"}`);
+      console.log(`  track:       ${res.track ?? "(unknown)"}`);
+      console.log(`  versionCode: ${res.version_code ?? "unavailable"}`);
+      if (res.rollout_percent != null) console.log(`  rollout:     ${res.rollout_percent}%`);
     });
 
   releases

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -4,7 +4,7 @@
 
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
-import { apiRequest } from "../lib/api.js";
+import { apiRequest, QuiverApiError } from "../lib/api.js";
 import { readEnv } from "../lib/env.js";
 
 interface AppRow {
@@ -24,6 +24,104 @@ interface ReleaseShare {
 interface ReleaseScope {
   scope_type: string;
   scope_value: string;
+}
+
+// Response shapes below follow docs/google-play-distribution-design.md. The
+// design pins endpoint paths, request bodies, and the error model but not the
+// exact success envelopes, so the CLI reads the repo's usual noun wrapper
+// (`{ distributions: [...] }`, `{ play: {...} }`, `{ receipt: {...} }`,
+// `{ receipts: [...] }`); keep the server implementation aligned with these.
+
+interface DistributionChannel {
+  channel: string;
+  state: string;
+  track?: string | null;
+  version_code?: number | null;
+  rollout_percent?: number | null;
+}
+
+interface PlayDistributionState {
+  track?: string | null;
+  version_code?: number | null;
+  rollout_percent?: number | null;
+  last_edit_id?: string | null;
+  last_receipt_id?: string | null;
+}
+
+interface PlayWriteReceipt {
+  id: string;
+  action?: string;
+  result?: string;
+  track?: string | null;
+  version_code?: number | null;
+  rollout_percent?: number | null;
+  play_edit_id?: string | null;
+}
+
+interface ReleaseReceipt {
+  id: string;
+  kind: string;
+  action?: string | null;
+  verdict?: string | null;
+  result?: string | null;
+  created_at?: number | null;
+}
+
+const PLAY_TRACKS = new Set(["internal", "closed", "production"]);
+
+function parsePlayTrack(value: string): string {
+  const track = value.trim();
+  if (!PLAY_TRACKS.has(track)) {
+    throw new Error("--track must be one of: internal, closed, production");
+  }
+  return track;
+}
+
+function parsePlayVersionCode(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("--to-version-code must be a positive integer");
+  }
+  return parsed;
+}
+
+/**
+ * Fetch the release detail only for its optimistic-concurrency revision; a
+ * missing/invalid revision refuses the Play write, same as update/publish.
+ */
+async function fetchReleaseRevision(appId: string, releaseId: string): Promise<number> {
+  const detail = await apiRequest<{ release?: { revision?: unknown } }>(
+    `/api/apps/${appId}/releases/${releaseId}`,
+  );
+  return releaseRevision(detail.release?.revision);
+}
+
+/**
+ * Map the fail-closed Play write error model ({error: {code, gate, message,
+ * receipt_id}}) onto a plain Error so the CLI exits non-zero with the gate
+ * name verbatim and never auto-retries or prints partial output.
+ */
+function playWriteError(action: string, err: unknown): Error {
+  if (err instanceof QuiverApiError) {
+    const info = (err.body as { error?: Record<string, unknown> } | undefined)?.error;
+    if (info && typeof info === "object") {
+      const code = typeof info.code === "string" ? info.code : "unknown_error";
+      const message = typeof info.message === "string" ? info.message : err.message;
+      const receiptId = typeof info.receipt_id === "string" ? info.receipt_id : null;
+      const receiptNote = receiptId ? ` (failed-closed receipt ${receiptId})` : "";
+      if (code === "gate_failed") {
+        const gate = typeof info.gate === "string" ? info.gate : "unknown";
+        return new Error(`Play ${action} blocked by gate ${gate}: ${message}${receiptNote}`);
+      }
+      if (code === "edit_conflict" || code === "version_conflict") {
+        return new Error(
+          `Play ${action} failed (${code}): ${message}. Not retried automatically; resolve the conflict and re-run the command.`,
+        );
+      }
+      return new Error(`Play ${action} failed (${code}): ${message}${receiptNote}`);
+    }
+  }
+  return err instanceof Error ? err : new Error(String(err));
 }
 
 const RELEASE_SCOPE_TYPES = new Set(["full", "platform", "user_cohort", "ip_range", "device_group"]);
@@ -471,6 +569,203 @@ export function registerReleaseCommands(program: Command): void {
       console.log(`  release: ${result.previous_release_id} -> ${result.release_id}`);
       console.log(`  target:  ${result.target.version_name} (${result.target.version_code})`);
       console.log(`  sha256:  ${result.target.file_hash ?? "unavailable"}`);
+    });
+
+  releases
+    .command("distributions <appIdOrSlug> <releaseId>")
+    .description("List distribution channels and state for a release (Hands + Google Play).")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }, command: Command) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const res = await apiRequest<{ distributions: DistributionChannel[] }>(
+        `/api/apps/${appId}/releases/${releaseId}/distributions`,
+      );
+      // Honor the root `--json` global as well as the subcommand flag (task #140 contract).
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      if (res.distributions.length === 0) {
+        console.log("No distribution channels.");
+        return;
+      }
+      for (const channel of res.distributions) {
+        const details = [
+          channel.track ? `track=${channel.track}` : "",
+          channel.version_code != null ? `versionCode=${channel.version_code}` : "",
+          channel.rollout_percent != null ? `rollout=${channel.rollout_percent}%` : "",
+        ].filter(Boolean).join("  ");
+        console.log(`${channel.channel}  ${channel.state}${details ? `  ${details}` : ""}`);
+      }
+    });
+
+  releases
+    .command("play-status <appIdOrSlug> <releaseId>")
+    .description("Show the current Google Play state for a release (track, versionCode, rollout).")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }, command: Command) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const res = await apiRequest<{ play: PlayDistributionState }>(
+        `/api/apps/${appId}/releases/${releaseId}/distributions/play`,
+      );
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      const play = res.play;
+      console.log(`Google Play state for release ${releaseId}`);
+      console.log(`  track:        ${play.track ?? "(none)"}`);
+      console.log(`  versionCode:  ${play.version_code ?? "(none)"}`);
+      console.log(`  rollout:      ${play.rollout_percent == null ? "(not started)" : `${play.rollout_percent}%`}`);
+      console.log(`  last edit:    ${play.last_edit_id ?? "(none)"}`);
+      console.log(`  last receipt: ${play.last_receipt_id ?? "(none)"}`);
+    });
+
+  releases
+    .command("play-promote <appIdOrSlug> <releaseId>")
+    .description("Promote the release's accepted AAB to a Google Play track (publisher role; fail-closed gates, no auto-retry).")
+    .requiredOption("--track <track>", "Play track: internal, closed, or production.")
+    .option("--rollout-percent <percent>", "Staged rollout percentage (0-100).")
+    .option("--note <note>", "Approval note recorded in the play-promotion receipt.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      releaseId: string,
+      opts: { track: string; rolloutPercent?: string; note?: string; json?: boolean },
+      command: Command,
+    ) => {
+      const track = parsePlayTrack(opts.track);
+      const rolloutPercent = opts.rolloutPercent === undefined
+        ? undefined
+        : parseRolloutPercent(opts.rolloutPercent);
+      const appId = await resolveAppId(appIdOrSlug);
+      const body: Record<string, unknown> = {
+        track,
+        expected_revision: await fetchReleaseRevision(appId, releaseId),
+        approval: { note: opts.note ?? "" },
+      };
+      if (rolloutPercent !== undefined) body.rollout_percent = rolloutPercent;
+      let res: { receipt: PlayWriteReceipt };
+      try {
+        res = await apiRequest<{ receipt: PlayWriteReceipt }>(
+          `/api/apps/${appId}/releases/${releaseId}/distributions/play/promote`,
+          { method: "POST", body },
+        );
+      } catch (err) {
+        throw playWriteError("promote", err);
+      }
+      const receipt = res.receipt;
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(`Promoted release ${releaseId} to Google Play.`);
+      console.log(`  receipt:     ${receipt.id}`);
+      console.log(`  play edit:   ${receipt.play_edit_id ?? "unavailable"}`);
+      console.log(`  track:       ${receipt.track ?? track}`);
+      console.log(`  versionCode: ${receipt.version_code ?? "unavailable"}`);
+    });
+
+  releases
+    .command("play-halt <appIdOrSlug> <releaseId>")
+    .description("Halt the staged Google Play rollout for a release (publisher role; no auto-retry).")
+    .option("--note <note>", "Approval note recorded in the play-promotion receipt.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      releaseId: string,
+      opts: { note?: string; json?: boolean },
+      command: Command,
+    ) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const body: Record<string, unknown> = {
+        expected_revision: await fetchReleaseRevision(appId, releaseId),
+        approval: { note: opts.note ?? "" },
+      };
+      let res: { receipt: PlayWriteReceipt };
+      try {
+        res = await apiRequest<{ receipt: PlayWriteReceipt }>(
+          `/api/apps/${appId}/releases/${releaseId}/distributions/play/halt`,
+          { method: "POST", body },
+        );
+      } catch (err) {
+        throw playWriteError("halt", err);
+      }
+      const receipt = res.receipt;
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(`Halted the Google Play rollout for release ${releaseId}.`);
+      console.log(`  receipt:     ${receipt.id}`);
+      console.log(`  play edit:   ${receipt.play_edit_id ?? "unavailable"}`);
+      console.log(`  track:       ${receipt.track ?? "(unknown)"}`);
+      console.log(`  versionCode: ${receipt.version_code ?? "unavailable"}`);
+    });
+
+  releases
+    .command("play-rollback <appIdOrSlug> <releaseId>")
+    .description("Republish a previous stable versionCode on Google Play (Play has no in-place downgrade; publisher role).")
+    .requiredOption("--to-version-code <versionCode>", "Previous stable versionCode to republish at a higher versionCode.")
+    .option("--note <note>", "Approval note recorded in the play-promotion receipt.")
+    .option("--json", "Output JSON.", false)
+    .action(async (
+      appIdOrSlug: string,
+      releaseId: string,
+      opts: { toVersionCode: string; note?: string; json?: boolean },
+      command: Command,
+    ) => {
+      const toVersionCode = parsePlayVersionCode(opts.toVersionCode);
+      const appId = await resolveAppId(appIdOrSlug);
+      const body: Record<string, unknown> = {
+        to_version_code: toVersionCode,
+        expected_revision: await fetchReleaseRevision(appId, releaseId),
+        approval: { note: opts.note ?? "" },
+      };
+      let res: { receipt: PlayWriteReceipt };
+      try {
+        res = await apiRequest<{ receipt: PlayWriteReceipt }>(
+          `/api/apps/${appId}/releases/${releaseId}/distributions/play/rollback`,
+          { method: "POST", body },
+        );
+      } catch (err) {
+        throw playWriteError("rollback", err);
+      }
+      const receipt = res.receipt;
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      console.log(`Rolled back release ${releaseId} on Google Play to versionCode ${toVersionCode}.`);
+      console.log(`  receipt:     ${receipt.id}`);
+      console.log(`  play edit:   ${receipt.play_edit_id ?? "unavailable"}`);
+      console.log(`  track:       ${receipt.track ?? "(unknown)"}`);
+      console.log(`  versionCode: ${receipt.version_code ?? "unavailable"}`);
+    });
+
+  releases
+    .command("receipts <appIdOrSlug> <releaseId>")
+    .description("List the immutable receipt chain for a release (acceptance + Play promotions).")
+    .option("--json", "Output JSON.", false)
+    .action(async (appIdOrSlug: string, releaseId: string, opts: { json?: boolean }, command: Command) => {
+      const appId = await resolveAppId(appIdOrSlug);
+      const res = await apiRequest<{ receipts: ReleaseReceipt[] }>(
+        `/api/apps/${appId}/releases/${releaseId}/receipts`,
+      );
+      if (opts.json || command.optsWithGlobals<{ json?: boolean }>().json) {
+        console.log(JSON.stringify(res, null, 2));
+        return;
+      }
+      if (res.receipts.length === 0) {
+        console.log("No receipts.");
+        return;
+      }
+      for (const receipt of res.receipts) {
+        const outcome = receipt.verdict ?? receipt.result ?? "";
+        const action = receipt.action ? `/${receipt.action}` : "";
+        const created = receipt.created_at == null ? "" : `  ${new Date(receipt.created_at).toISOString()}`;
+        console.log(`${receipt.id}  ${receipt.kind}${action}  ${outcome}${created}`);
+      }
     });
 }
 


### PR DESCRIPTION
## Problem

The Google Play self-service distribution line (server: #501, #504) is live, but there is no CLI surface for it. App admins need `hands releases` commands to inspect and drive Play distribution for a release without the console.

## Changes

Six Play subcommands under `hands releases`, against the landed API contract:

- `distributions <appIdOrSlug> <releaseId>` — list Hands + Google Play distribution state
- `play-status` — current Play track / versionCode / rollout / receipt
- `play-promote` — promote the accepted exact AAB to a track (requires `--note`; optional `--rollout-percent`, production-only per server gate)
- `play-halt` / `play-rollback` — write operations, require `--note`; rollback requires `--to-version-code` (server currently fail-closed 502 until the adapter implements them; CLI validates inputs first)
- `receipts` — list release receipts (acceptance + play-promotion)

All write commands send `expected_revision` (freshly fetched) and a non-empty `approval.note`, matching the server's optimistic-concurrency and human-approval contract. `--json` on all commands.

## Follow-up

- halt/rollback return the server's typed 502 until the adapter implements those operations; the CLI surfaces the typed error.
- Binding setup (service account, package, tracks) is intentionally console-only per the app-scoped self-service model; the CLI reports the server's 403/not-bound state.

## Testing

- `packages/cli` 99/99 tests green on this branch (rebased onto main @ d84d7bfd), including the six commands' contract tests.
- Contract verified against the landed server routes/OpenAPI (`worker/src/openapi/android_distribution.ts` at d84d7bfd): endpoints, `expected_revision`/`approval.note`/`to_version_code` shapes all match.