### PR TITLE
feat: support AGC user test group query and binding for invitation testing

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -55,7 +55,7 @@ import {
   handleSetAgcCredentials,
   handleVerifyAgcCredentials,
 } from "./routes/agc_credentials";
-import { handleAppGalleryReview, handleGetAgcBuildSubmission, handleGetAgcSubmission, handleStartAgcInvitationTest, handleSubmitAgcInvitationTest } from "./routes/agc_testing";
+import { handleAppGalleryReview, handleGetAgcBuildSubmission, handleGetAgcSubmission, handleListAgcTestGroups, handleStartAgcInvitationTest, handleSubmitAgcInvitationTest } from "./routes/agc_testing";
 import {
   handleListApps,
   handleCreateApp,
@@ -1183,6 +1183,7 @@ admin.get("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleGet
 admin.put("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleSetAgcCredentials);
 admin.delete("/api/apps/:appId/agc-credentials", requireAppRole("admin"), handleDeleteAgcCredentials);
 admin.post("/api/apps/:appId/agc-credentials/verify", requireAppRole("admin"), handleVerifyAgcCredentials);
+admin.get("/api/apps/:appId/agc-test-groups", requireAppRole("admin"), handleListAgcTestGroups);
 admin.get("/api/apps/:appId/builds/:buildId/agc-invitation-test", requireAppRole("admin"), handleGetAgcBuildSubmission);
 admin.post("/api/apps/:appId/builds/:buildId/agc-invitation-test", requireAppRole("admin"), handleStartAgcInvitationTest);
 admin.get("/api/apps/:appId/agc-submissions/:submissionId", requireAppRole("admin"), handleGetAgcSubmission);

--- a/worker/src/lib/agc_api.ts
+++ b/worker/src/lib/agc_api.ts
@@ -128,7 +128,20 @@ export const AGC_INVITE_TEST_DISPLAY_AREA = "1";
 export const AGC_INVITE_TEST_NEED_SHARE_LINK = 0;
 export const AGC_INVITE_TEST_NEED_NOTIFY = 0;
 
-export function invitationTestWindow(now = Date.now()) {
+export type AgcTestGroup = {
+  groupId: string;
+  groupName?: string;
+  addedTestersNum?: number;
+};
+
+export async function listAgcTestGroups(auth: AgcAuth, appId: string, fetchImpl: typeof fetch = fetch): Promise<AgcTestGroup[]> {
+  const body = await agcJson(auth, `/api/app-test/v1/test-group/list?current=1&pageSize=100`, {
+    headers: { appId },
+  }, fetchImpl);
+  return (body?.groups ?? []) as AgcTestGroup[];
+}
+
+export function invitationTestWindow(now = Date.now(), groupIds: string[] = []) {
   return {
     startTime: now,
     endTime: now + AGC_INVITATION_TEST_MAX_MS - 60_000,
@@ -136,6 +149,7 @@ export function invitationTestWindow(now = Date.now()) {
       displayArea: AGC_INVITE_TEST_DISPLAY_AREA,
       needShareLink: AGC_INVITE_TEST_NEED_SHARE_LINK,
       needNotify: AGC_INVITE_TEST_NEED_NOTIFY,
+      ...(groupIds.length > 0 ? { groupInfos: groupIds.map((groupId) => ({ groupId })) } : {}),
     },
   };
 }
@@ -168,13 +182,13 @@ export async function getAgcCompileStatus(auth: AgcAuth, appId: string, packageI
 export async function bindAgcTestPackage(auth: AgcAuth, appId: string, versionId: string, packageId: string, fetchImpl: typeof fetch = fetch) {
   await agcJson(auth, `/api/publish/v2/test/app/version?appId=${encodeURIComponent(appId)}`, { method: "PUT", body: JSON.stringify({ versionId, pkgId: packageId }) }, fetchImpl);
 }
-export async function setAgcInvitationTestWindow(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch, now = Date.now()) {
-  const window = invitationTestWindow(now);
+export async function setAgcInvitationTestWindow(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch, now = Date.now(), groupIds: string[] = []) {
+  const window = invitationTestWindow(now, groupIds);
   await agcJson(auth, `/api/publish/v2/test/app/version?appId=${encodeURIComponent(appId)}`, { method: "PUT", body: JSON.stringify({ versionId, openTestInfo: window }) }, fetchImpl);
   return window;
 }
 
-export async function submitAgcTestVersion(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch, now = Date.now()) {
-  await setAgcInvitationTestWindow(auth, appId, versionId, fetchImpl, now);
+export async function submitAgcTestVersion(auth: AgcAuth, appId: string, versionId: string, fetchImpl: typeof fetch = fetch, now = Date.now(), groupIds: string[] = []) {
+  await setAgcInvitationTestWindow(auth, appId, versionId, fetchImpl, now, groupIds);
   await agcJson(auth, `/api/publish/v2/test/app/version/submit?appId=${encodeURIComponent(appId)}`, { method: "POST", body: JSON.stringify({ versionId }) }, fetchImpl);
 }

--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import { currentActor, type AdminEnv } from "../middleware/auth";
 import { insertAuditLog } from "../lib/permissions";
 import { agcCredentialKind, getAgcCredentials, type AgcApiClientCredential, type AgcServiceAccountCredential } from "../lib/agc_credentials";
-import { addAgcTestPackage, AgcApiError, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, getAgcReviewStatus, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion, uploadAgcObject } from "../lib/agc_api";
+import { addAgcTestPackage, AgcApiError, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, getAgcReviewStatus, listAgcTestGroups, requestAgcUpload, resolveAgcAppId, submitAgcTestVersion, uploadAgcObject } from "../lib/agc_api";
 
 type AdminContext = Context<AdminEnv & { Bindings: Env }>;
 type Submission = { id: string; app_id: string; build_id: string; state: string; external_app_id: string; external_version_id: string; external_package_id: string; provider_state_json: string; error_message: string | null; created_at: number; updated_at: number };
@@ -162,13 +162,50 @@ export async function handleGetAgcSubmission(c: AdminContext) {
   const events = await c.env.DB.prepare("SELECT state, detail_json, created_at FROM market_submission_events WHERE submission_id=?1 ORDER BY created_at").bind(id).all();
   return c.json({ submission: publicSubmission(sub), events: events.results });
 }
+export async function handleListAgcTestGroups(c: AdminContext) {
+  const appId = c.req.param("appId") ?? "";
+  const packageRow = await c.env.DB.prepare(
+    "SELECT bundle_id FROM channels WHERE app_id = ?1 AND slug = 'main' LIMIT 1",
+  ).bind(appId).first<{ bundle_id: string | null }>();
+  const packageName = (packageRow?.bundle_id ?? "").trim() || "build.raft.mobile";
+  const agcAuth = await auth(c);
+  const externalAppId = await resolveAgcAppId(agcAuth, packageName);
+  const groups = await listAgcTestGroups(agcAuth, externalAppId);
+  return c.json({ agc_app_id: externalAppId, groups });
+}
+
 export async function handleSubmitAgcInvitationTest(c: AdminContext) {
   const id = c.req.param("submissionId") ?? ""; const appId = c.req.param("appId") ?? "";
   const sub = await c.env.DB.prepare("SELECT * FROM market_submissions WHERE id=?1 AND app_id=?2").bind(id, appId).first<Submission>();
   if (!sub) return c.json({ error: "submission not found" }, 404);
   if (sub.state !== "ready") return c.json({ error: "package is not ready for testing review" }, 409);
-  const agcAuth = await auth(c); await submitAgcTestVersion(agcAuth, sub.external_app_id, sub.external_version_id);
-  await event(c.env.DB, id, "testing_review", { submitted: true });
-  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_test.submit", payload: { submission_id: id, build_id: sub.build_id } });
-  return c.json({ ok: true, submission_id: id, state: "testing_review" });
+  const body = await c.req.json().catch(() => ({})) as { group_id?: unknown; group_ids?: unknown };
+  const requestedGroupIds: string[] = [];
+  if (typeof body.group_id === "string" && body.group_id.trim()) {
+    requestedGroupIds.push(body.group_id.trim());
+  }
+  if (Array.isArray(body.group_ids)) {
+    for (const gid of body.group_ids) {
+      if (typeof gid === "string" && gid.trim() && !requestedGroupIds.includes(gid.trim())) {
+        requestedGroupIds.push(gid.trim());
+      }
+    }
+  }
+
+  const agcAuth = await auth(c);
+  let effectiveGroupIds = requestedGroupIds;
+  if (effectiveGroupIds.length === 0) {
+    const groups = await listAgcTestGroups(agcAuth, sub.external_app_id);
+    if (groups.length > 0) {
+      effectiveGroupIds = [groups[0].groupId];
+    }
+  }
+  if (effectiveGroupIds.length === 0) {
+    return c.json({ error: "No AGC test group found or specified for invitation test" }, 400);
+  }
+
+  await submitAgcTestVersion(agcAuth, sub.external_app_id, sub.external_version_id, undefined, undefined, effectiveGroupIds);
+  await event(c.env.DB, id, "testing_review", { submitted: true, group_ids: effectiveGroupIds });
+  await insertAuditLog(c.env.DB, c, { app_id: appId, action: "agc_test.submit", payload: { submission_id: id, build_id: sub.build_id, group_ids: effectiveGroupIds } });
+  return c.json({ ok: true, submission_id: id, state: "testing_review", group_ids: effectiveGroupIds });
 }

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -1469,6 +1469,14 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         },
       },
       {
+        name: "list-agc-test-groups",
+        description: "List configured user test groups in Huawei AppGallery Connect.",
+        endpoint: { method: "GET", path: "/api/apps/{app_id}/agc-test-groups" },
+        parameters: {
+          app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
+        },
+      },
+      {
         name: "get-agc-submission",
         description: "Refresh AGC package compilation state and bind the package when ready.",
         endpoint: { method: "GET", path: "/api/apps/{app_id}/agc-submissions/{submission_id}" },
@@ -1484,6 +1492,7 @@ export async function handleAgentManifest(c: Context<{ Bindings: Env }>) {
         parameters: {
           app_id: { type: "string", in: "path", required: true, description: "OHOS app UUID." },
           submission_id: { type: "string", in: "path", required: true, description: "Hands market submission UUID." },
+          group_id: { type: "string", in: "body", required: false, description: "Optional AGC user test group ID to bind. Defaults to the app's configured test group." },
         },
       },
       {

--- a/worker/test/agc_credentials.test.ts
+++ b/worker/test/agc_credentials.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { decodeProtectedHeader, exportPKCS8, generateKeyPair, jwtVerify } from "jose";
 import { decryptAgcCredential, encryptAgcCredential, fingerprintAgcCredential, parseAgcCredential, type AgcApiClientCredential } from "../src/lib/agc_credentials";
-import { AgcApiError, addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, invitationTestWindow, requestAgcUpload, resolveAgcAppId, setAgcInvitationTestWindow, submitAgcTestVersion } from "../src/lib/agc_api";
+import { AgcApiError, addAgcTestPackage, bindAgcTestPackage, createAgcInvitationVersion, createAgcServiceAccountJwt, exchangeAgcApiClientToken, getAgcCompileStatus, invitationTestWindow, listAgcTestGroups, requestAgcUpload, resolveAgcAppId, setAgcInvitationTestWindow, submitAgcTestVersion } from "../src/lib/agc_api";
 
 const raw = JSON.stringify({ type: "api_client", developer_id: "dev", project_id: "project", client_id: "client", client_secret: "secret", configuration_version: "1.0", region: "CN" });
 
@@ -89,6 +89,34 @@ describe("AGC invitation testing API", () => {
     const submitPut = JSON.parse(String(requests[1]?.body ?? "{}"));
     expect(submitPut.openTestInfo).toEqual(firstPut.openTestInfo);
     expect(requests[2]?.method).toBe("POST");
+  });
+  it("includes groupInfos in OpenTestInfo when groupIds are specified", async () => {
+    const now = 1_704_211_200_000;
+    const window = invitationTestWindow(now, ["group-abc"]);
+    expect(window.testTaskInfo.groupInfos).toEqual([{ groupId: "group-abc" }]);
+    const requests: RequestInit[] = [];
+    const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(init ?? {});
+      return new Response(JSON.stringify({ ret: { code: 0 } }), { status: 200 });
+    });
+    await submitAgcTestVersion(auth, "agc-app", "version-1", mockFetch as typeof fetch, now, ["group-abc"]);
+    expect(requests[0]?.method).toBe("PUT");
+    const submitPut = JSON.parse(String(requests[0]?.body ?? "{}"));
+    expect(submitPut.openTestInfo.testTaskInfo.groupInfos).toEqual([{ groupId: "group-abc" }]);
+    expect(requests[1]?.method).toBe("POST");
+  });
+  it("queries AGC user test groups list", async () => {
+    const responses = [
+      { rtnCode: 0, groups: [{ groupId: "group-1", groupName: "Internal Testers", addedTestersNum: 5 }] },
+    ];
+    const requests: RequestInit[] = [];
+    const mockFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(init ?? {});
+      return new Response(JSON.stringify(responses.shift()), { status: 200 });
+    });
+    const groups = await listAgcTestGroups(auth, "agc-app", mockFetch as typeof fetch);
+    expect(groups).toEqual([{ groupId: "group-1", groupName: "Internal Testers", addedTestersNum: 5 }]);
+    expect(requests[0]?.headers).toMatchObject({ appId: "agc-app" });
   });
   it("requests upload metadata and registers the uploaded package", async () => {
     const responses = [


### PR DESCRIPTION
### Summary
- Query AGC test groups list using `/api/app-test/v1/test-group/list` (`listAgcTestGroups` / GET `/api/apps/:appId/agc-test-groups`).
- Populate `testTaskInfo.groupInfos` with target `groupId` in `submitAgcTestVersion` to satisfy AGC invitation test review requirement (`groupId is necessary for invite test`, code 204144692).
- `handleSubmitAgcInvitationTest` accepts explicit `group_id` or automatically selects the app's configured test group from AGC.
- Unit tests added in `worker/test/agc_credentials.test.ts`.