### PR TITLE
test(ci): drop the pinned dependency version literals from the publish contract

### DIFF
--- a/.github/lint-fixtures/test-publish-cli-workflow.py
+++ b/.github/lint-fixtures/test-publish-cli-workflow.py
@@ -9,20 +9,25 @@ steps = workflow["jobs"]["publish"]["steps"]
 verify_node = next(step for step in steps if step.get("name") == "Verify Hands Node SDK dependency is published")
 assert "scripts/resolve-workspace-dependency-version.mjs" in verify_node["run"]
 assert 'npm view "@botiverse/hands-node@${version}" version' in verify_node["run"]
-node_version = subprocess.check_output([
+# The resolver call is the gate, not its output. It throws unless the consumer
+# declares `workspace:*` and the dependency package carries a version, so running
+# it is what proves the contract. Comparing the printed value to a literal only
+# restated packages/node/package.json back to itself, and went red on every
+# legitimate version bump -- #510 bumped agent-session-store and the pinned copy
+# below it failed the publish contract check for a release it had nothing to say
+# about. Dropped per @artin 2026-09-04.
+subprocess.check_output([
     "node", "scripts/resolve-workspace-dependency-version.mjs",
     "packages/cli/package.json", "@botiverse/hands-node", "packages/node/package.json",
 ], cwd=ROOT, text=True)
-assert node_version == "0.5.1"
 verify_store = next(step for step in steps if step.get("name") == "Verify agent-session-store dependency is published")
 assert "scripts/resolve-workspace-dependency-version.mjs" in verify_store["run"]
 assert 'npm view "@botiverse/agent-session-store@${version}" version' in verify_store["run"]
-store_version = subprocess.check_output([
+subprocess.check_output([
     "node", "scripts/resolve-workspace-dependency-version.mjs",
     "packages/cli/package.json", "@botiverse/agent-session-store", "packages/agent-session-store/package.json",
 ], cwd=ROOT, text=True)
-assert store_version == "0.1.0"
 installed_json = next(step for step in steps if step.get("name") == "Verify installed device JSON commands")
 assert 'node packages/cli/test/installed-device-json.mjs "$PACKAGE_PATH"' in installed_json["run"]
 assert installed_json["env"]["PACKAGE_PATH"] == "${{ steps.pack.outputs.path }}"
-print("Publish CLI dependency contract clean: workspace:* resolves to exact published Node and session-store package versions.")
+print("Publish CLI dependency contract clean: both dependencies are declared workspace:*, the publish workflow resolves them through the resolver, and each is npm view-gated before publish.")


### PR DESCRIPTION
Unblocks the `Check CLI publish dependency contract` failure that is currently red on `main` and therefore on every PR, including #512 (which unblocks the Hands production deploy).

## Why these two asserts do nothing

```python
assert node_version  == "0.5.1"
assert store_version == "0.1.0"
```

`scripts/resolve-workspace-dependency-version.mjs` is five lines: it throws unless the consumer declares `workspace:*`, throws unless the dependency package has a `version`, and then prints **that package's own `version` field verbatim**. Comparing its output to a literal therefore asserts only that `packages/*/package.json` still says what it says — while going red on every legitimate version bump. #510 bumped agent-session-store to 0.2.0 and the pinned copy failed the publish contract check for a release it had nothing to say about.

The resolver **call** is kept. That call is the real gate.

## The three surviving gates, each shown able to fail

| mutation | result |
|---|---|
| remove the `Verify agent-session-store dependency is published` step from `publish-cli.yml` | **RED** — step lookup raises |
| change `packages/cli/package.json`'s `@botiverse/agent-session-store` from `workspace:*` to `0.2.0` | **RED** — resolver throws, `check_output` raises |
| replace either `npm view "<pkg>@${version}" version` line with something else | **RED** — step-body assertion |

Restored, the check passes:

```
Publish CLI dependency contract clean: both dependencies are declared workspace:*,
the publish workflow resolves them through the resolver, and each is npm view-gated before publish.
```

## Provenance

@artin ruled twice that these literals should be deleted rather than bumped. @曜衡 initially argued for keeping them as a drift gate, then withdrew after the resolver source was read, and asked that the surviving gates be proven red-able first — that is the table above. I authored this because it blocks my own #512 and no owner had claimed it; **I will not review or merge it**, and anyone who wants to take it over should feel free.