### PR TITLE
fix(deploy): anchor rollback before writes and read the terminal live version

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -669,6 +669,49 @@ jobs:
 
           exit "$fail"
 
+      # Production run 33790593239 measured what one "deploy" actually costs in
+      # Cloudflare versions: one `wrangler deploy` plus one per `wrangler secret
+      # put` -- ten for this workflow. /deployments returns ten entries, so a
+      # single run fills it end to end and evicts the version that was live
+      # before the run. Its second entry then names another version of THIS run and
+      # rolling back to it is a no-op wearing a rollback's clothes.
+      #
+      # So the anchor is captured here, before the first Worker write, while
+      # "currently live" is still unambiguous -- and cross-checked against
+      # /versions, which retains history past the ten-entry deployment window and
+      # is therefore where a later rollback must actually look it up.
+      - name: Capture pre-deploy rollback anchor
+        id: rollback_anchor
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          api="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${HANDS_WORKER_NAME}"
+          deployments=$(curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" "${api}/deployments")
+          if [[ "$(jq -r '.success' <<<"${deployments}")" != "true" ]]; then
+            echo "::error::cannot read current deployments; refusing to write without a rollback anchor" >&2
+            exit 1
+          fi
+          anchor=$(jq -r '.result.deployments[0].versions[0].version_id // empty' <<<"${deployments}")
+          if [[ -z "${anchor}" ]]; then
+            echo "::error::no live version found; refusing to write without a rollback anchor" >&2
+            exit 1
+          fi
+          # Durability check: the anchor is only useful later if /versions still
+          # carries it once /deployments has been flushed by this run.
+          versions=$(curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" "${api}/versions?per_page=50")
+          if [[ "$(jq -r '.success' <<<"${versions}")" != "true" ]]; then
+            echo "::error::cannot read /versions; the anchor would not be recoverable after this run" >&2
+            exit 1
+          fi
+          if ! jq -e --arg a "${anchor}" '[.result.items[]?.id, .result[]?.id] | index($a)' >/dev/null <<<"${versions}"; then
+            echo "::error::live version ${anchor} is absent from /versions; rollback target would be unrecoverable" >&2
+            exit 1
+          fi
+          echo "pre_deploy_version=${anchor}" >> "${GITHUB_OUTPUT}"
+          echo "Pre-deploy live version (ROLLBACK ANCHOR, look it up in /versions): ${anchor}"
+
       # Deploy the Worker BEFORE putting secrets. `wrangler secret put` refuses
       # when the latest uploaded Worker version isn't deployed (e.g. a stray
       # `wrangler versions upload` left a pending version); deploying first makes
@@ -831,6 +874,52 @@ jobs:
           if [[ -n "${R2_S3_SECRET_ACCESS_KEY:-}" ]]; then
             printf '%s' "${R2_S3_SECRET_ACCESS_KEY}" | pnpm exec wrangler secret put R2_S3_SECRET_ACCESS_KEY --config "${config}"
           fi
+
+
+      # The deploy step prints `Current Version ID`, but every `wrangler secret
+      # put` above creates a further version, so that id stops being live seconds
+      # after it is printed (run 33790593239: printed cd3f5f6d, live c8cbb03b).
+      # The receipt has to be read after the last write, from the running service.
+      - name: Read back the terminal live version
+        if: ${{ !cancelled() }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BOTIVERSE_API_TOKEN }}
+          PRE_DEPLOY_VERSION: ${{ steps.rollback_anchor.outputs.pre_deploy_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          api="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${HANDS_WORKER_NAME}"
+          deployments=$(curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" "${api}/deployments")
+          if [[ "$(jq -r '.success' <<<"${deployments}")" != "true" ]]; then
+            echo "::error::cannot read deployments; the deployed version is unverified" >&2
+            exit 1
+          fi
+          live=$(jq -r '.result.deployments[0].versions[0].version_id // empty' <<<"${deployments}")
+          traffic=$(jq -r '[.result.deployments[0].versions[]?.percentage] | add // 0' <<<"${deployments}")
+          if [[ -z "${live}" ]]; then
+            echo "::error::no live version after deploy" >&2
+            exit 1
+          fi
+          if [[ "${traffic}" != "100" ]]; then
+            echo "::error::live deployment is not serving 100% of traffic (got ${traffic})" >&2
+            exit 1
+          fi
+          if [[ "${live}" == "${PRE_DEPLOY_VERSION}" ]]; then
+            echo "::error::live version is unchanged from before the deploy (${live}); nothing was deployed" >&2
+            exit 1
+          fi
+          {
+            echo "### Hands production deploy"
+            echo ""
+            echo "| | version |"
+            echo "|---|---|"
+            echo "| terminal live (THIS is the deployed version) | \`${live}\` |"
+            echo "| rollback anchor (pre-deploy, find it in /versions) | \`${PRE_DEPLOY_VERSION}\` |"
+            echo ""
+            echo "Do NOT take a rollback target from the second entry of the deployments list: one deploy creates ~10 versions and fills that list end to end."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "Terminal live version: ${live} (traffic ${traffic}%)"
+          echo "Rollback anchor: ${PRE_DEPLOY_VERSION}"
 
       - name: Summary
         shell: bash

--- a/worker/test/deploy_rollback_provenance.test.ts
+++ b/worker/test/deploy_rollback_provenance.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Provenance guards for deploy-hands-server.yml (task #190).
+ *
+ * Measured on production run 33790593239 (2026-09-03, exact 42f3ae12):
+ * one protected deploy produced TEN Cloudflare versions — one `wrangler deploy`
+ * plus one per `wrangler secret put` (9 secrets). Two consequences, both of which
+ * make a receipt read correctly while pointing at the wrong thing:
+ *
+ *   1. The run printed `Current Version ID: cd3f5f6d…` from the deploy step, but
+ *      the terminal live version was `c8cbb03b…` — created 23s later by the last
+ *      secret put. Anyone recording the deploy step's id records a version that
+ *      was never the live one.
+ *   2. /deployments returns ten entries, so this single run filled it end to end
+ *      and evicted the pre-run live version. `deployments[1]` therefore points at
+ *      another version of the SAME run, not at the previous release. Rolling back
+ *      to it would be a no-op that looks like a rollback.
+ *
+ * These are ordering/sourcing properties of the workflow, so they are asserted
+ * against the real file rather than a copy: a step that moves re-binds the test.
+ */
+
+const workflowPath = resolve(
+  __dirname,
+  "../../.github/workflows/deploy-hands-server.yml",
+);
+const workflow = readFileSync(workflowPath, "utf8");
+
+/** Index of a top-level step by its `- name:` line. -1 when absent. */
+function stepIndex(name: string): number {
+  const re = new RegExp(`^      - name: ${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "m");
+  const m = workflow.match(re);
+  return m?.index ?? -1;
+}
+
+const ANCHOR_STEP = "Capture pre-deploy rollback anchor";
+const DEPLOY_STEP = "Deploy Hands Worker and admin assets";
+const SECRETS_STEP = "Configure Hands Worker secrets";
+const TERMINAL_STEP = "Read back the terminal live version";
+
+describe("deploy rollback provenance", () => {
+  it("captures a rollback anchor before the first Worker write", () => {
+    const anchor = stepIndex(ANCHOR_STEP);
+    const deploy = stepIndex(DEPLOY_STEP);
+    expect(anchor, `missing step: ${ANCHOR_STEP}`).toBeGreaterThan(-1);
+    expect(deploy, `missing step: ${DEPLOY_STEP}`).toBeGreaterThan(-1);
+    // Strictly before: after the deploy the pre-run version is already one
+    // eviction closer to falling out of /deployments.
+    expect(anchor).toBeLessThan(deploy);
+  });
+
+  it("reads the terminal live version AFTER the secret puts, not from the deploy step", () => {
+    const secrets = stepIndex(SECRETS_STEP);
+    const terminal = stepIndex(TERMINAL_STEP);
+    expect(secrets, `missing step: ${SECRETS_STEP}`).toBeGreaterThan(-1);
+    expect(terminal, `missing step: ${TERMINAL_STEP}`).toBeGreaterThan(-1);
+    expect(terminal).toBeGreaterThan(secrets);
+  });
+
+  it("never infers a rollback target from a /deployments index", () => {
+    // deployments[1] is the specific trap: it reads like "the previous release"
+    // and is another version of the same run.
+    expect(workflow).not.toMatch(/deployments\[\s*1\s*\]/);
+  });
+
+  it("proves the captured anchor is durable by checking it against /versions", () => {
+    const body = workflow.slice(stepIndex(ANCHOR_STEP), stepIndex(DEPLOY_STEP));
+    // Deliberately NOT a bare /versions match: the string also appears in the
+    // step's own prose, so a mention would satisfy it while the actual check was
+    // gone. Mutation M2 (delete the durability block, keep the wording) passed a
+    // bare match and is the reason these assert executable text.
+    expect(body, "anchor step must actually fetch /versions").toMatch(
+      /curl[^\n]*\$\{api\}\/versions/,
+    );
+    expect(body, "anchor must fail closed when absent from /versions").toMatch(
+      /absent from \/versions/,
+    );
+  });
+
+  it("fails closed when the anchor cannot be read", () => {
+    const body = workflow.slice(stepIndex(ANCHOR_STEP), stepIndex(DEPLOY_STEP));
+    // An unreadable anchor must stop the deploy, not proceed unanchored.
+    expect(body).toMatch(/exit 1/);
+  });
+});

--- a/worker/test/deploy_rollback_provenance.test.ts
+++ b/worker/test/deploy_rollback_provenance.test.ts
@@ -75,14 +75,36 @@ describe("deploy rollback provenance", () => {
     expect(body, "anchor step must actually fetch /versions").toMatch(
       /curl[^\n]*\$\{api\}\/versions/,
     );
-    expect(body, "anchor must fail closed when absent from /versions").toMatch(
-      /absent from \/versions/,
-    );
   });
 
-  it("fails closed when the anchor cannot be read", () => {
-    const body = workflow.slice(stepIndex(ANCHOR_STEP), stepIndex(DEPLOY_STEP));
-    // An unreadable anchor must stop the deploy, not proceed unanchored.
-    expect(body).toMatch(/exit 1/);
-  });
+  // Every rejection exit is bound to ITS OWN branch.
+  //
+  // The earlier version asserted only that the step contained the error text AND
+  // that *some* `exit 1` existed anywhere in the step. Those are independent, so
+  // deleting the terminating action of one guard — keeping its branch and message —
+  // left the suite 5/5 green (found by @Huarong reviewing PR #508). The runtime
+  // consequence was real: the anchor-absent branch printed "unrecoverable" and then
+  // fell through to the first Worker write, which is precisely what the frozen
+  // contract forbids.
+  const REJECTION_GUARDS: Array<[string, string]> = [
+    ["deployments read failure", "cannot read current deployments"],
+    ["empty live anchor", "no live version found"],
+    ["versions read failure", "cannot read /versions"],
+    ["anchor absent from /versions", "absent from /versions"],
+  ];
+
+  for (const [label, message] of REJECTION_GUARDS) {
+    it(`fails closed on ${label} — the exit belongs to that branch`, () => {
+      const body = workflow.slice(stepIndex(ANCHOR_STEP), stepIndex(DEPLOY_STEP));
+      const at = body.indexOf(message);
+      expect(at, `guard message not found: ${message}`).toBeGreaterThan(-1);
+      // Scope to this guard only: from its message to the `fi` that closes it.
+      const closing = body.indexOf("\n          fi", at);
+      expect(closing, `unterminated guard block for: ${message}`).toBeGreaterThan(at);
+      const branch = body.slice(at, closing);
+      expect(branch, `${label}: branch must terminate the job, not just log`).toMatch(
+        /\n\s*exit 1\b/,
+      );
+    });
+  }
 });


### PR DESCRIPTION
Repairs the deploy-receipt and rollback-anchor defects measured on production run `33790593239` (task #190). Opened as **Draft**: this needs an independent reviewer, and I am the author.

## What was wrong

One protected deploy creates **ten** Cloudflare versions — one `wrangler deploy` plus one per `wrangler secret put` (9 secrets). Two consequences, both of which produce a receipt that reads correctly while naming the wrong thing:

| | measured on run 33790593239 |
|---|---|
| deploy step printed | `cd3f5f6d…` |
| actually live | `c8cbb03b…` (created 23s later by the last secret put) |
| `/deployments` | all 10 entries from this one run; pre-run version evicted |
| real rollback anchor | `5fa9dd39…`, surviving only in `/versions` |

The list's second entry is another version of the *same run*, so a rollback to it is a no-op wearing a rollback's clothes.

## What this changes

- **`Capture pre-deploy rollback anchor`** — runs before the first Worker write, while "currently live" is still unambiguous, and cross-checks the anchor against `/versions` so it stays recoverable after this run flushes the deployment list. Fails closed if either read fails or the anchor is absent.
- **`Read back the terminal live version`** — runs after the last secret put; requires 100% traffic and requires the live version to differ from the anchor, so "nothing deployed" cannot pass as success.
- Both values land in the job summary, labelled so the anchor is not mistaken for a list index.

## Tests

`worker/test/deploy_rollback_provenance.test.ts` asserts against the real workflow file, so a moved step re-binds the test rather than silently passing a stale copy.

Mutation-tested, each red for its own reason: anchor moved after the deploy; terminal read moved before the secrets; fail-closed exits removed; durability check deleted.

⚠️ Worth knowing during review: the durability assertion **initially passed** the fourth mutation, because it matched `/versions` where the string appears in the step's own prose rather than in executable text. It now requires the `curl` and the fail-closed branch. Same class of defect as the thing being fixed — a check that reads right while pointing at the wrong text.

## Not addressed here

The card also asks whether the unconditional re-put of unchanged secrets can be avoided. I did **not** attempt that: the values are unreadable to me, so I cannot show a given put is a no-op, and skipping a secret write on an unverifiable assumption is a worse failure than an extra version. Left as a separate decision with the evidence recorded.

No production dispatch, rollback, secret/config mutation, deploy or release is performed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)