### PR TITLE
agent-session-store 0.2.0: readAgentSession() returns the whole stored record

### DIFF
--- a/packages/agent-session-store/package.json
+++ b/packages/agent-session-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botiverse/agent-session-store",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Fail-closed Raft agent admission and atomic per-agent integration session store.",
   "author": {
     "name": "jiacheng",

--- a/packages/agent-session-store/src/index.test.ts
+++ b/packages/agent-session-store/src/index.test.ts
@@ -131,9 +131,9 @@ describe("atomic store", () => {
   });
 
   it("readAgentSession returns the whole stored record, and null when the file is missing or malformed", () => {
-    expect(readAgentSession(env, SERVICE)).toBeNull();
-    const path = writeAgentSession(env, SERVICE, SESSION, "https://api.example");
-    const rec = readAgentSession(env, SERVICE);
+    expect(readAgentSession(a, SERVICE)).toBeNull();
+    const path = writeAgentSession(a, SERVICE, SESSION, "https://api.example");
+    const rec = readAgentSession(a, SERVICE);
     expect(rec).not.toBeNull();
     expect(rec!.refresh_token).toBe(SESSION.refresh_token);
     expect(rec!.access_expires_at).toBe(SESSION.access_expires_at);
@@ -142,9 +142,9 @@ describe("atomic store", () => {
     expect(typeof rec!.updated_at).toBe("string");
     // Fail-soft on garbage and on a record missing a required field: null, never a throw.
     writeFileSync(path, "{not json");
-    expect(readAgentSession(env, SERVICE)).toBeNull();
+    expect(readAgentSession(a, SERVICE)).toBeNull();
     writeFileSync(path, JSON.stringify({ ...SESSION, service: SERVICE, api_base: "x", updated_at: "t", refresh_token: "" }));
-    expect(readAgentSession(env, SERVICE)).toBeNull();
+    expect(readAgentSession(a, SERVICE)).toBeNull();
   });
 
   it("does not read another service's token", () => {

--- a/packages/agent-session-store/src/index.test.ts
+++ b/packages/agent-session-store/src/index.test.ts
@@ -131,6 +131,7 @@ describe("atomic store", () => {
   });
 
   it("readAgentSession returns the whole stored record, and null when the file is missing or malformed", () => {
+    const a = agentEnvAt(dir, "/t");
     expect(readAgentSession(a, SERVICE)).toBeNull();
     const path = writeAgentSession(a, SERVICE, SESSION, "https://api.example");
     const rec = readAgentSession(a, SERVICE);

--- a/packages/agent-session-store/src/index.test.ts
+++ b/packages/agent-session-store/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   writeAgentSession,
   readAgentAccessToken,
   readAgentApiBase,
+  readAgentSession,
   type AgentEnv,
   type AgentSession,
 } from "./index.js";
@@ -127,6 +128,23 @@ describe("atomic store", () => {
     chmodSync(wide, 0o777);
     writeAgentSession(a, SERVICE, SESSION, "https://api.example");
     expect(statSync(wide).mode & 0o077).toBe(0);
+  });
+
+  it("readAgentSession returns the whole stored record, and null when the file is missing or malformed", () => {
+    expect(readAgentSession(env, SERVICE)).toBeNull();
+    const path = writeAgentSession(env, SERVICE, SESSION, "https://api.example");
+    const rec = readAgentSession(env, SERVICE);
+    expect(rec).not.toBeNull();
+    expect(rec!.refresh_token).toBe(SESSION.refresh_token);
+    expect(rec!.access_expires_at).toBe(SESSION.access_expires_at);
+    expect(rec!.api_base).toBe("https://api.example");
+    expect(rec!.service).toBe(SERVICE);
+    expect(typeof rec!.updated_at).toBe("string");
+    // Fail-soft on garbage and on a record missing a required field: null, never a throw.
+    writeFileSync(path, "{not json");
+    expect(readAgentSession(env, SERVICE)).toBeNull();
+    writeFileSync(path, JSON.stringify({ ...SESSION, service: SERVICE, api_base: "x", updated_at: "t", refresh_token: "" }));
+    expect(readAgentSession(env, SERVICE)).toBeNull();
   });
 
   it("does not read another service's token", () => {

--- a/packages/agent-session-store/src/index.ts
+++ b/packages/agent-session-store/src/index.ts
@@ -8,6 +8,7 @@ export {
   writeAgentSession,
   readAgentAccessToken,
   readAgentApiBase,
+  readAgentSession,
   type AgentSession,
   type StoredAgentAuth,
 } from "./store.js";

--- a/packages/agent-session-store/src/store.ts
+++ b/packages/agent-session-store/src/store.ts
@@ -71,6 +71,38 @@ export function writeAgentSession(
   return path;
 }
 
+/**
+ * The whole stored record, or null when there is no readable, well-formed session.
+ * Consumers that refresh need `refresh_token`, `access_expires_at` and `api_base`
+ * together; without this both adopter CLIs re-read the JSON file themselves.
+ * Same fail-soft contract as the narrow readers: any error → null, never throws.
+ */
+export function readAgentSession(a: AgentEnv, service: string): StoredAgentAuth | null {
+  let path: string;
+  try {
+    path = agentAuthPath(a, service);
+  } catch {
+    return null;
+  }
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<StoredAgentAuth>;
+    if (
+      parsed?.schema !== "raft-cli-agent-session.v1" || parsed.token_type !== "Bearer" ||
+      typeof parsed.access_token !== "string" || parsed.access_token.length === 0 ||
+      typeof parsed.refresh_token !== "string" || parsed.refresh_token.length === 0 ||
+      typeof parsed.access_expires_at !== "string" ||
+      !(typeof parsed.refresh_expires_at === "string" || parsed.refresh_expires_at === null) ||
+      typeof parsed.service !== "string" || typeof parsed.api_base !== "string" || typeof parsed.updated_at !== "string"
+    ) {
+      return null;
+    }
+    return parsed as StoredAgentAuth;
+  } catch {
+    return null;
+  }
+}
+
 export function readAgentAccessToken(a: AgentEnv, service: string): string | null {
   let path: string;
   try {


### PR DESCRIPTION
`@botiverse/agent-session-store` 0.1.0 exposes only `readAgentAccessToken` and `readAgentApiBase`. A CLI that refreshes needs `refresh_token`, `access_expires_at` and `api_base` together, so both adopters — `hands-cli` (`lib/agent_refresh.ts`) and `testbed-cli` (`lib/agent-refresh.mjs`) — re-read `auth.json` themselves. artin asked today whether the extracted package is actually good to use; this is the one gap found in real consumption.

Adds `readAgentSession(env, service): StoredAgentAuth | null` with the same fail-soft contract as the narrow readers (null on missing, malformed, or field-incomplete record; never throws). Bumps to 0.2.0. Test covers read-back, garbage, and a field-incomplete record. Nothing else changes; the narrow readers stay.

Publish via `session-store-v0.2.0` tag after merge. Follow-up (separate, on artin's call): a second layer (`agent-cli-login`: PKCE, invoke parsing, exchange, refresh with the single-flight lock) so a third service CLI needs ~50 lines instead of ~500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)