### PR TITLE
feat(updater): advertise optional gzip artifacts for CLI updates

### DIFF
--- a/docs/hands-node-updater-v1.md
+++ b/docs/hands-node-updater-v1.md
@@ -61,3 +61,13 @@ backend is allowed.
 The staged receipt records the release/channel/artifact identity, expected and
 actual size/SHA-256, and candidate digest. It is evidence of byte verification,
 not evidence of installation or runtime health.
+
+## Optional gzip transport
+
+A candidate may include `artifact.gzip` with its own HTTPS URL, compressed byte
+size, and SHA-256. The metadata is part of the candidate identity. This SDK
+continues to stage the canonical artifact URL; a downstream installer such as
+K may select the gzip representation, verify its compressed digest, decompress
+with a bound, then verify the canonical size and digest. If gzip metadata is
+absent, clients use the canonical URL. Invalid or incomplete gzip metadata is
+rejected during update checking.

--- a/packages/node/src/updater/index.test.ts
+++ b/packages/node/src/updater/index.test.ts
@@ -26,6 +26,32 @@ function fixture(bytes = Buffer.from("verified computer binary")) {
 }
 
 describe("Hands updater", () => {
+  it("preserves optional gzip identity and binds it into the candidate digest", async () => {
+    const { response } = fixture();
+    const gzip = { download_url: "https://downloads.example/computer.gz", size_bytes: 12, sha256: "c".repeat(64) };
+    const updater = createHandsUpdater({ appSlug: "raft-computer", apiOrigin: "https://hands.example",
+      fetch: async () => Response.json({ ...response, artifact: { ...response.artifact, gzip } }),
+    });
+    const check = await updater.checkUpdate({ currentVersion: "1.0.18", channel: "main", target: { platform: "linux", arch: "x64" } });
+    if (check.kind !== "update") throw new Error("expected update");
+    expect(check.candidate.artifact.gzip).toEqual({ url: gzip.download_url, size: 12, sha256: gzip.sha256 });
+    const directory = await mkdtemp(join(tmpdir(), "hands-gzip-")); directories.push(directory);
+    check.candidate.artifact.gzip!.sha256 = "d".repeat(64);
+    await expect(updater.prepareUpdate({ candidate: check.candidate, stagingDir: directory }))
+      .rejects.toMatchObject({ code: "UPDATE_IDENTITY_DRIFT" });
+  });
+
+  it.each([null, {}, { download_url: "https://example.test/a.gz", size_bytes: 12, sha256: "bad" },
+    { download_url: "https://example.test/a.gz", size_bytes: -1, sha256: "c".repeat(64) }])(
+    "rejects malformed advertised gzip identity %j", async (gzip) => {
+      const { response } = fixture();
+      const updater = createHandsUpdater({ appSlug: "raft-computer", apiOrigin: "https://hands.example",
+        fetch: async () => Response.json({ ...response, artifact: { ...response.artifact, gzip } }),
+      });
+      await expect(updater.checkUpdate({ currentVersion: "1.0.18", channel: "main", target: { platform: "linux", arch: "x64" } }))
+        .rejects.toMatchObject({ code: "UPDATE_RESPONSE_INVALID" });
+    },
+  );
   it("keeps package and runtime SDK version carriers identical", () => {
     expect(HANDS_NODE_SDK_VERSION).toBe(packageJson.version);
   });

--- a/packages/node/src/updater/index.ts
+++ b/packages/node/src/updater/index.ts
@@ -24,6 +24,7 @@ export interface UpdateCandidate {
     url: string;
     size: number;
     sha256: string;
+    gzip?: { url: string; size: number; sha256: string };
   };
   candidateDigest: string;
 }
@@ -130,6 +131,7 @@ function candidateIdentity(candidate: Omit<UpdateCandidate, "candidateDigest">) 
       artifactId: candidate.artifact.artifactId,
       size: candidate.artifact.size,
       sha256: candidate.artifact.sha256,
+      ...(candidate.artifact.gzip ? { gzip: candidate.artifact.gzip } : {}),
     },
   };
 }
@@ -183,6 +185,15 @@ export function createHandsUpdater(options: HandsUpdaterOptions): HandsUpdater {
       const app = record(root.app); const release = record(root.release); const artifact = record(root.artifact);
       const sha256 = string(artifact.sha256, "artifact.sha256").toLowerCase();
       if (!SHA256.test(sha256)) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "artifact.sha256 invalid");
