### PR TITLE
fix: require auditable migration handshake reference

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -21,10 +21,15 @@ on:
         # A checkbox saying "someone is watching" is self-certifying: anyone can tick
         # it and nobody can tell afterwards whether they did. Asking for the id of the
         # owner's reply makes the same claim checkable — the readback can look it up,
-        # confirm who wrote it and confirm it predates the dispatch. It does not stop
-        # a fabricated id, but that is a traceable false statement rather than a
-        # careless click.
-        description: "If D1 migrations are pending they WILL be applied to production. Paste the message id of the owner's 'I am present' reply in #proj-hands:3308eb65, or leave as none."
+        # confirm who wrote it and confirm it predates the dispatch. The canonical
+        # thread is part of the value, not prose around the form: accepting a bare id
+        # allowed a real but private/off-surface reply to pass the shape gate while the
+        # readback owner could not resolve it in the required audit surface.
+        #
+        # This still cannot stop a fabricated reference because the GitHub runner
+        # cannot reach Raft. It does stop accidental opaque/off-surface references and
+        # makes any false canonical claim explicit and attributable.
+        description: "If D1 migrations are pending they WILL be applied to production. Paste '#proj-hands:3308eb65 msg=<message-id>' for the owner's pre-run 'I am present' reply, or leave as none."
         required: true
         type: string
         default: "none"
@@ -165,23 +170,29 @@ jobs:
           echo "Migrations pending, and this deploy will apply them to production:"
           echo "$pending"
 
