### PR TITLE
fix: send complete AGC invitation OpenTestInfo before submit

### DIFF
--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -117,8 +117,27 @@ export async function getAgcReviewStatus(
 /** Huawei invitation-test windows may not exceed 90 days. */
 export const AGC_INVITATION_TEST_MAX_MS = 90 * 24 * 60 * 60 * 1000;
 
+/**
+ * Huawei invite-test PUT example (`openTestInfo.testTaskInfo`):
+ * `displayArea: "1"` = 测试专区, `needShareLink: 0`, `needNotify: 0`.
+ * Submit 204144692 ("displayArea is necessary for invite test") is the live
+ * proof that the whole TestTaskInfo object is required at submit, not just
+ * startTime/endTime. Do not send groupInfos without a real groupId.
+ */
+export const AGC_INVITE_TEST_DISPLAY_AREA = "1";
+export const AGC_INVITE_TEST_NEED_SHARE_LINK = 0;
+export const AGC_INVITE_TEST_NEED_NOTIFY = 0;
+
 export function invitationTestWindow(now = Date.now()) {
-  return { startTime: now, endTime: now + AGC_INVITATION_TEST_MAX_MS - 60_000 };
+  return {
+    startTime: now,
+    endTime: now + AGC_INVITATION_TEST_MAX_MS - 60_000,
+    testTaskInfo: {
+      displayArea: AGC_INVITE_TEST_DISPLAY_AREA,
+      needShareLink: AGC_INVITE_TEST_NEED_SHARE_LINK,
+      needNotify: AGC_INVITE_TEST_NEED_NOTIFY,
+    },
+  };
 }
 
 export async function createAgcInvitationVersion(auth: AgcAuth, appId: string, description: string, selfDetect: boolean, fetchImpl: typeof fetch = fetch) {

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -63,7 +63,7 @@ describe("AGC invitation testing API", () => {
     expect(requests[1]?.body).toContain('"testType":3');
     expect(requests[1]?.body).not.toContain("openTestInfo");
   });
-  it("writes OpenTestInfo startTime/endTime on the update-version PUT before submit", async () => {
+  it("writes the full invitation OpenTestInfo on the update-version PUT before submit", async () => {
     const now = 1_704_211_200_000;
     const window = invitationTestWindow(now);
     const requests: RequestInit[] = [];
@@ -74,10 +74,20 @@ describe("AGC invitation testing API", () => {
     expect(await setAgcInvitationTestWindow(auth, "agc-app", "version-1", mockFetch as typeof fetch, now)).toEqual(window);
     await submitAgcTestVersion(auth, "agc-app", "version-1", mockFetch as typeof fetch, now);
     expect(requests[0]?.method).toBe("PUT");
-    expect(requests[0]?.body).toContain('"openTestInfo"');
-    expect(requests[0]?.body).toContain(`"startTime":${window.startTime}`);
-    expect(requests[0]?.body).toContain(`"endTime":${window.endTime}`);
+    const firstPut = JSON.parse(String(requests[0]?.body ?? "{}"));
+    expect(firstPut.openTestInfo).toEqual({
+      startTime: window.startTime,
+      endTime: window.endTime,
+      testTaskInfo: {
+        displayArea: "1",
+        needShareLink: 0,
+        needNotify: 0,
+      },
+    });
+    expect(firstPut.openTestInfo.testTaskInfo).not.toHaveProperty("groupInfos");
     expect(requests[1]?.method).toBe("PUT");
+    const submitPut = JSON.parse(String(requests[1]?.body ?? "{}"));
+    expect(submitPut.openTestInfo).toEqual(firstPut.openTestInfo);
     expect(requests[2]?.method).toBe("POST");
   });
   it("requests upload metadata and registers the uploaded package", async () => {


### PR DESCRIPTION
## Why
Huawei invitation-test submit returned `204144692` `displayArea is necessary for invite test`. Hands already PUT `openTestInfo.startTime/endTime` (PR #511) and then failed on the next required field.

## What
Write the full `openTestInfo` object Hands can send without creating a test group, matching the official update-version example:

- `startTime` / `endTime` (unchanged 90-day window)
- `testTaskInfo.displayArea` = `"1"` (测试专区)
- `testTaskInfo.needShareLink` = `0`
- `testTaskInfo.needNotify` = `0`

Do **not** invent `groupInfos` without a real `groupId`.

## Tests
`worker` `agc_credentials.test.ts` 15/15.

## Out of scope
No Worker deploy. No AGC resubmit. Not store.