### PR TITLE
fix(deploy): make the /versions durability guard parse the real response shape

### DIFF
--- a/.github/workflows/deploy-hands-server.yml
+++ b/.github/workflows/deploy-hands-server.yml
@@ -705,7 +705,12 @@ jobs:
             echo "::error::cannot read /versions; the anchor would not be recoverable after this run" >&2
             exit 1
           fi
-          if ! jq -e --arg a "${anchor}" '[.result.items[]?.id, .result[]?.id] | index($a)' >/dev/null <<<"${versions}"; then
+          # /versions returns {"result":{"items":[...]}}; tolerate a bare
+          # {"result":[...]} too. Do NOT write this as `.result[]?.id` — on the
+          # object shape that iterates the object's VALUES, yielding the items
+          # ARRAY, and `.id` on an array is a hard jq error, so the guard can
+          # never pass. See scripts/test_deploy_rollback_anchor_jq.sh.
+          if ! jq -e --arg a "${anchor}" '[ (if (.result|type) == "array" then .result else (.result.items // []) end)[] | .id? ] | index($a)' >/dev/null <<<"${versions}"; then
             echo "::error::live version ${anchor} is absent from /versions; rollback target would be unrecoverable" >&2
             exit 1
           fi

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -27,6 +27,11 @@ on:
     paths:
       - ".github/workflows/**"
       - ".github/lint-fixtures/**"
+      # The rollback-anchor guard test reads its expression out of
+      # deploy-hands-server.yml, so it has to re-run when either side moves —
+      # including when only the test moves. A check that cannot be triggered by
+      # editing the test is a check the test can be quietly weakened past.
+      - "scripts/test_deploy_rollback_anchor_jq.sh"
   push:
     branches: [main]
 
@@ -183,3 +188,9 @@ jobs:
 
       - name: Check CLI publish dependency contract
         run: python3 .github/lint-fixtures/test-publish-cli-workflow.py
+
+      # Self-tests against the #508 expression before reporting, on the same
+      # principle as the fixture above: a clean result is only worth something
+      # if the table it came from can still fail.
+      - name: Check deploy rollback-anchor durability guard
+        run: scripts/test_deploy_rollback_anchor_jq.sh

--- a/scripts/test_deploy_rollback_anchor_jq.sh
+++ b/scripts/test_deploy_rollback_anchor_jq.sh
@@ -7,46 +7,82 @@
 # which looks like "tolerate both shapes" but is a hard jq error on BOTH — on
 # the object shape `.result[]?` iterates the object's values, yields the items
 # ARRAY, and `.id` on an array aborts. The step is fail-closed, so every deploy
-# after #508 refused to write (run 33887600418). A guard that can never pass is
-# indistinguishable from a guard that is merely strict, so the expression is
-# extracted from the workflow itself here — not copied — and a copy would let
-# the two drift apart silently.
+# after #508 refused to write (run 33887600418), and it was the first deploy to
+# reach the new code: the guard never passed once.
+#
+# Two things this file does deliberately:
+#
+#   The expression is EXTRACTED from the workflow, not copied. A copy would let
+#   the tested text and the shipped text drift apart silently, which is the same
+#   class of failure as the bug itself — something that reads like a check while
+#   checking nothing.
+#
+#   It self-tests first, against the historical broken expression. "All cases
+#   passed" is worthless if the case table cannot tell the two expressions
+#   apart, and a table that cannot fail is indistinguishable in the log from a
+#   table that passed. So the known-bad expression must fail the positive cases
+#   before the real one is allowed to report anything.
 set -euo pipefail
 
 workflow="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows/deploy-hands-server.yml"
-[[ -r "$workflow" ]] || { echo "cannot read $workflow" >&2; exit 2; }
+[[ -r "$workflow" ]] || { echo "CANNOT RUN: cannot read $workflow" >&2; exit 2; }
 
