### PR TITLE
fix(agc): set invitation-test OpenTestInfo window before submit

### DIFF
--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -114,6 +114,13 @@ export async function getAgcReviewStatus(
   };
 }
 
+/** Huawei invitation-test windows may not exceed 90 days. */
+export const AGC_INVITATION_TEST_MAX_MS = 90 * 24 * 60 * 60 * 1000;
+
+export function invitationTestWindow(now = Date.now()) {
+  return { startTime: now, endTime: now + AGC_INVITATION_TEST_MAX_MS - 60_000 };
+}
+
 export async function createAgcInvitationVersion(auth: AgcAuth, appId: string, description: string, selfDetect: boolean, fetchImpl: typeof fetch = fetch) {
   const body = await agcJson(auth, `/api/publish/v2/test/app/version?appId=${encodeURIComponent(appId)}`, { method: "POST", body: JSON.stringify({ releaseType: 6, testType: 3, testDesc: description.slice(0, 50), onshelfSelfDetect: selfDetect ? 1 : 0 }) }, fetchImpl);
   if (!body?.versionId) throw new AgcApiError(502, "AGC did not return a test version id");
@@ -142,6 +149,13 @@ export async function getAgcCompileStatus(auth: AgcAuth, appId: string, packageI
 export async function bindAgcTestPackage(auth: AgcAuth, appId: string, versionId: string, packageId: string, fetchImpl: typeof fetch = fetch) {
   await agcJson(auth, `/api/publish/v2/test/app/version?appId=${encodeURIComponent(appId)}`, { method: "PUT", body: JSON.stringify({ versionId, pkgId: packageId }) }, fetchImpl);
 }
-export async function submitAgcTestVersion(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch) {
+export async function setAgcInvitationTestWindow(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch, now = Date.now()) {
+  const window = invitationTestWindow(now);
+  await agcJson(auth, `/api/publish/v2/test/app/version?appId=${encodeURIComponent(appId)}`, { method: "PUT", body: JSON.stringify({ versionId, openTestInfo: window }) }, fetchImpl);
+  return window;
+}
+
+export async function submitAgcTestVersion(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch, now = Date.now()) {
+  await setAgcInvitationTestWindow(auth, appId, versionId, fetchImpl, now);
   await agcJson(auth, `/api/publish/v2/test/app/version/submit?appId=${encodeURIComponent(appId)}`, { method: "POST", body: JSON.stringify({ versionId }) }, fetchImpl);
 }

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { decodeProtectedHeader, exportPKCS8, generateKeyPair, jwtVerify } from "jose";
 import { decryptAgcCredential, encryptAgcCredential, fingerprintAgcCredential, parseAgcCredential, type AgcApiClientCredential } from "../src/lib/agc_credentials";
-import { AgcApiError, addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion } from "../src/lib/agc_api";
+import { AgcApiError, addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, invitationTestWindow, requestAgcUpload, resolveAgcAppId, setAgcInvitationTestWindow, submitAgcTestVersion } from "../src/lib/agc_api";
 
 const raw = JSON.stringify({ type: "api_client", developer_id: "dev", project_id: "project", client_id: "client", client_secret: "secret", configuration_version: "1.0", region: "CN" });
 
@@ -61,6 +61,24 @@ describe("AGC invitation testing API", () => {
     expect(await resolveAgcAppId(auth, "build.raft.mobile", mockFetch as typeof fetch)).toBe("agc-app");
     expect(await createAgcInvitationVersion(auth, "agc-app", "Internal test", false, mockFetch as typeof fetch)).toBe("version-1");
     expect(requests[1]?.body).toContain('"testType":3');
+    expect(requests[1]?.body).not.toContain("openTestInfo");
+  });
+  it("writes OpenTestInfo startTime/endTime on the update-version PUT before submit", async () => {
+    const now = 1_704_211_200_000;
+    const window = invitationTestWindow(now);
+    const requests: RequestInit[] = [];
+    const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(init ?? {});
+      return new Response(JSON.stringify({ ret: { code: 0 } }), { status: 200 });
+    });
+    expect(await setAgcInvitationTestWindow(auth, "agc-app", "version-1", mockFetch as typeof fetch, now)).toEqual(window);
+    await submitAgcTestVersion(auth, "agc-app", "version-1", mockFetch as typeof fetch, now);
+    expect(requests[0]?.method).toBe("PUT");
+    expect(requests[0]?.body).toContain('"openTestInfo"');
+    expect(requests[0]?.body).toContain(`"startTime":${window.startTime}`);
+    expect(requests[0]?.body).toContain(`"endTime":${window.endTime}`);
+    expect(requests[1]?.method).toBe("PUT");
+    expect(requests[2]?.method).toBe("POST");
   });
   it("requests upload metadata and registers the uploaded package", async () => {
     const responses = [
@@ -77,6 +95,7 @@ describe("AGC invitation testing API", () => {
       { ret: { code: 0 }, pkgStateList: [{ pkgId: "pkg-1", successStatus: 0 }] },
       { ret: { code: 0 } },
       { ret: { code: 0 } },
+      { ret: { code: 0 } },
     ];
     const methods: Array<string | undefined> = [];
     const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => { methods.push(init?.method); return new Response(JSON.stringify(responses.shift()), { status: 200 }); });
@@ -84,7 +103,8 @@ describe("AGC invitation testing API", () => {
     await bindAgcTestPackage(auth, "agc-app", "version-1", "pkg-1", mockFetch as typeof fetch);
     await submitAgcTestVersion(auth, "agc-app", "version-1", mockFetch as typeof fetch);
     expect(methods[1]).toBe("PUT");
-    expect(methods[2]).toBe("POST");
+    expect(methods[2]).toBe("PUT");
+    expect(methods[3]).toBe("POST");
   });
   it("rejects provider business errors even on HTTP 200", async () => {
     const mockFetch = vi.fn(async () => new Response(JSON.stringify({ ret: { code: 204144688, msg: "invalid package" } }), { status: 200 }));


### PR DESCRIPTION
## Why

Live 1.11.0 OHOS invitation-test submit failed with Huawei `204144692 open test time not exist`. Hands created the test version and bound the package, then submitted without a test window.

## Huawei docs (checked, not guessed)

- [新建测试版本](https://developer.huawei.com/consumer/cn/doc/app/agc-help-test-api-add-test-version-0000002236041526): POST body is `releaseType` / `testType` / `testDesc` / `onshelfSelfDetect` only. **No time fields.**
- [更新测试版本](https://developer.huawei.com/consumer/cn/doc/app/agc-help-test-api-modify-test-version-0000002271160657) + [OpenTestInfo](https://developer.huawei.com/consumer/cn/doc/app/agc-help-test-api-data-opentestinfo-0000002272575553): before submit, PUT `openTestInfo.startTime` / `openTestInfo.endTime` (required, epoch ms). Max span 90 days.
- [更新有效期内的测试版本时间和额度信息](https://developer.huawei.com/consumer/cn/doc/App/agc-help-test-api-update-test-version-opentest-0000002236041530) (`PUT /test/version/open-test`) is only for versions already 正在测试 / 等待生效. Not this path.
- This is **not** Publishing API `on-shelf-time`.

## Change

`submitAgcTestVersion` now PUTs `openTestInfo` on the existing update-version endpoint, then POSTs submit. Create is unchanged.

## Tests

`pnpm --filter @botiverse/hands-worker test -- test/agc_credentials.test.ts`: 15/15 pass.

No production deploy from this PR.