-          # Shape only: an 8-character short id or a full UUID. Whether it is really
-          # the owner's reply is for the readback to check against Raft, which this
-          # runner cannot reach — so the gate refuses what is obviously not an id and
-          # prints what it was given, rather than pretending to have verified it.
-          if [[ ! "${READBACK_OWNER}" =~ ^[0-9a-fA-F]{8}(-[0-9a-fA-F-]{27,})?$ ]]; then
+          # Canonical-reference shape only: the exact auditable Raft thread plus an
+          # 8-character short id or full UUID. Whether the message exists, is really
+          # the owner's reply, and predates this run remains for the readback owner to
+          # verify against Raft, which this runner cannot reach.
+          #
+          # Requiring the surface in the value is intentional. A bare id, or an id
+          # from another/private thread, is not independently resolvable by the owner
+          # responsible for this production audit and must stop before apply.
+          if [[ ! "${READBACK_OWNER}" =~ ^#proj-hands:3308eb65[[:space:]]msg=([0-9a-fA-F]{8}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$ ]]; then
             echo "" >&2
             echo "Stopping before the apply." >&2
             echo "" >&2
             echo "This deploy would change the production database, and the dispatch" >&2
-            echo "said nobody is watching. That is the right answer when you came here" >&2
-            echo "to ship something unrelated - you are not being asked to take it on." >&2
+            echo "did not provide a canonical, independently auditable owner handshake." >&2
+            echo "That is the right answer when you came here to ship something unrelated" >&2
+            echo "- you are not being asked to take migration readback on." >&2
             echo "" >&2
-            echo "Got: '${READBACK_OWNER}'" >&2
+            echo "Expected: '#proj-hands:3308eb65 msg=<message-id>'" >&2
+            echo "Got:      '${READBACK_OWNER}'" >&2
             echo "" >&2
             echo "Ask the migration's owner in #proj-hands:3308eb65 and wait for their" >&2
-            echo "reply, then re-dispatch with that reply's message id. Their answer is" >&2
-            echo "the handshake - naming them is not." >&2
+            echo "reply, then re-dispatch with the exact thread-and-message reference." >&2
+            echo "Their answer is the handshake - naming them is not." >&2
             echo "" >&2
             echo "No migration has been applied and no Worker has been deployed." >&2
             echo "Scoped deliberately: the bootstrap step runs before this one and" >&2
@@ -192,9 +203,10 @@ jobs:
             exit 1
           fi
 
-          echo "Handshake reference given at dispatch: ${READBACK_OWNER}"
-          echo "The readback owner verifies this id exists, is their own reply, and"
-          echo "predates this run. This step has only checked that it is id-shaped." 
+          echo "Canonical handshake reference given at dispatch: ${READBACK_OWNER}"
+          echo "The readback owner verifies this message exists in that exact thread,"
+          echo "is their own reply, and predates this run. This step has only checked"
+          echo "the canonical thread-and-message reference shape."
 
       # Pre-apply census for the 0068 build_assets_legacy DROP. The migration guards
       # itself with an in-file CHECK that aborts before the DROP if any legacy row's

--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -178,7 +178,7 @@ jobs:
           # Requiring the surface in the value is intentional. A bare id, or an id
           # from another/private thread, is not independently resolvable by the owner
           # responsible for this production audit and must stop before apply.
-          if [[ ! "${READBACK_OWNER}" =~ ^#proj-hands:3308eb65[[:space:]]msg=([0-9a-fA-F]{8}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$ ]]; then
+          if [[ ! "${READBACK_OWNER}" =~ ^#proj-hands:3308eb65\ msg=([0-9a-fA-F]{8}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$ ]]; then
             echo "" >&2
             echo "Stopping before the apply." >&2
             echo "" >&2

--- a/worker/test/migration_handshake_gate.test.ts
+++ b/worker/test/migration_handshake_gate.test.ts
@@ -30,7 +30,7 @@ const workflow = readFileSync(workflowPath, "utf8");
 // Extract the canonical-reference regex verbatim from the gate step. If this
 // fails, the gate changed shape and the test should be re-read, not silently pass.
 const regexMatch = workflow.match(
-  /READBACK_OWNER\}"\s*=~\s*(\S+)\s*\]\]/,
+  /READBACK_OWNER\}"\s*=~\s*(.+?)\s+\]\]; then/,
 );
 const SHAPE_RE = regexMatch?.[1];
 
@@ -60,7 +60,7 @@ describe("migration handshake gate — the reject branch, exercised", () => {
     // The regex the gate actually uses. Pinned so a change to it fails here
     // rather than drifting from what the test exercises.
     expect(SHAPE_RE).toBe(
-      "^#proj-hands:3308eb65[[:space:]]msg=([0-9a-fA-F]{8}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+      "^#proj-hands:3308eb65\\ msg=([0-9a-fA-F]{8}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
     );
   });
 
@@ -75,6 +75,9 @@ describe("migration handshake gate — the reject branch, exercised", () => {
     ["an off-surface thread", "#joint-hands:dcbb01c3 msg=f9eca512"],
     ["a malformed canonical id", "#proj-hands:3308eb65 msg=f9eca512-extra"],
     ["a double-space separator", "#proj-hands:3308eb65  msg=f9eca512"],
+    ["a tab separator", "#proj-hands:3308eb65\tmsg=f9eca512"],
+    ["a newline separator", "#proj-hands:3308eb65\nmsg=f9eca512"],
+    ["a carriage-return separator", "#proj-hands:3308eb65\rmsg=f9eca512"],
   ])("stops before apply when pending and reference is %s", (_label, reference) => {
     const { code, out } = runGate("0063_something.sql (pending)", reference);
     expect(code).toBe(1);

--- a/worker/test/migration_handshake_gate.test.ts
+++ b/worker/test/migration_handshake_gate.test.ts
@@ -13,12 +13,12 @@ import { resolve } from "node:path";
  * migration was applied, and "the gate is fail-closed" only says it exists, not
  * that it blocks.
  *
- * This gives that branch a standing denominator: it extracts the shape regex
+ * This gives that branch a standing denominator: it extracts the reference regex
  * VERBATIM from the workflow (so a change to the gate re-binds the test rather
  * than testing a stale copy) and runs the gate's decision logic — stubbing only
  * the wrangler fetch — across the truth table. The reject branch is right-cause
- * RED: illegitimate owner ids stop before apply; id-shaped ids pass; no-pending
- * short-circuits.
+ * RED: opaque/off-surface references stop before apply; canonical reference
+ * shapes pass; no-pending short-circuits.
  */
 
 const workflowPath = resolve(
@@ -27,8 +27,8 @@ const workflowPath = resolve(
 );
 const workflow = readFileSync(workflowPath, "utf8");
 
-// Extract the id-shape regex verbatim from the gate step. If this fails, the gate
-// changed shape and the test should be re-read, not silently pass.
+// Extract the canonical-reference regex verbatim from the gate step. If this
+// fails, the gate changed shape and the test should be re-read, not silently pass.
 const regexMatch = workflow.match(
   /READBACK_OWNER\}"\s*=~\s*(\S+)\s*\]\]/,
 );
@@ -36,7 +36,7 @@ const SHAPE_RE = regexMatch?.[1];
 
 // Faithful reproduction of the gate's decision logic. Only the wrangler fetch is
 // replaced by $PENDING; everything else mirrors the workflow step.
-function runGate(pending: string, owner: string): { code: number; out: string } {
+function runGate(pending: string, reference: string): { code: number; out: string } {
   const script = `
     set -euo pipefail
     pending="$1"
@@ -49,39 +49,50 @@ function runGate(pending: string, owner: string): { code: number; out: string } 
     fi
     echo "proceeds-to-apply"
   `;
-  const r = spawnSync("bash", ["-c", script, "bash", pending, owner], {
+  const r = spawnSync("bash", ["-c", script, "bash", pending, reference], {
     encoding: "utf8",
   });
   return { code: r.status ?? -1, out: (r.stdout + r.stderr).trim() };
 }
 
 describe("migration handshake gate — the reject branch, exercised", () => {
-  it("extracts the id-shape regex from the live workflow", () => {
+  it("extracts the canonical-reference regex from the live workflow", () => {
     // The regex the gate actually uses. Pinned so a change to it fails here
     // rather than drifting from what the test exercises.
-    expect(SHAPE_RE).toBe("^[0-9a-fA-F]{8}(-[0-9a-fA-F-]{27,})?$");
+    expect(SHAPE_RE).toBe(
+      "^#proj-hands:3308eb65[[:space:]]msg=([0-9a-fA-F]{8}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+    );
   });
 
-  // The never-before-fired branch: migrations pending + an id that is not the
-  // owner's reply must stop before the apply.
+  // Migrations pending + a value that is not a canonical reference to the
+  // required independently visible thread must stop before the apply.
   it.each([
     ["none (the dispatch default)", "none"],
     ["too short", "12345"],
     ["illegal characters", "not-an-id!!"],
     ["empty", ""],
-  ])("stops before apply when pending and owner is %s", (_label, owner) => {
-    const { code, out } = runGate("0063_something.sql (pending)", owner);
+    ["a bare id", "f9eca512"],
+    ["an off-surface thread", "#joint-hands:dcbb01c3 msg=f9eca512"],
+    ["a malformed canonical id", "#proj-hands:3308eb65 msg=f9eca512-extra"],
+    ["a double-space separator", "#proj-hands:3308eb65  msg=f9eca512"],
+  ])("stops before apply when pending and reference is %s", (_label, reference) => {
+    const { code, out } = runGate("0063_something.sql (pending)", reference);
     expect(code).toBe(1);
     expect(out).toContain("stopped-before-apply");
   });
 
-  // Positive control: an id-shaped value passes the shape check, so the reject
-  // above is right-cause (rejecting non-ids), not a blanket failure.
+  // Positive control: canonical reference shapes pass, so the reject above is
+  // right-cause (wrong surface/shape), not a blanket failure. `deadbeef` is
+  // intentionally unverified: the runner has no Raft credential and this test
+  // preserves that existence/author/predates remain the readback owner's job.
   it.each([
-    ["8-char short id", "deadbeef"],
-    ["full UUID", "a1b2c3d4-1111-2222-3333-444455556666"],
-  ])("proceeds when pending and owner is an %s", (_label, owner) => {
-    const { code, out } = runGate("0063_something.sql (pending)", owner);
+    ["canonical short id", "#proj-hands:3308eb65 msg=deadbeef"],
+    [
+      "canonical full UUID",
+      "#proj-hands:3308eb65 msg=a1b2c3d4-1111-2222-3333-444455556666",
+    ],
+  ])("proceeds when pending and reference is a %s", (_label, reference) => {
+    const { code, out } = runGate("0063_something.sql (pending)", reference);
     expect(code).toBe(0);
     expect(out).toContain("proceeds-to-apply");
   });
@@ -133,6 +144,13 @@ describe("migration handshake gate — structure holds", () => {
     const exit1 = gateStep.indexOf("exit 1", shapeCheck);
     expect(shapeCheck).toBeGreaterThanOrEqual(0);
     expect(exit1).toBeGreaterThan(shapeCheck); // the reject branch really exits non-zero
+  });
+
+  it("states that canonical shape does not prove message existence", () => {
+    expect(gateStep).toContain("verify against Raft, which this runner cannot reach");
+    expect(gateStep).toContain("exists in that exact thread");
+    expect(gateStep).toContain("only checked");
+    expect(gateStep).toContain("reference shape");
   });
 
   it("places the gate BEFORE the apply step, so it can stop before apply", () => {


### PR DESCRIPTION
Raft author: @XX; GitHub carrier: stdrc.

## Summary
- require the exact canonical Raft thread plus message id before pending D1 migrations can apply
- reject bare ids and references to other/private threads before production mutation
- update the existing standing Worker gate test with the historical failure shape and the shape-only boundary

## Deliberate boundary
The GitHub runner has no Raft read credential. This gate proves only that a reference names the canonical audit surface with an id-shaped message. It does not prove the message exists, was authored by the readback owner, or predates the run; those remain explicit readback-owner checks. The standing tooth intentionally accepts canonical `msg=deadbeef` so that limitation cannot silently disappear from the contract.

## Validation
- mutation proof: replacing the new canonical regex with the old bare-id regex makes the existing standing tooth fail 4 tests for the intended reasons
- standing tooth: 17/17 green
- full Worker suite: 54 files / 561 tests green
- repository workflow checker
- actionlint v1.7.7 across all workflows
- existing notification and CLI publish workflow contract tests
- git diff --check

Scope: source PR only; no merge, deploy, migration, or production write.