-matches="$(grep -c 'live version ${anchor} is absent from /versions' "$workflow" || true)"
-[[ "$matches" == "1" ]] || { echo "expected exactly 1 durability guard, found $matches" >&2; exit 2; }
+guards="$(grep -c 'live version ${anchor} is absent from /versions' "$workflow" || true)"
+[[ "$guards" == "1" ]] || { echo "CANNOT RUN: expected exactly 1 durability guard, found $guards" >&2; exit 2; }
 
 # The jq program is the single-quoted argument on the `jq -e --arg a` line.
 program="$(grep -m1 -- 'jq -e --arg a "${anchor}"' "$workflow" | sed -E "s/^[^']*'//; s/'[^']*$//")"
-[[ -n "$program" ]] || { echo "could not extract the jq program from $workflow" >&2; exit 2; }
-echo "guard: $program"
+[[ -n "$program" ]] || { echo "CANNOT RUN: could not extract the jq program from $workflow" >&2; exit 2; }
 
-fail=0
-check() { # name expect anchor json
-  local name="$1" expect="$2" anchor="$3" json="$4" got
-  if jq -e --arg a "$anchor" "$program" >/dev/null 2>&1 <<<"$json"; then got=present; else got=absent; fi
-  if [[ "$got" == "$expect" ]]; then
-    printf 'ok   %-46s %s\n' "$name" "$got"
-  else
-    printf 'FAIL %-46s expected=%s got=%s\n' "$name" "$expect" "$got"; fail=1
-  fi
-}
+# The expression as it shipped in #508. Pinned here as the thing the case table
+# must be able to reject; it is not what runs in production.
+broken='[.result.items[]?.id, .result[]?.id] | index($a)'
 
 paged='{"success":true,"result":{"items":[{"id":"11111111-1111-1111-1111-111111111111"},{"id":"22222222-2222-2222-2222-222222222222"}]}}'
 bare='{"success":true,"result":[{"id":"11111111-1111-1111-1111-111111111111"}]}'
 empty='{"success":true,"result":{"items":[]}}'
 
-# The anchor really is in /versions: the guard must let the deploy proceed.
-check "paged shape, anchor present"        present 11111111-1111-1111-1111-111111111111 "$paged"
-check "paged shape, anchor present at end" present 22222222-2222-2222-2222-222222222222 "$paged"
-check "bare-array shape, anchor present"   present 11111111-1111-1111-1111-111111111111 "$bare"
-# The anchor is missing: the guard must fire, otherwise we would deploy without
-# a recoverable rollback target.
-check "paged shape, anchor absent"         absent  99999999-9999-9999-9999-999999999999 "$paged"
-check "bare-array shape, anchor absent"    absent  99999999-9999-9999-9999-999999999999 "$bare"
-check "no versions at all"                 absent  11111111-1111-1111-1111-111111111111 "$empty"
+# name | expected | anchor | payload. "present" means the guard lets the deploy
+# proceed; "absent" means it fires and the deploy is refused.
+cases=(
+  "paged shape, anchor present|present|11111111-1111-1111-1111-111111111111|$paged"
+  "paged shape, anchor present at end|present|22222222-2222-2222-2222-222222222222|$paged"
+  "bare-array shape, anchor present|present|11111111-1111-1111-1111-111111111111|$bare"
+  "paged shape, anchor absent|absent|99999999-9999-9999-9999-999999999999|$paged"
+  "bare-array shape, anchor absent|absent|99999999-9999-9999-9999-999999999999|$bare"
+  "no versions at all|absent|11111111-1111-1111-1111-111111111111|$empty"
+)
 
+evaluate() { # program anchor json -> present|absent
+  if jq -e --arg a "$2" "$1" >/dev/null 2>&1 <<<"$3"; then echo present; else echo absent; fi
+}
+
+# Self-test: the known-bad expression must fail every "present" case. If it does
+# not, the table cannot discriminate and a clean result below proves nothing.
+selftest_rejected=0
+for entry in "${cases[@]}"; do
+  IFS='|' read -r name expect anchor json <<<"$entry"
+  [[ "$expect" == "present" ]] || continue
+  if [[ "$(evaluate "$broken" "$anchor" "$json")" != "$expect" ]]; then
+    selftest_rejected=$((selftest_rejected + 1))
+  fi
+done
+if [[ "$selftest_rejected" -ne 3 ]]; then
+  echo "CANNOT RUN: the #508 expression failed only ${selftest_rejected} of 3 positive cases." >&2
+  echo "The table no longer distinguishes the regression it exists to catch." >&2
+  exit 2
+fi
+echo "self-test ok: the #508 expression fails all 3 positive cases"
+echo "guard: $program"
+
+fail=0
+for entry in "${cases[@]}"; do
+  IFS='|' read -r name expect anchor json <<<"$entry"
+  got="$(evaluate "$program" "$anchor" "$json")"
+  if [[ "$got" == "$expect" ]]; then
+    printf 'ok   %-46s %s\n' "$name" "$got"
+  else
+    printf 'FAIL %-46s expected=%s got=%s\n' "$name" "$expect" "$got"; fail=1
+  fi
+done
 exit "$fail"

--- a/scripts/test_deploy_rollback_anchor_jq.sh
+++ b/scripts/test_deploy_rollback_anchor_jq.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Exercises the /versions durability guard from deploy-hands-server.yml against
+# real Cloudflare response shapes.
+#
+# Why this exists: the guard shipped in #508 was written as
+#   [.result.items[]?.id, .result[]?.id] | index($a)
+# which looks like "tolerate both shapes" but is a hard jq error on BOTH — on
+# the object shape `.result[]?` iterates the object's values, yields the items
+# ARRAY, and `.id` on an array aborts. The step is fail-closed, so every deploy
+# after #508 refused to write (run 33887600418). A guard that can never pass is
+# indistinguishable from a guard that is merely strict, so the expression is
+# extracted from the workflow itself here — not copied — and a copy would let
+# the two drift apart silently.
+set -euo pipefail
+
+workflow="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows/deploy-hands-server.yml"
+[[ -r "$workflow" ]] || { echo "cannot read $workflow" >&2; exit 2; }
+
+matches="$(grep -c 'live version ${anchor} is absent from /versions' "$workflow" || true)"
+[[ "$matches" == "1" ]] || { echo "expected exactly 1 durability guard, found $matches" >&2; exit 2; }
+
+# The jq program is the single-quoted argument on the `jq -e --arg a` line.
+program="$(grep -m1 -- 'jq -e --arg a "${anchor}"' "$workflow" | sed -E "s/^[^']*'//; s/'[^']*$//")"
+[[ -n "$program" ]] || { echo "could not extract the jq program from $workflow" >&2; exit 2; }
+echo "guard: $program"
+
+fail=0
+check() { # name expect anchor json
+  local name="$1" expect="$2" anchor="$3" json="$4" got
+  if jq -e --arg a "$anchor" "$program" >/dev/null 2>&1 <<<"$json"; then got=present; else got=absent; fi
+  if [[ "$got" == "$expect" ]]; then
+    printf 'ok   %-46s %s\n' "$name" "$got"
+  else
+    printf 'FAIL %-46s expected=%s got=%s\n' "$name" "$expect" "$got"; fail=1
+  fi
+}
+
+paged='{"success":true,"result":{"items":[{"id":"11111111-1111-1111-1111-111111111111"},{"id":"22222222-2222-2222-2222-222222222222"}]}}'
+bare='{"success":true,"result":[{"id":"11111111-1111-1111-1111-111111111111"}]}'
+empty='{"success":true,"result":{"items":[]}}'
+
+# The anchor really is in /versions: the guard must let the deploy proceed.
+check "paged shape, anchor present"        present 11111111-1111-1111-1111-111111111111 "$paged"
+check "paged shape, anchor present at end" present 22222222-2222-2222-2222-222222222222 "$paged"
+check "bare-array shape, anchor present"   present 11111111-1111-1111-1111-111111111111 "$bare"
+# The anchor is missing: the guard must fire, otherwise we would deploy without
+# a recoverable rollback target.
+check "paged shape, anchor absent"         absent  99999999-9999-9999-9999-999999999999 "$paged"
+check "bare-array shape, anchor absent"    absent  99999999-9999-9999-9999-999999999999 "$bare"
+check "no versions at all"                 absent  11111111-1111-1111-1111-111111111111 "$empty"
+
+exit "$fail"


### PR DESCRIPTION
## What

The pre-deploy rollback-anchor durability check added in #508 can never pass. It shipped as:

```jq
[.result.items[]?.id, .result[]?.id] | index($a)
```

That reads like "tolerate both response shapes", but it is a hard jq error on **both**. On the real Cloudflare shape `{"result":{"items":[...]}}`, `.result[]?` iterates the object's *values*, yields the `items` **array**, and `.id` on an array aborts with `Cannot index array with string "id"`. The `?` guards the iteration, not the subsequent field access.

The step is fail-closed, so it refuses the deploy rather than writing without a recoverable anchor — which is the correct failure direction, but it fires unconditionally.

## Evidence

- Run [33887600418](https://github.com/botiverse/hands/actions/runs/33887600418) (PR #511 landing) died at `Capture pre-deploy rollback anchor` with `jq: error (at <stdin>:715): Cannot index array with string "id"`, then `live version c8cbb03b-... is absent from /versions`. No migration and no Worker write occurred.
- #508 landed 2026-09-04T07:27Z. The last successful deploy was 2026-09-03T18:27Z, **before** it. Run 33887600418 was the first deploy to reach this code, so the guard has never passed once — there is no "why did it work yesterday" gap to explain.

## Fix

Parse the two shapes explicitly and guard the `.id` access:

```jq
[ (if (.result|type) == "array" then .result else (.result.items // []) end)[] | .id? ] | index($a)
```

`index($a)` yields `0` for a first-position match, which `jq -e` treats as truthy, so an anchor that is the newest version still passes.

## Test

`scripts/test_deploy_rollback_anchor_jq.sh` **extracts the expression from the workflow** instead of copying it, so the test cannot silently drift from what ships. It asserts the guard lets the deploy proceed on both shapes and still fires when the anchor is absent or `/versions` is empty.

Right-cause check — restoring the old expression reds exactly the three should-pass cases:

```
FAIL paged shape, anchor present                    expected=present got=absent
FAIL paged shape, anchor present at end             expected=present got=absent
FAIL bare-array shape, anchor present               expected=present got=absent
ok   paged shape, anchor absent                     absent
ok   bare-array shape, anchor absent                absent
ok   no versions at all                             absent
```

## Review note

I wrote #508, so I should not review or land this. Ref task #190; @曜衡 asked the #190/#191 owner to fix the parse before any redeploy. Please do not re-run the production deploy until this is merged.