### PR TITLE
fix(worker): guard unchecked index on first AGC test group

### DIFF
--- a/worker/src/routes/agc_testing.ts
+++ b/worker/src/routes/agc_testing.ts
@@ -196,8 +196,9 @@ export async function handleSubmitAgcInvitationTest(c: AdminContext) {
   let effectiveGroupIds = requestedGroupIds;
   if (effectiveGroupIds.length === 0) {
     const groups = await listAgcTestGroups(agcAuth, sub.external_app_id);
-    if (groups.length > 0) {
-      effectiveGroupIds = [groups[0].groupId];
+    const firstGroup = groups[0];
+    if (firstGroup?.groupId) {
+      effectiveGroupIds = [firstGroup.groupId];
     }
   }
   if (effectiveGroupIds.length === 0) {


### PR DESCRIPTION
Guard `groups[0]` to satisfy strict null checks during Worker build.