+      const gzipRaw = artifact.gzip;
+      let gzip: UpdateCandidate["artifact"]["gzip"];
+      if (gzipRaw !== undefined) {
+        const gz = record(gzipRaw);
+        const gzipSha = string(gz.sha256, "artifact.gzip.sha256").toLowerCase();
+        const gzipSize = integer(gz.size_bytes, "artifact.gzip.size_bytes");
+        if (!SHA256.test(gzipSha) || gzipSize <= 0) throw new HandsUpdateError("UPDATE_RESPONSE_INVALID", "artifact.gzip identity invalid");
+        gzip = { url: string(gz.download_url, "artifact.gzip.download_url"), size: gzipSize, sha256: gzipSha };
+      }
       const plain: Omit<UpdateCandidate, "candidateDigest"> = {
         appId: string(app.id, "app.id"), appSlug: string(app.slug, "app.slug"),
         releaseId: string(release.id, "release.id"), releaseRevision: integer(release.revision, "release.revision"),
@@ -190,7 +201,7 @@ export function createHandsUpdater(options: HandsUpdaterOptions): HandsUpdater {
         version: string(release.version, "release.version"), versionCode: integer(release.version_code, "release.version_code"),
         versionRelation: string(release.version_relation, "release.version_relation") as UpdateCandidate["versionRelation"],
         publishedAt: integer(release.published_at, "release.published_at"), target: input.target,
-        artifact: { artifactId: string(artifact.id, "artifact.id"), url: string(artifact.download_url, "artifact.download_url"), size: integer(artifact.size_bytes, "artifact.size_bytes"), sha256 },
+        artifact: { artifactId: string(artifact.id, "artifact.id"), url: string(artifact.download_url, "artifact.download_url"), size: integer(artifact.size_bytes, "artifact.size_bytes"), sha256, ...(gzip ? { gzip } : {}) },
       };
       if (pinned && plain.version !== pinned) throw new HandsUpdateError("UPDATE_IDENTITY_DRIFT", "pinned version was not selected");
       const candidate: UpdateCandidate = { ...plain, candidateDigest: digest(candidateIdentity(plain)) };

--- a/worker/src/routes/public_v2.ts
+++ b/worker/src/routes/public_v2.ts
@@ -583,7 +583,8 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
             r.id AS release_id, r.revision, r.rollout_cohort_count,
             r.activated_at, r.channel_id,
             b.version_name, b.version_code,
-            e.id AS artifact_id, e.raw_sha256, e.raw_size_bytes
+            e.id AS artifact_id, e.raw_sha256, e.raw_size_bytes,
+            e.gzip_sha256, e.gzip_size_bytes
      FROM apps a
      JOIN channels ch ON ch.app_id = a.id
      JOIN releases r ON r.app_id = a.id AND r.channel_id = ch.id
@@ -607,6 +608,7 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
     activated_at: number; channel_id: string;
     version_name: string; version_code: number; artifact_id: string;
     raw_sha256: string; raw_size_bytes: number;
+    gzip_sha256: string | null; gzip_size_bytes: number | null;
   }>();
   if (rows.length === 0) return c.json({ error: "no active release for target", code: "UPDATE_NO_COMPATIBLE_ARTIFACT" }, 404);
   if (requestedVersion && rows.length > 1) {
@@ -628,6 +630,13 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
   if (relation === null) return c.json({ error: "published version is not semver", code: "UPDATE_RESPONSE_INVALID" }, 500);
   if (relation === 0) return c.json({ update_available: false, current_version: currentVersion, latest_version: row.version_name, checked_at: Date.now() });
   const origin = requestOrigin(c);
+  // Advertise only a complete attested representation of this same build target.
+  // An absent/incomplete optional representation leaves the canonical raw route usable.
+  const gzip = typeof row.gzip_sha256 === "string" && /^[a-f0-9]{64}$/u.test(row.gzip_sha256)
+    && typeof row.gzip_size_bytes === "number" && Number.isSafeInteger(row.gzip_size_bytes) && row.gzip_size_bytes > 0
+    ? { sha256: row.gzip_sha256, size_bytes: row.gzip_size_bytes,
+      download_url: `${origin}/dl/${encodeURIComponent(slug)}/releases/${encodeURIComponent(row.release_id)}/${encodeURIComponent(target)}.gz` }
+    : undefined;
   return c.json({
     update_available: true,
     app: { id: row.app_id, slug: row.slug },
@@ -642,6 +651,7 @@ export async function handlePublicCliBinaryUpdateCheck(c: Context<{ Bindings: En
       id: row.artifact_id, platform, arch,
       size_bytes: row.raw_size_bytes, sha256: row.raw_sha256,
       download_url: `${origin}/dl/${encodeURIComponent(slug)}/releases/${encodeURIComponent(row.release_id)}/${encodeURIComponent(target)}`,
+      ...(gzip ? { gzip } : {}),
     },
   });
 }

--- a/worker/test/public_cli_updates.test.ts
+++ b/worker/test/public_cli_updates.test.ts
@@ -36,7 +36,7 @@ describe("public cli-binary selection", () => {
       CREATE TABLE releases (id TEXT PRIMARY KEY, app_id TEXT, build_id TEXT, channel_id TEXT, product_type TEXT, release_type TEXT, status TEXT, hidden INTEGER, revision INTEGER, rollout_cohort_count INTEGER, activated_at INTEGER, availability_at INTEGER);
       CREATE TABLE release_scopes (id TEXT PRIMARY KEY, release_id TEXT, scope_type TEXT, scope_value TEXT);
       CREATE TABLE builds (id TEXT PRIMARY KEY, app_id TEXT, status TEXT, version_name TEXT, version_code INTEGER);
-      CREATE TABLE external_build_targets (id TEXT PRIMARY KEY, build_id TEXT, target TEXT, raw_sha256 TEXT, raw_size_bytes INTEGER);
+      CREATE TABLE external_build_targets (id TEXT PRIMARY KEY, build_id TEXT, target TEXT, raw_sha256 TEXT, raw_size_bytes INTEGER, gzip_sha256 TEXT, gzip_size_bytes INTEGER);
       INSERT INTO apps VALUES ('app', 'computer', 'desktop');
       INSERT INTO channels VALUES ('channel-main', 'app', 'main');
       INSERT INTO channels VALUES ('channel-alpha', 'app', 'alpha');
@@ -55,7 +55,7 @@ describe("public cli-binary selection", () => {
     const channel = options.channel ?? "main";
     if (!options.reuseArtifactFrom) {
       sqlite.prepare("INSERT INTO builds VALUES (?, 'app', 'succeeded', ?, ?)").run(buildId, version, activatedAt);
-      sqlite.prepare("INSERT INTO external_build_targets VALUES (?, ?, 'linux-x64', ?, 8)").run(artifactId, buildId, sha256);
+      sqlite.prepare("INSERT INTO external_build_targets (id, build_id, target, raw_sha256, raw_size_bytes) VALUES (?, ?, 'linux-x64', ?, 8)").run(artifactId, buildId, sha256);
     }
     sqlite.prepare("INSERT INTO releases VALUES (?, 'app', ?, ?, 'cli-binary', 'stable', ?, 0, 1, ?, ?, NULL)")
       .run(id, buildId, `channel-${channel}`, status, options.rolloutCohortCount ?? null, activatedAt);
@@ -69,6 +69,21 @@ describe("public cli-binary selection", () => {
   function versions(extra = "") {
     return app.request(`https://hands.example/public/v2/apps/computer/versions?channel=alpha&platform=linux&arch=x64${extra}`, {}, env);
   }
+
+  it("advertises only a complete gzip representation for the selected release", async () => {
+    seedRelease("r1", "1.0.0", "active", 100);
+    const plain = await (await check()).json() as { artifact: Record<string, unknown> };
+    expect(plain.artifact).not.toHaveProperty("gzip");
+    sqlite.prepare("UPDATE external_build_targets SET gzip_sha256 = ?, gzip_size_bytes = 4").run("c".repeat(64));
+    const compressed = await (await check()).json() as { artifact: Record<string, unknown> };
+    expect(compressed.artifact).toMatchObject({
+      size_bytes: 8, sha256: createHash("sha256").update("r1").digest("hex"),
+      gzip: { sha256: "c".repeat(64), size_bytes: 4,
+        download_url: "https://hands.example/dl/computer/releases/r1/linux-x64.gz" },
+    });
+    sqlite.prepare("UPDATE external_build_targets SET gzip_size_bytes = NULL").run();
+    expect((await (await check()).json() as { artifact: object }).artifact).not.toHaveProperty("gzip");
+  });
 
   it("selects an exact pinned active version", async () => {
     seedRelease("r1", "1.0.0", "active", 100);


### PR DESCRIPTION
The CLI update-check response now includes optional `artifact.gzip` metadata when the selected external target has a valid compressed SHA-256 and size. The existing versioned `.gz` download route binds it to the same release and target; raw artifact identity is unchanged. Missing/incomplete stored metadata omits the enhancement.

The Node updater validates and exposes this metadata and includes it in candidate identity. `prepareUpdate` still downloads raw bytes; K selects and double-verifies gzip in https://github.com/botiverse/k-carrier/pull/9. No schema, publication, or deployment change.

Validation: root build and tests passed; Worker update endpoint 14 tests and Node updater 32 tests passed. Worker types generated against `wrangler.hands.jsonc`. Root lint cannot run because existing Worker ESLint 9 setup has no `eslint.config.*`; no lint pass claimed.
